### PR TITLE
Account operation memory by operation count to account empty

### DIFF
--- a/src/java/org/apache/cassandra/db/Memtable.java
+++ b/src/java/org/apache/cassandra/db/Memtable.java
@@ -121,7 +121,7 @@ public class Memtable
     {
         // 25% fudge factor on the base throughput * liveRatio calculation.  (Based on observed
         // pre-slabbing behavior -- not sure what accounts for this. May have changed with introduction of slabbing.)
-        return (long) (currentThroughput.get() * cfs.liveRatio * 1.25);
+        return (long) (currentThroughput.get() * cfs.liveRatio * 1.25 + currentOperations.get() * 20);
     }
 
     public long getSerializedSize()


### PR DESCRIPTION
Currently delete operations are not accounted to live bytes as it has no columns. Im my case this leads to column families not flushed because they have 'no changes' (and futher OOMs). This patch fixes the problem by introducing per-operation overhead accounted. Note that it may be needed to reduce 1.25 parameter as 1.25 is the parameter that should account this overhead.
