### PR TITLE
Propagate streaming session errors while moving or decommissioning

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -69,7 +69,7 @@ import org.apache.cassandra.utils.NodeId;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.WrappedRunnable;
 
-/*
+/**
  * This abstraction contains the token/identifier of this node
  * on the identifier space. This token gets gossiped around.
  * This class will also maintain histograms of the load information
@@ -2701,8 +2701,8 @@ public class StorageService implements IEndpointStateChangeSubscriber, StorageSe
                 final Range<Token> range = endPointEntry.getKey();
                 final InetAddress newEndpoint = endPointEntry.getValue();
 
-                final Runnable callback = new RangeDoneCallback(pending, entry, latch);
-                final Runnable rangeErrorCallback = new RangeDoneCallback(pending, entry, latch, errorCallback);
+                final Runnable callback = new RangeDoneCallback(pending, endPointEntry, latch);
+                final Runnable rangeErrorCallback = new RangeDoneCallback(pending, endPointEntry, latch, errorCallback);
 
                 StageManager.getStage(Stage.STREAM).execute(new Runnable()
                 {

--- a/src/java/org/apache/cassandra/streaming/StreamOut.java
+++ b/src/java/org/apache/cassandra/streaming/StreamOut.java
@@ -81,9 +81,9 @@ public class StreamOut
     /**
      * Stream the given ranges to the target endpoint from each CF in the given keyspace.
     */
-    public static void transferRanges(InetAddress target, Table table, Collection<Range<Token>> ranges, Runnable callback, OperationType type)
+    public static void transferRanges(InetAddress target, Table table, Collection<Range<Token>> ranges, Runnable callback, Runnable errorCallback, OperationType type)
     {
-        StreamOutSession session = StreamOutSession.create(table.name, target, callback);
+        StreamOutSession session = StreamOutSession.create(table.name, target, callback, errorCallback);
         transferRanges(session, table.getColumnFamilyStores(), ranges, type);
     }
 


### PR DESCRIPTION
Currently if StreamOutSession fails during move or decommission, operation hangs. This patch should abort the operation.
