### PR TITLE
Provide initial size for ColumnFamily object.

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamily.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamily.java
@@ -256,7 +256,10 @@ public class ColumnFamily extends AbstractColumnContainer implements IRowCacheEn
 
     int size(DBTypeSizes typeSizes)
     {
-        int size = 0;
+        // 8 bytes for object itself,
+        // 8 bytes for cmf reference, and 24 bytes for
+        // the minimal column storage in AbstractColumnContainer.
+        int size = 40;
         for (IColumn column : columns)
         {
             size += column.size(typeSizes);


### PR DESCRIPTION
It's fix for https://issues.apache.org/jira/browse/CASSANDRA-3741.
The problem there is that when ColumnFamily got all columns deleted, the size() method returns 0 despite the fact that actual object size is at least 40 bytes. 
It affects calculations of whole Memtable size. In my case I deleted millions of columns and Cassandra didn't calculate Memtable size correctly, and didn't flush it. It caused OOM crash of DB.
