### PR TITLE
a second attempt to fix CASSANDRA-5181

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -484,6 +484,7 @@
         
         <!-- don't need jamm unless running a server in which case it needs to be a -javagent to be used anyway -->
         <dependency groupId="com.github.stephenc" artifactId="jamm"/>
+        <dependency groupId="io.netty" artifactId="netty"/>
       </artifact:pom>
       <artifact:pom id="thrift-pom"
                     artifactId="cassandra-thrift"


### PR DESCRIPTION
The fix to https://issues.apache.org/jira/browse/CASSANDRA-5181 did
not make cassandra-all depend on netty.  The patch added netty to the 
dependency-management section of the pom not the dependency section.  

This fix should add netty to the dependency section of cassandra-all
