### PR TITLE
Overwrite cqlsh prompt by setting CQLSH_PROMPT environment variable

### DIFF
--- a/bin/cqlsh
+++ b/bin/cqlsh
@@ -424,10 +424,14 @@ def describe_interval(seconds):
         words = desc[0] + ' and ' + words
     return words
 
+custom_prompt = os.getenv('CQLSH_PROMPT','')
+if custom_prompt is not '':
+	custom_prompt+="\n"
+
 class Shell(cmd.Cmd):
-    default_prompt  = "cqlsh> "
+    default_prompt  = custom_prompt+"cqlsh> "
     continue_prompt = "   ... "
-    keyspace_prompt          = "cqlsh:%s> "
+    keyspace_prompt          = custom_prompt+"cqlsh:%s> "
     keyspace_continue_prompt = "%s    ... "
     num_retries = 4
     show_line_nums = False


### PR DESCRIPTION
We use it to warn people about not using WHERE filter for example
