### PR TITLE
JDK7 u40 stack size fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+src/gen-java

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -190,7 +190,7 @@ if [ "`uname`" = "Linux" ] ; then
     # be pooled anyway.) Only do so on Linux where it is known to be
     # supported.
     # u34 and greater need 180k
-    JVM_OPTS="$JVM_OPTS -Xss180k"
+    JVM_OPTS="$JVM_OPTS -Xss228k"
 fi
 echo "xss = $JVM_OPTS"
 

--- a/test/cassandra.in.sh
+++ b/test/cassandra.in.sh
@@ -39,7 +39,7 @@ JVM_OPTS=" \
         -Xrunjdwp:transport=dt_socket,server=y,address=8898,suspend=n \
         -Xms128M \
         -Xmx1G \
-        -Xss180k \
+        -Xss228k \
         -XX:SurvivorRatio=8 \
         -XX:TargetSurvivorRatio=90 \
         -XX:+AggressiveOpts \


### PR DESCRIPTION
I use Archlinux, and the latest OpenJDK, and run my cassandra via @pcmanus's ccm.

When I tried the cassandra-2.0.0 branch via:

```
$ ccm create dev -v git:cassandra-2.0.0
```

Then when I say:

```
$ ccm populate -n3
$ ccm node1 start -v
```

I get the following error:

```
xss =  -ea -javaagent:/home/blah/.ccm/repository/1.2.2/lib/jamm-0.2.5.jar -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms1985M -Xmx1985M -Xmn496M -XX:+HeapDumpOnOutOfMemoryError -Xss180k

The stack size specified is too small, Specify at least 228k
Error starting node node1
Standard error output is:
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

I tracked it down to conf/cassandra-env.sh, and changed the -Xss180k => -Xss228k and the node started.
