### PR TITLE
patch for CASSANDRA-5949 : don't consume composite partition key components

### DIFF
--- a/src/java/org/apache/cassandra/hadoop/cql3/CqlRecordWriter.java
+++ b/src/java/org/apache/cassandra/hadoop/cql3/CqlRecordWriter.java
@@ -307,7 +307,7 @@ final class CqlRecordWriter extends AbstractColumnFamilyRecordWriter<Map<String,
         {
             ByteBuffer[] keys = new ByteBuffer[partitionKeyColumns.length];
             for (int i = 0; i< keys.length; i++)
-                keys[i] = keyColumns.get(partitionKeyColumns[i]);
+                keys[i] = keyColumns.get(partitionKeyColumns[i]).duplicate();
 
             partitionKey = ((CompositeType) keyValidator).build(keys);
         }


### PR DESCRIPTION
when building the key
