### PR TITLE
Fix cassandra daemon management under debian/ubuntu

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -5,3 +5,4 @@ usr/bin
 etc/cassandra
 var/lib/cassandra
 var/log/cassandra
+var/run/cassandra

--- a/debian/init
+++ b/debian/init
@@ -105,7 +105,7 @@ classpath()
 # process is not running but the pidfile exists (to match the exit codes for
 # the "status" command; see LSB core spec 3.1, section 20.2)
 #
-CMD_PATT="-user.cassandra.+CassandraDaemon"
+CMD_PATT="cassandra.+CassandraDaemon"
 is_running()
 {
     if [ -f $PIDFILE ]; then


### PR DESCRIPTION
This PR tries to fix 2 problems when installing the package on Ubuntu (and I think Debian)
1. `/var/run/cassandra` is missing and the pid file is not created on start, which renders the init script useless
2. the regexp used to check if cassandra is running does not match the launching command line (There is no "-user." in the launch command)
