### PR TITLE
Out-of-the-box rpc_server_type set is {sync, hsha} these days, update docs.

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -335,7 +335,7 @@ rpc_port: 9160
 # enable or disable keepalive on rpc connections
 rpc_keepalive: true
 
-# Cassandra provides three out-of-the-box options for the RPC Server:
+# Cassandra provides two out-of-the-box options for the RPC Server:
 #
 # sync  -> One thread per thrift connection. For a very large number of clients, memory
 #          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size

--- a/src/java/org/apache/cassandra/thrift/TServerCustomFactory.java
+++ b/src/java/org/apache/cassandra/thrift/TServerCustomFactory.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.thrift.server.TServer;
 
 /**
- * Helper implementation to create a thrift TServer based on one of the common types we support (sync, async, hsha),
+ * Helper implementation to create a thrift TServer based on one of the common types we support (sync, hsha),
  * or a custom type by setting the fully qualified java class name in the rpc_server_type setting.
  */
 public class TServerCustomFactory implements TServerFactory


### PR DESCRIPTION
Update inline documentation in the wake of where 1.2 stood, "async - Deprecated and will be removed in the next major release. Do not use." 
