### PR TITLE
Added patterns to cover ISO8601 dates with miliseconds.

### DIFF
--- a/src/java/org/apache/cassandra/serializers/TimestampSerializer.java
+++ b/src/java/org/apache/cassandra/serializers/TimestampSerializer.java
@@ -30,10 +30,14 @@ public class TimestampSerializer implements TypeSerializer<Date>
             "yyyy-MM-dd HH:mm:ss",
             "yyyy-MM-dd HH:mmZ",
             "yyyy-MM-dd HH:mm:ssZ",
+            "yyyy-MM-dd HH:mm:ss.SSS",
+            "yyyy-MM-dd HH:mm:ss.SSSZ",
             "yyyy-MM-dd'T'HH:mm",
             "yyyy-MM-dd'T'HH:mmZ",
             "yyyy-MM-dd'T'HH:mm:ss",
             "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ss.SSS",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
             "yyyy-MM-dd",
             "yyyy-MM-ddZ"
     };


### PR DESCRIPTION
Currently it is impossible to query for dates with sub-second accuracy from cqlsh because the parser doesn't recognise dates formatted like `2013-09-30 22:19:06.591`. This pull request adds the following four ISO8601 patterns:

```
"yyyy-MM-dd HH:mm:ss.SSS",
"yyyy-MM-dd HH:mm:ss.SSSZ",
"yyyy-MM-dd'T'HH:mm:ss.SSS",
"yyyy-MM-dd'T'HH:mm:ss.SSSZ",
```

This change also allows the minTimeuuid/maxTimeuuid functions to take dates with milisecond granularity. 
