### PR TITLE
Fix bug in setting up remote host min/max simul requests

### DIFF
--- a/src/java/org/apache/cassandra/hadoop/cql3/CqlConfigHelper.java
+++ b/src/java/org/apache/cassandra/hadoop/cql3/CqlConfigHelper.java
@@ -429,8 +429,8 @@ public class CqlConfigHelper
 
         poolingOptions.setCoreConnectionsPerHost(HostDistance.REMOTE, 0)
                       .setMaxConnectionsPerHost(HostDistance.REMOTE, 0)
-                      .setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE, 0)
-                      .setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE, 0);
+                      .setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE, 0)
+                      .setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE, 0);
 
         return poolingOptions;
     }  


### PR DESCRIPTION
Without this fix, using the CqlConfigHelper will run into an exception where it complains MaxRequests cannot be higher than MinRequests.
