### PR TITLE
Need to export JVM_OPTS

### DIFF
--- a/debian/init
+++ b/debian/init
@@ -38,6 +38,8 @@ if [ -z "$JVM_OPTS" ]; then
     exit 3
 fi
 
+export JVM_OPTS
+
 # Export JAVA_HOME, if set.
 [ -n "$JAVA_HOME" ] && export JAVA_HOME
 


### PR DESCRIPTION
Without exporting them, use defined options from /etc/default/cassandra never actually get applied.
