### PR TITLE
change private evictionCheckTimer to public

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -88,7 +88,7 @@ public class QueryProcessor implements QueryHandler
     public static final CQLMetrics metrics = new CQLMetrics();
 
     private static final AtomicInteger lastMinuteEvictionsCount = new AtomicInteger(0);
-    private static final ScheduledExecutorService evictionCheckTimer = Executors.newScheduledThreadPool(1);
+    public static final ScheduledExecutorService evictionCheckTimer = Executors.newScheduledThreadPool(1);
 
     static
     {


### PR DESCRIPTION
When used in client mode (for bulk loading sstable by example). QueryProcessor will starts the evictionCheckTimer thread pool, however, we have to handle on it to shut it down from the application.
