### PR TITLE
opinion on refactoring ListenableFuture to Java 8 CompletableFuture

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -65,8 +65,8 @@
     <property name="test.pig.src" value="${test.dir}/pig"/>
     <property name="dist.dir" value="${build.dir}/dist"/>
 	
-	<property name="source.version" value="1.7"/>
-	<property name="target.version" value="1.7"/>
+	<property name="source.version" value="1.8"/>
+	<property name="target.version" value="1.8"/>
 	
     <condition property="version" value="${base.version}">
       <isset property="release"/>

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.repair;
 
 import java.net.InetAddress;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 import com.google.common.util.concurrent.*;
 import org.slf4j.Logger;
@@ -34,7 +35,7 @@ import org.apache.cassandra.utils.Pair;
 /**
  * RepairJob runs repair on given ColumnFamily.
  */
-public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
+public class RepairJob extends CompletableFuture<RepairResult> implements Runnable
 {
     private static Logger logger = LoggerFactory.getLogger(RepairJob.class);
 
@@ -156,7 +157,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             public void onSuccess(List<SyncStat> stats)
             {
                 logger.info(String.format("[repair #%s] %s is fully synced", session.getId(), desc.columnFamily));
-                set(new RepairResult(desc, stats));
+                complete(new RepairResult(desc, stats));
             }
 
             /**
@@ -165,7 +166,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             public void onFailure(Throwable t)
             {
                 logger.warn(String.format("[repair #%s] %s sync failed", session.getId(), desc.columnFamily));
-                setException(t);
+                completeExceptionally(t);
             }
         }, taskExecutor);
 

--- a/src/java/org/apache/cassandra/utils/concurrent/FutureTransform.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/FutureTransform.java
@@ -1,0 +1,33 @@
+package org.apache.cassandra.utils.concurrent;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+
+public class FutureTransform {
+    /**
+     * We'd like to utilize existing CompletableFuture.allOf(). Unfortunately,
+     * it has two minor drawbacks - it takes vararg instead of Collection and
+     * doesn't return a future of aggregated results but Void instead. By
+     * aggregated results I mean: if we provide List<CompletableFuture<Double>>,
+     * it should return CompletableFuture<List<Double>>, not
+     * CompletableFuture<Void>! Luckily it's easy to fix with a bit of glue
+     * code.
+     */
+    public static <T> CompletableFuture<List<T>> allAsList(
+            Collection<? extends CompletableFuture<T>> futures) {
+        // the trick is to use existing allOf() but when allDoneFuture completes
+        // (which means all/ underlying futures are done),
+        // simply iterate overall futures and join() (blocking wait) on each.
+        // However this call is guaranteed not to block because
+        // by now all futures completed!
+        CompletableFuture<Void> allDoneFuture = CompletableFuture.allOf(futures
+                .toArray(new CompletableFuture[futures.size()]));
+        return allDoneFuture.thenApply(v -> {
+            return futures.stream().map(CompletableFuture::join)
+                    .collect(Collectors.toList());
+        });
+    }
+}


### PR DESCRIPTION
I'm doing research on new concurrent constructs in Java 8. I found `CompletableFuture` in Java 8 has the same functionality as Guava `ListenableFuture`. But `CompletableFuture` is much nicer because it comes together with Lambda expression in Java 8, and it is monadic, which makes the code more readable and cleaner. Also, it provides more ways to compose different tasks. Therefore, using `CompletableFuture` instead of `ListenableFuture` is better for future extension and maintenance of the code.

I tried to refactoring one Guava `ListenableFuture` to Java 8 `CompletableFuture` in Cassandra, so you can see the difference in the code. You don't have to merge this pull request. I'm just wondering your opinion on this kind of refactoring (or migrating the code from Java 7 to Java 8). Do you think the refactoring is useful? Do you have any plan to use Java 8?
