### PR TITLE
Added support for IBM zSystems architecture (s390x)

### DIFF
--- a/src/java/org/apache/cassandra/io/util/Memory.java
+++ b/src/java/org/apache/cassandra/io/util/Memory.java
@@ -59,7 +59,7 @@ public class Memory implements AutoCloseable
     {
         String arch = System.getProperty("os.arch");
         unaligned = arch.equals("i386") || arch.equals("x86")
-                    || arch.equals("amd64") || arch.equals("x86_64");
+                    || arch.equals("amd64") || arch.equals("x86_64") || arch.equals("s390x");
     }
 
     protected long peer;

--- a/src/java/org/apache/cassandra/utils/FastByteOperations.java
+++ b/src/java/org/apache/cassandra/utils/FastByteOperations.java
@@ -104,7 +104,7 @@ public class FastByteOperations
         {
             String arch = System.getProperty("os.arch");
             boolean unaligned = arch.equals("i386") || arch.equals("x86")
-                                || arch.equals("amd64") || arch.equals("x86_64");
+                                || arch.equals("amd64") || arch.equals("x86_64") || arch.equals("s390x") ;
             if (!unaligned)
                 return new PureJavaOperations();
             try


### PR DESCRIPTION
Added support for IBM zSystems architecture (s390x). These code changes are required to make few test cases 'pass' for zSystems.
