### PR TITLE
remove duplicated control for flush mesage control

### DIFF
--- a/src/java/org/apache/cassandra/transport/Message.java
+++ b/src/java/org/apache/cassandra/transport/Message.java
@@ -449,7 +449,7 @@ public abstract class Message
 
                 runsSinceFlush++;
 
-                if (!doneWork || runsSinceFlush > 2 || flushed.size() > 50)
+                if (runsSinceFlush > 2 || flushed.size() > 50)
                 {
                     for (ChannelHandlerContext channel : channels)
                         channel.flush();


### PR DESCRIPTION
Motivation:

the !doneWork's control is duplicated and confused with runsSinceFlush > 2

if on the first run:the queue size is 20
donework will be set to true and not do flush due to the size<50 and runsSinceFlush<2.

if on the second run. the queue size is 0,
donework will be reset to false and not set to true due to no new items in queue, but the flush will be triggered due to:
  if (!doneWork || runsSinceFlush > 2 || flushed.size() > 50)
now the runsSinceFlush is 2. so in actual, its function is similar with runsSinceFlush>1.
so it is no need to keep it so that the code is confused and duplicated.

Modifications:

remove it

Result:

after remove it, it will more clear and no confused.
