### PR TITLE
Fix bug for running on ppc64

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -725,6 +725,7 @@
             <src path="${build.src.gen-java}"/>
             <classpath refid="cassandra.classpath"/>
             <compilerarg value="-XDignore.symbol.file"/>
+            <compilerarg line="-encoding utf-8"/>
         </javac>
         <antcall target="createVersionPropFile"/>
         <copy todir="${build.classes.main}">
@@ -1086,6 +1087,7 @@
       <src path="${test.unit.src}"/>
       <src path="${test.long.src}"/>
       <src path="${test.pig.src}"/>
+      <compilerarg line="-encoding utf-8"/>
     </javac>
 
     <!-- Non-java resources needed by the test suite -->


### PR DESCRIPTION
I was getting errors like the one below when trying to build on POWERpc.  I fixed this by adding <compilerarg line="-encoding utf-8"/> in the build.xml.  Thanks.

```
    [javac] /tmp/pkb/cassandra/test/unit/org/apache/cassandra/cql3/validation/operations/UpdateTest.java:38: error: unmappable character for encoding ASCII
    [javac]         execute("INSERT INTO %s (k, c, v, s) VALUES ('??', '??', '??', {'??'})");
```
