### PR TITLE
Follow up commit 028f539eaa7f5ebcda42495145686dc1fa40acd9

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -377,10 +377,7 @@ public class SelectStatement implements CQLStatement
 
         // Please note that the isExhausted state of the pager only gets updated when we've closed the page, so this
         // shouldn't be moved inside the 'try' above.
-        if (!pager.isExhausted())
-            msg.result.metadata.setHasMorePages(pager.state());
-
-        return msg;
+        return pager.isExhausted() ? msg : msg.withPagingState(pager.state());
     }
 
     private void warn(String msg)


### PR DESCRIPTION
We replaced an if-statement and a return-statement with another return-statement with a ternary operator because the same change was conducted in a past commit.

https://github.com/apache/cassandra/commit/028f539eaa7f5ebcda42495145686dc1fa40acd9#diff-75ebe654dcf6c8c474f787abaf47bb68

Yoshiki, Shinpei, Hideaki, and Mei
