### PR TITLE
Fix flapping test in 2.0.17. Looks like an eventual consistency issue.

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/MultiColumnRelationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/MultiColumnRelationTest.java
@@ -738,6 +738,7 @@ public class MultiColumnRelationTest
             execute("INSERT INTO %s.multiple_clustering_reversed" + tableSuffix + " (a, b, c, d) VALUES (0, 0, 1, 0)");
 
 
+            Thread.sleep(5000); // There is a race here: if the SELECT is read before all of the first 3 INSERTS propagate, the test fails.
             UntypedResultSet results = execute("SELECT * FROM %s.multiple_clustering_reversed" + tableSuffix + " WHERE a=0 AND (b) > (0)");
             assertEquals(3, results.size());
             checkRow(0, results, 0, 1, 0, 0);


### PR DESCRIPTION
Not the best fix - would prefer to have a way to have the test wait until it knows the 6 INSERTs ahead of checking the results had completed instead.
