### PR TITLE
added encoding param to non-debug printmsg function

### DIFF
--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -240,13 +240,12 @@ class CopyTask(object):
             global DEBUG
             DEBUG = True
 
-        # do not display messages when exporting to STDOUT unless --debug is set
-        self.printmsg = printmsg if self.fname is not None or direction == 'from' or DEBUG \
-            else lambda _, eol='\n': None
         self.options = self.parse_options(opts, direction)
-
         self.num_processes = self.options.copy['numprocesses']
         self.encoding = self.options.copy['encoding']
+        # do not display messages when exporting to STDOUT unless --debug is set
+        self.printmsg = printmsg if self.fname is not None or direction == 'from' or DEBUG \
+            else lambda _, eol='\n', encoding=self.encoding : None
         self.printmsg('Using %d child processes' % (self.num_processes,))
 
         if direction == 'from':


### PR DESCRIPTION
`cqlsh> copy test.image3d_impressions to STDOUT;`
Running this ^ without `--debug` produces:
`<lambda>() got an unexpected keyword argument 'encoding'`