### PR TITLE
fix typo in the clustering columns section

### DIFF
--- a/doc/source/cql/ddl.rst
+++ b/doc/source/cql/ddl.rst
@@ -359,7 +359,7 @@ instance, given::
         a int,
         b int,
         c int,
-        PRIMARY KEY (a, c, d)
+        PRIMARY KEY (a, b)
     );
 
     SELECT * FROM t;


### PR DESCRIPTION
clustering column should be 'b' , not 'c' and 'd'