### PR TITLE
CASSANDRA-10726: Read repair inserts should use speculative retry

### DIFF
--- a/src/java/org/apache/cassandra/db/ConsistencyLevel.java
+++ b/src/java/org/apache/cassandra/db/ConsistencyLevel.java
@@ -101,6 +101,31 @@ public enum ConsistencyLevel
              : quorumFor(keyspace);
     }
 
+    public boolean satisfiesQuorumFor(Keyspace keyspace)
+    {
+        switch (this)
+        {
+            case ONE:
+            case LOCAL_ONE:
+            case ANY:
+                return quorumFor(keyspace) <= 1;
+            case QUORUM:
+            case EACH_QUORUM:
+            case LOCAL_QUORUM:
+            case ALL:
+            case SERIAL:
+            case LOCAL_SERIAL:
+                return true;
+            case TWO:
+                return quorumFor(keyspace) <= 2;
+            case THREE:
+                return quorumFor(keyspace) <= 3;
+            default:
+                throw new IllegalStateException(this + " is not supported");
+        }
+    }
+
+
     public int blockFor(Keyspace keyspace)
     {
         switch (this)

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1773,11 +1773,13 @@ public class StorageProxy implements StorageProxyMBean
                 ReadRepairMetrics.repairedBlocking.mark();
 
                 // Do a full data read to resolve the correct response (and repair node that need be)
+
                 Keyspace keyspace = Keyspace.open(command.metadata().keyspace);
-                DataResolver resolver = new DataResolver(keyspace, command, ConsistencyLevel.ALL, executor.handler.endpoints.size(), queryStartNanoTime);
+                DataResolver resolver = new DataResolver(keyspace, command, consistency, executor.handler.endpoints.size(), queryStartNanoTime, executor.spareReadRepairNode);
+                // we don't need to block for all replicas to reply no matter whether it's in read repair chance or speculative retry
                 repairHandler = new ReadCallback(resolver,
-                                                 ConsistencyLevel.ALL,
-                                                 executor.getContactedReplicas().size(),
+                                                 consistency,
+                                                 consistency.blockFor(keyspace),
                                                  command,
                                                  keyspace,
                                                  executor.handler.endpoints,

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -411,7 +411,6 @@ public class FBUtilities
         for (AsyncOneResponse result : results)
             result.get(ms, TimeUnit.MILLISECONDS);
     }
-
     /**
      * Create a new instance of a partitioner defined in an SSTable Descriptor
      * @param desc Descriptor of an sstable

--- a/test/unit/org/apache/cassandra/db/ConsistencyLevelTest.java
+++ b/test/unit/org/apache/cassandra/db/ConsistencyLevelTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.KeyspaceParams;
+
+
+public class ConsistencyLevelTest
+{
+    @Test
+    public void testSatisfiesQuorumFor()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        Keyspace keyspace = Keyspace.mockKS(KeyspaceMetadata.create("test", KeyspaceParams.simple(3)));
+        Assert.assertTrue(ConsistencyLevel.ALL.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.EACH_QUORUM.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.QUORUM.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.LOCAL_ONE.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.LOCAL_QUORUM.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.ONE.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.TWO.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.THREE.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.SERIAL.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.LOCAL_SERIAL.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.ANY.satisfiesQuorumFor(keyspace));
+
+        keyspace = Keyspace.mockKS(KeyspaceMetadata.create("test", KeyspaceParams.nts("DC1", 3, "DC2", 3)));
+        Assert.assertTrue(ConsistencyLevel.ALL.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.EACH_QUORUM.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.QUORUM.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.LOCAL_ONE.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.LOCAL_QUORUM.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.ONE.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.TWO.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.THREE.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.SERIAL.satisfiesQuorumFor(keyspace));
+        Assert.assertTrue(ConsistencyLevel.LOCAL_SERIAL.satisfiesQuorumFor(keyspace));
+        Assert.assertFalse(ConsistencyLevel.ANY.satisfiesQuorumFor(keyspace));
+
+    }
+}

--- a/test/unit/org/apache/cassandra/service/ReadExecutorTest.java
+++ b/test/unit/org/apache/cassandra/service/ReadExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.service;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
@@ -77,7 +78,7 @@ public class ReadExecutorTest
     {
         assertEquals(0, cfs.metric.speculativeInsufficientReplicas.getCount());
         assertEquals(0, ks.metric.speculativeInsufficientReplicas.getCount());
-        AbstractReadExecutor executor = new AbstractReadExecutor.NeverSpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime(), true);
+        AbstractReadExecutor executor = new AbstractReadExecutor.NeverSpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime(), true, Optional.empty());
         executor.maybeTryAdditionalReplicas();
         try
         {
@@ -92,7 +93,7 @@ public class ReadExecutorTest
         assertEquals(1, ks.metric.speculativeInsufficientReplicas.getCount());
 
         //Shouldn't increment
-        executor = new AbstractReadExecutor.NeverSpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime(), false);
+        executor = new AbstractReadExecutor.NeverSpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime(), false, Optional.empty());
         executor.maybeTryAdditionalReplicas();
         try
         {
@@ -118,7 +119,7 @@ public class ReadExecutorTest
         assertEquals(0, cfs.metric.speculativeFailedRetries.getCount());
         assertEquals(0, ks.metric.speculativeRetries.getCount());
         assertEquals(0, ks.metric.speculativeFailedRetries.getCount());
-        AbstractReadExecutor executor = new AbstractReadExecutor.SpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(TimeUnit.DAYS.toMillis(365)), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime());
+        AbstractReadExecutor executor = new AbstractReadExecutor.SpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(TimeUnit.DAYS.toMillis(365)), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime(), Optional.empty());
         executor.maybeTryAdditionalReplicas();
         new Thread()
         {
@@ -159,7 +160,7 @@ public class ReadExecutorTest
         assertEquals(0, cfs.metric.speculativeFailedRetries.getCount());
         assertEquals(0, ks.metric.speculativeRetries.getCount());
         assertEquals(0, ks.metric.speculativeFailedRetries.getCount());
-        AbstractReadExecutor executor = new AbstractReadExecutor.SpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime());
+        AbstractReadExecutor executor = new AbstractReadExecutor.SpeculatingReadExecutor(ks, cfs, new MockSinglePartitionReadCommand(), ConsistencyLevel.LOCAL_QUORUM, targets, System.nanoTime(), Optional.empty());
         executor.maybeTryAdditionalReplicas();
         try
         {


### PR DESCRIPTION
1. do an extra read repair retry to only guarantee “monotonic quorum
read”. Here “quorum” means majority of nodes among replicas
2. only block what is needed for resolving the digest mismatch no
matter whether it’s speculative retry or read repair chance.