### PR TITLE
CASSANDRA-13265 Expire messages by a single Thread

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -989,7 +989,8 @@ windows_timer_interval: 1
 # How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
 # Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
 # taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
-# will be appropriate. A smaller interval can help on high-throughput installations.
-# An interval of 0 disables any wait time, which is the behaviour of former Cassandra versions.
+# will be appropriate. A smaller value could potentially expire messages slightly sooner at the expense of more CPU
+# time and queue contention while iterating the backlog of messages.
+# An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
 #
 # otc_backlog_expiration_interval_ms: 200

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -989,7 +989,7 @@ windows_timer_interval: 1
 # How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
 # Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
 # taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
-# will be appropriate. A smaller interval helps keeping the memory footprint on high-throughput installation low,
-# but will lock the backlog queue more frequently. 
-# 
+# will be appropriate. A smaller interval can help on high-throughput installations.
+# An interval of 0 disables any wait time, which is the behaviour of former Cassandra versions.
+#
 # otc_backlog_expiration_interval_ms: 200

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -985,3 +985,11 @@ windows_timer_interval: 1
 
 # Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
 # otc_coalescing_enough_coalesced_messages: 8
+
+# How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
+# Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
+# taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
+# will be appropriate. A smaller interval helps keeping the memory footprint on high-throughput installation low,
+# but will lock the backlog queue more frequently. 
+# 
+# otc_backlog_expiration_interval_ms: 200

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -302,7 +302,7 @@ public class Config
      * Backlog expiration interval in milliseconds for the OutboundTcpConnection.  
      */
     public static final int otc_backlog_expiration_interval_ms_default = 200;
-    public volatile Integer otc_backlog_expiration_interval_ms = otc_backlog_expiration_interval_ms_default;
+    public volatile int otc_backlog_expiration_interval_ms = otc_backlog_expiration_interval_ms_default;
     
     public int windows_timer_interval = 0;
 

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -298,6 +298,12 @@ public class Config
     public int otc_coalescing_window_us = otc_coalescing_window_us_default;
     public int otc_coalescing_enough_coalesced_messages = 8;
 
+    /**
+     * Backlog expiration interval in milliseconds for the OutboundTcpConnection.  
+     */
+    public static final int otc_backlog_expiration_interval_ms_default = 200;
+    public volatile Integer otc_backlog_expiration_interval_ms = otc_backlog_expiration_interval_ms_default;
+    
     public int windows_timer_interval = 0;
 
     public boolean enable_user_defined_functions = false;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -303,7 +303,7 @@ public class Config
      */
     public static final int otc_backlog_expiration_interval_ms_default = 200;
     public volatile int otc_backlog_expiration_interval_ms = otc_backlog_expiration_interval_ms_default;
-    
+ 
     public int windows_timer_interval = 0;
 
     public boolean enable_user_defined_functions = false;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -299,7 +299,7 @@ public class Config
     public int otc_coalescing_enough_coalesced_messages = 8;
 
     /**
-     * Backlog expiration interval in milliseconds for the OutboundTcpConnection.  
+     * Backlog expiration interval in milliseconds for the OutboundTcpConnection.
      */
     public static final int otc_backlog_expiration_interval_ms_default = 200;
     public volatile int otc_backlog_expiration_interval_ms = otc_backlog_expiration_interval_ms_default;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1975,9 +1975,8 @@ public class DatabaseDescriptor
     public static void setOtcBacklogExpirationInterval(int intervalInMillis)
     {
         conf.otc_backlog_expiration_interval_ms = intervalInMillis;
-        
     }
-    
+ 
     public static int getWindowsTimerInterval()
     {
         return conf.windows_timer_interval;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1967,6 +1967,18 @@ public class DatabaseDescriptor
         conf.otc_coalescing_enough_coalesced_messages = otc_coalescing_enough_coalesced_messages;
     }
 
+    public static Integer getOtcBacklogExpirationInterval()
+    {
+        Integer confValue = conf.otc_backlog_expiration_interval_ms;
+        return confValue != null ? confValue : Config.otc_backlog_expiration_interval_ms_default;
+    }
+
+    public static void setOtcBacklogExpirationInterval(Integer intervalInMillis)
+    {
+        conf.otc_backlog_expiration_interval_ms = intervalInMillis;
+        
+    }
+    
     public static int getWindowsTimerInterval()
     {
         return conf.windows_timer_interval;
@@ -2031,5 +2043,4 @@ public class DatabaseDescriptor
     {
         return conf.gc_warn_threshold_in_ms;
     }
-
 }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1967,13 +1967,12 @@ public class DatabaseDescriptor
         conf.otc_coalescing_enough_coalesced_messages = otc_coalescing_enough_coalesced_messages;
     }
 
-    public static Integer getOtcBacklogExpirationInterval()
+    public static int getOtcBacklogExpirationInterval()
     {
-        Integer confValue = conf.otc_backlog_expiration_interval_ms;
-        return confValue != null ? confValue : Config.otc_backlog_expiration_interval_ms_default;
+        return conf.otc_backlog_expiration_interval_ms;
     }
 
-    public static void setOtcBacklogExpirationInterval(Integer intervalInMillis)
+    public static void setOtcBacklogExpirationInterval(int intervalInMillis)
     {
         conf.otc_backlog_expiration_interval_ms = intervalInMillis;
         
@@ -2043,4 +2042,5 @@ public class DatabaseDescriptor
     {
         return conf.gc_warn_threshold_in_ms;
     }
+
 }

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -118,7 +118,7 @@ public class OutboundTcpConnection extends Thread
                     "Value provided for coalescing window must be greather than 0: " + coalescingWindow);
     }
 
-    private static final MessageOut CLOSE_SENTINEL = new MessageOut(MessagingService.Verb.INTERNAL_RESPONSE);
+    private static final MessageOut<?> CLOSE_SENTINEL = new MessageOut<MessagingService.Verb>(MessagingService.Verb.INTERNAL_RESPONSE);
     private volatile boolean isStopped = false;
 
     private static final int OPEN_RETRY_DELAY = 100; // ms between retries
@@ -346,7 +346,7 @@ public class OutboundTcpConnection extends Thread
         }
     }
 
-    private void writeInternal(MessageOut message, int id, long timestamp) throws IOException
+    private void writeInternal(MessageOut<?> message, int id, long timestamp) throws IOException
     {
         out.writeInt(MessagingService.PROTOCOL_MAGIC);
 

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -135,8 +135,9 @@ public class OutboundTcpConnection extends Thread
     static final int LZ4_HASH_SEED = 0x9747b28c;
 
     private final BlockingQueue<QueuedMessage> backlog = new LinkedBlockingQueue<>();
+    private static final String BACKLOG_PURGE_SIZE_PROPERTY = PREFIX + "otc_backlog_purge_size";
     @VisibleForTesting
-    static final int BACKLOG_PURGE_SIZE = Integer.getInteger("OTC_BACKLOG_PURGE_SIZE", 1024);
+    static final int BACKLOG_PURGE_SIZE = Integer.getInteger(BACKLOG_PURGE_SIZE_PROPERTY, 1024);
     private final AtomicBoolean backlogExpirationActive = new AtomicBoolean(false);
     private volatile long backlogNextExpirationTime;
 

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -646,7 +646,7 @@ public class OutboundTcpConnection extends Thread
         boolean isTimedOut(long nowNanos)
         {
             long messageTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(message.getTimeout());
-            return droppable && timestampNanos - (nowNanos - messageTimeoutNanos) < 0;
+            return droppable && nowNanos - timestampNanos  > messageTimeoutNanos;
         }
 
         boolean shouldRetry()

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -258,6 +258,9 @@ public class OutboundTcpConnection extends Thread
                     {
                         // clear out the queue, else gossip messages back up.
                         drainedMessages.clear();
+                        // Clear the backlog and update dropped statistics. Hint: The statistics may be slightly
+                        // too low, if messages are added between the calls of backlog.size() and backlog.clear()
+                        dropped.addAndGet(backlog.size());
                         backlog.clear();
                         break inner;
                     }

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -257,10 +257,11 @@ public class OutboundTcpConnection extends Thread
                     else
                     {
                         // clear out the queue, else gossip messages back up.
+                        int drainCount = drainedMessages.size();
                         drainedMessages.clear();
                         // Clear the backlog and update dropped statistics. Hint: The statistics may be slightly
                         // too low, if messages are added between the calls of backlog.size() and backlog.clear()
-                        dropped.addAndGet(backlog.size());
+                        dropped.addAndGet(backlog.size() + drainCount);
                         backlog.clear();
                         break inner;
                     }
@@ -601,7 +602,7 @@ public class OutboundTcpConnection extends Thread
 
         /**
          * Expiration is an expensive process. Iterating the queue locks the queue for both writes and
-         * reads during iter.next() and iter.remove(). Thus let only a single Thread do expiration.
+         * reads during iter.next() and iter.remove(). Thus letting only a single Thread do expiration.
          */
         if (backlogNextExpirationTime.compareAndSet(nextExpirationTime, timestampNanos + BACKLOG_EXPIRATION_INTERVAL_NANOS))
         {
@@ -622,7 +623,6 @@ public class OutboundTcpConnection extends Thread
                 long duration = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - timestampNanos);
                 logger.trace("Expiration of {} took {}μs", getName(), duration);
             }
-
         }
     }
 

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -31,6 +31,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.Checksum;
@@ -117,6 +118,11 @@ public class OutboundTcpConnection extends Thread
         if (coalescingWindow < 0)
             throw new ExceptionInInitializerError(
                     "Value provided for coalescing window must be greather than 0: " + coalescingWindow);
+        
+        int otc_backlog_expiration_interval_in_ms = DatabaseDescriptor.getOtcBacklogExpirationInterval();
+        if (otc_backlog_expiration_interval_in_ms != Config.otc_backlog_expiration_interval_ms_default)
+            logger.info("OutboundTcpConnection backlog expiration interval set to to {}ms", otc_backlog_expiration_interval_in_ms);
+        
     }
 
     private static final MessageOut<?> CLOSE_SENTINEL = new MessageOut<MessagingService.Verb>(MessagingService.Verb.INTERNAL_RESPONSE);
@@ -131,7 +137,7 @@ public class OutboundTcpConnection extends Thread
     private final BlockingQueue<QueuedMessage> backlog = new LinkedBlockingQueue<>();
     @VisibleForTesting
     static final int BACKLOG_PURGE_SIZE = 1024;
-    private static final long BACKLOG_EXPIRATION_INTERVAL_NANOS = 10 * 1000 * 1000 * 1000; // 10s
+    private final AtomicBoolean backlogExpirationActive = new AtomicBoolean(false);
     private final AtomicLong backlogNextExpirationTime = new AtomicLong(System.nanoTime());
 
     private final OutboundTcpConnectionPool poolReference;
@@ -181,13 +187,13 @@ public class OutboundTcpConnection extends Thread
         }
     }
 
-    @VisibleForTesting // (otherwise = VisibleForTesting.NONE)
     /**
      * This is a helper method for unit testing. Disclaimer: Do not use this method outside unit tests, as
      * this method is iterating the queue which can be an expensive operation (CPU time, queue locking).
      * 
      * @return true, if the queue contains at least one expired element
      */
+    @VisibleForTesting // (otherwise = VisibleForTesting.NONE)
     boolean backlogContainsExpiredMessages(long nowNanos)
     {
         return backlog.stream().anyMatch(entry -> entry.isTimedOut(nowNanos));
@@ -604,24 +610,34 @@ public class OutboundTcpConnection extends Thread
          * Expiration is an expensive process. Iterating the queue locks the queue for both writes and
          * reads during iter.next() and iter.remove(). Thus letting only a single Thread do expiration.
          */
-        if (backlogNextExpirationTime.compareAndSet(nextExpirationTime, timestampNanos + BACKLOG_EXPIRATION_INTERVAL_NANOS))
+        if (backlogExpirationActive.compareAndSet(false, true))
         {
-            Iterator<QueuedMessage> iter = backlog.iterator();
-            while (iter.hasNext())
+            try
             {
-                QueuedMessage qm = iter.next();
-                if (!qm.droppable)
-                    continue;
-                if (!qm.isTimedOut(timestampNanos))
-                    continue;
-                iter.remove();
-                dropped.incrementAndGet();
+                Iterator<QueuedMessage> iter = backlog.iterator();
+                while (iter.hasNext())
+                {
+                    QueuedMessage qm = iter.next();
+                    if (!qm.droppable)
+                        continue;
+                    if (!qm.isTimedOut(timestampNanos))
+                        continue;
+                    iter.remove();
+                    dropped.incrementAndGet();
+                }
+                
+                if (logger.isTraceEnabled())
+                {
+                    long duration = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - timestampNanos);
+                    logger.trace("Expiration of {} took {}μs", getName(), duration);
+                }
             }
-            
-            if (logger.isTraceEnabled())
+            finally
             {
-                long duration = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - timestampNanos);
-                logger.trace("Expiration of {} took {}μs", getName(), duration);
+                backlogExpirationActive.set(false);
+                long backlogExplirationIntervalNanos = TimeUnit.MILLISECONDS.toNanos(DatabaseDescriptor.getOtcBacklogExpirationInterval());
+                backlogNextExpirationTime.set(timestampNanos + backlogExplirationIntervalNanos);
+
             }
         }
     }

--- a/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundTcpConnection.java
@@ -118,11 +118,11 @@ public class OutboundTcpConnection extends Thread
         if (coalescingWindow < 0)
             throw new ExceptionInInitializerError(
                     "Value provided for coalescing window must be greather than 0: " + coalescingWindow);
-        
+
         int otc_backlog_expiration_interval_in_ms = DatabaseDescriptor.getOtcBacklogExpirationInterval();
         if (otc_backlog_expiration_interval_in_ms != Config.otc_backlog_expiration_interval_ms_default)
             logger.info("OutboundTcpConnection backlog expiration interval set to to {}ms", otc_backlog_expiration_interval_in_ms);
-        
+
     }
 
     private static final MessageOut<?> CLOSE_SENTINEL = new MessageOut<MessagingService.Verb>(MessagingService.Verb.INTERNAL_RESPONSE);
@@ -623,7 +623,7 @@ public class OutboundTcpConnection extends Thread
                     iter.remove();
                     dropped.incrementAndGet();
                 }
-                
+
                 if (logger.isTraceEnabled())
                 {
                     long duration = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - timestampNanos);

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -72,8 +72,6 @@ import org.apache.cassandra.triggers.TriggerExecutor;
 import org.apache.cassandra.utils.*;
 import org.apache.cassandra.utils.AbstractIterator;
 
-import static com.google.common.collect.Iterables.contains;
-
 public class StorageProxy implements StorageProxyMBean
 {
     public static final String MBEAN_NAME = "org.apache.cassandra.db:type=StorageProxy";
@@ -2682,5 +2680,13 @@ public class StorageProxy implements StorageProxyMBean
 
     public long getReadRepairRepairedBackground() {
         return ReadRepairMetrics.repairedBackground.getCount();
+    }
+
+    public Integer getOtcBacklogExpirationInterval() {
+        return DatabaseDescriptor.getOtcBacklogExpirationInterval();
+    }
+
+    public void setOtcBacklogExpirationInterval(Integer intervalInMillis) {
+        DatabaseDescriptor.setOtcBacklogExpirationInterval(intervalInMillis);
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2682,11 +2682,11 @@ public class StorageProxy implements StorageProxyMBean
         return ReadRepairMetrics.repairedBackground.getCount();
     }
 
-    public Integer getOtcBacklogExpirationInterval() {
+    public int getOtcBacklogExpirationInterval() {
         return DatabaseDescriptor.getOtcBacklogExpirationInterval();
     }
 
-    public void setOtcBacklogExpirationInterval(Integer intervalInMillis) {
+    public void setOtcBacklogExpirationInterval(int intervalInMillis) {
         DatabaseDescriptor.setOtcBacklogExpirationInterval(intervalInMillis);
     }
 }

--- a/src/java/org/apache/cassandra/service/StorageProxyMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageProxyMBean.java
@@ -58,6 +58,9 @@ public interface StorageProxyMBean
     public long getReadRepairAttempted();
     public long getReadRepairRepairedBlocking();
     public long getReadRepairRepairedBackground();
+    
+    public Integer getOtcBacklogExpirationInterval();
+    public void setOtcBacklogExpirationInterval(Integer intervalInMillis);
 
     /** Returns each live node's schema version */
     public Map<String, List<String>> getSchemaVersions();

--- a/src/java/org/apache/cassandra/service/StorageProxyMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageProxyMBean.java
@@ -58,9 +58,9 @@ public interface StorageProxyMBean
     public long getReadRepairAttempted();
     public long getReadRepairRepairedBlocking();
     public long getReadRepairRepairedBackground();
-    
-    public Integer getOtcBacklogExpirationInterval();
-    public void setOtcBacklogExpirationInterval(Integer intervalInMillis);
+
+    public int getOtcBacklogExpirationInterval();
+    public void setOtcBacklogExpirationInterval(int intervalInMillis);
 
     /** Returns each live node's schema version */
     public Map<String, List<String>> getSchemaVersions();

--- a/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
@@ -1,11 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the
- * NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF
- * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
- * OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package org.apache.cassandra.net;
@@ -20,11 +27,8 @@ import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * The tests check whether Queue expiration ion the OutboundTcpConnection behaves properly for droppable and
+ * The tests check whether Queue expiration in the OutboundTcpConnection behaves properly for droppable and
  * non-droppable messages.
- * 
- * @author cesken
- *
  */
 public class OutboundTcpConnectionTest
 {
@@ -124,11 +128,12 @@ public class OutboundTcpConnectionTest
     }
 
     /**
-     * Adds BACKLOG_PURGE_SIZE elements to the queue. At BACKLOG_PURGE_SIZE expiration starts to work. Filling
-     * is done with non-droppable entries to make sure that they won't get expired.
+     * Adds BACKLOG_PURGE_SIZE messages to the queue. Hint: At BACKLOG_PURGE_SIZE expiration starts to work.
      * 
      * @param otc
      *            The OutboundTcpConnection
+     * @param verb
+     *            The verb that defines the message type
      */
     private void fillToPurgeSize(OutboundTcpConnection otc, Verb verb)
     {

--- a/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the
+ * NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.net;
+
+import org.apache.cassandra.net.MessagingService.Verb;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The tests check whether Queue expiration ion the OutboundTcpConnection behaves properly for droppable and
+ * non-droppable messages.
+ * 
+ * @author cesken
+ *
+ */
+public class OutboundTcpConnectionTest
+{
+    AtomicInteger messageId = new AtomicInteger(0);
+
+    final static Verb VERB_DROPPABLE = Verb.MUTATION; // Droppable, 2s timeout
+    final static Verb VERB_NONDROPPABLE = Verb.GOSSIP_DIGEST_ACK; // Not droppable
+
+    long NANOS_100S = 100_000_000_000L;
+
+    /**
+     * Tests that non-droppable messages are never expired
+     */
+    @Test
+    public void testNondroppable() throws UnknownHostException
+    {
+        OutboundTcpConnection otc = getOutboundTcpConnectionForLocalhost();
+        long nanoTimeBeforeEnqueue = System.nanoTime();
+
+        assertFalse("Fresh OutboundTcpConnection contains expired messages",
+                otc.backlogContainsExpiredMessages(nanoTimeBeforeEnqueue));
+
+        fillToPurgeSize(otc, VERB_NONDROPPABLE);
+        fillToPurgeSize(otc, VERB_NONDROPPABLE);
+        otc.expireMessages(futureNanos());
+
+        assertFalse("OutboundTcpConnection with non-droppable verbs should not expire",
+                otc.backlogContainsExpiredMessages(futureNanos()));
+    }
+
+    /**
+     * Tests that droppable messages will be dropped after they expire, but not before.
+     * 
+     * @throws UnknownHostException
+     */
+    @Test
+    public void testDroppable() throws UnknownHostException
+    {
+        OutboundTcpConnection otc = getOutboundTcpConnectionForLocalhost();
+        long nanoTimeBeforeEnqueue = System.nanoTime();
+
+        initialFill(otc, VERB_DROPPABLE);
+        assertFalse("OutboundTcpConnection with droppable verbs should not expire immediately",
+                otc.backlogContainsExpiredMessages(nanoTimeBeforeEnqueue));
+
+        otc.expireMessages(nanoTimeBeforeEnqueue);
+        assertFalse("OutboundTcpConnection with droppable verbs should not expire with enqueue-time expiration",
+                otc.backlogContainsExpiredMessages(nanoTimeBeforeEnqueue));
+
+        // Lets presume, 100s have passed => At that time there shall be expired messages in the Queue
+        long nanoTimeWhenExpired = System.nanoTime() + NANOS_100S;
+        assertTrue("OutboundTcpConnection with droppable verbs should have expired after 100s",
+                otc.backlogContainsExpiredMessages(nanoTimeWhenExpired));
+
+        // Using the same timestamp, lets expire them and check whether they have gone
+        otc.expireMessages(nanoTimeWhenExpired);
+        assertFalse("OutboundTcpConnection should not have any expired entries after 100s",
+                otc.backlogContainsExpiredMessages(nanoTimeWhenExpired));
+
+        // Actually the previous test can be done in a harder way: As expireMessages() has run, we cannot have
+        // ANY expired values, thus lets test against nanoTimeWhenExpired
+        assertFalse("OutboundTcpConnection should not have any expired entries",
+                otc.backlogContainsExpiredMessages(nanoTimeBeforeEnqueue));
+
+    }
+
+    /**
+     * Fills the given OutboundTcpConnection with (1 + BACKLOG_PURGE_SIZE), elements. The first
+     * BACKLOG_PURGE_SIZE elements are non-droppable, the last one is a message with the given Verb and can be
+     * droppable or non-droppable.
+     */
+    private void initialFill(OutboundTcpConnection otc, Verb verb)
+    {
+        assertFalse("Fresh OutboundTcpConnection contains expired messages",
+                otc.backlogContainsExpiredMessages(System.nanoTime()));
+
+        fillToPurgeSize(otc, VERB_NONDROPPABLE);
+        MessageOut<?> messageDroppable10s = new MessageOut<>(verb);
+        otc.enqueue(messageDroppable10s, nextMessageId());
+        otc.expireMessages(System.nanoTime());
+    }
+
+    /**
+     * Returns a nano timestamp in the far future. The offset of 100s is chosen, as it is bigger than the
+     * highest default expiration of any Verb.
+     * 
+     * @return The future nano timestamp
+     */
+    private long futureNanos()
+    {
+        return System.nanoTime() + 100_000_000_000L;
+    }
+
+    private int nextMessageId()
+    {
+        return messageId.incrementAndGet();
+    }
+
+    /**
+     * Adds BACKLOG_PURGE_SIZE elements to the queue. At BACKLOG_PURGE_SIZE expiration starts to work. Filling
+     * is done with non-droppable entries to make sure that they won't get expired.
+     * 
+     * @param otc
+     *            The OutboundTcpConnection
+     */
+    private void fillToPurgeSize(OutboundTcpConnection otc, Verb verb)
+    {
+        for (int i = 0; i < OutboundTcpConnection.BACKLOG_PURGE_SIZE; i++)
+        {
+            MessageOut<?> messageNonDroppable = new MessageOut<>(verb);
+            otc.enqueue(messageNonDroppable, nextMessageId());
+        }
+    }
+
+    private OutboundTcpConnection getOutboundTcpConnectionForLocalhost() throws UnknownHostException
+    {
+        InetAddress lo = InetAddress.getByName("127.0.0.1");
+        OutboundTcpConnectionPool otcPool = new OutboundTcpConnectionPool(lo);
+        OutboundTcpConnection otc = new OutboundTcpConnection(otcPool);
+        return otc;
+    }
+}

--- a/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
@@ -129,7 +129,7 @@ public class OutboundTcpConnectionTest
     }
 
     /**
-     * Returns a nano timestamp in the far future, where expiration should have been performed for VERB_DROPPABLE.
+     * Returns a nano timestamp in the far future, when expiration should have been performed for VERB_DROPPABLE.
      * The offset is chosen as 2 times of the expiration time of VERB_DROPPABLE.
      * 
      * @return The future nano timestamp
@@ -156,8 +156,7 @@ public class OutboundTcpConnectionTest
     {
         for (int i = 0; i < OutboundTcpConnection.BACKLOG_PURGE_SIZE; i++)
         {
-            MessageOut<?> messageNonDroppable = new MessageOut<>(verb);
-            otc.enqueue(messageNonDroppable, nextMessageId());
+            otc.enqueue(new MessageOut<>(verb), nextMessageId());
         }
     }
 

--- a/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/OutboundTcpConnectionTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -37,7 +38,7 @@ public class OutboundTcpConnectionTest
     final static Verb VERB_DROPPABLE = Verb.MUTATION; // Droppable, 2s timeout
     final static Verb VERB_NONDROPPABLE = Verb.GOSSIP_DIGEST_ACK; // Not droppable
 
-    long NANOS_100S = 100_000_000_000L;
+    final static long NANOS_100S = TimeUnit.SECONDS.toNanos(100);
 
     /**
      * Tests that non-droppable messages are never expired
@@ -79,7 +80,7 @@ public class OutboundTcpConnectionTest
                 otc.backlogContainsExpiredMessages(nanoTimeBeforeEnqueue));
 
         // Lets presume, 100s have passed => At that time there shall be expired messages in the Queue
-        long nanoTimeWhenExpired = System.nanoTime() + NANOS_100S;
+        long nanoTimeWhenExpired = futureNanos();
         assertTrue("OutboundTcpConnection with droppable verbs should have expired after 100s",
                 otc.backlogContainsExpiredMessages(nanoTimeWhenExpired));
 
@@ -119,7 +120,7 @@ public class OutboundTcpConnectionTest
      */
     private long futureNanos()
     {
-        return System.nanoTime() + 100_000_000_000L;
+        return System.nanoTime() + NANOS_100S;
     }
 
     private int nextMessageId()


### PR DESCRIPTION
When queue expiration is done, one single Thread is elected to do the
work. Previously, all Threads would go in and do the same work,
producing high lock contention. The Thread reading from the Queue could
even be starved by not be able to acquire the read lock. CASSANDRA-13265