### PR TITLE
Fix invalid value for rowCache size (in MB). CASSANDRA-13393

### DIFF
--- a/src/java/org/apache/cassandra/cache/OHCProvider.java
+++ b/src/java/org/apache/cassandra/cache/OHCProvider.java
@@ -96,7 +96,7 @@ public class OHCProvider implements CacheProvider<RowCacheKey, IRowCacheEntry>
 
         public long weightedSize()
         {
-            return ohCache.size();
+            return ohCache.memUsed();
         }
 
         public void clear()


### PR DESCRIPTION
Row Cache size is reported in entries but should be reported in bytes (as KeyCache do).
It happens because incorrect OHCProvider.OHCacheAdapter.weightedSize method. Currently it returns cache size but should return ohCache.memUsed()