### PR TITLE
Cassandra-13541 Mark couple of API methods for compactions as deprecated

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -213,10 +213,12 @@ public abstract class AbstractCompactionStrategy
      */
     public abstract long getMaxSSTableBytes();
 
+    @Deprecated
     public void enable()
     {
     }
 
+    @Deprecated
     public void disable()
     {
     }
@@ -540,6 +542,7 @@ public abstract class AbstractCompactionStrategy
         return uncheckedOptions;
     }
 
+    @Deprecated
     public boolean shouldBeEnabled()
     {
         String optionValue = options.get(COMPACTION_ENABLED);

--- a/src/java/org/apache/cassandra/db/compaction/PendingRepairManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/PendingRepairManager.java
@@ -183,11 +183,13 @@ class PendingRepairManager
         strategies.values().forEach(AbstractCompactionStrategy::shutdown);
     }
 
+    @Deprecated
     synchronized void enable()
     {
         strategies.values().forEach(AbstractCompactionStrategy::enable);
     }
 
+    @Deprecated
     synchronized void disable()
     {
         strategies.values().forEach(AbstractCompactionStrategy::disable);


### PR DESCRIPTION
As they are handled by CompactionStrategyManager. 

https://issues.apache.org/jira/browse/CASSANDRA-13541

@krummas 