### PR TITLE
Changing access row cache serializer

### DIFF
--- a/doc/source/development/plugin_documentation.rst
+++ b/doc/source/development/plugin_documentation.rst
@@ -1,0 +1,4 @@
+Working on Plugin Documentation
+*******************************
+
+Adding plugin support to cassandra's web page !!!

--- a/doc/source/development/plugin_documentation.rst
+++ b/doc/source/development/plugin_documentation.rst
@@ -1,4 +1,0 @@
-Working on Plugin Documentation
-*******************************
-
-Adding plugin support to cassandra's web page !!!

--- a/doc/source/plugins/index.rst
+++ b/doc/source/plugins/index.rst
@@ -1,0 +1,24 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
+Cassandra's Plugins
+=====================
+The below lists out the different plugins supported in Apache Cassandra
+
+.. toctree::
+   :maxdepth: 1
+
+   CAPI-Power

--- a/src/java/org/apache/cassandra/cache/SerializingCacheProvider.java
+++ b/src/java/org/apache/cassandra/cache/SerializingCacheProvider.java
@@ -33,7 +33,7 @@ public class SerializingCacheProvider implements CacheProvider<RowCacheKey, IRow
         return SerializingCache.create(DatabaseDescriptor.getRowCacheSizeInMB() * 1024 * 1024, new RowCacheSerializer());
     }
 
-    // Package protected for tests
+    // Package Public: used by external Row Cache plugins
     public static class RowCacheSerializer implements ISerializer<IRowCacheEntry>
     {
         public void serialize(IRowCacheEntry entry, DataOutputPlus out) throws IOException

--- a/src/java/org/apache/cassandra/cache/SerializingCacheProvider.java
+++ b/src/java/org/apache/cassandra/cache/SerializingCacheProvider.java
@@ -34,7 +34,7 @@ public class SerializingCacheProvider implements CacheProvider<RowCacheKey, IRow
     }
 
     // Package protected for tests
-    static class RowCacheSerializer implements ISerializer<IRowCacheEntry>
+    public static class RowCacheSerializer implements ISerializer<IRowCacheEntry>
     {
         public void serialize(IRowCacheEntry entry, DataOutputPlus out) throws IOException
         {


### PR DESCRIPTION
org.apache.cassandra.cache.SerializingCacheProvider.RowCacheSerializer is a package-private class, but necessary for capirowcache plugin implementation. hence requesting to change the accessibility for "RowCacheSerializer"