### PR TITLE
CASSANDRA-13601 Increasing stack size for specific platform

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -42,6 +42,17 @@ calculate_heap_sizes()
             system_cpu_cores="2"
         ;;
     esac
+    
+    # Adding a check if arch==ppc64le 
+    # Increase the stack size to 512k,
+    # Tickets reference: #13345 #13601
+    case "`uname -m`" in
+        ppc64le)
+           # Per-thread stack size.
+           JVM_OPTS="$JVM_OPTS -Xss512k"
+
+       ;;
+    esac
 
     # some systems like the raspberry pi don't report cores, use at least 1
     if [ "$system_cpu_cores" -lt "1" ]

--- a/src/java/org/apache/cassandra/utils/Architecture.java
+++ b/src/java/org/apache/cassandra/utils/Architecture.java
@@ -34,7 +34,8 @@ public final class Architecture
     "amd64",
     "x86_64",
     "s390x",
-    "aarch64"
+    "aarch64",
+    "ppc64le"    
     ));
 
     public static final boolean IS_UNALIGNED = UNALIGNED_ARCH.contains(System.getProperty("os.arch"));


### PR DESCRIPTION
As per discussions in JIRA : https://issues.apache.org/jira/browse/CASSANDRA-13601 and https://issues.apache.org/jira/browse/CASSANDRA-13345 , adding a check to increasing the stack size only if architecture type is ppc64le.