### PR TITLE
CASSANDRA-13363/CASSANDRA-12435 fix index flag before not be consistent with follow data content

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -634,7 +634,7 @@ public abstract class ReadCommand extends MonitorableImpl implements ReadQuery
             RowFilter.serializer.serialize(command.rowFilter(), out, version);
             DataLimits.serializer.serialize(command.limits(), out, version, command.metadata.comparator);
             if (optional.isPresent())
-                IndexMetadata.serializer.serialize(command.index.get(), out, version);
+                IndexMetadata.serializer.serialize(optional.get(), out, version);
 
             command.serializeSelection(out, version);
         }


### PR DESCRIPTION
fix CASSANDRA-13363/CASSANDRA-12435

when the command will be executed by local node and target node.
the command.index will be reload by local thread.

when code reach indexFlag(command.index.isPresent())  is false
but reach if (command.index.isPresent()) , it is changed to true, because the "command.index" has been loaded by local execute thread.

the command.index can be reload by target node, so it's serialize is optional。 but the flag must be consistent with follow data content.