### PR TITLE
CASSANDRA-8727 add command 'statusautocompaction'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0
+ * Add nodetool statusautocompaction (CASSANDRA-8727)
  * Don't use RangeFetchMapCalculator when RF=1 (CASSANDRA-13576)
  * Don't optimise trivial ranges in RangeFetchMapCalculator (CASSANDRA-13664)
  * Use an ExecutorService for repair commands instead of new Thread(..).start() (CASSANDRA-13594)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4960,6 +4960,15 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    public Map<String, Boolean> getAutoCompactionDisabled(String ks, String... tables) throws IOException
+    {
+        Map<String, Boolean> status = new HashMap<String, Boolean>();
+        for (ColumnFamilyStore cfs : getValidColumnFamilies(true, true, ks, tables))
+            status.put(cfs.getTableName(), cfs.isAutoCompactionDisabled());
+        return status;
+    }
+
+
     /** Returns the name of the cluster */
     public String getClusterName()
     {

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -597,6 +597,7 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     void disableAutoCompaction(String ks, String ... tables) throws IOException;
     void enableAutoCompaction(String ks, String ... tables) throws IOException;
+    Map<String, Boolean> getAutoCompactionDisabled(String ks, String... tables) throws IOException;
 
     public void deliverHints(String host) throws UnknownHostException;
 

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -57,6 +57,7 @@ import javax.rmi.ssl.SslRMIClientSocketFactory;
 import org.apache.cassandra.batchlog.BatchlogManager;
 import org.apache.cassandra.batchlog.BatchlogManagerMBean;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.db.HintedHandOffManagerMBean;
 import org.apache.cassandra.db.compaction.CompactionManager;
@@ -720,6 +721,11 @@ public class NodeProbe implements AutoCloseable
     public void enableAutoCompaction(String ks, String ... tableNames) throws IOException
     {
         ssProxy.enableAutoCompaction(ks, tableNames);
+    }
+
+    public Map<String, Boolean> getAutoCompactionDisabled(String ks, String ... tableNames) throws IOException
+    {
+        return ssProxy.getAutoCompactionDisabled(ks, tableNames);
     }
 
     public void setIncrementalBackupsEnabled(boolean enabled)

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -122,6 +122,7 @@ public class NodeTool
                 StatusGossip.class,
                 StatusBackup.class,
                 StatusHandoff.class,
+                StatusAutoCompaction.class,
                 Stop.class,
                 StopDaemon.class,
                 Version.class,

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusAutoCompaction.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusAutoCompaction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+import org.apache.cassandra.tools.nodetool.formatter.TableBuilder;
+
+@Command(name = "statusautocompaction", description = "status of autocompaction of the given keyspace and table")
+public class StatusAutoCompaction extends NodeToolCmd
+{
+    @Arguments(usage = "[<keyspace> <tables>...]", description = "The keyspace followed by one or many tables")
+    private List<String> args = new ArrayList<>();
+
+    @Option(title = "show_all", name = { "-a", "--all" }, description = "Show auto compaction status for each keyspace/table")
+    private boolean showAll = false;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        List<String> keyspaces = parseOptionalKeyspace(args, probe);
+        String[] tableNames = parseOptionalTables(args);
+
+        boolean allDisabled = true;
+        boolean allEnabled = true;
+        TableBuilder table = new TableBuilder();
+        table.add("Keyspace", "Table", "Status");
+        try
+        {
+            for (String keyspace : keyspaces)
+            {
+                Map<String, Boolean> statuses = probe.getAutoCompactionDisabled(keyspace, tableNames);
+                for (Map.Entry<String, Boolean> status : statuses.entrySet())
+                {
+                    String tableName = status.getKey();
+                    boolean disabled = status.getValue();
+                    allDisabled &= disabled;
+                    allEnabled &= !disabled;
+                    table.add(keyspace, tableName, !disabled ? "running" : "not running");
+                }
+            }
+            if (showAll)
+                table.printTo(System.out);
+            else
+                System.out.println(allEnabled ? "running" :
+                                   allDisabled ? "not running" : "partially running");
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error occurred during status-auto-compaction", e);
+        }
+    }
+}


### PR DESCRIPTION
Added nodetool command 'statusautocompaction'
By default, the status is summarized: running, not running or partially running (some of the specified tables have it enabled, some don't).
```
$ nodetool statusautocompaction
partially running
```
The `--all` option can be used to see a detailed status output.
```
$ nodetool statusautocompaction -a
Keyspace           Table                          Status
system_schema      dropped_columns                not running
system_schema      tables                         not running
...
system             built_views                    running
system             sstable_activity               running
...
test               test2                          not running
test               test_cf                        not running
system_auth        role_permissions               not running
system_auth        resource_role_permissons_index not running
```

You can specify keyspace (and table).
```
$ nodetool statusautocompaction test test2 -a
Keyspace Table Status
test     test2 not running
```
