### PR TITLE
[CASSANDRA-13782] RPM has wrong owner for /usr/share directories

### DIFF
--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -132,8 +132,8 @@ exit 0
 %attr(755,root,root) /%{_sysconfdir}/rc.d/init.d/%{username}
 %attr(755,root,root) /%{_sysconfdir}/default/%{username}
 %attr(755,root,root) /%{_sysconfdir}/security/limits.d/%{username}.conf
-%attr(755,%{username},%{username}) /usr/share/%{username}*
-%attr(755,%{username},%{username}) %config(noreplace) /%{_sysconfdir}/%{username}
+%attr(755,root,root) /usr/share/%{username}*
+%attr(755,root,root) %config(noreplace) /%{_sysconfdir}/%{username}
 %attr(755,%{username},%{username}) %config(noreplace) /var/lib/%{username}/*
 %attr(755,%{username},%{username}) /var/log/%{username}*
 %attr(755,%{username},%{username}) /var/run/%{username}*


### PR DESCRIPTION
Some Cassandra RPM directories are owned by "cassandra" user against the fedora package guidelines.
I changed redhat/cassandra.spec for giving the directories and files to appropriate owner.
```
$ls -l /usr/share | grep cassandra
[Before]
drwxr-xr-x   3 cassandra cassandra    86 Aug 30 10:46 cassandra
[After]
drwxr-xr-x   3 root root    86 Aug 29 18:03 cassandra

$ls -l /usr/share/cassandra/
[Before]
-rwxr-xr-x 1 cassandra cassandra 6406219 Aug 30 10:44 apache-cassandra-4.0.jar
-rwxr-xr-x 1 cassandra cassandra     742 Aug 30 10:22 cassandra.in.sh
drwxr-xr-x 4 cassandra cassandra    4096 Aug 30 10:46 lib
-rwxr-xr-x 1 cassandra cassandra  505000 Aug 30 10:44 stress.jar
[After]
-rwxr-xr-x 1 root root 6405131 Aug 29 18:01 apache-cassandra-4.0.jar
-rwxr-xr-x 1 root root     742 Aug 29 17:12 cassandra.in.sh
drwxr-xr-x 4 root root    4096 Aug 29 18:03 lib
-rwxr-xr-x 1 root root  505000 Aug 29 18:01 stress.jar
```