### PR TITLE
[wip] CASSANDRA-10496

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -161,8 +161,8 @@ USING_G1=$?
 # times. If in doubt, and if you do not particularly want to tweak, go with
 # 100 MB per physical CPU core.
 
-#MAX_HEAP_SIZE="4G"
-#HEAP_NEWSIZE="800M"
+MAX_HEAP_SIZE="1G"
+HEAP_NEWSIZE="200M"
 
 # Set this to control the amount of arenas per-thread in glibc
 #export MALLOC_ARENA_MAX=4

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -98,4 +98,6 @@ appender reference in the root level section below.
   </root>
 
   <logger name="org.apache.cassandra" level="DEBUG"/>
+  <logger name="org.apache.cassandra.db.compaction.writers.SplittingTimeWindowCompactionWriter" level="TRACE"/>
+  <logger name="org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy" level="TRACE"/>
 </configuration>

--- a/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java
@@ -300,9 +300,9 @@ public class TimeWindowCompactionStrategy extends AbstractCompactionStrategy
                 if (!stcsInterestingBucket.isEmpty())
                     return stcsInterestingBucket;
             }
-            else if (bucket.size() >= 2 && key < now)
+            else if (bucket.size() >= minThreshold && key < now)
             {
-                logger.debug("bucket size {} >= 2 and not in current bucket, compacting what's here: {}", bucket.size(), bucket);
+                logger.debug("bucket size {} >= {} and not in current bucket, compacting what's here: {}", bucket.size(), minThreshold, bucket);
                 return trimToThreshold(bucket, maxThreshold);
             }
             else

--- a/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategyOptions.java
+++ b/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategyOptions.java
@@ -50,6 +50,7 @@ public final class TimeWindowCompactionStrategyOptions
     SizeTieredCompactionStrategyOptions stcsOptions;
 
     protected final static ImmutableList<TimeUnit> validTimestampTimeUnits = ImmutableList.of(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, TimeUnit.MICROSECONDS, TimeUnit.NANOSECONDS);
+    // Don't forget to modify getWindowBoundsInMillis() if you add values to this list.
     protected final static ImmutableList<TimeUnit> validWindowTimeUnits = ImmutableList.of(TimeUnit.MINUTES, TimeUnit.HOURS, TimeUnit.DAYS);
 
     public TimeWindowCompactionStrategyOptions(Map<String, String> options)
@@ -144,5 +145,17 @@ public final class TimeWindowCompactionStrategyOptions
         uncheckedOptions = SizeTieredCompactionStrategyOptions.validateOptions(options, uncheckedOptions);
 
         return uncheckedOptions;
+    }
+
+    public int getSstableWindowSize() {
+        return sstableWindowSize;
+    }
+
+    public TimeUnit getSstableWindowUnit() {
+        return sstableWindowUnit;
+    }
+
+    public TimeUnit getTimestampResolution() {
+        return timestampResolution;
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
@@ -60,9 +60,9 @@ public abstract class CompactionAwareWriter extends Transactional.AbstractTransa
 
     protected final SSTableRewriter sstableWriter;
     protected final LifecycleTransaction txn;
-    private final Directories.DataDirectory[] locations;
-    private final List<PartitionPosition> diskBoundaries;
-    private int locationIndex;
+    protected final Directories.DataDirectory[] locations;
+    protected final List<PartitionPosition> diskBoundaries;
+    protected int locationIndex;
 
     @Deprecated
     public CompactionAwareWriter(ColumnFamilyStore cfs,

--- a/src/java/org/apache/cassandra/db/compaction/writers/SplittingTimeWindowCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/SplittingTimeWindowCompactionWriter.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.compaction.writers;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.*;
+
+import org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy;
+import org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.db.RowIndexEntry;
+import org.apache.cassandra.db.SerializationHeader;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableWriter;
+import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
+import org.apache.cassandra.utils.Pair;
+
+/**
+ * CompactionAwareWriter that splits input in different sstables for each time window.
+ *
+ * Biggest sstable will be total_compaction_size / 2, second biggest total_compaction_size / 4 etc until
+ * the result would be sub 50MB, all those are put in the same
+ */
+public class SplittingTimeWindowCompactionWriter extends CompactionAwareWriter
+{
+    private static final Logger logger = LoggerFactory.getLogger(SplittingTimeWindowCompactionWriter.class);
+
+    private final TimeWindowCompactionStrategyOptions options;
+    private final Set<SSTableReader> allSSTables;
+    Pair<HashMultimap<Long, SSTableReader>, Long> buckets;
+    private HashMap<Long, SSTableWriter> writersByBounds;
+    private Directories.DataDirectory location;
+    private Pair<Long, Long> currentBounds;
+
+    public SplittingTimeWindowCompactionWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
+    {
+        this(cfs, directories, txn, nonExpiredSSTables, new TimeWindowCompactionStrategyOptions());
+    }
+
+    public SplittingTimeWindowCompactionWriter(ColumnFamilyStore cfs,
+                                               Directories directories,
+                                               LifecycleTransaction txn,
+                                               Set<SSTableReader> nonExpiredSSTables,
+                                               TimeWindowCompactionStrategyOptions options)
+    {
+        super(cfs, directories, txn, nonExpiredSSTables,false);
+        this.currentBounds = Pair.create(0L, 0L);
+        this.allSSTables = txn.originals();
+        this.options = options;
+        this.writersByBounds = new HashMap<>();
+        this.buckets = TimeWindowCompactionStrategy.getBuckets(
+                allSSTables,
+                options.getSstableWindowUnit(),
+                options.getSstableWindowSize(),
+                options.getTimestampResolution()
+        );
+        logger.info("bucket: {}", buckets);
+    }
+
+    @Override
+    public boolean realAppend(UnfilteredRowIterator partition)
+    {
+        // TODO: Should we group by minLocalDeletionTime instead ? (which probably makes more sense if we want to optimize full compactions).
+        long timestamp = TimeUnit.MILLISECONDS.convert(
+                partition.stats().minTimestamp, options.getTimestampResolution());
+
+        logger.info("minTimestamp: {}, localDeletionTime: {}",
+                partition.stats().minTimestamp,
+                partition.stats().minLocalDeletionTime);
+        logger.info("key: {}",
+                partition.metadata().partitionKeyType.getString(partition.partitionKey().getKey()));
+        Pair<Long,Long> bounds = TimeWindowCompactionStrategy.getWindowBoundsInMillis(
+                options.getSstableWindowUnit(), options.getSstableWindowSize(),
+                timestamp);
+
+        logger.info("bounds: {}", bounds);
+
+        if (currentBounds.left == 0) {
+            // For the first partition, save the current context.
+            currentBounds = bounds;
+            logger.trace("Saving writer for {}", bounds);
+            writersByBounds.put(bounds.left, sstableWriter.currentWriter());
+        }
+
+        // Then switch writers when necessary.
+        if (!currentBounds.left.equals(bounds.left))
+        {
+            SSTableWriter writer = writersByBounds.getOrDefault(bounds.left, null);
+            if (writer == null) {
+                logger.trace("Creating writer for {}", bounds);
+                switchCompactionLocation(location);
+                writer = sstableWriter.currentWriter();
+                writersByBounds.put(bounds.left, writer);
+            } else {
+                sstableWriter.switchWriter(writer);
+            }
+            logger.debug("Switching to writer {} for bounds {}", writer, bounds);
+            currentBounds = bounds;
+        }
+        RowIndexEntry rie = sstableWriter.append(partition);
+        return rie != null;
+    }
+
+    @Override
+    public void switchCompactionLocation(Directories.DataDirectory location)
+    {
+        this.location = location;
+        /* TODO: We could get a better estimate by looking at the SSTables supposed to match this.currentBounds */
+        long estimatedKeys = estimatedKeys() / this.buckets.left.size();
+
+        @SuppressWarnings("resource")
+        SSTableWriter writer = SSTableWriter.create(
+                cfs.newSSTableDescriptor(getDirectories().getLocationForDisk(location)),
+                estimatedKeys,
+                minRepairedAt,
+                pendingRepair,
+                cfs.metadata,
+                new MetadataCollector(txn.originals(), cfs.metadata().comparator, 0),
+                SerializationHeader.make(cfs.metadata(), nonExpiredSSTables),
+                cfs.indexManager.listIndexes(),
+                txn);
+
+        logger.trace("Switching writer");
+        sstableWriter.switchWriter(writer);
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -64,7 +64,7 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
 
     private long currentlyOpenedEarlyAt; // the position (in MB) in the target file we last (re)opened at
 
-    private final List<SSTableWriter> writers = new ArrayList<>();
+    private final Set<SSTableWriter> writers = new HashSet<>();
     private final boolean keepOriginals; // true if we do not want to obsolete the originals
 
     private SSTableWriter writer;


### PR DESCRIPTION
Done:
- --split-output kind of work when running nodetool compact
- Values with timestamps outside of the first window should be isolated
  and merged back to the correct sstable (which maybe quite costly for now as
  it involves re-writing huge sstables for single values)

TODO:
- Unit tests
- Fix remaining TODOs