### PR TITLE
Add link to driver for the Dart programming language

### DIFF
--- a/doc/source/getting_started/drivers.rst
+++ b/doc/source/getting_started/drivers.rst
@@ -116,3 +116,8 @@ Elixir
 
 - `Xandra <https://github.com/lexhide/xandra>`__
 - `CQEx <https://github.com/matehat/cqex>`__
+
+Dart
+^^^^
+
+- `dart_cassandra_cql <https://github.com/achilleasa/dart_cassandra_cql>`__


### PR DESCRIPTION
This PR updates the driver list to include a link to the driver for the Dart programming language.