### PR TITLE
Fix a few possible metrics.rst bugs

### DIFF
--- a/doc/source/operating/metrics.rst
+++ b/doc/source/operating/metrics.rst
@@ -185,7 +185,7 @@ Reported name format:
     ``org.apache.cassandra.metrics.ThreadPools.<MetricName>.<Path>.<ThreadPoolName>``
 
 **JMX MBean**
-    ``org.apache.cassandra.metrics:type=ThreadPools scope=<ThreadPoolName> type=<Type> name=<MetricName>``
+    ``org.apache.cassandra.metrics:type=ThreadPools path=<Path> scope=<ThreadPoolName> name=<MetricName>``
 
 ===================== ============== ===========
 Name                  Type           Description
@@ -405,10 +405,10 @@ Dropped writes are stored and retried by ``Hinted Handoff``
 Reported name format:
 
 **Metric Name**
-    ``org.apache.cassandra.metrics.DroppedMessages.<MetricName>.<Type>``
+    ``org.apache.cassandra.metrics.DroppedMessage.<MetricName>.<Type>``
 
 **JMX MBean**
-    ``org.apache.cassandra.metrics:type=DroppedMetrics scope=<Type> name=<MetricName>``
+    ``org.apache.cassandra.metrics:type=DroppedMessage scope=<Type> name=<MetricName>``
 
 ========================== ============== ===========
 Name                       Type           Description


### PR DESCRIPTION
I was trying to implement a Prometheus exporter with 2.2, but ran into a few issues.

I did check the source and it seems as though 3.0 matches 2.2 for these specific edits.

The path/scope ordering was needed to allow Prometheus to export correctly.

https://github.com/apache/cassandra/blob/9a47974d6378b62dd2cdb2d3e509374b002caa2c/src/java/org/apache/cassandra/metrics/ThreadPoolMetrics.java#L117

Although it sounds weird, it seems as though DroppedMessages is now DroppedMessage.

https://github.com/apache/cassandra/blob/9a47974d6378b62dd2cdb2d3e509374b002caa2c/src/java/org/apache/cassandra/metrics/DroppedMessageMetrics.java#L43

I was, however, unsure where to check on the `Metric Name` portion and just looked at the MBean code referenced above.
