### PR TITLE
Replace the valueOf() method with parseXXX() method.

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/IndexSummaryBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/IndexSummaryBuilder.java
@@ -39,7 +39,7 @@ public class IndexSummaryBuilder implements AutoCloseable
     private static final Logger logger = LoggerFactory.getLogger(IndexSummaryBuilder.class);
 
     static final String defaultExpectedKeySizeName = Config.PROPERTY_PREFIX + "index_summary_expected_key_size";
-    static long defaultExpectedKeySize = Long.valueOf(System.getProperty(defaultExpectedKeySizeName, "64"));
+    static long defaultExpectedKeySize = Long.parseLong(System.getProperty(defaultExpectedKeySizeName, "64"));
 
     // the offset in the keys memory region to look for a given summary boundary
     private final SafeMemoryWriter offsets;

--- a/src/java/org/apache/cassandra/io/sstable/SSTable.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTable.java
@@ -62,7 +62,7 @@ public abstract class SSTable
 
     public static final int TOMBSTONE_HISTOGRAM_BIN_SIZE = 100;
     public static final int TOMBSTONE_HISTOGRAM_SPOOL_SIZE = 100000;
-    public static final int TOMBSTONE_HISTOGRAM_TTL_ROUND_SECONDS = Integer.valueOf(System.getProperty("cassandra.streaminghistogram.roundseconds", "60"));
+    public static final int TOMBSTONE_HISTOGRAM_TTL_ROUND_SECONDS = Integer.parseInt(System.getProperty("cassandra.streaminghistogram.roundseconds", "60"));
 
     public final Descriptor descriptor;
     protected final Set<Component> components;


### PR DESCRIPTION
It is more efficient to just call the static parseXXX method to extract the unboxed primitive value from a String.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_BOXED_PRIMITIVE_FOR_PARSING