### PR TITLE
Replace the keySet iterator with an entrySet iterator.

### DIFF
--- a/src/java/org/apache/cassandra/hadoop/cql3/CqlInputFormat.java
+++ b/src/java/org/apache/cassandra/hadoop/cql3/CqlInputFormat.java
@@ -146,12 +146,13 @@ public class CqlInputFormat extends org.apache.hadoop.mapreduce.InputFormat<Long
             // canonical ranges and nodes holding replicas
             Map<TokenRange, Set<Host>> masterRangeNodes = getRangeMap(keyspace, metadata);
 
-            for (TokenRange range : masterRangeNodes.keySet())
+            for (Map.Entry<TokenRange, Set<Host>> entry : masterRangeNodes.entrySet())
             {
+                TokenRange range = entry.getKey();
                 if (jobRange == null)
                 {
                     // for each tokenRange, pick a live owner and ask it to compute bite-sized splits
-                    splitfutures.add(executor.submit(new SplitCallable(range, masterRangeNodes.get(range), conf, session)));
+                    splitfutures.add(executor.submit(new SplitCallable(range, entry.getValue(), conf, session)));
                 }
                 else
                 {
@@ -161,7 +162,7 @@ public class CqlInputFormat extends org.apache.hadoop.mapreduce.InputFormat<Long
                         for (TokenRange intersection: range.intersectWith(jobTokenRange))
                         {
                             // for each tokenRange, pick a live owner and ask it to compute bite-sized splits
-                            splitfutures.add(executor.submit(new SplitCallable(intersection,  masterRangeNodes.get(range), conf, session)));
+                            splitfutures.add(executor.submit(new SplitCallable(intersection,  entry.getValue(), conf, session)));
                         }
                     }
                 }

--- a/src/java/org/apache/cassandra/tools/nodetool/DescribeCluster.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DescribeCluster.java
@@ -41,9 +41,9 @@ public class DescribeCluster extends NodeToolCmd
         // display schema version for each node
         System.out.println("\tSchema versions:");
         Map<String, List<String>> schemaVersions = probe.getSpProxy().getSchemaVersions();
-        for (String version : schemaVersions.keySet())
+        for (Map.Entry<String, List<String>> entry : schemaVersions.entrySet())
         {
-            System.out.println(format("\t\t%s: %s%n", version, schemaVersions.get(version)));
+            System.out.println(format("\t\t%s: %s%n", entry.getKey(), entry.getValue()));
         }
     }
 }

--- a/src/java/org/apache/cassandra/utils/MerkleTrees.java
+++ b/src/java/org/apache/cassandra/utils/MerkleTrees.java
@@ -211,10 +211,11 @@ public class MerkleTrees implements Iterable<Map.Entry<Range<Token>, MerkleTree>
      */
     private MerkleTree getMerkleTree(Token t)
     {
-        for (Range<Token> range : merkleTrees.keySet())
+        for (Map.Entry<Range<Token>, MerkleTree> entry : merkleTrees.entrySet())
         {
+            Range<Token> range = entry.getKey();
             if (range.contains(t))
-                return merkleTrees.get(range);
+                return entry.getValue();
         }
 
         throw new AssertionError("Expected tree for token " + t);
@@ -290,11 +291,12 @@ public class MerkleTrees implements Iterable<Map.Entry<Range<Token>, MerkleTree>
 
         try
         {
-            for (Range<Token> rt : merkleTrees.keySet())
+            for (Map.Entry<Range<Token>, MerkleTree> entry : merkleTrees.entrySet())
             {
+                Range<Token> rt = entry.getKey();
                 if (rt.intersects(range))
                 {
-                    byte[] bytes = merkleTrees.get(rt).hash(range);
+                    byte[] bytes = entry.getValue().hash(range);
                     if (bytes != null)
                     {
                         baos.write(bytes);


### PR DESCRIPTION
The current source code accesses the value of the Map entry, using a key that is retrieved from a keySet iterator.
It is more efficient to use an iterator on the entrySet of the Map, to avoid the Map.get(key) lookup.
http://findbugs.sourceforge.net/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR