### PR TITLE
SliceQueryFilter can fetch more data than needed

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/ColumnCounter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnCounter.java
@@ -66,6 +66,13 @@ public class ColumnCounter
         return tombstones;
     }
 
+    /**
+     * @return true if this counter has counted at least {@code numLiveCellsDesired} live cells, accounting for groupings.
+     */
+    public boolean hasSeenAtLeast(int numLiveCellsDesired) {
+        return live() >= numLiveCellsDesired;
+    }
+
     public ColumnCounter countAll(ColumnFamily container)
     {
         if (container == null)
@@ -156,6 +163,12 @@ public class ColumnCounter
 
             return true;
         }
+
+        @Override
+        public boolean hasSeenAtLeast(int numLiveCellsDesired) {
+            // we can't know we've seen N full groups until we've seen the start of the N+1st group
+            return live() > numLiveCellsDesired;
+        }
     }
 
     /**
@@ -212,6 +225,12 @@ public class ColumnCounter
             }
 
             return true;
+        }
+
+        @Override
+        public boolean hasSeenAtLeast(int numLiveCellsDesired) {
+            // we can't know we've seen N full groups until we've seen the start of the N+1st group
+            return live() > numLiveCellsDesired;
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/SliceQueryFilter.java
@@ -261,7 +261,7 @@ public class SliceQueryFilter implements IDiskAtomFilter
         columnCounter = columnCounter(container.getComparator(), now);
         DeletionInfo.InOrderTester tester = container.deletionInfo().inOrderTester(reversed);
 
-        while (reducedColumns.hasNext())
+        while (!columnCounter.hasSeenAtLeast(count) && reducedColumns.hasNext())
         {
             Cell cell = reducedColumns.next();
 
@@ -273,6 +273,8 @@ public class SliceQueryFilter implements IDiskAtomFilter
             if (cell.getLocalDeletionTime() < gcBefore || !columnCounter.count(cell, tester))
                 continue;
 
+            // always safe to exit if we've seen more then we need. this will happen if we're grouping composite columns
+            // (ColumnCounter#hasSeenAtLeast won't return true until we've seen the start of the next group)
             if (columnCounter.live() > count)
                 break;
 


### PR DESCRIPTION
Slice queries currently fetch more data then necessary, when there is only one column not part of the primary key. Specifically, SliceQueryFilter does not stop reading until it has seen `limit + 1` live cells, even though in the case we can stop after seeing `limit` live cells.

We have a use case where we use wide rows to implement versioning, by including a timestamp as part of the primary key. Every once in a while, we "garbage collect" old versions by deleting them. This results in a single column containing the latest version, followed by many tombstones.

We use a `LIMIT 1` query to select the latest version (which is the first column in the row). However, because SliceQueryFilter does not stop until it has seen `limit + 1` live cells, we have to read all the tombstones following the single live cell. Furthermore, if these tombstones are covering data in other sstables, we have to read all the corresponding data when merging the sstable iterators. This can be a massive performance hit, and is unexpectedly caused by deleting data.

This patch allows the `ColumnCounter` implementation to decide when it has seen enough cells. For counters that don't require grouping, we can stop immediately after finding the first cell.
