### PR TITLE
CASSANDRA-14055 Index redistribution breaks SASI index

### DIFF
--- a/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
@@ -127,12 +127,17 @@ public class SSTableIndex
 
     public void release()
     {
+        release(false);
+    }
+
+    public void release(boolean keepFile)
+    {
         int n = references.decrementAndGet();
         if (n == 0)
         {
             FileUtils.closeQuietly(index);
             sstableRef.release();
-            if (obsolete.get() || sstableRef.globalCount() == 0)
+            if (!keepFile && (obsolete.get() || sstableRef.globalCount() == 0))
                 FileUtils.delete(index.getIndexPath());
         }
     }

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.index.sasi;
 
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystems;
@@ -60,6 +61,7 @@ import org.apache.cassandra.index.sasi.exceptions.TimeQuotaExceededException;
 import org.apache.cassandra.index.sasi.memory.IndexMemtable;
 import org.apache.cassandra.index.sasi.plan.QueryController;
 import org.apache.cassandra.index.sasi.plan.QueryPlan;
+import org.apache.cassandra.io.sstable.IndexSummaryManager;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.schema.IndexMetadata;
 import org.apache.cassandra.schema.KeyspaceMetadata;
@@ -894,6 +896,55 @@ public class SASIIndexTest
 
         rows = getIndexed(store, 10, buildExpression(age, Operator.EQ, Int32Type.instance.decompose(40)));
         Assert.assertTrue(rows.toString(), Arrays.equals(new String[]{ "key9" }, rows.toArray(new String[rows.size()])));
+    }
+
+
+    @Test
+    public void testIndexRedistribution() throws IOException, InterruptedException
+    {
+        testIndexRedistribution(false);
+        cleanupData();
+        testIndexRedistribution(true);
+    }
+
+    private void testIndexRedistribution(boolean forceFlush) throws IOException, InterruptedException
+    {
+        Map<String, Pair<String, Integer>> part1 = new HashMap<String, Pair<String, Integer>>()
+        {{
+            put("key01", Pair.create("a", 33));
+            put("key02", Pair.create("a", 41));
+            put("key03", Pair.create("a", 22));
+            put("key04", Pair.create("a", 45));
+            put("key05", Pair.create("a", 32));
+            put("key06", Pair.create("a", 38));
+            put("key07", Pair.create("a", 36));
+            put("key08", Pair.create("a", 36));
+            put("key09", Pair.create("a", 21));
+            put("key10", Pair.create("a", 35));
+        }};
+
+        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
+
+        final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
+
+        Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
+        Assert.assertEquals(rows.toString(), 10, rows.size());
+
+        int minIndexInterval = store.metadata.params.minIndexInterval;
+        store.metadata.minIndexInterval(minIndexInterval * 2);
+        try
+        {
+            IndexSummaryManager.instance.redistributeSummaries();
+
+            if (forceFlush)
+                store.forceBlockingFlush();
+
+            rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
+            Assert.assertEquals(rows.toString(), 10, rows.size());
+        } finally
+        {
+            store.metadata.minIndexInterval(minIndexInterval);
+        }
     }
 
     @Test


### PR DESCRIPTION
During index redistribution process, a new view is created.
During this creation, old indexes should be released.

But, new indexes are "attached" to the same SSTable as the old indexes.

This leads to the deletion of the last SASI index file and breaks the index.