### PR TITLE
Fix: Page width exceeding the viewport width

### DIFF
--- a/doc/source/_theme/cassandra_theme/layout.html
+++ b/doc/source/_theme/cassandra_theme/layout.html
@@ -73,7 +73,7 @@ extra-footer: '
     </div>
     <div class="col-md-8">
       <div class="content doc-content">
-        <div class="container">
+        <div class="content-container">
           {% block body %}{% endblock %}
 
           {% if next or prev %}


### PR DESCRIPTION
**Change Made:** renamed class `.container` to .`content-container`
where the styling rule for `.content-container` is as follows
```
.content-container{
padding-right: 15px;
    padding-left: 15px;
    margin-right: auto;
    margin-left: auto;
}
```

Reason: Bootstrap advises not to use nested containers as it would break the "fitting the viewport.". The current one breaks and results in being able to scroll horizontally too which is annoying for the reader (especially for large-screens).

I'll proportionally update the css file too