### PR TITLE
Extension: for pull request #175

### DIFF
--- a/doc/source/_static/extra.css
+++ b/doc/source/_static/extra.css
@@ -50,3 +50,10 @@ div#wipwarning {
     padding: 10px 30px;
     margin-bottom: 30px;
 }
+.content-container{
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+    width:100%;
+}


### PR DESCRIPTION
**Change Made:** renamed class `.container` to .`content-container`
where the styling rule for `.content-container` is as follows
```
.content-container{
padding-right: 15px;
    padding-left: 15px;
    margin-right: auto;
    margin-left: auto;
}
```

Reason: Bootstrap advises not to use nested containers as it would break the "fitting the viewport.". The current one breaks and results in being able to scroll horizontally too which is annoying for the reader (especially for large-screens).

I'll proportionally update the css file too