### PR TITLE
CASSANDRA-13391 Added --all to ClearSnapshot command

### DIFF
--- a/src/java/org/apache/cassandra/service/EmbeddedCassandraService.java
+++ b/src/java/org/apache/cassandra/service/EmbeddedCassandraService.java
@@ -50,4 +50,9 @@ public class EmbeddedCassandraService
         cassandraDaemon.init(null);
         cassandraDaemon.start();
     }
+
+    public void stop()
+    {
+        cassandraDaemon.stop();
+    }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
@@ -40,9 +40,18 @@ public class ClearSnapshot extends NodeToolCmd
     @Option(title = "snapshot_name", name = "-t", description = "Remove the snapshot with a given name")
     private String snapshotName = EMPTY;
 
+    @Option(title = "clear_all_snapshots", name = "--all", description = "Removes all snapshots")
+    private boolean clearAllSnapshots = false;
+
     @Override
     public void execute(NodeProbe probe)
     {
+        if(snapshotName.isEmpty() && !clearAllSnapshots)
+            throw new RuntimeException("Specify snapshot name or --all");
+
+        if(!snapshotName.isEmpty() && clearAllSnapshots)
+            throw new RuntimeException("Specify only one of snapshot name or --all");
+
         StringBuilder sb = new StringBuilder();
 
         sb.append("Requested clearing snapshot(s) for ");
@@ -52,7 +61,9 @@ public class ClearSnapshot extends NodeToolCmd
         else
             sb.append("[").append(join(keyspaces, ", ")).append("]");
 
-        if (!snapshotName.isEmpty())
+        if (snapshotName.isEmpty())
+            sb.append(" with [all snapshots]");
+        else
             sb.append(" with snapshot name [").append(snapshotName).append("]");
 
         System.out.println(sb.toString());

--- a/test/unit/org/apache/cassandra/tools/ClearSnapshotTest.java
+++ b/test/unit/org/apache/cassandra/tools/ClearSnapshotTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.management.openmbean.TabularData;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.service.EmbeddedCassandraService;
+
+public class ClearSnapshotTest extends ToolsTester
+{
+    private static EmbeddedCassandraService cassandra;
+    private static String initialJmxPortValue;
+    private static NodeProbe probe;
+    private static final int JMX_PORT = 7188;
+
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        // Set system property to enable JMX port on localhost for embedded server
+        initialJmxPortValue = System.getProperty("cassandra.jmx.local.port");
+        System.setProperty("cassandra.jmx.local.port", String.valueOf(JMX_PORT));
+
+        SchemaLoader.prepareServer();
+        cassandra = new EmbeddedCassandraService();
+        cassandra.start();
+
+        probe = new NodeProbe("127.0.0.1", JMX_PORT);
+    }
+
+    @AfterClass
+    public static void teardown() throws IOException
+    {
+        cassandra.stop();
+        if (initialJmxPortValue != null)
+        {
+            System.setProperty("cassandra.jmx.local.port", initialJmxPortValue);
+        }
+
+        probe.close();
+    }
+
+    private String[] constructParamaterArray(final String command, final String... commandParams)
+    {
+        String[] baseCommandLine = {"-p", String.valueOf(JMX_PORT), command};
+        return ArrayUtils.addAll(baseCommandLine, commandParams);
+    }
+
+    @Test
+    public void testClearSnapshot_NoArgs() throws IOException
+    {
+        runTool(2, "org.apache.cassandra.tools.NodeTool",
+                constructParamaterArray("clearsnapshot"));
+    }
+
+    @Test
+    public void testClearSnapshot_AllAndName() throws IOException
+    {
+        runTool(2, "org.apache.cassandra.tools.NodeTool",
+                constructParamaterArray("clearsnapshot", "-t", "some-name", "--all"));
+    }
+
+    @Test
+    public void testClearSnapshot_RemoveByName() throws IOException
+    {
+         runTool(0,"org.apache.cassandra.tools.NodeTool",
+                 constructParamaterArray("snapshot","-t","some-name"));
+
+         Map<String, TabularData> snapshots_before = probe.getSnapshotDetails();
+         Assert.assertTrue(snapshots_before.containsKey("some-name"));
+
+         runTool(0,"org.apache.cassandra.tools.NodeTool",
+                 constructParamaterArray("clearsnapshot","-t","some-name"));
+         Map<String, TabularData> snapshots_after = probe.getSnapshotDetails();
+         Assert.assertFalse(snapshots_after.containsKey("some-name"));
+    }
+
+    @Test
+    public void testClearSnapshot_RemoveMultiple() throws IOException
+    {
+        runTool(0,"org.apache.cassandra.tools.NodeTool",
+                constructParamaterArray("snapshot","-t","some-name"));
+        runTool(0,"org.apache.cassandra.tools.NodeTool",
+                constructParamaterArray("snapshot","-t","some-other-name"));
+
+        Map<String, TabularData> snapshots_before = probe.getSnapshotDetails();
+        Assert.assertTrue(snapshots_before.size() == 2);
+
+        runTool(0,"org.apache.cassandra.tools.NodeTool",
+                constructParamaterArray("clearsnapshot","--all"));
+        Map<String, TabularData> snapshots_after = probe.getSnapshotDetails();
+        Assert.assertTrue(snapshots_after.size() == 0);
+    }
+    
+}


### PR DESCRIPTION
Added --all to ClearSnapshot command, so entering the command without a parameter will now throw an exception instead of deleting all the snapshots.