### PR TITLE
Resolve nodetool formatting in CASSANDRA-14233

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -52,9 +52,9 @@ public class TableStatsPrinter
                 // print each keyspace's information
                 out.println("Keyspace : " + keyspace.name);
                 out.println("\tRead Count: " + keyspace.readCount);
-                out.println("\tRead Latency: " + keyspace.readLatency() + " ms.");
+                out.println("\tRead Latency: " + keyspace.readLatency() + " ms");
                 out.println("\tWrite Count: " + keyspace.writeCount);
-                out.println("\tWrite Latency: " + keyspace.writeLatency() + " ms.");
+                out.println("\tWrite Latency: " + keyspace.writeLatency() + " ms");
                 out.println("\tPending Flushes: " + keyspace.pendingFlushes);
 
                 // print each table's information


### PR DESCRIPTION
Remove trailing "." from latency reports at keyspace level.

For [CASSANDRA-14233](https://issues.apache.org/jira/browse/CASSANDRA-14233).