### PR TITLE
fix for CASSANDRA-14243

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -192,6 +192,7 @@
  * CQLSH: Don't pause when capturing data (CASSANDRA-13743)
  * nodetool clearsnapshot requires --all to clear all snapshots (CASSANDRA-13391)
  * Correctly count range tombstones in traces and tombstone thresholds (CASSANDRA-8527)
+ * cqlshrc.sample uses incorrect option for time formatting (CASSANDRA-14243)
 
 3.11.3
  * RateBasedBackPressure unnecessarily invokes a lock on the Guava RateLimiter  (CASSANDRA-14163)

--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -30,7 +30,7 @@
 ; color = on
 
 ;; Used for displaying timestamps (and reading them with COPY)
-; datetimeformat = %Y-%m-%d %H:%M:%S%z
+; time_format = %Y-%m-%d %H:%M:%S%z
 
 ;; Display timezone
 ;timezone = Etc/UTC


### PR DESCRIPTION
`datetimeformat` option that was used in the `conf/cqlshrc.sample` file is sub-option of
the `COPY FROM` command, not of the `cqlsh` itself.