### PR TITLE
CASSANDRA-13891 CQL fromJson(null) throws NullPointerException

### DIFF
--- a/src/java/org/apache/cassandra/cql3/functions/FunctionCall.java
+++ b/src/java/org/apache/cassandra/cql3/functions/FunctionCall.java
@@ -98,6 +98,8 @@ public class FunctionCall extends Term.NonTerminal
 
     private static Term.Terminal makeTerminal(Function fun, ByteBuffer result, int version) throws InvalidRequestException
     {
+        if (result == null)
+            return null;
         if (!(fun.returnType() instanceof CollectionType))
             return new Constants.Value(result);
 

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/JsonTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/JsonTest.java
@@ -39,7 +39,8 @@ import java.util.*;
 import java.util.concurrent.*;
 import static org.junit.Assert.fail;
 
-public class JsonTest extends CQLTester
+public class
+JsonTest extends CQLTester
 {
     @BeforeClass
     public static void setUp()
@@ -248,6 +249,13 @@ public class JsonTest extends CQLTester
 
         // handle nulls
         execute("INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, null);
+        assertRows(execute("SELECT k, asciival FROM %s WHERE k = ?", 0), row(0, null));
+
+        execute("INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))", 0, null);
+        assertRows(execute("SELECT k, frozenmapval FROM %s WHERE k = ?", 0), row(0, null));
+
+        execute("INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, null);
+        assertRows(execute("SELECT k, udtval FROM %s WHERE k = ?", 0), row(0, null));
 
         // ================ ascii ================
         execute("INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, "\"ascii text\"");


### PR DESCRIPTION
JIRA 13891 - CQL fromJson(null) throws NullPointerException