### PR TITLE
CASSANDRA-14385

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/AlterViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/AlterViewStatement.java
@@ -62,6 +62,8 @@ public class AlterViewStatement extends SchemaAlteringStatement
             throw new InvalidRequestException("Cannot use ALTER MATERIALIZED VIEW on Table");
 
         ViewMetadata current = Schema.instance.getView(keyspace(), columnFamily());
+        if (current == null)
+            throw new InvalidRequestException("There is no materialized view in keyspace " + keyspace());
 
         if (attrs == null)
             throw new InvalidRequestException("ALTER MATERIALIZED VIEW WITH invoked, but no parameters found");

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -406,7 +406,9 @@ public class LocalSessions
     {
         TableId tid = Schema.instance.getTableMetadata(keyspace, table).id;
         ColumnFamilyStore cfm = Schema.instance.getColumnFamilyStoreInstance(tid);
-        cfm.forceBlockingFlush();
+        if (cfm != null) {
+            cfm.forceBlockingFlush();
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/streaming/StreamReceiveTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamReceiveTask.java
@@ -53,7 +53,13 @@ public class StreamReceiveTask extends StreamTask
     public StreamReceiveTask(StreamSession session, TableId tableId, int totalStreams, long totalSize)
     {
         super(session, tableId);
-        this.receiver = ColumnFamilyStore.getIfExists(tableId).getStreamManager().createStreamReceiver(session, totalStreams);
+        ColumnFamilyStore cfs = ColumnFamilyStore.getIfExists(tableId);
+        if (cfs != null) {
+        	this.receiver = cfs.getStreamManager().createStreamReceiver(session, 
+        			totalStreams);
+        }else {
+        	this.receiver = null;
+        }
         this.totalStreams = totalStreams;
         this.totalSize = totalSize;
     }


### PR DESCRIPTION
@LJ1043041006 found a potential NPE in cassandra
---
We have developed a static analysis tool [NPEDetector](https://github.com/lujiefsi/NPEDetector) to find some potential NPE. Our analysis shows that some callees may return null in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. In this issue we post a patch which can add  !=null  based on existed !=null  check. For example:

Calle Schema#getView may return null:
```
public ViewMetadata getView(String keyspaceName, String viewName)
{
    assert keyspaceName != null;
    KeyspaceMetadata ksm = keyspaces.getNullable(keyspaceName);
    return (ksm == null) ? null : ksm.views.getNullable(viewName);//may return null
}
```

 it have 4 callers, 3 of them have !=null check, like its caller MigrationManager#announceViewDrop have !=null check()
```
public static void announceViewDrop(String ksName, String viewName, boolean announceLocally) throws ConfigurationException
{
   ViewMetadata view = Schema.instance.getView(ksName, viewName);
    if (view == null)//null pointer checker
        throw new ConfigurationException(String.format("Cannot drop non existing materialized view '%s' in keyspace '%s'.", viewName,     ksName));
   KeyspaceMetadata ksm = Schema.instance.getKeyspaceMetadata(ksName);

   logger.info("Drop table '{}/{}'", view.keyspace, view.name);
   announce(SchemaKeyspace.makeDropViewMutation(ksm, view, FBUtilities.timestampMicros()), announceLocally);
}
```
but caller MigrationManager#announceMigration does not have 

We add !=null check based on MigrationManager#announceViewDrop:
```
if (current == null)
    throw new InvalidRequestException("There is no materialized view in keyspace " + keyspace());
```
But due to we are not very  familiar with CASSANDRA, hope some expert can review it.

Thanks!!!!