### PR TITLE
CASSANDRA-14425 cassandra-stress doesn't report correctly when profile file is not found

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/Stress.java
+++ b/tools/stress/src/org/apache/cassandra/stress/Stress.java
@@ -93,8 +93,7 @@ public final class Stress
             	Throwable rc = ExceptionUtils.getRootCause(e);
             	if (rc instanceof FileNotFoundException)
             	{
-            		e.printStackTrace();
-                    System.out.printf("File '%s' doesn't exist!!%n", rc.getMessage());
+                    System.out.printf("File '%s' doesn't exist!%n", rc.getMessage());
                     printHelpMessage();
                     return 1;
             	}

--- a/tools/stress/src/org/apache/cassandra/stress/Stress.java
+++ b/tools/stress/src/org/apache/cassandra/stress/Stress.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.stress.settings.StressSettings;
 import org.apache.cassandra.stress.util.MultiResultLogger;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.WindowsTimer;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public final class Stress
 {
@@ -86,6 +87,18 @@ public final class Stress
                 System.out.printf("%s%n", e.getMessage());
                 printHelpMessage();
                 return 1;
+            }
+            catch (Throwable e)
+            {
+            	Throwable rc = ExceptionUtils.getRootCause(e);
+            	if (rc instanceof FileNotFoundException)
+            	{
+            		e.printStackTrace();
+                    System.out.printf("File '%s' doesn't exist!!%n", rc.getMessage());
+                    printHelpMessage();
+                    return 1;
+            	}
+            	throw e;
             }
 
             MultiResultLogger logout = settings.log.getOutput();

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommandUser.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommandUser.java
@@ -22,6 +22,7 @@ package org.apache.cassandra.stress.settings;
 
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,7 +74,17 @@ public class SettingsCommandUser extends SettingsCommand
         for (String curYamlPath : yamlPaths)
         {
             File yamlFile = new File(curYamlPath);
-            StressProfile profile = StressProfile.load(yamlFile.exists() ? yamlFile.toURI() : URI.create(curYamlPath));
+            URI yamlURI;
+            if (yamlFile.exists()) {
+            	yamlURI = yamlFile.toURI();
+            } else {
+            	yamlURI = URI.create(curYamlPath);
+            	String uriScheme = yamlURI.getScheme();
+            	if (uriScheme == null || "file".equals(uriScheme)) {
+                    throw new IllegalArgumentException("File '" + yamlURI.getPath() + "' doesn't exist.");
+            	}
+            }
+            StressProfile profile = StressProfile.load(yamlURI);
             String specName = profile.specName;
             if (default_profile_name == null) {default_profile_name=specName;} //first file is default
             if (profiles.containsKey(specName))

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommandUser.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommandUser.java
@@ -81,7 +81,7 @@ public class SettingsCommandUser extends SettingsCommand
             	yamlURI = URI.create(curYamlPath);
             	String uriScheme = yamlURI.getScheme();
             	if (uriScheme == null || "file".equals(uriScheme)) {
-                    throw new IllegalArgumentException("File '" + yamlURI.getPath() + "' doesn't exist.");
+                    throw new IllegalArgumentException("File '" + yamlURI.getPath() + "' doesn't exist!");
             	}
             }
             StressProfile profile = StressProfile.load(yamlURI);


### PR DESCRIPTION
Fix affects 2 files:
- `SettingsCommandUser.java` where there is a check, is the file exists
- `Stress.java` where error handling happens.  The main reason for this is that when file
   is loaded from URI, then the caught exception is wrapped into generic `IOError`
   exception that isn't handled explicitly.