### PR TITLE
CASSANDRA-14432: clean up build artifacts in docs container

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -6,12 +6,15 @@ FROM python:2.7
 
 WORKDIR /usr/src/code
 
-RUN pip install sphinx sphinx_rtd_theme
+RUN pip install --no-cache-dir \
+        sphinx \
+        sphinx_rtd_theme
 
 RUN apt-get update \
     && apt-get install -y \
         ant \
-        default-jdk
+        default-jdk \
+    && apt-get clean
 
 CMD ant gen-doc \
     && echo "The locally built documentation can be found here:\n\n    build/html/index.html\n\n"


### PR DESCRIPTION
Small PR to cut out some unnecessary stuff in the docs container. Please see the PR description in [CASSANDRA-14432](https://issues.apache.org/jira/browse/CASSANDRA-14432).