### PR TITLE
changed memtable_flush_writers value

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -114,7 +114,7 @@ public class Config
     @Deprecated
     public Integer concurrent_replicates = null;
 
-    public int memtable_flush_writers = 0;
+    public int memtable_flush_writers = 1;
     public Integer memtable_heap_space_in_mb;
     public Integer memtable_offheap_space_in_mb;
     public Float memtable_cleanup_threshold = null;


### PR DESCRIPTION
If we work in Client Mode, and `memtable_flush_writers = 0` there is a problem with `ColumnFamilyStore` when we want to add Tables & views. There is an `java.lang.IllegalArgumentException` because of the `flushExecutor` 
in `JMXEnabledThreadPoolExecutor:68` the `maxPoolSize` is equal to `corePoolSize`. This exception is caused by `java.lang.IllegalArgumentException at java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1314) ... ` 
 `maximumPoolSize is <= 0 ` because in our case `maximumPoolSize == corePoolSize == 0` 