### PR TITLE
CASSANDRA-14488 Avoid unneeded memory allocations / cpu for disabled log levels

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2002,7 +2002,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
                 ephemeralSnapshotMarker.getParentFile().mkdirs();
 
             Files.createFile(ephemeralSnapshotMarker.toPath());
-            logger.trace("Created ephemeral snapshot marker file on {}.", ephemeralSnapshotMarker.getAbsolutePath());
+            if (logger.isTraceEnabled())
+            	logger.trace("Created ephemeral snapshot marker file on {}.", ephemeralSnapshotMarker.getAbsolutePath());
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/db/ConsistencyLevel.java
+++ b/src/java/org/apache/cassandra/db/ConsistencyLevel.java
@@ -293,7 +293,8 @@ public enum ConsistencyLevel
                 int live = Iterables.size(liveEndpoints);
                 if (live < blockFor)
                 {
-                    logger.trace("Live nodes {} do not satisfy ConsistencyLevel ({} required)", Iterables.toString(liveEndpoints), blockFor);
+                	if (logger.isTraceEnabled())
+                		logger.trace("Live nodes {} do not satisfy ConsistencyLevel ({} required)", Iterables.toString(liveEndpoints), blockFor);
                     throw new UnavailableException(this, blockFor, live);
                 }
                 break;

--- a/src/java/org/apache/cassandra/db/Keyspace.java
+++ b/src/java/org/apache/cassandra/db/Keyspace.java
@@ -554,7 +554,8 @@ public class Keyspace
                             for (int j = 0; j < i; j++)
                                 locks[j].unlock();
 
-                            logger.trace("Could not acquire lock for {} and table {}", ByteBufferUtil.bytesToHex(mutation.key().getKey()), columnFamilyStores.get(tableId).name);
+                            if (logger.isTraceEnabled())
+                            	logger.trace("Could not acquire lock for {} and table {}", ByteBufferUtil.bytesToHex(mutation.key().getKey()), columnFamilyStores.get(tableId).name);
                             Tracing.trace("Could not acquire MV lock");
                             if (future != null)
                             {

--- a/src/java/org/apache/cassandra/db/Memtable.java
+++ b/src/java/org/apache/cassandra/db/Memtable.java
@@ -453,7 +453,8 @@ public class Memtable implements Comparable<Memtable>
 
         private void writeSortedContents()
         {
-            logger.debug("Writing {}, flushed range = ({}, {}]", Memtable.this.toString(), from, to);
+        	if (logger.isDebugEnabled())
+        		logger.debug("Writing {}, flushed range = ({}, {}]", Memtable.this.toString(), from, to);
 
             boolean trackContention = logger.isTraceEnabled();
             int heavilyContendedRowCount = 0;
@@ -482,7 +483,8 @@ public class Memtable implements Comparable<Memtable>
             }
 
             long bytesFlushed = writer.getFilePointer();
-            logger.debug("Completed flushing {} ({}) for commitlog position {}",
+            if (logger.isDebugEnabled())
+            	logger.debug("Completed flushing {} ({}) for commitlog position {}",
                                                                               writer.getFilename(),
                                                                               FBUtilities.prettyPrintMemory(bytesFlushed),
                                                                               commitLogUpperBound);

--- a/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
+++ b/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
@@ -77,7 +77,8 @@ public class SizeEstimatesRecorder extends SchemaChangeListener implements Runna
                 long start = System.nanoTime();
                 recordSizeEstimates(table, localRanges);
                 long passed = System.nanoTime() - start;
-                logger.trace("Spent {} milliseconds on estimating {}.{} size",
+                if (logger.isTraceEnabled())
+                	logger.trace("Spent {} milliseconds on estimating {}.{} size",
                              TimeUnit.NANOSECONDS.toMillis(passed),
                              table.metadata.keyspace,
                              table.metadata.name);

--- a/src/java/org/apache/cassandra/db/TruncateVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/TruncateVerbHandler.java
@@ -50,7 +50,7 @@ public class TruncateVerbHandler implements IVerbHandler<Truncation>
         Tracing.trace("Enqueuing response to truncate operation to {}", message.from);
 
         TruncateResponse response = new TruncateResponse(t.keyspace, t.columnFamily, true);
-        logger.trace("{} applied.  Enqueuing response to {}@{} ", new Object[]{ t, id, message.from });
+        logger.trace("{} applied.  Enqueuing response to {}@{} ", t, id, message.from );
         MessagingService.instance().sendReply(response.createMessage(), id, message.from);
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -697,8 +697,10 @@ public class CompactionManager implements CompactionManagerMBean
             ActiveRepairService.ParentRepairSession prs = ActiveRepairService.instance.getParentRepairSession(parentRepairSession);
             Preconditions.checkArgument(!prs.isPreview(), "Cannot anticompact for previews");
 
-            logger.info("{} Starting anticompaction for {}.{} on {}/{} sstables", PreviewKind.NONE.logPrefix(parentRepairSession), cfs.keyspace.getName(), cfs.getTableName(), validatedForRepair.size(), cfs.getLiveSSTables().size());
-            logger.trace("{} Starting anticompaction for ranges {}", PreviewKind.NONE.logPrefix(parentRepairSession), ranges);
+            if (logger.isInfoEnabled())
+            	logger.info("{} Starting anticompaction for {}.{} on {}/{} sstables", PreviewKind.NONE.logPrefix(parentRepairSession), cfs.keyspace.getName(), cfs.getTableName(), validatedForRepair.size(), cfs.getLiveSSTables().size());
+            if (logger.isTraceEnabled())
+            	logger.trace("{} Starting anticompaction for ranges {}", PreviewKind.NONE.logPrefix(parentRepairSession), ranges);
             Set<SSTableReader> sstables = new HashSet<>(validatedForRepair);
 
             Iterator<SSTableReader> sstableIterator = sstables.iterator();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -254,7 +254,9 @@ public class CompactionTask extends AbstractCompactionTask
                     totalSourceRows += mergedRowCounts[i] * (i + 1);
 
                 String mergeSummary = updateCompactionHistory(cfs.keyspace.getName(), cfs.getTableName(), mergedRowCounts, startsize, endsize);
-                logger.debug(String.format("Compacted (%s) %d sstables to [%s] to level=%d.  %s to %s (~%d%% of original) in %,dms.  Read Throughput = %s, Write Throughput = %s, Row Throughput = ~%,d/s.  %,d total partitions merged to %,d.  Partition merge counts were {%s}",
+                
+                if (logger.isDebugEnabled())
+                	logger.debug(String.format("Compacted (%s) %d sstables to [%s] to level=%d.  %s to %s (~%d%% of original) in %,dms.  Read Throughput = %s, Write Throughput = %s, Row Throughput = ~%,d/s.  %,d total partitions merged to %,d.  Partition merge counts were {%s}",
                                            taskId,
                                            transaction.originals().size(),
                                            newSSTableNames.toString(),
@@ -269,8 +271,10 @@ public class CompactionTask extends AbstractCompactionTask
                                            totalSourceRows,
                                            totalKeysWritten,
                                            mergeSummary));
-                logger.trace("CF Total Bytes Compacted: {}", FBUtilities.prettyPrintMemory(CompactionTask.addToTotalBytesCompacted(endsize)));
-                logger.trace("Actual #keys: {}, Estimated #keys:{}, Err%: {}", totalKeysWritten, estimatedKeys, ((double)(totalKeysWritten - estimatedKeys)/totalKeysWritten));
+                if (logger.isTraceEnabled()) {
+                	logger.trace("CF Total Bytes Compacted: {}", FBUtilities.prettyPrintMemory(CompactionTask.addToTotalBytesCompacted(endsize)));
+                	logger.trace("Actual #keys: {}, Estimated #keys:{}, Err%: {}", totalKeysWritten, estimatedKeys, ((double)(totalKeysWritten - estimatedKeys)/totalKeysWritten));
+                }
                 cfs.getCompactionStrategyManager().compactionLogger.compaction(startTime, transaction.originals(), System.currentTimeMillis(), newSStables);
 
                 // update the metrics

--- a/src/java/org/apache/cassandra/gms/TokenSerializer.java
+++ b/src/java/org/apache/cassandra/gms/TokenSerializer.java
@@ -54,7 +54,8 @@ public class TokenSerializer
             int size = in.readInt();
             if (size < 1)
                 break;
-            logger.trace("Reading token of {}", FBUtilities.prettyPrintMemory(size));
+            if (logger.isTraceEnabled())
+            	logger.trace("Reading token of {}", FBUtilities.prettyPrintMemory(size));
             byte[] bintoken = new byte[size];
             in.readFully(bintoken);
             tokens.add(partitioner.getTokenFactory().fromByteArray(ByteBuffer.wrap(bintoken)));

--- a/src/java/org/apache/cassandra/hadoop/cql3/LimitedLocalNodeFirstLocalBalancingPolicy.java
+++ b/src/java/org/apache/cassandra/hadoop/cql3/LimitedLocalNodeFirstLocalBalancingPolicy.java
@@ -71,7 +71,8 @@ class LimitedLocalNodeFirstLocalBalancingPolicy implements LoadBalancingPolicy
                 logger.warn("Invalid replica host name: {}, skipping it", replica);
             }
         }
-        logger.trace("Created instance with the following replicas: {}", Arrays.asList(replicas));
+        if (logger.isTraceEnabled())
+        	logger.trace("Created instance with the following replicas: {}", Arrays.asList(replicas));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/IndexSummaryRedistribution.java
+++ b/src/java/org/apache/cassandra/io/sstable/IndexSummaryRedistribution.java
@@ -125,7 +125,8 @@ public class IndexSummaryRedistribution extends CompactionInfo.Holder
         total = 0;
         for (SSTableReader sstable : Iterables.concat(compacting, newSSTables))
             total += sstable.getIndexSummaryOffHeapSize();
-        logger.trace("Completed resizing of index summaries; current approximate memory used: {}",
+        if (logger.isTraceEnabled())
+        	logger.trace("Completed resizing of index summaries; current approximate memory used: {}",
                      FBUtilities.prettyPrintMemory(total));
 
         return newSSTables;
@@ -177,7 +178,8 @@ public class IndexSummaryRedistribution extends CompactionInfo.Holder
             int numEntriesAtNewSamplingLevel = IndexSummaryBuilder.entriesAtSamplingLevel(newSamplingLevel, maxSummarySize);
             double effectiveIndexInterval = sstable.getEffectiveIndexInterval();
 
-            logger.trace("{} has {} reads/sec; ideal space for index summary: {} ({} entries); considering moving " +
+            if (logger.isTraceEnabled())
+            	logger.trace("{} has {} reads/sec; ideal space for index summary: {} ({} entries); considering moving " +
                     "from level {} ({} entries, {}) " +
                     "to level {} ({} entries, {})",
                     sstable.getFilename(), readsPerSec, FBUtilities.prettyPrintMemory(idealSpace), targetNumEntries,

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -428,7 +428,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         }
 
         long fileLength = new File(descriptor.filenameFor(Component.DATA)).length();
-        logger.debug("Opening {} ({})", descriptor, FBUtilities.prettyPrintMemory(fileLength));
+        if (logger.isDebugEnabled())
+        	logger.debug("Opening {} ({})", descriptor, FBUtilities.prettyPrintMemory(fileLength));
         SSTableReader sstable = internalOpen(descriptor,
                                              components,
                                              metadata,
@@ -518,7 +519,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         }
 
         long fileLength = new File(descriptor.filenameFor(Component.DATA)).length();
-        logger.debug("Opening {} ({})", descriptor, FBUtilities.prettyPrintMemory(fileLength));
+        if (logger.isDebugEnabled())
+        	logger.debug("Opening {} ({})", descriptor, FBUtilities.prettyPrintMemory(fileLength));
         SSTableReader sstable = internalOpen(descriptor,
                                              components,
                                              metadata,

--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataSerializer.java
@@ -221,7 +221,8 @@ public class MetadataSerializer implements IMetadataSerializer
 
     public void mutateLevel(Descriptor descriptor, int newLevel) throws IOException
     {
-        logger.trace("Mutating {} to level {}", descriptor.filenameFor(Component.STATS), newLevel);
+    	if (logger.isTraceEnabled())
+    		logger.trace("Mutating {} to level {}", descriptor.filenameFor(Component.STATS), newLevel);
         Map<MetadataType, MetadataComponent> currentComponents = deserialize(descriptor, EnumSet.allOf(MetadataType.class));
         StatsMetadata stats = (StatsMetadata) currentComponents.remove(MetadataType.STATS);
         // mutate level
@@ -231,7 +232,8 @@ public class MetadataSerializer implements IMetadataSerializer
 
     public void mutateRepaired(Descriptor descriptor, long newRepairedAt, UUID newPendingRepair) throws IOException
     {
-        logger.trace("Mutating {} to repairedAt time {} and pendingRepair {}",
+    	if (logger.isTraceEnabled())
+    		logger.trace("Mutating {} to repairedAt time {} and pendingRepair {}",
                      descriptor.filenameFor(Component.STATS), newRepairedAt, newPendingRepair);
         Map<MetadataType, MetadataComponent> currentComponents = deserialize(descriptor, EnumSet.allOf(MetadataType.class));
         StatsMetadata stats = (StatsMetadata) currentComponents.remove(MetadataType.STATS);

--- a/src/java/org/apache/cassandra/net/async/InboundHandshakeHandler.java
+++ b/src/java/org/apache/cassandra/net/async/InboundHandshakeHandler.java
@@ -247,7 +247,8 @@ class InboundHandshakeHandler extends ByteToMessageDecoder
         // record the (true) version of the endpoint
         InetAddressAndPort from = msg.address;
         MessagingService.instance().setVersion(from, maxVersion);
-        logger.trace("Set version for {} to {} (will use {})", from, maxVersion, MessagingService.instance().getVersion(from));
+        if (logger.isTraceEnabled())
+        	logger.trace("Set version for {} to {} (will use {})", from, maxVersion, MessagingService.instance().getVersion(from));
 
         setupMessagingPipeline(ctx.pipeline(), from, compressed, version);
         return State.HANDSHAKE_COMPLETE;

--- a/src/java/org/apache/cassandra/repair/RepairSession.java
+++ b/src/java/org/apache/cassandra/repair/RepairSession.java
@@ -238,7 +238,8 @@ public class RepairSession extends AbstractFuture<RepairSessionResult> implement
             return;
         }
 
-        logger.debug("{} Repair completed between {} and {} on {}", previewKind.logPrefix(getId()), nodes.endpoint1, nodes.endpoint2, desc.columnFamily);
+        if (logger.isDebugEnabled())
+        	logger.debug("{} Repair completed between {} and {} on {}", previewKind.logPrefix(getId()), nodes.endpoint1, nodes.endpoint2, desc.columnFamily);
         task.syncComplete(success, summaries);
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamCoordinator.java
+++ b/src/java/org/apache/cassandra/streaming/StreamCoordinator.java
@@ -135,7 +135,8 @@ public class StreamCoordinator
         if (sessionsToConnect.hasNext())
         {
             StreamSession next = sessionsToConnect.next();
-            logger.debug("Connecting next session {} with {}.", next.planId(), next.peer.toString());
+            if (logger.isDebugEnabled())
+            	logger.debug("Connecting next session {} with {}.", next.planId(), next.peer.toString());
             startSession(next);
         }
         else

--- a/src/java/org/apache/cassandra/streaming/async/NettyStreamingMessageSender.java
+++ b/src/java/org/apache/cassandra/streaming/async/NettyStreamingMessageSender.java
@@ -170,7 +170,8 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
     private void scheduleKeepAliveTask(Channel channel)
     {
         int keepAlivePeriod = DatabaseDescriptor.getStreamingKeepAlivePeriod();
-        logger.debug("{} Scheduling keep-alive task with {}s period.", createLogTag(session, channel), keepAlivePeriod);
+        if (logger.isDebugEnabled())
+        	logger.debug("{} Scheduling keep-alive task with {}s period.", createLogTag(session, channel), keepAlivePeriod);
 
         KeepAliveTask task = new KeepAliveTask(channel, session);
         ScheduledFuture<?> scheduledFuture = channel.eventLoop().scheduleAtFixedRate(task, 0, keepAlivePeriod, TimeUnit.SECONDS);
@@ -188,7 +189,7 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
         return channel;
     }
 
-     static String createLogTag(StreamSession session, Channel channel)
+    static String createLogTag(StreamSession session, Channel channel)
     {
         StringBuilder sb = new StringBuilder(64);
         sb.append("[Stream");
@@ -213,7 +214,8 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
         {
             if (isPreview)
                 throw new RuntimeException("Cannot send stream data messages for preview streaming sessions");
-            logger.debug("{} Sending {}", createLogTag(session, null), message);
+            if (logger.isDebugEnabled())
+            	logger.debug("{} Sending {}", createLogTag(session, null), message);
             fileTransferExecutor.submit(new FileStreamTask((OutgoingStreamMessage)message));
             return;
         }
@@ -232,7 +234,8 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
 
     private void sendControlMessage(Channel channel, StreamMessage message, GenericFutureListener listener) throws IOException
     {
-        logger.debug("{} Sending {}", createLogTag(session, channel), message);
+    	if (logger.isDebugEnabled())
+    		logger.debug("{} Sending {}", createLogTag(session, channel), message);
 
         // we anticipate that the control messages are rather small, so allocating a ByteBuf shouldn't  blow out of memory.
         long messageSize = StreamMessage.serializedSize(message, protocolVersion);
@@ -358,7 +361,9 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
                     {
                         timeOfLastLogging = now;
                         OutgoingStreamMessage ofm = (OutgoingStreamMessage)msg;
-                        logger.info("{} waiting to acquire a permit to begin streaming {}. This message logs every {} minutes",
+                        
+                        if (logger.isInfoEnabled())
+                        	logger.info("{} waiting to acquire a permit to begin streaming {}. This message logs every {} minutes",
                                     createLogTag(session, null), ofm.getName(), logInterval);
                     }
                 }
@@ -448,7 +453,8 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
 
             try
             {
-                logger.trace("{} Sending keep-alive to {}.", createLogTag(session, channel), session.peer);
+            	if (logger.isTraceEnabled())
+            		logger.trace("{} Sending keep-alive to {}.", createLogTag(session, channel), session.peer);
                 sendControlMessage(channel, new KeepAliveMessage(), this::keepAliveListener);
             }
             catch (IOException ioe)
@@ -462,7 +468,8 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
             if (future.isSuccess() || future.isCancelled())
                 return;
 
-            logger.debug("{} Could not send keep-alive message (perhaps stream session is finished?).",
+            if (logger.isDebugEnabled())
+            	logger.debug("{} Could not send keep-alive message (perhaps stream session is finished?).",
                          createLogTag(session, channel), future.cause());
         }
     }
@@ -495,7 +502,8 @@ public class NettyStreamingMessageSender implements StreamingMessageSender
     public void close()
     {
         closed = true;
-        logger.debug("{} Closing stream connection channels on {}", createLogTag(session, null), connectionId);
+        if (logger.isDebugEnabled())
+        	logger.debug("{} Closing stream connection channels on {}", createLogTag(session, null), connectionId);
         for (ScheduledFuture<?> future : channelKeepAlives)
             future.cancel(false);
         channelKeepAlives.clear();

--- a/src/java/org/apache/cassandra/streaming/async/StreamingInboundHandler.java
+++ b/src/java/org/apache/cassandra/streaming/async/StreamingInboundHandler.java
@@ -180,13 +180,16 @@ public class StreamingInboundHandler extends ChannelInboundHandlerAdapter
                     // wrt session lifecycle, due to races), just log that we received the message and carry on
                     if (message instanceof KeepAliveMessage)
                     {
-                        logger.debug("{} Received {}", createLogTag(session, channel), message);
+                    	if (logger.isDebugEnabled())
+                    		logger.debug("{} Received {}", createLogTag(session, channel), message);
                         continue;
                     }
 
                     if (session == null)
                         session = deriveSession(message);
-                    logger.debug("{} Received {}", createLogTag(session, channel), message);
+                    
+                    if (logger.isDebugEnabled())
+                    	logger.debug("{} Received {}", createLogTag(session, channel), message);
                     session.messageReceived(message);
                 }
             }

--- a/src/java/org/apache/cassandra/utils/JMXServerUtils.java
+++ b/src/java/org/apache/cassandra/utils/JMXServerUtils.java
@@ -248,7 +248,8 @@ public class JMXServerUtils
 
     private static void logJmxSslConfig(SslRMIServerSocketFactory serverFactory)
     {
-        logger.debug("JMX SSL configuration. { protocols: [{}], cipher_suites: [{}], require_client_auth: {} }",
+    	if (logger.isDebugEnabled())
+    		logger.debug("JMX SSL configuration. { protocols: [{}], cipher_suites: [{}], require_client_auth: {} }",
                      serverFactory.getEnabledProtocols() == null
                      ? "'JVM defaults'"
                      : Arrays.stream(serverFactory.getEnabledProtocols()).collect(Collectors.joining("','", "'", "'")),


### PR DESCRIPTION
add debug and trace log guard when the parameters creation implies memory allocations and / or cpu.

Especially for StreamingInboundHandler/NettyStreamingMessageSender where
createLogTag is allocating 64*2+UUID#toString bytes