### PR TITLE
CASSANDRA-12926 - rejected execution exception logged when task already completed

### DIFF
--- a/src/java/org/apache/cassandra/repair/SnapshotTask.java
+++ b/src/java/org/apache/cassandra/repair/SnapshotTask.java
@@ -77,7 +77,10 @@ public class SnapshotTask extends AbstractFuture<InetAddressAndPort> implements 
         public void onFailure(InetAddressAndPort from, RequestFailureReason failureReason)
         {
             //listener.failedSnapshot();
-            task.setException(new RuntimeException("Could not create snapshot at " + from));
+            if (!task.isDone())
+            {
+                task.setException(new RuntimeException("Could not create snapshot at " + from));
+            }
         }
     }
 }


### PR DESCRIPTION
this [improvement](https://issues.apache.org/jira/browse/CASSANDRA-12926) 