### PR TITLE
Add stack trace to a logging statement

### DIFF
--- a/src/java/org/apache/cassandra/utils/NativeLibrary.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibrary.java
@@ -369,7 +369,7 @@ public final class NativeLibrary
         }
         catch (IllegalArgumentException|IllegalAccessException e)
         {
-            logger.warn("Unable to read fd field from FileChannel");
+            logger.warn("Unable to read fd field from FileChannel", e);
         }
         return -1;
     }


### PR DESCRIPTION
There is a logging statement that is able to catch two exception types (IllegalArgumentException or IllegalAccessException) but cannot distinguish which type of exception occurred just base on the log message. Maybe adding a stack trace could help.