### PR TITLE
CASSANDRA-14829 make stop-server.bat wait for Cassandra to terminate

### DIFF
--- a/bin/stop-server.bat
+++ b/bin/stop-server.bat
@@ -38,7 +38,7 @@ FOR /F "tokens=2 delims= " %%A IN ('TASKLIST /FI ^"WINDOWTITLE eq %rand%^" /NH')
 
 REM Start with /B -> the control+c event we generate in stop-server.ps1 percolates
 REM up and hits this external batch file if we call powershell directly.
-start /B powershell /file "%CASSANDRA_HOME%/bin/stop-server.ps1" -batchpid %PID% %*
+start /WAIT /B powershell /file "%CASSANDRA_HOME%/bin/stop-server.ps1" -batchpid %PID% %*
 goto finally
 
 REM -----------------------------------------------------------------------------


### PR DESCRIPTION
While administering a single node Cassandra on Windows, I noticed that the stop-server.bat script returns before the cassandra process has actually terminated. For use cases like creating a script "shut down & create backup of data directory without having to worry about open files, then restart", it would be good to make stop-server.bat wait for Cassandra to terminate.

All that is needed for that is to change in apache-cassandra-3.11.3\bin\stop-server.bat "start /B powershell /file ..." to "start /WAIT /B powershell /file ..." (additional /WAIT parameter).