### PR TITLE
Missing 'hppc' transitive dependency in 'cassandra-all' 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -689,6 +689,7 @@
         <dependency groupId="net.openhft" artifactId="chronicle-wire" version="${chronicle-wire.version}"/>
         <dependency groupId="net.openhft" artifactId="chronicle-threads" version="${chronicle-threads.version}"/>
         <dependency groupId="joda-time" artifactId="joda-time"/>
+        <dependency groupId="com.carrotsearch" artifactId="hppc"/>
         <dependency groupId="org.fusesource" artifactId="sigar"/>
         <dependency groupId="org.eclipse.jdt.core.compiler" artifactId="ecj"/>
         <dependency groupId="org.caffinitas.ohc" artifactId="ohc-core"/>


### PR DESCRIPTION
When I run:
`$ ant mvn-install`
I get, as expected, `cassandra-all-4.0-SNAPSHOT` generated and installed in my local repo.

Unfortunately, to make use of it as a dependency in my gradle project, I also have to add `com.carrotsearch:hppc:0.5.4` as a dependency in that project.

As hppc is required by cassandra, I'd rather expected it to be automatically resolved as a dependency, and appear in my project without any extra effort (same way as it works for all other cassandra deps, like joda-time, sigar, etc.)

This PR makes it working :)