### PR TITLE
 CASSANDRA-15092:Add a new snitch for Alibaba cloud platform 

### DIFF
--- a/.circleci/config-2_1.yml
+++ b/.circleci/config-2_1.yml
@@ -1,0 +1,463 @@
+version: 2.1
+
+default_env_vars: &default_env_vars
+    JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    ANT_HOME: /usr/share/ant
+    LANG: en_US.UTF-8
+    KEEP_TEST_DIR: true
+    DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    PYTHONIOENCODING: utf-8
+    PYTHONUNBUFFERED: true
+    CASS_DRIVER_NO_EXTENSIONS: true
+    CASS_DRIVER_NO_CYTHON: true
+    #Skip all syncing to disk to avoid performance issues in flaky CI environments
+    CASSANDRA_SKIP_SYNC: true
+    DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    DTEST_BRANCH: master
+    CCM_MAX_HEAP_SIZE: 1024M
+    CCM_HEAP_NEWSIZE: 256M
+
+j8_par_executor: &j8_par_executor
+  executor:
+    name: java8-executor
+    #exec_resource_class: xlarge
+  parallelism: 4
+
+j8_seq_executor: &j8_seq_executor
+  executor:
+    name: java8-executor
+    #exec_resource_class: xlarge
+  parallelism: 1 # sequential, single container tests: no parallelism benefits
+
+with_dtests_jobs: &with_dtest_jobs
+        jobs:
+            - build
+            # Java 8 unit tests will be run automatically
+            - j8_unit_tests:
+                requires:
+                  - build
+            - j8_jvm_dtests:
+                requires:
+                  - build
+            # specialized unit tests (all run on request using Java 8)
+            - start_utests_long:
+                type: approval
+                requires:
+                  - build
+            - utests_long:
+                requires:
+                  - start_utests_long
+            - start_utests_compression:
+                type: approval
+                requires:
+                  - build
+            - utests_compression:
+                requires:
+                  - start_utests_compression
+            - start_utests_stress:
+                type: approval
+                requires:
+                  - build
+            - utests_stress:
+                requires:
+                  - start_utests_stress
+            # Java 8 dtests (on request)
+            - start_j8_dtests:
+                type: approval
+                requires:
+                  - build
+            - j8_dtests-with-vnodes:
+                requires:
+                  - start_j8_dtests
+            - j8_dtests-no-vnodes:
+                requires:
+                  - start_j8_dtests
+            # Java 8 upgrade tests
+            - start_upgrade_tests:
+                type: approval
+                requires:
+                  - build
+            - j8_upgradetests-no-vnodes:
+                requires:
+                  - start_upgrade_tests
+
+with_dtest_jobs_only: &with_dtest_jobs_only
+        jobs:
+            - build
+            - j8_dtests-with-vnodes:
+                  requires:
+                      - build
+            - j8_dtests-no-vnodes:
+                  requires:
+                      - build
+
+workflows:
+    version: 2
+    build_and_run_tests: *with_dtest_jobs
+    #build_and_run_tests: *with_dtest_jobs_only
+
+executors:
+  java8-executor:
+    parameters:
+      exec_resource_class:
+        type: string
+        default: medium
+    docker:
+      - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: << parameters.exec_resource_class >>
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    environment:
+      <<: *default_env_vars
+      JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+      JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+
+jobs:
+  build:
+    executor: java8-executor
+    parallelism: 1 # This job doesn't benefit from parallelism
+    steps:
+      - log_environment
+      - clone_cassandra
+      - build_cassandra
+      - run_eclipse_warnings
+      - persist_to_workspace:
+            root: /home/cassandra
+            paths:
+                - cassandra
+                - .m2
+
+  j8_unit_tests:
+    <<: *j8_par_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - create_junit_containers
+      - log_environment
+      - run_parallel_junit_tests
+
+  j8_jvm_dtests:
+    <<: *j8_seq_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - run_junit_tests:
+          target: test-jvm-dtest-forking
+
+  utests_long:
+    <<: *j8_seq_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - run_junit_tests:
+          target: long-test
+
+  utests_compression:
+    <<: *j8_par_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - create_junit_containers
+      - log_environment
+      - run_parallel_junit_tests:
+          target: testclasslist-compression
+
+  utests_stress:
+    <<: *j8_seq_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - run_junit_tests:
+          target: stress-test
+
+  j8_dtests-with-vnodes:
+    <<: *j8_par_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - clone_dtest
+      - create_venv
+      - create_dtest_containers:
+          file_tag: j8_with_vnodes
+          run_dtests_extra_args: '--use-vnodes --skip-resource-intensive-tests'
+      - run_dtests:
+          file_tag: j8_with_vnodes
+          pytest_extra_args: '--use-vnodes --num-tokens=32 --skip-resource-intensive-tests'
+
+  j8_dtests-no-vnodes:
+    <<: *j8_par_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - clone_dtest
+      - create_venv
+      - create_dtest_containers:
+          file_tag: j8_without_vnodes
+          run_dtests_extra_args: '--skip-resource-intensive-tests'
+      - run_dtests:
+          file_tag: j8_without_vnodes
+          pytest_extra_args: '--skip-resource-intensive-tests'
+
+  j8_upgradetests-no-vnodes:
+    <<: *j8_par_executor
+    steps:
+      - attach_workspace:
+          at: /home/cassandra
+      - clone_dtest
+      - create_venv
+      - create_dtest_containers:
+          file_tag: j8_upgradetests_without_vnodes
+          run_dtests_extra_args: '--execute-upgrade-tests'
+          extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+          tests_filter_pattern: '^upgrade_tests'
+      - run_dtests:
+          file_tag: j8_upgradetests_without_vnodes
+          extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+          pytest_extra_args: '--execute-upgrade-tests'
+
+commands:
+  log_environment:
+    steps:
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+
+  clone_cassandra:
+    steps:
+    - run:
+        name: Clone Cassandra Repository (via git)
+        command: |
+          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+
+  clone_dtest:
+    steps:
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+
+  build_cassandra:
+    steps:
+    - run:
+        name: Build Cassandra
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+          for x in $(seq 1 3); do
+              ${ANT_HOME}/bin/ant clean jar
+              RETURN="$?"
+              if [ "${RETURN}" -eq "0" ]; then
+                  break
+              fi
+          done
+          # Exit, if we didn't build successfully
+          if [ "${RETURN}" -ne "0" ]; then
+              echo "Build failed with exit code: ${RETURN}"
+              exit ${RETURN}
+          fi
+        no_output_timeout: 15m
+
+  run_eclipse_warnings:
+    steps:
+    - run:
+        name: Run eclipse-warnings
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          ant eclipse-warnings
+
+  create_junit_containers:
+    steps:
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+        no_output_timeout: 15m
+
+  run_junit_tests:
+    parameters:
+      target:
+        type: string
+      no_output_timeout:
+        type: string
+        default: 15m
+    steps:
+    - run:
+        name: Run Unit Tests (<<parameters.target>>)
+        # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+        # based on Java 11 builds.
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean <<parameters.target>>
+        no_output_timeout: <<parameters.no_output_timeout>>
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+
+  run_parallel_junit_tests:
+    parameters:
+      target:
+        type: string
+        default: testclasslist
+      no_output_timeout:
+        type: string
+        default: 15m
+    steps:
+    - run:
+        name: Run Unit Tests (<<parameters.target>>)
+        # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+        # based on Java 11 builds.
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant <<parameters.target>> -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: <<parameters.no_output_timeout>>
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+
+  create_venv:
+    steps:
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+
+  create_dtest_containers:
+    parameters:
+      file_tag:
+        type: string
+      run_dtests_extra_args:
+        type: string
+        default: ''
+      extra_env_args:
+        type: string
+        default: ''
+      tests_filter_pattern:
+        type: string
+        default: ''
+    steps:
+    - run:
+        name: Determine Tests to Run (<<parameters.file_tag>>)
+        no_output_timeout: 5m
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          cd cassandra-dtest
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          if [ -n '<<parameters.extra_env_args>>' ]; then
+            export <<parameters.extra_env_args>>
+          fi
+
+          echo "***Collected DTests (<<parameters.file_tag>>)***"
+          set -eo pipefail && ./run_dtests.py <<parameters.run_dtests_extra_args>> --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_<<parameters.file_tag>>_raw --cassandra-dir=../cassandra
+          if [ -z '<<parameters.tests_filter_pattern>>' ]; then
+            mv /tmp/all_dtest_tests_<<parameters.file_tag>>_raw /tmp/all_dtest_tests_<<parameters.file_tag>>
+          else
+            grep -e '<<parameters.tests_filter_pattern>>' /tmp/all_dtest_tests_<<parameters.file_tag>>_raw > /tmp/all_dtest_tests_<<parameters.file_tag>> || { echo "Filter did not match any tests! Exiting build."; exit 0; }
+          fi
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_<<parameters.file_tag>> > /tmp/split_dtest_tests_<<parameters.file_tag>>.txt
+          cat /tmp/split_dtest_tests_<<parameters.file_tag>>.txt | tr '\n' ' ' > /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+          cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+
+  run_dtests:
+    parameters:
+      file_tag:
+        type: string
+      pytest_extra_args:
+        type: string
+        default: ''
+      extra_env_args:
+        type: string
+        default: ''
+    steps:
+      - run:
+          name: Run dtests (<<parameters.file_tag>>)
+          no_output_timeout: 15m
+          command: |
+            echo "cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt"
+            cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+
+            source ~/env/bin/activate
+            export PATH=$JAVA_HOME/bin:$PATH
+            if [ -n '<<parameters.extra_env_args>>' ]; then
+              export <<parameters.extra_env_args>>
+            fi
+
+            java -version
+            cd ~/cassandra-dtest
+            mkdir -p /tmp/dtest
+
+            echo "env: $(env)"
+            echo "** done env"
+            mkdir -p /tmp/results/dtests
+            # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+            export SPLIT_TESTS=`cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt`
+            set -o pipefail && cd ~/cassandra-dtest && pytest <<parameters.pytest_extra_args>> --log-level="INFO" --junit-xml=/tmp/results/dtests/pytest_result_<<parameters.file_tag>>.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+      - store_test_results:
+          path: /tmp/results
+      - store_artifacts:
+          path: /tmp/dtest
+          destination: dtest_<<parameters.file_tag>>
+      - store_artifacts:
+          path: ~/cassandra-dtest/logs
+          destination: dtest_<<parameters.file_tag>>_logs

--- a/.circleci/config-2_1.yml.high_res.patch
+++ b/.circleci/config-2_1.yml.high_res.patch
@@ -1,0 +1,16 @@
+17,18c17,18
+<     CCM_MAX_HEAP_SIZE: 1024M
+<     CCM_HEAP_NEWSIZE: 256M
+---
+>     CCM_MAX_HEAP_SIZE: 2048M
+>     CCM_HEAP_NEWSIZE: 512M
+23,24c23,24
+<     #exec_resource_class: xlarge
+<   parallelism: 4
+---
+>     exec_resource_class: xlarge
+>   parallelism: 100
+29c29
+<     #exec_resource_class: xlarge
+---
+>     exec_resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,1160 @@
+version: 2
+jobs:
+  build:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Clone Cassandra Repository (via git)
+        command: |
+          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+    - run:
+        name: Build Cassandra
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+          for x in $(seq 1 3); do
+              ${ANT_HOME}/bin/ant clean jar
+              RETURN="$?"
+              if [ "${RETURN}" -eq "0" ]; then
+                  break
+              fi
+          done
+          # Exit, if we didn't build successfully
+          if [ "${RETURN}" -ne "0" ]; then
+              echo "Build failed with exit code: ${RETURN}"
+              exit ${RETURN}
+          fi
+        no_output_timeout: 15m
+    - run:
+        name: Run eclipse-warnings
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          ant eclipse-warnings
+    - persist_to_workspace:
+        root: /home/cassandra
+        paths:
+        - cassandra
+        - .m2
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_dtests-no-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --dtest-print-tests-only\
+          \ --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+    - run:
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-level=\"\
+          INFO\" --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_without_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_without_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_upgradetests-no-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
+        no_output_timeout: 5m
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          cd cassandra-dtest
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          if [ -n 'RUN_STATIC_UPGRADE_MATRIX=true' ]; then
+            export RUN_STATIC_UPGRADE_MATRIX=true
+          fi
+
+          echo "***Collected DTests (j8_upgradetests_without_vnodes)***"
+          set -eo pipefail && ./run_dtests.py --execute-upgrade-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw --cassandra-dir=../cassandra
+          if [ -z '^upgrade_tests' ]; then
+            mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw /tmp/all_dtest_tests_j8_upgradetests_without_vnodes
+          else
+            grep -e '^upgrade_tests' /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes || { echo "Filter did not match any tests! Exiting build."; exit 0; }
+          fi
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\n' ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+    - run:
+        name: Run dtests (j8_upgradetests_without_vnodes)
+        no_output_timeout: 15m
+        command: |
+          echo "cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt"
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          if [ -n 'RUN_STATIC_UPGRADE_MATRIX=true' ]; then
+            export RUN_STATIC_UPGRADE_MATRIX=true
+          fi
+
+          java -version
+          cd ~/cassandra-dtest
+          mkdir -p /tmp/dtest
+
+          echo "env: $(env)"
+          echo "** done env"
+          mkdir -p /tmp/results/dtests
+          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`
+          set -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests --log-level="INFO" --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_upgradetests_without_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_upgradetests_without_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_stress:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (stress-test)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean stress-test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_unit_tests:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+        no_output_timeout: 15m
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Run Unit Tests (testclasslist)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant testclasslist -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_dtests-with-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --dtest-print-tests-only\
+          \ --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\n\
+          if [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\n\
+          else\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes\
+          \ || { echo \"Filter did not match any tests! Exiting build.\"; exit 0;\
+          \ }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname\
+          \ /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\n\
+          cat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+    - run:
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=32 --skip-resource-intensive-tests\
+          \ --log-level=\"INFO\" --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_with_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_with_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_jvm_dtests:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (test-jvm-dtest-forking)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean test-jvm-dtest-forking
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_long:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (long-test)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean long-test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_compression:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+        no_output_timeout: 15m
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Run Unit Tests (testclasslist-compression)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant testclasslist-compression -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+workflows:
+  version: 2
+  build_and_run_tests:
+    jobs:
+    - build
+    - j8_unit_tests:
+        requires:
+        - build
+    - j8_jvm_dtests:
+        requires:
+        - build
+    - start_utests_long:
+        type: approval
+        requires:
+        - build
+    - utests_long:
+        requires:
+        - start_utests_long
+    - start_utests_compression:
+        type: approval
+        requires:
+        - build
+    - utests_compression:
+        requires:
+        - start_utests_compression
+    - start_utests_stress:
+        type: approval
+        requires:
+        - build
+    - utests_stress:
+        requires:
+        - start_utests_stress
+    - start_j8_dtests:
+        type: approval
+        requires:
+        - build
+    - j8_dtests-with-vnodes:
+        requires:
+        - start_j8_dtests
+    - j8_dtests-no-vnodes:
+        requires:
+        - start_j8_dtests
+    - start_upgrade_tests:
+        type: approval
+        requires:
+        - build
+    - j8_upgradetests-no-vnodes:
+        requires:
+        - start_upgrade_tests
+
+# Original config.yml file:
+# version: 2.1
+# 
+# default_env_vars: &default_env_vars
+#     JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+#     ANT_HOME: /usr/share/ant
+#     LANG: en_US.UTF-8
+#     KEEP_TEST_DIR: true
+#     DEFAULT_DIR: /home/cassandra/cassandra-dtest
+#     PYTHONIOENCODING: utf-8
+#     PYTHONUNBUFFERED: true
+#     CASS_DRIVER_NO_EXTENSIONS: true
+#     CASS_DRIVER_NO_CYTHON: true
+#     #Skip all syncing to disk to avoid performance issues in flaky CI environments
+#     CASSANDRA_SKIP_SYNC: true
+#     DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+#     DTEST_BRANCH: master
+#     CCM_MAX_HEAP_SIZE: 1024M
+#     CCM_HEAP_NEWSIZE: 256M
+# 
+# j8_par_executor: &j8_par_executor
+#   executor:
+#     name: java8-executor
+#     #exec_resource_class: xlarge
+#   parallelism: 4
+# 
+# j8_seq_executor: &j8_seq_executor
+#   executor:
+#     name: java8-executor
+#     #exec_resource_class: xlarge
+#   parallelism: 1 # sequential, single container tests: no parallelism benefits
+# 
+# with_dtests_jobs: &with_dtest_jobs
+#         jobs:
+#             - build
+#             # Java 8 unit tests will be run automatically
+#             - j8_unit_tests:
+#                 requires:
+#                   - build
+#             - j8_jvm_dtests:
+#                 requires:
+#                   - build
+#             # specialized unit tests (all run on request using Java 8)
+#             - start_utests_long:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_long:
+#                 requires:
+#                   - start_utests_long
+#             - start_utests_compression:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_compression:
+#                 requires:
+#                   - start_utests_compression
+#             - start_utests_stress:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_stress:
+#                 requires:
+#                   - start_utests_stress
+#             # Java 8 dtests (on request)
+#             - start_j8_dtests:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - j8_dtests-with-vnodes:
+#                 requires:
+#                   - start_j8_dtests
+#             - j8_dtests-no-vnodes:
+#                 requires:
+#                   - start_j8_dtests
+#             # Java 8 upgrade tests
+#             - start_upgrade_tests:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - j8_upgradetests-no-vnodes:
+#                 requires:
+#                   - start_upgrade_tests
+# 
+# with_dtest_jobs_only: &with_dtest_jobs_only
+#         jobs:
+#             - build
+#             - j8_dtests-with-vnodes:
+#                   requires:
+#                       - build
+#             - j8_dtests-no-vnodes:
+#                   requires:
+#                       - build
+# 
+# workflows:
+#     version: 2
+#     build_and_run_tests: *with_dtest_jobs
+#     #build_and_run_tests: *with_dtest_jobs_only
+# 
+# executors:
+#   java8-executor:
+#     parameters:
+#       exec_resource_class:
+#         type: string
+#         default: medium
+#     docker:
+#       - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+#     resource_class: << parameters.exec_resource_class >>
+#     working_directory: ~/
+#     shell: /bin/bash -eo pipefail -l
+#     environment:
+#       <<: *default_env_vars
+#       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+#       JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+# 
+# jobs:
+#   build:
+#     executor: java8-executor
+#     parallelism: 1 # This job doesn't benefit from parallelism
+#     steps:
+#       - log_environment
+#       - clone_cassandra
+#       - build_cassandra
+#       - run_eclipse_warnings
+#       - persist_to_workspace:
+#             root: /home/cassandra
+#             paths:
+#                 - cassandra
+#                 - .m2
+# 
+#   j8_unit_tests:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - create_junit_containers
+#       - log_environment
+#       - run_parallel_junit_tests
+# 
+#   j8_jvm_dtests:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: test-jvm-dtest-forking
+# 
+#   utests_long:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: long-test
+# 
+#   utests_compression:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - create_junit_containers
+#       - log_environment
+#       - run_parallel_junit_tests:
+#           target: testclasslist-compression
+# 
+#   utests_stress:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: stress-test
+# 
+#   j8_dtests-with-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_with_vnodes
+#           run_dtests_extra_args: '--use-vnodes --skip-resource-intensive-tests'
+#       - run_dtests:
+#           file_tag: j8_with_vnodes
+#           pytest_extra_args: '--use-vnodes --num-tokens=32 --skip-resource-intensive-tests'
+# 
+#   j8_dtests-no-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_without_vnodes
+#           run_dtests_extra_args: '--skip-resource-intensive-tests'
+#       - run_dtests:
+#           file_tag: j8_without_vnodes
+#           pytest_extra_args: '--skip-resource-intensive-tests'
+# 
+#   j8_upgradetests-no-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_upgradetests_without_vnodes
+#           run_dtests_extra_args: '--execute-upgrade-tests'
+#           extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+#           tests_filter_pattern: '^upgrade_tests'
+#       - run_dtests:
+#           file_tag: j8_upgradetests_without_vnodes
+#           extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+#           pytest_extra_args: '--execute-upgrade-tests'
+# 
+# commands:
+#   log_environment:
+#     steps:
+#     - run:
+#         name: Log Environment Information
+#         command: |
+#           echo '*** id ***'
+#           id
+#           echo '*** cat /proc/cpuinfo ***'
+#           cat /proc/cpuinfo
+#           echo '*** free -m ***'
+#           free -m
+#           echo '*** df -m ***'
+#           df -m
+#           echo '*** ifconfig -a ***'
+#           ifconfig -a
+#           echo '*** uname -a ***'
+#           uname -a
+#           echo '*** mount ***'
+#           mount
+#           echo '*** env ***'
+#           env
+#           echo '*** java ***'
+#           which java
+#           java -version
+# 
+#   clone_cassandra:
+#     steps:
+#     - run:
+#         name: Clone Cassandra Repository (via git)
+#         command: |
+#           git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+# 
+#   clone_dtest:
+#     steps:
+#     - run:
+#         name: Clone Cassandra dtest Repository (via git)
+#         command: |
+#           git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+# 
+#   build_cassandra:
+#     steps:
+#     - run:
+#         name: Build Cassandra
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           cd ~/cassandra
+#           # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+#           for x in $(seq 1 3); do
+#               ${ANT_HOME}/bin/ant clean jar
+#               RETURN=\"$?\"
+#               if [ \"${RETURN}\" -eq \"0\" ]; then
+#                   break
+#               fi
+#           done
+#           # Exit, if we didn't build successfully
+#           if [ \"${RETURN}\" -ne \"0\" ]; then
+#               echo \"Build failed with exit code: ${RETURN}\"
+#               exit ${RETURN}
+#           fi
+#         no_output_timeout: 15m
+# 
+#   run_eclipse_warnings:
+#     steps:
+#     - run:
+#         name: Run eclipse-warnings
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           cd ~/cassandra
+#           ant eclipse-warnings
+# 
+#   create_junit_containers:
+#     steps:
+#     - run:
+#         name: Determine Unit Tests to Run
+#         command: |
+#           # reminder: this code (along with all the steps) is independently executed on every circle container
+#           # so the goal here is to get the circleci script to return the tests *this* container will run
+#           # which we do via the `circleci` cli tool.
+# 
+#           rm -fr ~/cassandra-dtest/upgrade_tests
+#           echo \"***java tests***\"
+# 
+#           # get all of our unit test filenames
+#           set -eo pipefail && circleci tests glob \"$HOME/cassandra/test/unit/**/*.java\" > /tmp/all_java_unit_tests.txt
+# 
+#           # split up the unit tests into groups based on the number of containers we have
+#           set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+#           set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep \"Test\\.java$\" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+#           echo \"** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\"
+#           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+# 
+#         no_output_timeout: 15m
+# 
+#   run_junit_tests:
+#     parameters:
+#       target:
+#         type: string
+#       no_output_timeout:
+#         type: string
+#         default: 15m
+#     steps:
+#     - run:
+#         name: Run Unit Tests (<<parameters.target>>)
+#         # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+#         # based on Java 11 builds.
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           time mv ~/cassandra /tmp
+#           cd /tmp/cassandra
+#           ant clean <<parameters.target>>
+#         no_output_timeout: <<parameters.no_output_timeout>>
+#     - store_test_results:
+#         path: /tmp/cassandra/build/test/output/
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/output
+#         destination: junitxml
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/logs
+#         destination: logs
+# 
+#   run_parallel_junit_tests:
+#     parameters:
+#       target:
+#         type: string
+#         default: testclasslist
+#       no_output_timeout:
+#         type: string
+#         default: 15m
+#     steps:
+#     - run:
+#         name: Run Unit Tests (<<parameters.target>>)
+#         # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+#         # based on Java 11 builds.
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           time mv ~/cassandra /tmp
+#           cd /tmp/cassandra
+#           ant <<parameters.target>> -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+#         no_output_timeout: <<parameters.no_output_timeout>>
+#     - store_test_results:
+#         path: /tmp/cassandra/build/test/output/
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/output
+#         destination: junitxml
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/logs
+#         destination: logs
+# 
+#   create_venv:
+#     steps:
+#     - run:
+#         name: Configure virtualenv and python Dependencies
+#         command: |
+#           # note, this should be super quick as all dependencies should be pre-installed in the docker image
+#           # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+#           # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+#           # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+#           source ~/env/bin/activate
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+#           pip3 freeze
+# 
+#   create_dtest_containers:
+#     parameters:
+#       file_tag:
+#         type: string
+#       run_dtests_extra_args:
+#         type: string
+#         default: ''
+#       extra_env_args:
+#         type: string
+#         default: ''
+#       tests_filter_pattern:
+#         type: string
+#         default: ''
+#     steps:
+#     - run:
+#         name: Determine Tests to Run (<<parameters.file_tag>>)
+#         no_output_timeout: 5m
+#         command: |
+#           # reminder: this code (along with all the steps) is independently executed on every circle container
+#           # so the goal here is to get the circleci script to return the tests *this* container will run
+#           # which we do via the `circleci` cli tool.
+# 
+#           cd cassandra-dtest
+#           source ~/env/bin/activate
+#           export PATH=$JAVA_HOME/bin:$PATH
+# 
+#           if [ -n '<<parameters.extra_env_args>>' ]; then
+#             export <<parameters.extra_env_args>>
+#           fi
+# 
+#           echo \"***Collected DTests (<<parameters.file_tag>>)***\"
+#           set -eo pipefail && ./run_dtests.py <<parameters.run_dtests_extra_args>> --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_<<parameters.file_tag>>_raw --cassandra-dir=../cassandra
+#           if [ -z '<<parameters.tests_filter_pattern>>' ]; then
+#             mv /tmp/all_dtest_tests_<<parameters.file_tag>>_raw /tmp/all_dtest_tests_<<parameters.file_tag>>
+#           else
+#             grep -e '<<parameters.tests_filter_pattern>>' /tmp/all_dtest_tests_<<parameters.file_tag>>_raw > /tmp/all_dtest_tests_<<parameters.file_tag>> || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }
+#           fi
+#           set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_<<parameters.file_tag>> > /tmp/split_dtest_tests_<<parameters.file_tag>>.txt
+#           cat /tmp/split_dtest_tests_<<parameters.file_tag>>.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+#           cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+# 
+#   run_dtests:
+#     parameters:
+#       file_tag:
+#         type: string
+#       pytest_extra_args:
+#         type: string
+#         default: ''
+#       extra_env_args:
+#         type: string
+#         default: ''
+#     steps:
+#       - run:
+#           name: Run dtests (<<parameters.file_tag>>)
+#           no_output_timeout: 15m
+#           command: |
+#             echo \"cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt\"
+#             cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+# 
+#             source ~/env/bin/activate
+#             export PATH=$JAVA_HOME/bin:$PATH
+#             if [ -n '<<parameters.extra_env_args>>' ]; then
+#               export <<parameters.extra_env_args>>
+#             fi
+# 
+#             java -version
+#             cd ~/cassandra-dtest
+#             mkdir -p /tmp/dtest
+# 
+#             echo \"env: $(env)\"
+#             echo \"** done env\"
+#             mkdir -p /tmp/results/dtests
+#             # we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+#             export SPLIT_TESTS=`cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt`
+#             set -o pipefail && cd ~/cassandra-dtest && pytest <<parameters.pytest_extra_args>> --log-level=\"INFO\" --junit-xml=/tmp/results/dtests/pytest_result_<<parameters.file_tag>>.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+#       - store_test_results:
+#           path: /tmp/results
+#       - store_artifacts:
+#           path: /tmp/dtest
+#           destination: dtest_<<parameters.file_tag>>
+#       - store_artifacts:
+#           path: ~/cassandra-dtest/logs
+#           destination: dtest_<<parameters.file_tag>>_logs

--- a/.circleci/config.yml.HIGHRES
+++ b/.circleci/config.yml.HIGHRES
@@ -1,0 +1,1160 @@
+version: 2
+jobs:
+  build:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Clone Cassandra Repository (via git)
+        command: |
+          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+    - run:
+        name: Build Cassandra
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+          for x in $(seq 1 3); do
+              ${ANT_HOME}/bin/ant clean jar
+              RETURN="$?"
+              if [ "${RETURN}" -eq "0" ]; then
+                  break
+              fi
+          done
+          # Exit, if we didn't build successfully
+          if [ "${RETURN}" -ne "0" ]; then
+              echo "Build failed with exit code: ${RETURN}"
+              exit ${RETURN}
+          fi
+        no_output_timeout: 15m
+    - run:
+        name: Run eclipse-warnings
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          ant eclipse-warnings
+    - persist_to_workspace:
+        root: /home/cassandra
+        paths:
+        - cassandra
+        - .m2
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_dtests-no-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 100
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --dtest-print-tests-only\
+          \ --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+    - run:
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-level=\"\
+          INFO\" --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_without_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_without_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_upgradetests-no-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 100
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
+        no_output_timeout: 5m
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          cd cassandra-dtest
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          if [ -n 'RUN_STATIC_UPGRADE_MATRIX=true' ]; then
+            export RUN_STATIC_UPGRADE_MATRIX=true
+          fi
+
+          echo "***Collected DTests (j8_upgradetests_without_vnodes)***"
+          set -eo pipefail && ./run_dtests.py --execute-upgrade-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw --cassandra-dir=../cassandra
+          if [ -z '^upgrade_tests' ]; then
+            mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw /tmp/all_dtest_tests_j8_upgradetests_without_vnodes
+          else
+            grep -e '^upgrade_tests' /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes || { echo "Filter did not match any tests! Exiting build."; exit 0; }
+          fi
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\n' ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+    - run:
+        name: Run dtests (j8_upgradetests_without_vnodes)
+        no_output_timeout: 15m
+        command: |
+          echo "cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt"
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          if [ -n 'RUN_STATIC_UPGRADE_MATRIX=true' ]; then
+            export RUN_STATIC_UPGRADE_MATRIX=true
+          fi
+
+          java -version
+          cd ~/cassandra-dtest
+          mkdir -p /tmp/dtest
+
+          echo "env: $(env)"
+          echo "** done env"
+          mkdir -p /tmp/results/dtests
+          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`
+          set -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests --log-level="INFO" --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_upgradetests_without_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_upgradetests_without_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_stress:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (stress-test)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean stress-test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_unit_tests:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 100
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+        no_output_timeout: 15m
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Run Unit Tests (testclasslist)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant testclasslist -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_dtests-with-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 100
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --dtest-print-tests-only\
+          \ --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\n\
+          if [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\n\
+          else\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes\
+          \ || { echo \"Filter did not match any tests! Exiting build.\"; exit 0;\
+          \ }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname\
+          \ /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\n\
+          cat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+    - run:
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=32 --skip-resource-intensive-tests\
+          \ --log-level=\"INFO\" --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_with_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_with_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_jvm_dtests:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (test-jvm-dtest-forking)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean test-jvm-dtest-forking
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_long:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (long-test)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean long-test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_compression:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: xlarge
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 100
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+        no_output_timeout: 15m
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Run Unit Tests (testclasslist-compression)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant testclasslist-compression -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 2048M
+    - CCM_HEAP_NEWSIZE: 512M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+workflows:
+  version: 2
+  build_and_run_tests:
+    jobs:
+    - build
+    - j8_unit_tests:
+        requires:
+        - build
+    - j8_jvm_dtests:
+        requires:
+        - build
+    - start_utests_long:
+        type: approval
+        requires:
+        - build
+    - utests_long:
+        requires:
+        - start_utests_long
+    - start_utests_compression:
+        type: approval
+        requires:
+        - build
+    - utests_compression:
+        requires:
+        - start_utests_compression
+    - start_utests_stress:
+        type: approval
+        requires:
+        - build
+    - utests_stress:
+        requires:
+        - start_utests_stress
+    - start_j8_dtests:
+        type: approval
+        requires:
+        - build
+    - j8_dtests-with-vnodes:
+        requires:
+        - start_j8_dtests
+    - j8_dtests-no-vnodes:
+        requires:
+        - start_j8_dtests
+    - start_upgrade_tests:
+        type: approval
+        requires:
+        - build
+    - j8_upgradetests-no-vnodes:
+        requires:
+        - start_upgrade_tests
+
+# Original config.yml file:
+# version: 2.1
+# 
+# default_env_vars: &default_env_vars
+#     JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+#     ANT_HOME: /usr/share/ant
+#     LANG: en_US.UTF-8
+#     KEEP_TEST_DIR: true
+#     DEFAULT_DIR: /home/cassandra/cassandra-dtest
+#     PYTHONIOENCODING: utf-8
+#     PYTHONUNBUFFERED: true
+#     CASS_DRIVER_NO_EXTENSIONS: true
+#     CASS_DRIVER_NO_CYTHON: true
+#     #Skip all syncing to disk to avoid performance issues in flaky CI environments
+#     CASSANDRA_SKIP_SYNC: true
+#     DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+#     DTEST_BRANCH: master
+#     CCM_MAX_HEAP_SIZE: 2048M
+#     CCM_HEAP_NEWSIZE: 512M
+# 
+# j8_par_executor: &j8_par_executor
+#   executor:
+#     name: java8-executor
+#     exec_resource_class: xlarge
+#   parallelism: 100
+# 
+# j8_seq_executor: &j8_seq_executor
+#   executor:
+#     name: java8-executor
+#     exec_resource_class: xlarge
+#   parallelism: 1 # sequential, single container tests: no parallelism benefits
+# 
+# with_dtests_jobs: &with_dtest_jobs
+#         jobs:
+#             - build
+#             # Java 8 unit tests will be run automatically
+#             - j8_unit_tests:
+#                 requires:
+#                   - build
+#             - j8_jvm_dtests:
+#                 requires:
+#                   - build
+#             # specialized unit tests (all run on request using Java 8)
+#             - start_utests_long:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_long:
+#                 requires:
+#                   - start_utests_long
+#             - start_utests_compression:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_compression:
+#                 requires:
+#                   - start_utests_compression
+#             - start_utests_stress:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_stress:
+#                 requires:
+#                   - start_utests_stress
+#             # Java 8 dtests (on request)
+#             - start_j8_dtests:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - j8_dtests-with-vnodes:
+#                 requires:
+#                   - start_j8_dtests
+#             - j8_dtests-no-vnodes:
+#                 requires:
+#                   - start_j8_dtests
+#             # Java 8 upgrade tests
+#             - start_upgrade_tests:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - j8_upgradetests-no-vnodes:
+#                 requires:
+#                   - start_upgrade_tests
+# 
+# with_dtest_jobs_only: &with_dtest_jobs_only
+#         jobs:
+#             - build
+#             - j8_dtests-with-vnodes:
+#                   requires:
+#                       - build
+#             - j8_dtests-no-vnodes:
+#                   requires:
+#                       - build
+# 
+# workflows:
+#     version: 2
+#     build_and_run_tests: *with_dtest_jobs
+#     #build_and_run_tests: *with_dtest_jobs_only
+# 
+# executors:
+#   java8-executor:
+#     parameters:
+#       exec_resource_class:
+#         type: string
+#         default: medium
+#     docker:
+#       - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+#     resource_class: << parameters.exec_resource_class >>
+#     working_directory: ~/
+#     shell: /bin/bash -eo pipefail -l
+#     environment:
+#       <<: *default_env_vars
+#       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+#       JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+# 
+# jobs:
+#   build:
+#     executor: java8-executor
+#     parallelism: 1 # This job doesn't benefit from parallelism
+#     steps:
+#       - log_environment
+#       - clone_cassandra
+#       - build_cassandra
+#       - run_eclipse_warnings
+#       - persist_to_workspace:
+#             root: /home/cassandra
+#             paths:
+#                 - cassandra
+#                 - .m2
+# 
+#   j8_unit_tests:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - create_junit_containers
+#       - log_environment
+#       - run_parallel_junit_tests
+# 
+#   j8_jvm_dtests:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: test-jvm-dtest-forking
+# 
+#   utests_long:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: long-test
+# 
+#   utests_compression:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - create_junit_containers
+#       - log_environment
+#       - run_parallel_junit_tests:
+#           target: testclasslist-compression
+# 
+#   utests_stress:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: stress-test
+# 
+#   j8_dtests-with-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_with_vnodes
+#           run_dtests_extra_args: '--use-vnodes --skip-resource-intensive-tests'
+#       - run_dtests:
+#           file_tag: j8_with_vnodes
+#           pytest_extra_args: '--use-vnodes --num-tokens=32 --skip-resource-intensive-tests'
+# 
+#   j8_dtests-no-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_without_vnodes
+#           run_dtests_extra_args: '--skip-resource-intensive-tests'
+#       - run_dtests:
+#           file_tag: j8_without_vnodes
+#           pytest_extra_args: '--skip-resource-intensive-tests'
+# 
+#   j8_upgradetests-no-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_upgradetests_without_vnodes
+#           run_dtests_extra_args: '--execute-upgrade-tests'
+#           extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+#           tests_filter_pattern: '^upgrade_tests'
+#       - run_dtests:
+#           file_tag: j8_upgradetests_without_vnodes
+#           extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+#           pytest_extra_args: '--execute-upgrade-tests'
+# 
+# commands:
+#   log_environment:
+#     steps:
+#     - run:
+#         name: Log Environment Information
+#         command: |
+#           echo '*** id ***'
+#           id
+#           echo '*** cat /proc/cpuinfo ***'
+#           cat /proc/cpuinfo
+#           echo '*** free -m ***'
+#           free -m
+#           echo '*** df -m ***'
+#           df -m
+#           echo '*** ifconfig -a ***'
+#           ifconfig -a
+#           echo '*** uname -a ***'
+#           uname -a
+#           echo '*** mount ***'
+#           mount
+#           echo '*** env ***'
+#           env
+#           echo '*** java ***'
+#           which java
+#           java -version
+# 
+#   clone_cassandra:
+#     steps:
+#     - run:
+#         name: Clone Cassandra Repository (via git)
+#         command: |
+#           git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+# 
+#   clone_dtest:
+#     steps:
+#     - run:
+#         name: Clone Cassandra dtest Repository (via git)
+#         command: |
+#           git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+# 
+#   build_cassandra:
+#     steps:
+#     - run:
+#         name: Build Cassandra
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           cd ~/cassandra
+#           # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+#           for x in $(seq 1 3); do
+#               ${ANT_HOME}/bin/ant clean jar
+#               RETURN=\"$?\"
+#               if [ \"${RETURN}\" -eq \"0\" ]; then
+#                   break
+#               fi
+#           done
+#           # Exit, if we didn't build successfully
+#           if [ \"${RETURN}\" -ne \"0\" ]; then
+#               echo \"Build failed with exit code: ${RETURN}\"
+#               exit ${RETURN}
+#           fi
+#         no_output_timeout: 15m
+# 
+#   run_eclipse_warnings:
+#     steps:
+#     - run:
+#         name: Run eclipse-warnings
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           cd ~/cassandra
+#           ant eclipse-warnings
+# 
+#   create_junit_containers:
+#     steps:
+#     - run:
+#         name: Determine Unit Tests to Run
+#         command: |
+#           # reminder: this code (along with all the steps) is independently executed on every circle container
+#           # so the goal here is to get the circleci script to return the tests *this* container will run
+#           # which we do via the `circleci` cli tool.
+# 
+#           rm -fr ~/cassandra-dtest/upgrade_tests
+#           echo \"***java tests***\"
+# 
+#           # get all of our unit test filenames
+#           set -eo pipefail && circleci tests glob \"$HOME/cassandra/test/unit/**/*.java\" > /tmp/all_java_unit_tests.txt
+# 
+#           # split up the unit tests into groups based on the number of containers we have
+#           set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+#           set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep \"Test\\.java$\" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+#           echo \"** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\"
+#           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+# 
+#         no_output_timeout: 15m
+# 
+#   run_junit_tests:
+#     parameters:
+#       target:
+#         type: string
+#       no_output_timeout:
+#         type: string
+#         default: 15m
+#     steps:
+#     - run:
+#         name: Run Unit Tests (<<parameters.target>>)
+#         # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+#         # based on Java 11 builds.
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           time mv ~/cassandra /tmp
+#           cd /tmp/cassandra
+#           ant clean <<parameters.target>>
+#         no_output_timeout: <<parameters.no_output_timeout>>
+#     - store_test_results:
+#         path: /tmp/cassandra/build/test/output/
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/output
+#         destination: junitxml
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/logs
+#         destination: logs
+# 
+#   run_parallel_junit_tests:
+#     parameters:
+#       target:
+#         type: string
+#         default: testclasslist
+#       no_output_timeout:
+#         type: string
+#         default: 15m
+#     steps:
+#     - run:
+#         name: Run Unit Tests (<<parameters.target>>)
+#         # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+#         # based on Java 11 builds.
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           time mv ~/cassandra /tmp
+#           cd /tmp/cassandra
+#           ant <<parameters.target>> -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+#         no_output_timeout: <<parameters.no_output_timeout>>
+#     - store_test_results:
+#         path: /tmp/cassandra/build/test/output/
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/output
+#         destination: junitxml
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/logs
+#         destination: logs
+# 
+#   create_venv:
+#     steps:
+#     - run:
+#         name: Configure virtualenv and python Dependencies
+#         command: |
+#           # note, this should be super quick as all dependencies should be pre-installed in the docker image
+#           # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+#           # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+#           # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+#           source ~/env/bin/activate
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+#           pip3 freeze
+# 
+#   create_dtest_containers:
+#     parameters:
+#       file_tag:
+#         type: string
+#       run_dtests_extra_args:
+#         type: string
+#         default: ''
+#       extra_env_args:
+#         type: string
+#         default: ''
+#       tests_filter_pattern:
+#         type: string
+#         default: ''
+#     steps:
+#     - run:
+#         name: Determine Tests to Run (<<parameters.file_tag>>)
+#         no_output_timeout: 5m
+#         command: |
+#           # reminder: this code (along with all the steps) is independently executed on every circle container
+#           # so the goal here is to get the circleci script to return the tests *this* container will run
+#           # which we do via the `circleci` cli tool.
+# 
+#           cd cassandra-dtest
+#           source ~/env/bin/activate
+#           export PATH=$JAVA_HOME/bin:$PATH
+# 
+#           if [ -n '<<parameters.extra_env_args>>' ]; then
+#             export <<parameters.extra_env_args>>
+#           fi
+# 
+#           echo \"***Collected DTests (<<parameters.file_tag>>)***\"
+#           set -eo pipefail && ./run_dtests.py <<parameters.run_dtests_extra_args>> --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_<<parameters.file_tag>>_raw --cassandra-dir=../cassandra
+#           if [ -z '<<parameters.tests_filter_pattern>>' ]; then
+#             mv /tmp/all_dtest_tests_<<parameters.file_tag>>_raw /tmp/all_dtest_tests_<<parameters.file_tag>>
+#           else
+#             grep -e '<<parameters.tests_filter_pattern>>' /tmp/all_dtest_tests_<<parameters.file_tag>>_raw > /tmp/all_dtest_tests_<<parameters.file_tag>> || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }
+#           fi
+#           set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_<<parameters.file_tag>> > /tmp/split_dtest_tests_<<parameters.file_tag>>.txt
+#           cat /tmp/split_dtest_tests_<<parameters.file_tag>>.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+#           cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+# 
+#   run_dtests:
+#     parameters:
+#       file_tag:
+#         type: string
+#       pytest_extra_args:
+#         type: string
+#         default: ''
+#       extra_env_args:
+#         type: string
+#         default: ''
+#     steps:
+#       - run:
+#           name: Run dtests (<<parameters.file_tag>>)
+#           no_output_timeout: 15m
+#           command: |
+#             echo \"cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt\"
+#             cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+# 
+#             source ~/env/bin/activate
+#             export PATH=$JAVA_HOME/bin:$PATH
+#             if [ -n '<<parameters.extra_env_args>>' ]; then
+#               export <<parameters.extra_env_args>>
+#             fi
+# 
+#             java -version
+#             cd ~/cassandra-dtest
+#             mkdir -p /tmp/dtest
+# 
+#             echo \"env: $(env)\"
+#             echo \"** done env\"
+#             mkdir -p /tmp/results/dtests
+#             # we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+#             export SPLIT_TESTS=`cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt`
+#             set -o pipefail && cd ~/cassandra-dtest && pytest <<parameters.pytest_extra_args>> --log-level=\"INFO\" --junit-xml=/tmp/results/dtests/pytest_result_<<parameters.file_tag>>.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+#       - store_test_results:
+#           path: /tmp/results
+#       - store_artifacts:
+#           path: /tmp/dtest
+#           destination: dtest_<<parameters.file_tag>>
+#       - store_artifacts:
+#           path: ~/cassandra-dtest/logs
+#           destination: dtest_<<parameters.file_tag>>_logs

--- a/.circleci/config.yml.LOWRES
+++ b/.circleci/config.yml.LOWRES
@@ -1,0 +1,1160 @@
+version: 2
+jobs:
+  build:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Clone Cassandra Repository (via git)
+        command: |
+          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+    - run:
+        name: Build Cassandra
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+          for x in $(seq 1 3); do
+              ${ANT_HOME}/bin/ant clean jar
+              RETURN="$?"
+              if [ "${RETURN}" -eq "0" ]; then
+                  break
+              fi
+          done
+          # Exit, if we didn't build successfully
+          if [ "${RETURN}" -ne "0" ]; then
+              echo "Build failed with exit code: ${RETURN}"
+              exit ${RETURN}
+          fi
+        no_output_timeout: 15m
+    - run:
+        name: Run eclipse-warnings
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          cd ~/cassandra
+          ant eclipse-warnings
+    - persist_to_workspace:
+        root: /home/cassandra
+        paths:
+        - cassandra
+        - .m2
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_dtests-no-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --dtest-print-tests-only\
+          \ --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+    - run:
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-level=\"\
+          INFO\" --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_without_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_without_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_upgradetests-no-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
+        no_output_timeout: 5m
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          cd cassandra-dtest
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          if [ -n 'RUN_STATIC_UPGRADE_MATRIX=true' ]; then
+            export RUN_STATIC_UPGRADE_MATRIX=true
+          fi
+
+          echo "***Collected DTests (j8_upgradetests_without_vnodes)***"
+          set -eo pipefail && ./run_dtests.py --execute-upgrade-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw --cassandra-dir=../cassandra
+          if [ -z '^upgrade_tests' ]; then
+            mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw /tmp/all_dtest_tests_j8_upgradetests_without_vnodes
+          else
+            grep -e '^upgrade_tests' /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes || { echo "Filter did not match any tests! Exiting build."; exit 0; }
+          fi
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\n' ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+    - run:
+        name: Run dtests (j8_upgradetests_without_vnodes)
+        no_output_timeout: 15m
+        command: |
+          echo "cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt"
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt
+
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          if [ -n 'RUN_STATIC_UPGRADE_MATRIX=true' ]; then
+            export RUN_STATIC_UPGRADE_MATRIX=true
+          fi
+
+          java -version
+          cd ~/cassandra-dtest
+          mkdir -p /tmp/dtest
+
+          echo "env: $(env)"
+          echo "** done env"
+          mkdir -p /tmp/results/dtests
+          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`
+          set -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests --log-level="INFO" --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_upgradetests_without_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_upgradetests_without_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_stress:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (stress-test)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean stress-test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_unit_tests:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+        no_output_timeout: 15m
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Run Unit Tests (testclasslist)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant testclasslist -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_dtests-with-vnodes:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Clone Cassandra dtest Repository (via git)
+        command: |
+          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+    - run:
+        name: Configure virtualenv and python Dependencies
+        command: |
+          # note, this should be super quick as all dependencies should be pre-installed in the docker image
+          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+          source ~/env/bin/activate
+          export PATH=$JAVA_HOME/bin:$PATH
+          pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+          pip3 freeze
+    - run:
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --dtest-print-tests-only\
+          \ --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\n\
+          if [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\n\
+          else\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes\
+          \ || { echo \"Filter did not match any tests! Exiting build.\"; exit 0;\
+          \ }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname\
+          \ /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\n\
+          cat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+    - run:
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=32 --skip-resource-intensive-tests\
+          \ --log-level=\"INFO\" --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        path: /tmp/dtest
+        destination: dtest_j8_with_vnodes
+    - store_artifacts:
+        path: ~/cassandra-dtest/logs
+        destination: dtest_j8_with_vnodes_logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  j8_jvm_dtests:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (test-jvm-dtest-forking)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean test-jvm-dtest-forking
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_long:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 1
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Run Unit Tests (long-test)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant clean long-test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  utests_compression:
+    docker:
+    - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+    resource_class: medium
+    working_directory: ~/
+    shell: /bin/bash -eo pipefail -l
+    parallelism: 4
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        name: Determine Unit Tests to Run
+        command: |
+          # reminder: this code (along with all the steps) is independently executed on every circle container
+          # so the goal here is to get the circleci script to return the tests *this* container will run
+          # which we do via the `circleci` cli tool.
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+          echo "***java tests***"
+
+          # get all of our unit test filenames
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
+
+          # split up the unit tests into groups based on the number of containers we have
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep "Test\.java$" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+        no_output_timeout: 15m
+    - run:
+        name: Log Environment Information
+        command: |
+          echo '*** id ***'
+          id
+          echo '*** cat /proc/cpuinfo ***'
+          cat /proc/cpuinfo
+          echo '*** free -m ***'
+          free -m
+          echo '*** df -m ***'
+          df -m
+          echo '*** ifconfig -a ***'
+          ifconfig -a
+          echo '*** uname -a ***'
+          uname -a
+          echo '*** mount ***'
+          mount
+          echo '*** env ***'
+          env
+          echo '*** java ***'
+          which java
+          java -version
+    - run:
+        name: Run Unit Tests (testclasslist-compression)
+        command: |
+          export PATH=$JAVA_HOME/bin:$PATH
+          time mv ~/cassandra /tmp
+          cd /tmp/cassandra
+          ant testclasslist-compression -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/output
+        destination: junitxml
+    - store_artifacts:
+        path: /tmp/cassandra/build/test/logs
+        destination: logs
+    environment:
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - ANT_HOME: /usr/share/ant
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: master
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+workflows:
+  version: 2
+  build_and_run_tests:
+    jobs:
+    - build
+    - j8_unit_tests:
+        requires:
+        - build
+    - j8_jvm_dtests:
+        requires:
+        - build
+    - start_utests_long:
+        type: approval
+        requires:
+        - build
+    - utests_long:
+        requires:
+        - start_utests_long
+    - start_utests_compression:
+        type: approval
+        requires:
+        - build
+    - utests_compression:
+        requires:
+        - start_utests_compression
+    - start_utests_stress:
+        type: approval
+        requires:
+        - build
+    - utests_stress:
+        requires:
+        - start_utests_stress
+    - start_j8_dtests:
+        type: approval
+        requires:
+        - build
+    - j8_dtests-with-vnodes:
+        requires:
+        - start_j8_dtests
+    - j8_dtests-no-vnodes:
+        requires:
+        - start_j8_dtests
+    - start_upgrade_tests:
+        type: approval
+        requires:
+        - build
+    - j8_upgradetests-no-vnodes:
+        requires:
+        - start_upgrade_tests
+
+# Original config.yml file:
+# version: 2.1
+# 
+# default_env_vars: &default_env_vars
+#     JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+#     ANT_HOME: /usr/share/ant
+#     LANG: en_US.UTF-8
+#     KEEP_TEST_DIR: true
+#     DEFAULT_DIR: /home/cassandra/cassandra-dtest
+#     PYTHONIOENCODING: utf-8
+#     PYTHONUNBUFFERED: true
+#     CASS_DRIVER_NO_EXTENSIONS: true
+#     CASS_DRIVER_NO_CYTHON: true
+#     #Skip all syncing to disk to avoid performance issues in flaky CI environments
+#     CASSANDRA_SKIP_SYNC: true
+#     DTEST_REPO: git://github.com/apache/cassandra-dtest.git
+#     DTEST_BRANCH: master
+#     CCM_MAX_HEAP_SIZE: 1024M
+#     CCM_HEAP_NEWSIZE: 256M
+# 
+# j8_par_executor: &j8_par_executor
+#   executor:
+#     name: java8-executor
+#     #exec_resource_class: xlarge
+#   parallelism: 4
+# 
+# j8_seq_executor: &j8_seq_executor
+#   executor:
+#     name: java8-executor
+#     #exec_resource_class: xlarge
+#   parallelism: 1 # sequential, single container tests: no parallelism benefits
+# 
+# with_dtests_jobs: &with_dtest_jobs
+#         jobs:
+#             - build
+#             # Java 8 unit tests will be run automatically
+#             - j8_unit_tests:
+#                 requires:
+#                   - build
+#             - j8_jvm_dtests:
+#                 requires:
+#                   - build
+#             # specialized unit tests (all run on request using Java 8)
+#             - start_utests_long:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_long:
+#                 requires:
+#                   - start_utests_long
+#             - start_utests_compression:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_compression:
+#                 requires:
+#                   - start_utests_compression
+#             - start_utests_stress:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - utests_stress:
+#                 requires:
+#                   - start_utests_stress
+#             # Java 8 dtests (on request)
+#             - start_j8_dtests:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - j8_dtests-with-vnodes:
+#                 requires:
+#                   - start_j8_dtests
+#             - j8_dtests-no-vnodes:
+#                 requires:
+#                   - start_j8_dtests
+#             # Java 8 upgrade tests
+#             - start_upgrade_tests:
+#                 type: approval
+#                 requires:
+#                   - build
+#             - j8_upgradetests-no-vnodes:
+#                 requires:
+#                   - start_upgrade_tests
+# 
+# with_dtest_jobs_only: &with_dtest_jobs_only
+#         jobs:
+#             - build
+#             - j8_dtests-with-vnodes:
+#                   requires:
+#                       - build
+#             - j8_dtests-no-vnodes:
+#                   requires:
+#                       - build
+# 
+# workflows:
+#     version: 2
+#     build_and_run_tests: *with_dtest_jobs
+#     #build_and_run_tests: *with_dtest_jobs_only
+# 
+# executors:
+#   java8-executor:
+#     parameters:
+#       exec_resource_class:
+#         type: string
+#         default: medium
+#     docker:
+#       - image: spod/cassandra-testing-ubuntu1810-java11-w-dependencies:20190306
+#     resource_class: << parameters.exec_resource_class >>
+#     working_directory: ~/
+#     shell: /bin/bash -eo pipefail -l
+#     environment:
+#       <<: *default_env_vars
+#       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+#       JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+# 
+# jobs:
+#   build:
+#     executor: java8-executor
+#     parallelism: 1 # This job doesn't benefit from parallelism
+#     steps:
+#       - log_environment
+#       - clone_cassandra
+#       - build_cassandra
+#       - run_eclipse_warnings
+#       - persist_to_workspace:
+#             root: /home/cassandra
+#             paths:
+#                 - cassandra
+#                 - .m2
+# 
+#   j8_unit_tests:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - create_junit_containers
+#       - log_environment
+#       - run_parallel_junit_tests
+# 
+#   j8_jvm_dtests:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: test-jvm-dtest-forking
+# 
+#   utests_long:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: long-test
+# 
+#   utests_compression:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - create_junit_containers
+#       - log_environment
+#       - run_parallel_junit_tests:
+#           target: testclasslist-compression
+# 
+#   utests_stress:
+#     <<: *j8_seq_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - run_junit_tests:
+#           target: stress-test
+# 
+#   j8_dtests-with-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_with_vnodes
+#           run_dtests_extra_args: '--use-vnodes --skip-resource-intensive-tests'
+#       - run_dtests:
+#           file_tag: j8_with_vnodes
+#           pytest_extra_args: '--use-vnodes --num-tokens=32 --skip-resource-intensive-tests'
+# 
+#   j8_dtests-no-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_without_vnodes
+#           run_dtests_extra_args: '--skip-resource-intensive-tests'
+#       - run_dtests:
+#           file_tag: j8_without_vnodes
+#           pytest_extra_args: '--skip-resource-intensive-tests'
+# 
+#   j8_upgradetests-no-vnodes:
+#     <<: *j8_par_executor
+#     steps:
+#       - attach_workspace:
+#           at: /home/cassandra
+#       - clone_dtest
+#       - create_venv
+#       - create_dtest_containers:
+#           file_tag: j8_upgradetests_without_vnodes
+#           run_dtests_extra_args: '--execute-upgrade-tests'
+#           extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+#           tests_filter_pattern: '^upgrade_tests'
+#       - run_dtests:
+#           file_tag: j8_upgradetests_without_vnodes
+#           extra_env_args: 'RUN_STATIC_UPGRADE_MATRIX=true'
+#           pytest_extra_args: '--execute-upgrade-tests'
+# 
+# commands:
+#   log_environment:
+#     steps:
+#     - run:
+#         name: Log Environment Information
+#         command: |
+#           echo '*** id ***'
+#           id
+#           echo '*** cat /proc/cpuinfo ***'
+#           cat /proc/cpuinfo
+#           echo '*** free -m ***'
+#           free -m
+#           echo '*** df -m ***'
+#           df -m
+#           echo '*** ifconfig -a ***'
+#           ifconfig -a
+#           echo '*** uname -a ***'
+#           uname -a
+#           echo '*** mount ***'
+#           mount
+#           echo '*** env ***'
+#           env
+#           echo '*** java ***'
+#           which java
+#           java -version
+# 
+#   clone_cassandra:
+#     steps:
+#     - run:
+#         name: Clone Cassandra Repository (via git)
+#         command: |
+#           git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH git://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
+# 
+#   clone_dtest:
+#     steps:
+#     - run:
+#         name: Clone Cassandra dtest Repository (via git)
+#         command: |
+#           git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+# 
+#   build_cassandra:
+#     steps:
+#     - run:
+#         name: Build Cassandra
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           cd ~/cassandra
+#           # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
+#           for x in $(seq 1 3); do
+#               ${ANT_HOME}/bin/ant clean jar
+#               RETURN=\"$?\"
+#               if [ \"${RETURN}\" -eq \"0\" ]; then
+#                   break
+#               fi
+#           done
+#           # Exit, if we didn't build successfully
+#           if [ \"${RETURN}\" -ne \"0\" ]; then
+#               echo \"Build failed with exit code: ${RETURN}\"
+#               exit ${RETURN}
+#           fi
+#         no_output_timeout: 15m
+# 
+#   run_eclipse_warnings:
+#     steps:
+#     - run:
+#         name: Run eclipse-warnings
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           cd ~/cassandra
+#           ant eclipse-warnings
+# 
+#   create_junit_containers:
+#     steps:
+#     - run:
+#         name: Determine Unit Tests to Run
+#         command: |
+#           # reminder: this code (along with all the steps) is independently executed on every circle container
+#           # so the goal here is to get the circleci script to return the tests *this* container will run
+#           # which we do via the `circleci` cli tool.
+# 
+#           rm -fr ~/cassandra-dtest/upgrade_tests
+#           echo \"***java tests***\"
+# 
+#           # get all of our unit test filenames
+#           set -eo pipefail && circleci tests glob \"$HOME/cassandra/test/unit/**/*.java\" > /tmp/all_java_unit_tests.txt
+# 
+#           # split up the unit tests into groups based on the number of containers we have
+#           set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+#           set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | cut -c 37-1000000 | grep \"Test\\.java$\" > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+#           echo \"** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\"
+#           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+# 
+#         no_output_timeout: 15m
+# 
+#   run_junit_tests:
+#     parameters:
+#       target:
+#         type: string
+#       no_output_timeout:
+#         type: string
+#         default: 15m
+#     steps:
+#     - run:
+#         name: Run Unit Tests (<<parameters.target>>)
+#         # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+#         # based on Java 11 builds.
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           time mv ~/cassandra /tmp
+#           cd /tmp/cassandra
+#           ant clean <<parameters.target>>
+#         no_output_timeout: <<parameters.no_output_timeout>>
+#     - store_test_results:
+#         path: /tmp/cassandra/build/test/output/
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/output
+#         destination: junitxml
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/logs
+#         destination: logs
+# 
+#   run_parallel_junit_tests:
+#     parameters:
+#       target:
+#         type: string
+#         default: testclasslist
+#       no_output_timeout:
+#         type: string
+#         default: 15m
+#     steps:
+#     - run:
+#         name: Run Unit Tests (<<parameters.target>>)
+#         # Please note that we run `clean` and therefore rebuild the project, as we can't run tests on Java 8 in case
+#         # based on Java 11 builds.
+#         command: |
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           time mv ~/cassandra /tmp
+#           cd /tmp/cassandra
+#           ant <<parameters.target>> -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+#         no_output_timeout: <<parameters.no_output_timeout>>
+#     - store_test_results:
+#         path: /tmp/cassandra/build/test/output/
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/output
+#         destination: junitxml
+#     - store_artifacts:
+#         path: /tmp/cassandra/build/test/logs
+#         destination: logs
+# 
+#   create_venv:
+#     steps:
+#     - run:
+#         name: Configure virtualenv and python Dependencies
+#         command: |
+#           # note, this should be super quick as all dependencies should be pre-installed in the docker image
+#           # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
+#           # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
+#           # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+#           source ~/env/bin/activate
+#           export PATH=$JAVA_HOME/bin:$PATH
+#           pip3 install --upgrade -r ~/cassandra-dtest/requirements.txt
+#           pip3 freeze
+# 
+#   create_dtest_containers:
+#     parameters:
+#       file_tag:
+#         type: string
+#       run_dtests_extra_args:
+#         type: string
+#         default: ''
+#       extra_env_args:
+#         type: string
+#         default: ''
+#       tests_filter_pattern:
+#         type: string
+#         default: ''
+#     steps:
+#     - run:
+#         name: Determine Tests to Run (<<parameters.file_tag>>)
+#         no_output_timeout: 5m
+#         command: |
+#           # reminder: this code (along with all the steps) is independently executed on every circle container
+#           # so the goal here is to get the circleci script to return the tests *this* container will run
+#           # which we do via the `circleci` cli tool.
+# 
+#           cd cassandra-dtest
+#           source ~/env/bin/activate
+#           export PATH=$JAVA_HOME/bin:$PATH
+# 
+#           if [ -n '<<parameters.extra_env_args>>' ]; then
+#             export <<parameters.extra_env_args>>
+#           fi
+# 
+#           echo \"***Collected DTests (<<parameters.file_tag>>)***\"
+#           set -eo pipefail && ./run_dtests.py <<parameters.run_dtests_extra_args>> --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_<<parameters.file_tag>>_raw --cassandra-dir=../cassandra
+#           if [ -z '<<parameters.tests_filter_pattern>>' ]; then
+#             mv /tmp/all_dtest_tests_<<parameters.file_tag>>_raw /tmp/all_dtest_tests_<<parameters.file_tag>>
+#           else
+#             grep -e '<<parameters.tests_filter_pattern>>' /tmp/all_dtest_tests_<<parameters.file_tag>>_raw > /tmp/all_dtest_tests_<<parameters.file_tag>> || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }
+#           fi
+#           set -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_<<parameters.file_tag>> > /tmp/split_dtest_tests_<<parameters.file_tag>>.txt
+#           cat /tmp/split_dtest_tests_<<parameters.file_tag>>.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+#           cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+# 
+#   run_dtests:
+#     parameters:
+#       file_tag:
+#         type: string
+#       pytest_extra_args:
+#         type: string
+#         default: ''
+#       extra_env_args:
+#         type: string
+#         default: ''
+#     steps:
+#       - run:
+#           name: Run dtests (<<parameters.file_tag>>)
+#           no_output_timeout: 15m
+#           command: |
+#             echo \"cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt\"
+#             cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt
+# 
+#             source ~/env/bin/activate
+#             export PATH=$JAVA_HOME/bin:$PATH
+#             if [ -n '<<parameters.extra_env_args>>' ]; then
+#               export <<parameters.extra_env_args>>
+#             fi
+# 
+#             java -version
+#             cd ~/cassandra-dtest
+#             mkdir -p /tmp/dtest
+# 
+#             echo \"env: $(env)\"
+#             echo \"** done env\"
+#             mkdir -p /tmp/results/dtests
+#             # we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
+#             export SPLIT_TESTS=`cat /tmp/split_dtest_tests_<<parameters.file_tag>>_final.txt`
+#             set -o pipefail && cd ~/cassandra-dtest && pytest <<parameters.pytest_extra_args>> --log-level=\"INFO\" --junit-xml=/tmp/results/dtests/pytest_result_<<parameters.file_tag>>.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
+#       - store_test_results:
+#           path: /tmp/results
+#       - store_artifacts:
+#           path: /tmp/dtest
+#           destination: dtest_<<parameters.file_tag>>
+#       - store_artifacts:
+#           path: ~/cassandra-dtest/logs
+#           destination: dtest_<<parameters.file_tag>>_logs

--- a/.circleci/generate.sh
+++ b/.circleci/generate.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+BASEDIR=`dirname $0`
+
+circleci config process $BASEDIR/config-2_1.yml > $BASEDIR/config.yml.LOWRES
+patch -o $BASEDIR/config-2_1.yml.HIGHRES $BASEDIR/config-2_1.yml $BASEDIR/config-2_1.yml.high_res.patch
+circleci config process $BASEDIR/config-2_1.yml.HIGHRES > $BASEDIR/config.yml.HIGHRES
+rm $BASEDIR/config-2_1.yml.HIGHRES
+

--- a/.circleci/readme.md
+++ b/.circleci/readme.md
@@ -1,0 +1,32 @@
+# CircleCI config files
+
+## Switching to high resource settings
+This directory contains generated files for high and low resource settings. Switch
+between them by copying the correct file to config.yml and committing the result;
+
+`cp .circleci/config.yml.HIGHRES .circleci/config.yml`
+
+Make sure you never edit the config.yml manually.
+
+## Updating the config master
+To update the config (other than just swapping high/low resources) you need to install
+the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/#install).
+
+The directory contains `config-2_1.yml` which is then converted to the actual HIGH/LOW
+resource files. There is a script called `generate.sh` which creates the LOWRES and
+HIGHRES files, read below for details how to do it manually;
+
+1. make your edits to config-2_1.yml - let it stay at lowres settings
+1. generate a valid LOWRES file:
+   `circleci config process config-2_1.yml > config.yml.LOWRES`
+1. then apply the highres patch to config-2_1.yml;
+   `patch -o config-2_1.yml.HIGHRES config-2_1.yml config-2_1.yml.high_res.patch`
+   (this creates a new file `config-2_1.yml.HIGHRES` instead of in-place patching
+   config-2_1.yml)
+   Note that if the patch no longer applies to `config-2_1.yml` a new patch file
+   is needed, do this by manually making `config-2_1.yml` high resource and create
+   the patch file based on the diff (don't commit it though).
+1. generate the HIGHRES file:
+   `circleci config process config-2_1.yml.HIGHRES > config.yml.HIGHRES`
+1. and remove the temporary patched highres `config-2_1.yml.HIGHRES`
+

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -729,6 +729,10 @@ cross_node_timeout: false
 # of the snitch, which will be assumed to be on your classpath.
 endpoint_snitch: SimpleSnitch
 
+# if set true will use DynamicEndpointSnitch , and the endpoint_snitch
+# will be used as the subsnitch in the DynamicEndpointSnitch, if set false
+# will directly use the configured endpoint_snitch.
+dynamic_snitch: true
 # controls how often to perform the more expensive part of host score
 # calculation
 dynamic_snitch_update_interval_in_ms: 100 

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -174,7 +174,7 @@ public class Config
     public int commitlog_periodic_queue_size = -1;
 
     public String endpoint_snitch;
-    public Boolean dynamic_snitch = true;
+    public Boolean dynamic_snitch;
     public Integer dynamic_snitch_update_interval_in_ms = 100;
     public Integer dynamic_snitch_reset_interval_in_ms = 600000;
     public Double dynamic_snitch_badness_threshold = 0.1;

--- a/src/java/org/apache/cassandra/locator/AlibabaCloudSnitch.java
+++ b/src/java/org/apache/cassandra/locator/AlibabaCloudSnitch.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.io.DataInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.utils.FBUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *  A snitch that assumes an ECS region is a DC and an ECS availability_zone
+ *  is a rack. This information is available in the config for the node. the 
+ *  format of the zone-id is like :cn-hangzhou-a where cn means china, hangzhou
+ *  means the hangzhou region, a means the az id. We use cn-hangzhou as the dc,
+ *  and f as the zone-id.
+ */
+public class AlibabaCloudSnitch extends AbstractNetworkTopologySnitch
+{
+    protected static final Logger logger = LoggerFactory.getLogger(AlibabaCloudSnitch.class);
+    protected static final String ZONE_NAME_QUERY_URL = "http://100.100.100.200/latest/meta-data/zone-id";
+    private static final String DEFAULT_DC = "UNKNOWN-DC";
+    private static final String DEFAULT_RACK = "UNKNOWN-RACK";
+    private Map<InetAddress, Map<String, String>> savedEndpoints; 
+    protected String ecsZone;
+    protected String ecsRegion;
+    
+    private static final int HTTP_CONNECT_TIMEOUT = 30000;
+    
+    
+    public AlibabaCloudSnitch() throws MalformedURLException, IOException 
+    {
+        String response = alibabaApiCall(ZONE_NAME_QUERY_URL);
+        String[] splits = response.split("/");
+        String az = splits[splits.length - 1];
+
+        // Split "us-central1-a" or "asia-east1-a" into "us-central1"/"a" and "asia-east1"/"a".
+        splits = az.split("-");
+        ecsZone = splits[splits.length - 1];
+
+        int lastRegionIndex = az.lastIndexOf("-");
+        ecsRegion = az.substring(0, lastRegionIndex);
+
+        String datacenterSuffix = (new SnitchProperties()).get("dc_suffix", "");
+        ecsRegion = ecsRegion.concat(datacenterSuffix);
+        logger.info("AlibabaSnitch using region: {}, zone: {}.", ecsRegion, ecsZone);
+    
+    }
+    
+    String alibabaApiCall(String url) throws ConfigurationException, IOException, SocketTimeoutException
+    {
+        // Populate the region and zone by introspection, fail if 404 on metadata
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        DataInputStream d = null;
+        try
+        {
+            conn.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+            conn.setRequestMethod("GET");
+            
+            int code = conn.getResponseCode();
+            if (code != HttpURLConnection.HTTP_OK)
+                throw new ConfigurationException("AlibabaSnitch was unable to execute the API call. Not an ecs node? and the returun code is " + code);
+
+            // Read the information. I wish I could say (String) conn.getContent() here...
+            int cl = conn.getContentLength();
+            byte[] b = new byte[cl];
+            d = new DataInputStream((FilterInputStream) conn.getContent());
+            d.readFully(b);
+            return new String(b, StandardCharsets.UTF_8);
+        }
+        catch (SocketTimeoutException e)
+        {
+            throw new SocketTimeoutException("SocketTimeout occurs when get response code from Alibaba ECS meta data center.");
+        }
+        finally
+        {
+            FileUtils.close(d);
+            conn.disconnect();
+        }
+    }
+    
+    @Override
+    public String getRack(InetAddress endpoint)
+    {
+        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+            return ecsZone;
+        EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
+        if (state == null || state.getApplicationState(ApplicationState.RACK) == null)
+        {
+            if (savedEndpoints == null)
+                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+            if (savedEndpoints.containsKey(endpoint))
+                return savedEndpoints.get(endpoint).get("rack");
+            return DEFAULT_RACK;
+        }
+        return state.getApplicationState(ApplicationState.RACK).value;
+    
+    }
+
+    @Override
+    public String getDatacenter(InetAddress endpoint) 
+    {
+        if (endpoint.equals(FBUtilities.getBroadcastAddress()))
+            return ecsRegion;
+        EndpointState state = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
+        if (state == null || state.getApplicationState(ApplicationState.DC) == null)
+        {
+            if (savedEndpoints == null)
+                savedEndpoints = SystemKeyspace.loadDcRackInfo();
+            if (savedEndpoints.containsKey(endpoint))
+                return savedEndpoints.get(endpoint).get("data_center");
+            return DEFAULT_DC;
+        }
+        return state.getApplicationState(ApplicationState.DC).value;
+    
+    }
+
+}

--- a/test/unit/org/apache/cassandra/locator/AlibabaCloudSnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/AlibabaCloudSnitchTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import static org.junit.Assert.assertEquals;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.EnumMap;
+import java.util.Map;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.service.StorageService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AlibabaCloudSnitchTest 
+{
+    private static String az;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        DatabaseDescriptor.daemonInitialization();
+        SchemaLoader.mkdirs();
+        SchemaLoader.cleanup();
+        Keyspace.setInitialized();
+        StorageService.instance.initServer(0);
+    }
+
+    private class TestAlibabaCloudSnitch extends AlibabaCloudSnitch
+    {
+        public TestAlibabaCloudSnitch() throws IOException, ConfigurationException
+        {
+            super();
+        }
+
+        @Override
+        String alibabaApiCall(String url) throws IOException, ConfigurationException
+        {
+            return az;
+        }
+    }
+
+    @Test
+    public void testRac() throws IOException, ConfigurationException
+    {
+        az = "cn-hangzhou-f";
+        AlibabaCloudSnitch snitch = new TestAlibabaCloudSnitch();
+        InetAddress local = InetAddress.getByName("127.0.0.1");
+        InetAddress nonlocal = InetAddress.getByName("127.0.0.7");
+
+        Gossiper.instance.addSavedEndpoint(nonlocal);
+        Map<ApplicationState, VersionedValue> stateMap = new EnumMap<>(ApplicationState.class);
+        stateMap.put(ApplicationState.DC, StorageService.instance.valueFactory.datacenter("cn-shanghai"));
+        stateMap.put(ApplicationState.RACK, StorageService.instance.valueFactory.datacenter("a"));
+        Gossiper.instance.getEndpointStateForEndpoint(nonlocal).addApplicationStates(stateMap);
+
+        assertEquals("cn-shanghai", snitch.getDatacenter(nonlocal));
+        assertEquals("a", snitch.getRack(nonlocal));
+
+        assertEquals("cn-hangzhou", snitch.getDatacenter(local));
+        assertEquals("f", snitch.getRack(local));
+    }
+    
+    @Test
+    public void testNewRegions() throws IOException, ConfigurationException
+    {
+        az = "us-east-1a";
+        AlibabaCloudSnitch snitch = new TestAlibabaCloudSnitch();
+        InetAddress local = InetAddress.getByName("127.0.0.1");
+        assertEquals("us-east", snitch.getDatacenter(local));
+        assertEquals("1a", snitch.getRack(local));
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        StorageService.instance.stopClient();
+    }
+
+    
+}


### PR DESCRIPTION
We add a new snitch for Alibaba cloud platform, which user can deploy Cassandra on Alibaba cloud platform more easily. we get the meta data of Alibaba cloud ECS location information (zone-id) from the center throgh http. the zone-id format are the same as aws zone/google cloud platform , like : us-east-a that us-east means the us east region , a is a az under the region . other az may be like b,c,d and so on. 