### PR TITLE
CASSANDRA-15125 Replace Math.random with Replace.nextDouble to remo…

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsNode.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsNode.java
@@ -132,7 +132,8 @@ public class SettingsNode implements Serializable
 
     public String randomNode()
     {
-        int index = (int) (Math.random() * nodes.size());
+	Random rand = new Random();
+        int index = (int) (rand.nextDouble() * nodes.size());
         if (index >= nodes.size())
             index = nodes.size() - 1;
         return nodes.get(index);


### PR DESCRIPTION
…ve performance overhead

[CASSANDRA-15125](https://issues.apache.org/jira/browse/CASSANDRA-15125) Math.random has a slight performance overhead associated with itself that does not exist in Random.nextDouble. These instances of Math.random, such as those sampled below, can be replaced with random.nextDouble. Furthermore, the randomness can be configured via the Random class if such a feature is needed in the future.