### PR TITLE
Remove mismatched placeholder in log

### DIFF
--- a/src/java/org/apache/cassandra/service/NativeTransportService.java
+++ b/src/java/org/apache/cassandra/service/NativeTransportService.java
@@ -153,7 +153,7 @@ public class NativeTransportService
         final boolean enableEpoll = Boolean.parseBoolean(System.getProperty("cassandra.native.epoll.enabled", "true"));
 
         if (enableEpoll && !Epoll.isAvailable() && NativeLibrary.osType == NativeLibrary.OSType.LINUX)
-            logger.warn("epoll not available {}", Epoll.unavailabilityCause());
+            logger.warn("epoll not available", Epoll.unavailabilityCause());
 
         return enableEpoll && Epoll.isAvailable();
     }


### PR DESCRIPTION
A simple change: the placeholder `{}` is mismatched (and misleading) as there is no argument for that. The next argument is a `Throwable` . I.e. the `logger.warn` here is of prototype:
```
void warn(String var1, Throwable var2);
```
