### PR TITLE
Updated git clone url to avoid repository not found exception

### DIFF
--- a/doc/source/development/ide.rst
+++ b/doc/source/development/ide.rst
@@ -24,7 +24,7 @@ Getting started with Cassandra and IntelliJ IDEA or Eclipse is simple, once you 
 
 The source code for Cassandra is shared through the central Apache Git repository and organized by different branches. You can access the code for the current development branch through git as follows::
 
-   git clone http://git-wip-us.apache.org/repos/asf/cassandra.git cassandra-trunk
+   git clone https://git-wip-us.apache.org/repos/asf/cassandra.git cassandra-trunk
 
 Other branches will point to different versions of Cassandra. Switching to a different branch requires checking out the branch by its name::
 


### PR DESCRIPTION
Git clone URL throws repository not found fatal exception.

This issue caught resolved after changing http to https.