### PR TITLE
CASSANDRA-15173 fix log for inconsistent-left-subrange in merkle-tree

### DIFF
--- a/src/java/org/apache/cassandra/utils/MerkleTree.java
+++ b/src/java/org/apache/cassandra/utils/MerkleTree.java
@@ -313,7 +313,7 @@ public class MerkleTree implements Serializable
         }
         else if (!lreso)
         {
-            logger.debug("({}) Left sub-range fully inconsistent {}", active.depth, right);
+            logger.debug("({}) Left sub-range fully inconsistent {}", active.depth, left);
             ldiff = FULLY_INCONSISTENT;
         }
 


### PR DESCRIPTION
see [CASSANDRA-15173](https://issues.apache.org/jira/browse/CASSANDRA-15173)