### PR TITLE
Adds Direct IO support for reads.

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1332,3 +1332,6 @@ enable_sasi_indexes: false
 # Enables creation of transiently replicated keyspaces on this node.
 # Transient replication is experimental and is not recommended for production use.
 enable_transient_replication: false
+
+# enables direct_io for read path of data files.
+enable_direct_io_for_read_path: false

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -461,6 +461,11 @@ public class Config
     public volatile boolean report_unconfirmed_repaired_data_mismatches = false;
 
     /**
+     * Enables direct_io for data file reads.
+     */
+    public boolean enable_direct_io_for_read_path = false;
+
+    /**
      * @deprecated migrate to {@link DatabaseDescriptor#isClientInitialized()}
      */
     @Deprecated

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -75,6 +75,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.cassandra.io.util.FileUtils.ONE_GB;
+import org.apache.cassandra.utils.JavaUtils;
 
 public class DatabaseDescriptor
 {
@@ -294,6 +295,13 @@ public class DatabaseDescriptor
         {
             hasLoggedConfig = true;
             Config.log(config);
+        }
+
+        if (config.enable_direct_io_for_read_path)
+        {
+            logger.info("Initializing support for O_DIRECT");
+            if (JavaUtils.parseJavaVersion(System.getProperty("java.version")) < 11)
+                throw new RuntimeException("Java 11 required, but found " + System.getProperty("java.version"));
         }
 
         return config;
@@ -2866,5 +2874,10 @@ public class DatabaseDescriptor
     public static boolean strictRuntimeChecks()
     {
         return strictRuntimeChecks;
+    }
+
+    public static boolean useDirectIO()
+    {
+        return conf.enable_direct_io_for_read_path;
     }
 }

--- a/src/java/org/apache/cassandra/io/compress/BufferType.java
+++ b/src/java/org/apache/cassandra/io/compress/BufferType.java
@@ -24,13 +24,11 @@ public enum BufferType
 {
     ON_HEAP
     {
-        @Override
         public ByteBuffer allocate(int size)
         {
             return ByteBuffer.allocate(size);
         }
 
-        @Override
         public ByteBuffer allocate(int size, boolean aligned)
         {
             return this.allocate(size);
@@ -38,14 +36,11 @@ public enum BufferType
     },
     OFF_HEAP
     {
-
-        @Override
         public ByteBuffer allocate(int size)
         {
             return ByteBuffer.allocateDirect(size);
         }
 
-        @Override
         public ByteBuffer allocate(int size, boolean aligned) {
             return DirectIOUtils.allocate(size);
         }

--- a/src/java/org/apache/cassandra/io/compress/BufferType.java
+++ b/src/java/org/apache/cassandra/io/compress/BufferType.java
@@ -18,25 +18,42 @@
 package org.apache.cassandra.io.compress;
 
 import java.nio.ByteBuffer;
+import org.apache.cassandra.io.util.DirectIOUtils;
 
 public enum BufferType
 {
     ON_HEAP
     {
+        @Override
         public ByteBuffer allocate(int size)
         {
             return ByteBuffer.allocate(size);
         }
+
+        @Override
+        public ByteBuffer allocate(int size, boolean aligned)
+        {
+            return this.allocate(size);
+        }
     },
     OFF_HEAP
     {
+
+        @Override
         public ByteBuffer allocate(int size)
         {
             return ByteBuffer.allocateDirect(size);
         }
+
+        @Override
+        public ByteBuffer allocate(int size, boolean aligned) {
+            return DirectIOUtils.allocate(size);
+        }
     };
 
     public abstract ByteBuffer allocate(int size);
+
+    public abstract ByteBuffer allocate(int size, boolean aligned);
 
     public static BufferType typeOf(ByteBuffer buffer)
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -452,7 +452,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         try(FileHandle.Builder ibuilder = new FileHandle.Builder(sstable.descriptor.filenameFor(Component.PRIMARY_INDEX))
                                                      .mmapped(DatabaseDescriptor.getIndexAccessMode() == Config.DiskAccessMode.mmap)
                                                      .withChunkCache(ChunkCache.instance);
-            FileHandle.Builder dbuilder = new FileHandle.Builder(sstable.descriptor.filenameFor(Component.DATA)).compressed(sstable.compression)
+            FileHandle.Builder dbuilder = new FileHandle.Builder(sstable.descriptor.filenameFor(Component.DATA), DatabaseDescriptor.useDirectIO()).compressed(sstable.compression)
                                                      .mmapped(DatabaseDescriptor.getDiskAccessMode() == Config.DiskAccessMode.mmap)
                                                      .withChunkCache(ChunkCache.instance))
         {
@@ -787,7 +787,7 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         try(FileHandle.Builder ibuilder = new FileHandle.Builder(descriptor.filenameFor(Component.PRIMARY_INDEX))
                                                      .mmapped(DatabaseDescriptor.getIndexAccessMode() == Config.DiskAccessMode.mmap)
                                                      .withChunkCache(ChunkCache.instance);
-            FileHandle.Builder dbuilder = new FileHandle.Builder(descriptor.filenameFor(Component.DATA)).compressed(compression)
+            FileHandle.Builder dbuilder = new FileHandle.Builder(descriptor.filenameFor(Component.DATA), DatabaseDescriptor.useDirectIO()).compressed(compression)
                                                      .mmapped(DatabaseDescriptor.getDiskAccessMode() == Config.DiskAccessMode.mmap)
                                                      .withChunkCache(ChunkCache.instance))
         {

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -94,8 +94,8 @@ public class BigTableWriter extends SSTableWriter
                     new File(descriptor.filenameFor(Component.DIGEST)),
                     writerOption);
         }
-        dbuilder = new FileHandle.Builder(descriptor.filenameFor(Component.DATA)).compressed(compression)
-                                              .mmapped(DatabaseDescriptor.getDiskAccessMode() == Config.DiskAccessMode.mmap);
+        dbuilder = new FileHandle.Builder(descriptor.filenameFor(Component.DATA), DatabaseDescriptor.useDirectIO()).compressed(compression)
+                                                                                 .mmapped(DatabaseDescriptor.getDiskAccessMode() == Config.DiskAccessMode.mmap);
         chunkCache.ifPresent(dbuilder::withChunkCache);
         iwriter = new IndexWriter(keyCount);
 

--- a/src/java/org/apache/cassandra/io/util/ChannelProxy.java
+++ b/src/java/org/apache/cassandra/io/util/ChannelProxy.java
@@ -55,7 +55,6 @@ public final class ChannelProxy extends SharedCloseableImpl
                    FileChannel.open(file.toPath(), StandardOpenOption.READ, 
                       (OpenOption) Enum.valueOf((Class<? extends Enum>) 
                         Class.forName("com.sun.nio.file.ExtendedOpenOption"), "DIRECT"));
-
         }
         catch (Exception e)
         {
@@ -71,7 +70,6 @@ public final class ChannelProxy extends SharedCloseableImpl
     public ChannelProxy(String filePath, FileChannel channel, boolean useDirectIO)
     {
         super(new Cleanup(filePath, channel));
-
         this.filePath = filePath;
         this.channel = channel;
         this.useDirectIO = useDirectIO;
@@ -108,7 +106,6 @@ public final class ChannelProxy extends SharedCloseableImpl
     public ChannelProxy(ChannelProxy copy)
     {
         super(copy);
-
         this.filePath = copy.filePath;
         this.channel = copy.channel;
         this.useDirectIO = copy.useDirectIO;

--- a/src/java/org/apache/cassandra/io/util/ChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/ChunkReader.java
@@ -48,4 +48,6 @@ public interface ChunkReader extends RebuffererFactory
      * This is not guaranteed to be fulfilled.
      */
     BufferType preferredBufferType();
+
+    boolean useDirectIO();
 }

--- a/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/CompressedChunkReader.java
@@ -124,7 +124,6 @@ public abstract class CompressedChunkReader extends AbstractReaderFileProxy impl
             return !useDirectIO ?
                    metadata.compressor().preferredBufferType().allocate(size) :
                    BufferType.OFF_HEAP.allocate(size + DirectIOUtils.BLOCK_SIZE, true);
-
         }
 
         @Override

--- a/src/java/org/apache/cassandra/io/util/DirectIOUtils.java
+++ b/src/java/org/apache/cassandra/io/util/DirectIOUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.util;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.FSReadError;
+
+public class DirectIOUtils
+{
+    public static final int BLOCK_SIZE;
+
+    static
+    {
+        try
+        {
+            // BLOCK_SIZE is the max of the block sizes of the data file directories.
+            int blockSize = 0;
+            for (String datadir : DatabaseDescriptor.getAllDataFileLocations())
+            {
+                Path path = Paths.get(datadir);
+                if (datadir == null || !Files.exists(path))
+                    throw new ConfigurationException("data_file_directories is not set or does not exist.", false);
+
+                FileStore fs = Files.getFileStore(path);
+                Method method = FileStore.class.getDeclaredMethod("getBlockSize");
+
+                int n = ((Long) method.invoke(fs)).intValue();
+                if (n > blockSize)
+                    blockSize = n;
+            }
+            BLOCK_SIZE = blockSize;
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Allocates a block aligned direct byte buffer. The size of the returned
+     * buffer is the nearest multiple of BLOCK_SIZE to the requested size.
+     *
+     * @param size the requested size of a byte buffer.
+     * @return aligned byte buffer.
+     */
+    public static ByteBuffer allocate(int size)
+    {
+        try
+        {
+            int n = (size + BLOCK_SIZE - 1) / BLOCK_SIZE + 1;
+            Method method = ByteBuffer.class.getDeclaredMethod("alignedSlice", int.class);
+            ByteBuffer buf = ByteBuffer.allocateDirect(n * BLOCK_SIZE);
+            return (ByteBuffer) method.invoke(buf, BLOCK_SIZE);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads a sequence of bytes from the file channel into the given byte buffer.
+     *
+     * We rely on ByteBuffer.compact() method so that the caller of this method
+     * can safely flip() the buffer for reading. Avoiding compact() improves
+     * performance but requires callers of this method to avoid using flip() and
+     * not rely on a position-0 invariant for chunk reader.
+     *
+     * @param channel the channel to read from.
+     * @param dst the destination byte buffer.
+     * @param position the position of the channel to start reading from.
+     * @return the number of bytes read.
+     * @throws IOException
+     */
+    public static int read(FileChannel channel, ByteBuffer dst, long position) throws IOException
+    {
+        int lim = dst.limit();
+        int r = (int) (position & (BLOCK_SIZE - 1));
+        int len = lim + r;
+        dst.limit((len & (BLOCK_SIZE - 1)) == 0 ? len : (len & -BLOCK_SIZE) + BLOCK_SIZE);
+        int n = channel.read(dst, position & -BLOCK_SIZE);
+        n -= r;
+        n = n < lim ? n : lim;
+        dst.position(r).limit(r + n);
+        return n;
+    }
+}
+

--- a/src/java/org/apache/cassandra/io/util/SimpleChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/SimpleChunkReader.java
@@ -46,7 +46,6 @@ class SimpleChunkReader extends AbstractReaderFileProxy implements ChunkReader
     {
         buffer.clear();
         channel.read(buffer, position);
-
         // direct io reads must not reset position, refer to DirectIOUtils.read
         // for details.
         if (!useDirectIO)

--- a/src/java/org/apache/cassandra/io/util/SimpleChunkReader.java
+++ b/src/java/org/apache/cassandra/io/util/SimpleChunkReader.java
@@ -26,12 +26,19 @@ class SimpleChunkReader extends AbstractReaderFileProxy implements ChunkReader
 {
     private final int bufferSize;
     private final BufferType bufferType;
+    private boolean useDirectIO;
 
-    SimpleChunkReader(ChannelProxy channel, long fileLength, BufferType bufferType, int bufferSize)
+    SimpleChunkReader(ChannelProxy channel, long fileLength, BufferType bufferType, int bufferSize, boolean useDirectIO)
     {
         super(channel, fileLength);
         this.bufferSize = bufferSize;
         this.bufferType = bufferType;
+        this.useDirectIO = useDirectIO;
+    }
+
+    SimpleChunkReader(ChannelProxy channel, long fileLength, BufferType bufferType, int bufferSize)
+    {
+        this(channel, fileLength, bufferType, bufferSize, false);
     }
 
     @Override
@@ -39,7 +46,13 @@ class SimpleChunkReader extends AbstractReaderFileProxy implements ChunkReader
     {
         buffer.clear();
         channel.read(buffer, position);
-        buffer.flip();
+
+        // direct io reads must not reset position, refer to DirectIOUtils.read
+        // for details.
+        if (!useDirectIO)
+        {
+            buffer.flip();
+        }
     }
 
     @Override
@@ -69,4 +82,11 @@ class SimpleChunkReader extends AbstractReaderFileProxy implements ChunkReader
                              bufferSize,
                              fileLength());
     }
+
+    @Override
+    public boolean useDirectIO()
+    {
+        return useDirectIO;
+    }
+
 }

--- a/src/java/org/apache/cassandra/utils/JavaUtils.java
+++ b/src/java/org/apache/cassandra/utils/JavaUtils.java
@@ -63,7 +63,7 @@ public final class JavaUtils
      * @return the java version number
      * @throws NumberFormatException if the version cannot be retrieved
      */
-    private static int parseJavaVersion(String jreVersion)
+    public static int parseJavaVersion(String jreVersion)
     {
         String version;
         if (jreVersion.startsWith("1."))


### PR DESCRIPTION
This patch adds a Direct IO support for the read patch. The feature is disabled by default and is enabled by setting the enable_direct_io_for_read_path to true.

Signed-off-by: Mulugeta Mammo <mulugeta.mammo@intel.com>