### PR TITLE
Modernize python 2 codes

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -30,6 +30,7 @@ exit 1
 ":"""
 
 from __future__ import with_statement
+from __future__ import print_function
 
 import cmd
 import codecs
@@ -47,6 +48,13 @@ from StringIO import StringIO
 from contextlib import contextmanager
 from glob import glob
 from uuid import UUID
+
+try:
+    raw_input
+    unicode
+except NameError:
+    raw_input = input
+    unicode = str
 
 if sys.version_info[0] != 2 or sys.version_info[1] != 7:
     sys.exit("\nCQL Shell supports only Python 2.7\n")
@@ -243,7 +251,7 @@ HISTORY_DIR = os.path.expanduser(os.path.join('~', '.cassandra'))
 if hasattr(options, 'cqlshrc'):
     CONFIG_FILE = options.cqlshrc
     if not os.path.exists(CONFIG_FILE):
-        print '\nWarning: Specified cqlshrc location `%s` does not exist.  Using `%s` instead.\n' % (CONFIG_FILE, HISTORY_DIR)
+        print('\nWarning: Specified cqlshrc location `%s` does not exist.  Using `%s` instead.\n' % (CONFIG_FILE, HISTORY_DIR))
         CONFIG_FILE = os.path.join(HISTORY_DIR, 'cqlshrc')
 else:
     CONFIG_FILE = os.path.join(HISTORY_DIR, 'cqlshrc')
@@ -253,16 +261,16 @@ if not os.path.exists(HISTORY_DIR):
     try:
         os.mkdir(HISTORY_DIR)
     except OSError:
-        print '\nWarning: Cannot create directory at `%s`. Command history will not be saved.\n' % HISTORY_DIR
+        print('\nWarning: Cannot create directory at `%s`. Command history will not be saved.\n' % HISTORY_DIR)
 
 OLD_CONFIG_FILE = os.path.expanduser(os.path.join('~', '.cqlshrc'))
 if os.path.exists(OLD_CONFIG_FILE):
     if os.path.exists(CONFIG_FILE):
-        print '\nWarning: cqlshrc config files were found at both the old location (%s) and \
+        print('\nWarning: cqlshrc config files were found at both the old location (%s) and \
                 the new location (%s), the old config file will not be migrated to the new \
                 location, and the new location will be used for now.  You should manually \
                 consolidate the config files at the new location and remove the old file.' \
-                % (OLD_CONFIG_FILE, CONFIG_FILE)
+                % (OLD_CONFIG_FILE, CONFIG_FILE))
     else:
         os.rename(OLD_CONFIG_FILE, CONFIG_FILE)
 OLD_HISTORY = os.path.expanduser(os.path.join('~', '.cqlsh_history'))
@@ -424,7 +432,7 @@ class FrozenType(cassandra.cqltypes._ParameterizedType):
 
 class Shell(cmd.Cmd):
     custom_prompt = os.getenv('CQLSH_PROMPT', '')
-    if custom_prompt is not '':
+    if custom_prompt != '':
         custom_prompt += "\n"
     default_prompt = custom_prompt + "cqlsh> "
     continue_prompt = "   ... "
@@ -538,7 +546,7 @@ class Shell(cmd.Cmd):
         if tty:
             self.reset_prompt()
             self.report_connection()
-            print 'Use HELP for help.'
+            print('Use HELP for help.')
         else:
             self.show_line_nums = True
         self.stdin = stdin
@@ -605,10 +613,10 @@ class Shell(cmd.Cmd):
         self.show_version()
 
     def show_host(self):
-        print "Connected to %s at %s:%d." % \
+        print("Connected to %s at %s:%d." % \
             (self.applycolor(self.get_cluster_name(), BLUE),
               self.hostname,
-              self.port)
+              self.port))
 
     def show_version(self):
         vers = self.connection_versions.copy()
@@ -616,7 +624,7 @@ class Shell(cmd.Cmd):
         # system.Versions['cql'] apparently does not reflect changes with
         # set_cql_version.
         vers['cql'] = self.cql_version
-        print "[cqlsh %(shver)s | Cassandra %(build)s | CQL spec %(cql)s | Native protocol v%(protocol)s]" % vers
+        print("[cqlsh %(shver)s | Cassandra %(build)s | CQL spec %(cql)s | Native protocol v%(protocol)s]" % vers)
 
     def show_session(self, sessionid, partial_session=False):
         print_trace_session(self, self.session, sessionid, partial_session)
@@ -898,7 +906,7 @@ class Shell(cmd.Cmd):
                 import readline
             except ImportError:
                 if is_win:
-                    print "WARNING: pyreadline dependency missing.  Install to enable tab completion."
+                    print("WARNING: pyreadline dependency missing.  Install to enable tab completion.")
                 pass
             else:
                 old_completer = readline.get_completer()
@@ -966,7 +974,7 @@ class Shell(cmd.Cmd):
                     self.printerr(cqlerr.message.decode(encoding='utf-8'))
                 except KeyboardInterrupt:
                     self.reset_statement()
-                    print
+                    print()
 
     def onecmd(self, statementtext):
         """
@@ -1006,7 +1014,7 @@ class Shell(cmd.Cmd):
 
     def handle_eof(self):
         if self.tty:
-            print
+            print()
         statement = self.statement.getvalue()
         if statement.strip():
             if not self.onecmd(statement):
@@ -1348,63 +1356,63 @@ class Shell(cmd.Cmd):
         out.write("\n")
 
     def describe_keyspaces(self):
-        print
+        print()
         cmd.Cmd.columnize(self, protect_names(self.get_keyspace_names()))
-        print
+        print()
 
     def describe_keyspace(self, ksname):
-        print
+        print()
         self.print_recreate_keyspace(self.get_keyspace_meta(ksname), sys.stdout)
-        print
+        print()
 
     def describe_columnfamily(self, ksname, cfname):
         if ksname is None:
             ksname = self.current_keyspace
         if ksname is None:
             raise NoKeyspaceError("No keyspace specified and no current keyspace")
-        print
+        print()
         self.print_recreate_columnfamily(ksname, cfname, sys.stdout)
-        print
+        print()
 
     def describe_index(self, ksname, idxname):
-        print
+        print()
         self.print_recreate_index(ksname, idxname, sys.stdout)
-        print
+        print()
 
     def describe_materialized_view(self, ksname, viewname):
         if ksname is None:
             ksname = self.current_keyspace
         if ksname is None:
             raise NoKeyspaceError("No keyspace specified and no current keyspace")
-        print
+        print()
         self.print_recreate_materialized_view(ksname, viewname, sys.stdout)
-        print
+        print()
 
     def describe_object(self, ks, name):
-        print
+        print()
         self.print_recreate_object(ks, name, sys.stdout)
-        print
+        print()
 
     def describe_columnfamilies(self, ksname):
-        print
+        print()
         if ksname is None:
             for k in self.get_keyspaces():
                 name = protect_name(k.name)
-                print 'Keyspace %s' % (name,)
-                print '---------%s' % ('-' * len(name))
+                print('Keyspace %s' % (name,))
+                print('---------%s' % ('-' * len(name)))
                 cmd.Cmd.columnize(self, protect_names(self.get_columnfamily_names(k.name)))
-                print
+                print()
         else:
             cmd.Cmd.columnize(self, protect_names(self.get_columnfamily_names(ksname)))
-            print
+            print()
 
     def describe_functions(self, ksname):
-        print
+        print()
         if ksname is None:
             for ksmeta in self.get_keyspaces():
                 name = protect_name(ksmeta.name)
-                print 'Keyspace %s' % (name,)
-                print '---------%s' % ('-' * len(name))
+                print('Keyspace %s' % (name,))
+                print('---------%s' % ('-' * len(name)))
                 self._columnize_unicode(ksmeta.functions.keys())
         else:
             ksmeta = self.get_keyspace_meta(ksname)
@@ -1415,21 +1423,21 @@ class Shell(cmd.Cmd):
             ksname = self.current_keyspace
         if ksname is None:
             raise NoKeyspaceError("No keyspace specified and no current keyspace")
-        print
+        print()
         ksmeta = self.get_keyspace_meta(ksname)
         functions = filter(lambda f: f.name == functionname, ksmeta.functions.values())
         if len(functions) == 0:
             raise FunctionNotFound("User defined function %r not found" % functionname)
-        print "\n\n".join(func.export_as_string() for func in functions)
-        print
+        print("\n\n".join(func.export_as_string() for func in functions))
+        print()
 
     def describe_aggregates(self, ksname):
-        print
+        print()
         if ksname is None:
             for ksmeta in self.get_keyspaces():
                 name = protect_name(ksmeta.name)
-                print 'Keyspace %s' % (name,)
-                print '---------%s' % ('-' * len(name))
+                print('Keyspace %s' % (name,))
+                print('---------%s' % ('-' * len(name)))
                 self._columnize_unicode(ksmeta.aggregates.keys())
         else:
             ksmeta = self.get_keyspace_meta(ksname)
@@ -1440,21 +1448,21 @@ class Shell(cmd.Cmd):
             ksname = self.current_keyspace
         if ksname is None:
             raise NoKeyspaceError("No keyspace specified and no current keyspace")
-        print
+        print()
         ksmeta = self.get_keyspace_meta(ksname)
         aggregates = filter(lambda f: f.name == aggregatename, ksmeta.aggregates.values())
         if len(aggregates) == 0:
             raise FunctionNotFound("User defined aggregate %r not found" % aggregatename)
-        print "\n\n".join(aggr.export_as_string() for aggr in aggregates)
-        print
+        print("\n\n".join(aggr.export_as_string() for aggr in aggregates))
+        print()
 
     def describe_usertypes(self, ksname):
-        print
+        print()
         if ksname is None:
             for ksmeta in self.get_keyspaces():
                 name = protect_name(ksmeta.name)
-                print 'Keyspace %s' % (name,)
-                print '---------%s' % ('-' * len(name))
+                print('Keyspace %s' % (name,))
+                print('---------%s' % ('-' * len(name)))
                 self._columnize_unicode(ksmeta.user_types.keys(), quote=True)
         else:
             ksmeta = self.get_keyspace_meta(ksname)
@@ -1465,13 +1473,13 @@ class Shell(cmd.Cmd):
             ksname = self.current_keyspace
         if ksname is None:
             raise NoKeyspaceError("No keyspace specified and no current keyspace")
-        print
+        print()
         ksmeta = self.get_keyspace_meta(ksname)
         try:
             usertype = ksmeta.user_types[typename]
         except KeyError:
             raise UserTypeNotFound("User type %r not found" % typename)
-        print usertype.export_as_string()
+        print(usertype.export_as_string())
 
     def _columnize_unicode(self, name_list, quote=False):
         """
@@ -1481,28 +1489,28 @@ class Shell(cmd.Cmd):
         if quote:
             names = protect_names(names)
         cmd.Cmd.columnize(self, names)
-        print
+        print()
 
     def describe_cluster(self):
-        print '\nCluster: %s' % self.get_cluster_name()
+        print('\nCluster: %s' % self.get_cluster_name())
         p = trim_if_present(self.get_partitioner(), 'org.apache.cassandra.dht.')
-        print 'Partitioner: %s\n' % p
+        print('Partitioner: %s\n' % p)
         # TODO: snitch?
         # snitch = trim_if_present(self.get_snitch(), 'org.apache.cassandra.locator.')
         # print 'Snitch: %s\n' % snitch
         if self.current_keyspace is not None and self.current_keyspace != 'system':
-            print "Range ownership:"
+            print("Range ownership:")
             ring = self.get_ring(self.current_keyspace)
             for entry in ring.items():
-                print ' %39s  [%s]' % (str(entry[0].value), ', '.join([host.address for host in entry[1]]))
-            print
+                print(' %39s  [%s]' % (str(entry[0].value), ', '.join([host.address for host in entry[1]])))
+            print()
 
     def describe_schema(self, include_system=False):
-        print
+        print()
         for k in self.get_keyspaces():
             if include_system or k.name not in cql3handling.SYSTEM_KEYSPACES:
                 self.print_recreate_keyspace(k, sys.stdout)
-                print
+                print()
 
     def do_describe(self, parsed):
         """
@@ -1880,9 +1888,9 @@ class Shell(cmd.Cmd):
         fname = parsed.get_binding('fname')
         if fname is None:
             if self.shunted_query_out is not None:
-                print "Currently capturing query output to %r." % (self.query_out.name,)
+                print("Currently capturing query output to %r." % (self.query_out.name,))
             else:
-                print "Currently not capturing query output."
+                print("Currently not capturing query output.")
             return
 
         if fname.upper() == 'OFF':
@@ -1911,7 +1919,7 @@ class Shell(cmd.Cmd):
         self.shunted_color = self.color
         self.query_out = f
         self.color = False
-        print 'Now capturing query output to %r.' % (fname,)
+        print('Now capturing query output to %r.' % (fname,))
 
     def do_tracing(self, parsed):
         """
@@ -1975,11 +1983,11 @@ class Shell(cmd.Cmd):
         """
         level = parsed.get_binding('level')
         if level is None:
-            print 'Current consistency level is %s.' % (cassandra.ConsistencyLevel.value_to_name[self.consistency_level])
+            print('Current consistency level is %s.' % (cassandra.ConsistencyLevel.value_to_name[self.consistency_level]))
             return
 
         self.consistency_level = cassandra.ConsistencyLevel.name_to_value[level.upper()]
-        print 'Consistency level set to %s.' % (level.upper(),)
+        print('Consistency level set to %s.' % (level.upper(),))
 
     def do_serial(self, parsed):
         """
@@ -2001,11 +2009,11 @@ class Shell(cmd.Cmd):
         """
         level = parsed.get_binding('level')
         if level is None:
-            print 'Current serial consistency level is %s.' % (cassandra.ConsistencyLevel.value_to_name[self.serial_consistency_level])
+            print('Current serial consistency level is %s.' % (cassandra.ConsistencyLevel.value_to_name[self.serial_consistency_level]))
             return
 
         self.serial_consistency_level = cassandra.ConsistencyLevel.name_to_value[level.upper()]
-        print 'Serial consistency level set to %s.' % (level.upper(),)
+        print('Serial consistency level set to %s.' % (level.upper(),))
 
     def do_login(self, parsed):
         """
@@ -2205,11 +2213,11 @@ class SwitchCommand(object):
         switch = parsed.get_binding('switch')
         if switch is None:
             if state:
-                print "%s is currently enabled. Use %s OFF to disable" \
-                      % (self.description, self.command)
+                print("%s is currently enabled. Use %s OFF to disable" \
+                      % (self.description, self.command))
             else:
-                print "%s is currently disabled. Use %s ON to enable." \
-                      % (self.description, self.command)
+                print("%s is currently disabled. Use %s ON to enable." \
+                      % (self.description, self.command))
             return state
 
         if switch.upper() == 'ON':
@@ -2217,14 +2225,14 @@ class SwitchCommand(object):
                 printerr('%s is already enabled. Use %s OFF to disable.'
                          % (self.description, self.command))
                 return state
-            print 'Now %s is enabled' % (self.description,)
+            print('Now %s is enabled' % (self.description,))
             return True
 
         if switch.upper() == 'OFF':
             if not state:
                 printerr('%s is not enabled.' % (self.description,))
                 return state
-            print 'Disabled %s.' % (self.description,)
+            print('Disabled %s.' % (self.description,))
             return False
 
 

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -143,7 +143,7 @@ for lib in third_parties:
 warnings.filterwarnings("ignore", r".*blist.*")
 try:
     import cassandra
-except ImportError, e:
+except ImportError as e:
     sys.exit("\nPython Cassandra driver not installed, or not on PYTHONPATH.\n"
              'You might try "pip install cassandra-driver".\n\n'
              'Python: %s\n'
@@ -583,7 +583,7 @@ class Shell(cmd.Cmd):
             return format_value(val, cqltype=cqltype, encoding=self.output_codec.name,
                                 addcolor=self.color, date_time_format=dtformats,
                                 float_precision=precision, **kwargs)
-        except Exception, e:
+        except Exception as e:
             err = FormatError(val, e)
             self.decoding_errors.append(err)
             return format_value(err, cqltype=cqltype, encoding=self.output_codec.name, addcolor=self.color)
@@ -962,7 +962,7 @@ class Shell(cmd.Cmd):
                         self.reset_statement()
                 except EOFError:
                     self.handle_eof()
-                except CQL_ERRORS, cqlerr:
+                except CQL_ERRORS as cqlerr:
                     self.printerr(cqlerr.message.decode(encoding='utf-8'))
                 except KeyboardInterrupt:
                     self.reset_statement()
@@ -976,7 +976,7 @@ class Shell(cmd.Cmd):
 
         try:
             statements, endtoken_escaped = cqlruleset.cql_split_statements(statementtext)
-        except pylexotron.LexingError, e:
+        except pylexotron.LexingError as e:
             if self.show_line_nums:
                 self.printerr('Invalid syntax at char %d' % (e.charnum,))
             else:
@@ -997,7 +997,7 @@ class Shell(cmd.Cmd):
         for st in statements:
             try:
                 self.handle_statement(st, statementtext)
-            except Exception, e:
+            except Exception as e:
                 if self.debug:
                     traceback.print_exc()
                 else:
@@ -1085,7 +1085,7 @@ class Shell(cmd.Cmd):
                     self.writeresult(msg, color=RED)
                     for trace_id in future.get_query_trace_ids():
                         self.show_session(trace_id, partial_session=True)
-                except Exception, err:
+                except Exception as err:
                     self.printerr("Unable to fetch query trace: %s" % (str(err),))
 
         return success
@@ -1122,7 +1122,7 @@ class Shell(cmd.Cmd):
         result = None
         try:
             result = future.result()
-        except CQL_ERRORS, err:
+        except CQL_ERRORS as err:
             self.printerr(unicode(err.__class__.__name__) + u": " + err.message.decode(encoding='utf-8'))
         except Exception:
             import traceback
@@ -1827,7 +1827,7 @@ class Shell(cmd.Cmd):
             encoding, bom_size = get_file_encoding_bomsize(fname)
             f = codecs.open(fname, 'r', encoding)
             f.seek(bom_size)
-        except IOError, e:
+        except IOError as e:
             self.printerr('Could not open %r: %s' % (fname, e))
             return
         username = self.auth_provider.username if self.auth_provider else None
@@ -1904,7 +1904,7 @@ class Shell(cmd.Cmd):
         fname = os.path.expanduser(self.cql_unprotect_value(fname))
         try:
             f = open(fname, 'a')
-        except IOError, e:
+        except IOError as e:
             self.printerr('Could not open %r for append: %s' % (fname, e))
             return
         self.shunted_query_out = self.query_out
@@ -2431,7 +2431,7 @@ def main(options, hostname, port):
             encoding, bom_size = get_file_encoding_bomsize(options.file)
             stdin = codecs.open(options.file, 'r', encoding)
             stdin.seek(bom_size)
-        except IOError, e:
+        except IOError as e:
             sys.exit("Can't open %r: %s" % (options.file, e))
 
     if options.debug:
@@ -2498,9 +2498,9 @@ def main(options, hostname, port):
                       allow_server_port_discovery=options.allow_server_port_discovery)
     except KeyboardInterrupt:
         sys.exit('Connection aborted.')
-    except CQL_ERRORS, e:
+    except CQL_ERRORS as e:
         sys.exit('Connection error: %s' % (e,))
-    except VersionNotSupported, e:
+    except VersionNotSupported as e:
         sys.exit('Unsupported CQL version: %s' % (e,))
     if options.debug:
         shell.debug = True

--- a/doc/convert_yaml_to_rst.py
+++ b/doc/convert_yaml_to_rst.py
@@ -22,6 +22,7 @@ Usage:
 
     convert_yaml_to_rest.py conf/cassandra.yaml docs/source/conf.rst
 """
+from __future__ import print_function
 
 import sys
 import re
@@ -137,7 +138,7 @@ def write_complex_option(lines, outfile):
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print >> sys.stderr, "Usage: %s <yaml source file> <rst dest file>" % (sys.argv[0],)
+        print("Usage: %s <yaml source file> <rst dest file>" % (sys.argv[0],), file=sys.stderr)
         sys.exit(1)
 
     yaml_file = sys.argv[1]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,7 @@ cassandra_build_file = '../../build.xml'
 with open(cassandra_build_file) as f:
     m = re.search("name=\"base\.version\" value=\"([^\"]+)\"", f.read())
     if not m or m.lastindex != 1:
-        raise RuntimeException("Problem finding version in build.xml file, this shouldn't happen.")
+        raise RuntimeError("Problem finding version in build.xml file, this shouldn't happen.")
     cassandra_version = m.group(1)
 
 def setup(sphinx):

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -138,7 +138,7 @@ class SendingChannel(object):
                 try:
                     msg = self.pending_messages.get()
                     self.pipe.send(msg)
-                except Exception, e:
+                except Exception as e:
                     printmsg('%s: %s' % (e.__class__.__name__, e.message))
 
         feeding_thread = threading.Thread(target=feed)
@@ -580,7 +580,7 @@ class ExportWriter(object):
                 ret = CsvDest(output=open(source_name, 'wb'), close=True)
                 self.num_files += 1
                 return ret
-            except IOError, e:
+            except IOError as e:
                 self.shell.printerr("Can't open %r for writing: %s" % (source_name, e))
                 return None
 
@@ -730,8 +730,7 @@ class ExportTask(CopyTask):
             ranges[(begin_token, end_token)] = make_range_data()
             return ranges
 
-        ring = shell.get_ring(self.ks).items()
-        ring.sort()
+        ring = sorted(shell.get_ring(self.ks).items())
 
         if not ring:
             #  If the ring is empty we get the entire ring from the host we are currently connected to
@@ -882,7 +881,7 @@ class FilesReader(object):
         def make_source(fname):
             try:
                 return open(fname, 'rb')
-            except IOError, e:
+            except IOError as e:
                 raise IOError("Can't open %r for reading: %s" % (fname, e))
 
         for path in paths.split(','):
@@ -913,14 +912,14 @@ class FilesReader(object):
         self.close_current_source()
         while self.current_source is None:
             try:
-                self.current_source = self.sources.next()
+                self.current_source = next(self.sources)
                 if self.current_source:
                     self.num_sources += 1
             except StopIteration:
                 return False
 
         if self.header:
-            self.current_source.next()
+            next(self.current_source)
 
         return True
 
@@ -941,7 +940,7 @@ class FilesReader(object):
         rows = []
         for i in xrange(min(max_rows, self.chunk_size)):
             try:
-                row = self.current_source.next()
+                row = next(self.current_source)
                 self.num_read += 1
 
                 if 0 <= self.max_rows < self.num_read:
@@ -1172,7 +1171,7 @@ class ImportTask(CopyTask):
             if pr:
                 profile_off(pr, file_name='parent_profile_%d.txt' % (os.getpid(),))
 
-        except Exception, exc:
+        except Exception as exc:
             shell.printerr(unicode(exc))
             if shell.debug:
                 traceback.print_exc()
@@ -1329,7 +1328,7 @@ class FeedingProcess(mp.Process):
         reader = self.reader
         try:
             reader.start()
-        except IOError, exc:
+        except IOError as exc:
             self.outmsg.send(ImportTaskError(exc.__class__.__name__, exc.message))
 
         channels = self.worker_channels
@@ -1358,7 +1357,7 @@ class FeedingProcess(mp.Process):
                     rows = reader.read_rows(max_rows)
                     if rows:
                         sent += self.send_chunk(ch, rows)
-                except Exception, exc:
+                except Exception as exc:
                     self.outmsg.send(ImportTaskError(exc.__class__.__name__, exc.message))
 
                 if reader.exhausted:
@@ -1626,7 +1625,7 @@ class ExportProcess(ChildProcess):
         for host in hosts:
             try:
                 ret = self.connect(host)
-            except Exception, e:
+            except Exception as e:
                 errors.append(self.get_error_message(e))
 
             if ret:
@@ -1697,7 +1696,7 @@ class ExportProcess(ChildProcess):
             self.send((token_range, data))
             output.close()
 
-        except Exception, e:
+        except Exception as e:
             self.report_error(e, token_range)
 
     def format_value(self, val, cqltype):
@@ -2102,7 +2101,7 @@ class ImportConversion(object):
         def convert(c, v):
             try:
                 return c(v) if v != self.nullval else self.get_null_val()
-            except Exception, e:
+            except Exception as e:
                 # if we could not convert an empty string, then self.nullval has been set to a marker
                 # because the user needs to import empty strings, except that the converters for some types
                 # will fail to convert an empty string, in this case the null value should be inserted
@@ -2321,7 +2320,7 @@ class ImportProcess(ChildProcess):
             if pr:
                 profile_off(pr, file_name='worker_profile_%d.txt' % (os.getpid(),))
 
-        except Exception, exc:
+        except Exception as exc:
             self.report_error(exc)
 
         finally:
@@ -2399,14 +2398,14 @@ class ImportProcess(ChildProcess):
                     # causes the statement to be None, then we should not report the error so that we can test
                     # the parent process handling missing batches from child processes
 
-            except Exception, exc:
+            except Exception as exc:
                 self.report_error(exc, chunk, chunk['rows'])
 
     def wrap_make_statement(self, inner_make_statement):
         def make_statement(query, conv, chunk, batch, replicas):
             try:
                 return inner_make_statement(query, conv, batch, replicas)
-            except Exception, exc:
+            except Exception as exc:
                 print "Failed to make batch statement: {}".format(exc)
                 self.report_error(exc, chunk, batch['rows'])
                 return None
@@ -2477,7 +2476,7 @@ class ImportProcess(ChildProcess):
         def convert_row(r):
             try:
                 return conv.convert_row(r)
-            except Exception, err:
+            except Exception as err:
                 errors[err.message].append(r)
                 return None
 
@@ -2549,7 +2548,7 @@ class ImportProcess(ChildProcess):
             try:
                 pk = get_row_partition_key_values(row)
                 rows_by_ring_pos[get_ring_pos(ring, pk_to_token_value(pk))].append(row)
-            except Exception, e:
+            except Exception as e:
                 errors[e.message].append(row)
 
         if errors:

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # cython: profile=True
 
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -55,6 +56,15 @@ from cql3handling import CqlRuleSet
 from displaying import NO_COLOR_MAP
 from formatting import format_value_default, CqlType, DateTimeFormat, EMPTY, get_formatter
 from sslhandling import ssl_settings
+
+try:
+    long
+    unicode
+    xrange
+except NameError:
+    long = int
+    unicode = str
+    xrange = range
 
 PROFILE_ON = False
 STRACE_ON = False
@@ -1194,7 +1204,7 @@ class ImportTask(CopyTask):
 
         self.outmsg.channels[-1].send(None)
         if shell.tty:
-            print
+            print()
 
     def import_records(self):
         """
@@ -2406,7 +2416,7 @@ class ImportProcess(ChildProcess):
             try:
                 return inner_make_statement(query, conv, batch, replicas)
             except Exception as exc:
-                print "Failed to make batch statement: {}".format(exc)
+                print("Failed to make batch statement: {}".format(exc))
                 self.report_error(exc, chunk, batch['rows'])
                 return None
 

--- a/pylib/cqlshlib/cqlhandling.py
+++ b/pylib/cqlshlib/cqlhandling.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -74,7 +75,7 @@ class CqlParsingRuleSet(pylexotron.ParsingRuleSet):
                 if cass is None:
                     return ()
                 return f(ctxt, cass)
-            completerwrapper.func_name = 'completerwrapper_on_' + f.func_name
+            completerwrapper.__name__ = 'completerwrapper_on_' + f.__name__
             self.register_completer(completerwrapper, rulename, symname)
             return completerwrapper
         return registrator
@@ -257,7 +258,7 @@ class CqlParsingRuleSet(pylexotron.ParsingRuleSet):
         init_bindings = {'cassandra_conn': cassandra_conn}
         if debug:
             init_bindings['*DEBUG*'] = True
-            print "cql_complete(%r, partial=%r)" % (text, partial)
+            print("cql_complete(%r, partial=%r)" % (text, partial))
 
         completions, hints = self.cql_complete_single(text, partial, init_bindings,
                                                       startsymbol=startsymbol)
@@ -269,12 +270,12 @@ class CqlParsingRuleSet(pylexotron.ParsingRuleSet):
         if len(completions) == 1 and len(hints) == 0:
             c = completions[0]
             if debug:
-                print "** Got one completion: %r. Checking for further matches...\n" % (c,)
+                print("** Got one completion: %r. Checking for further matches...\n" % (c,))
             if not c.isspace():
                 new_c = self.cql_complete_multiple(text, c, init_bindings, startsymbol=startsymbol)
                 completions = [new_c]
             if debug:
-                print "** New list of completions: %r" % (completions,)
+                print("** New list of completions: %r" % (completions,))
 
         return hints + completions
 
@@ -285,18 +286,18 @@ class CqlParsingRuleSet(pylexotron.ParsingRuleSet):
                                                           startsymbol=startsymbol)
         except Exception:
             if debug:
-                print "** completion expansion had a problem:"
+                print("** completion expansion had a problem:")
                 traceback.print_exc()
             return first
         if hints:
             if not first[-1].isspace():
                 first += ' '
             if debug:
-                print "** completion expansion found hints: %r" % (hints,)
+                print("** completion expansion found hints: %r" % (hints,))
             return first
         if len(completions) == 1 and completions[0] != '':
             if debug:
-                print "** Got another completion: %r." % (completions[0],)
+                print("** Got another completion: %r." % (completions[0],))
             if completions[0][0] in (',', ')', ':') and first[-1] == ' ':
                 first = first[:-1]
             first += completions[0]
@@ -307,10 +308,10 @@ class CqlParsingRuleSet(pylexotron.ParsingRuleSet):
             if common_prefix[0] in (',', ')', ':') and first[-1] == ' ':
                 first = first[:-1]
             if debug:
-                print "** Got a partial completion: %r." % (common_prefix,)
+                print("** Got a partial completion: %r." % (common_prefix,))
             return first + common_prefix
         if debug:
-            print "** New total completion: %r. Checking for further matches...\n" % (first,)
+            print("** New total completion: %r. Checking for further matches...\n" % (first,))
         return self.cql_complete_multiple(text, first, init_bindings, startsymbol=startsymbol)
 
     @staticmethod

--- a/pylib/cqlshlib/cqlhandling.py
+++ b/pylib/cqlshlib/cqlhandling.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,9 +17,16 @@ from __future__ import print_function
 # code for dealing with CQL's syntax, rules, interpretation
 # i.e., stuff that's not necessarily cqlsh-specific
 
+from __future__ import print_function
+
 import traceback
 from cassandra.metadata import cql_keywords_reserved
 from . import pylexotron, util
+
+try:
+    unicode
+except NameError:
+    unicode = str
 
 Hint = pylexotron.Hint
 

--- a/pylib/cqlshlib/formatting.py
+++ b/pylib/cqlshlib/formatting.py
@@ -453,14 +453,14 @@ def decode_unsigned_vint(buf):
     For example, if we need to read 3 more bytes the first byte will start with 1110.
     """
 
-    first_byte = buf.next()
+    first_byte = next(buf)
     if (first_byte >> 7) == 0:
         return first_byte
 
     size = number_of_extra_bytes_to_read(first_byte)
     retval = first_byte & (0xff >> size)
     for i in range(size):
-        b = buf.next()
+        b = next(buf)
         retval <<= 8
         retval |= b & 0xff
 

--- a/pylib/cqlshlib/pylexotron.py
+++ b/pylib/cqlshlib/pylexotron.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -146,7 +147,7 @@ class matcher:
         except KeyError:
             return False
         if debugging:
-            print "Trying completer %r with %r" % (completer, ctxt)
+            print("Trying completer %r with %r" % (completer, ctxt))
         try:
             new_compls = completer(ctxt)
         except Exception:
@@ -155,7 +156,7 @@ class matcher:
                 traceback.print_exc()
             return False
         if debugging:
-            print "got %r" % (new_compls,)
+            print("got %r" % (new_compls,))
         completions.update(new_compls)
         return True
 
@@ -284,7 +285,7 @@ class text_match(terminal_matcher):
         try:
             terminal_matcher.__init__(self, eval(text))
         except SyntaxError:
-            print "bad syntax %r" % (text,)
+            print("bad syntax %r" % (text,))
 
     def match(self, ctxt, completions):
         if ctxt.remainder:
@@ -382,7 +383,7 @@ class ParsingRuleSet:
         tokeniter = iter(tokens)
         for t in tokeniter:
             if isinstance(t, tuple) and t[0] in ('reference', 'junk'):
-                assign = tokeniter.next()
+                assign = next(tokeniter)
                 if assign != '::=':
                     raise ValueError('Unexpected token %r; expected "::="' % (assign,))
                 name = t[1]
@@ -441,7 +442,7 @@ class ParsingRuleSet:
             elif t == '*':
                 t = repeat(myrules.pop(-1))
             elif t == '@':
-                x = tokeniter.next()
+                x = next(tokeniter)
                 if not isinstance(x, tuple) or x[0] != 'litstring':
                     raise ValueError("Unexpected token %r following '@'" % (x,))
                 t = case_match(x[1])

--- a/pylib/cqlshlib/pylexotron.py
+++ b/pylib/cqlshlib/pylexotron.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,9 +14,15 @@ from __future__ import print_function
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import re
 from .saferscanner import SaferScanner
 
+try:
+    basestring
+except NameError:
+    basestring = str
 
 class LexingError(Exception):
 

--- a/pylib/cqlshlib/test/ansi_colors.py
+++ b/pylib/cqlshlib/test/ansi_colors.py
@@ -16,7 +16,7 @@
 
 import re
 
-LIGHT = 010
+LIGHT = 0o10
 
 ansi_CSI = '\033['
 ansi_seq = re.compile(re.escape(ansi_CSI) + r'(?P<params>[\x20-\x3f]*)(?P<final>[\x40-\x7e])')
@@ -24,21 +24,21 @@ ansi_cmd_SGR = 'm'  # set graphics rendition
 
 color_defs = (
     (000, 'k', 'black'),
-    (001, 'r', 'dark red'),
-    (002, 'g', 'dark green'),
-    (003, 'w', 'brown', 'dark yellow'),
-    (004, 'b', 'dark blue'),
-    (005, 'm', 'dark magenta', 'dark purple'),
-    (006, 'c', 'dark cyan'),
-    (007, 'n', 'light grey', 'light gray', 'neutral', 'dark white'),
-    (010, 'B', 'dark grey', 'dark gray', 'light black'),
-    (011, 'R', 'red', 'light red'),
-    (012, 'G', 'green', 'light green'),
-    (013, 'Y', 'yellow', 'light yellow'),
-    (014, 'B', 'blue', 'light blue'),
-    (015, 'M', 'magenta', 'purple', 'light magenta', 'light purple'),
-    (016, 'C', 'cyan', 'light cyan'),
-    (017, 'W', 'white', 'light white'),
+    (0o01, 'r', 'dark red'),
+    (0o02, 'g', 'dark green'),
+    (0o03, 'w', 'brown', 'dark yellow'),
+    (0o04, 'b', 'dark blue'),
+    (0o05, 'm', 'dark magenta', 'dark purple'),
+    (0o06, 'c', 'dark cyan'),
+    (0o07, 'n', 'light grey', 'light gray', 'neutral', 'dark white'),
+    (0o10, 'B', 'dark grey', 'dark gray', 'light black'),
+    (0o11, 'R', 'red', 'light red'),
+    (0o12, 'G', 'green', 'light green'),
+    (0o13, 'Y', 'yellow', 'light yellow'),
+    (0o14, 'B', 'blue', 'light blue'),
+    (0o15, 'M', 'magenta', 'purple', 'light magenta', 'light purple'),
+    (0o16, 'C', 'cyan', 'light cyan'),
+    (0o17, 'W', 'white', 'light white'),
 )
 
 colors_by_num = {}
@@ -76,8 +76,8 @@ class ColoredChar:
         return getattr(self.c, name)
 
     def ansi_color(self):
-        clr = str(30 + (07 & self._colorcode))
-        if self._colorcode & 010:
+        clr = str(30 + (0o7 & self._colorcode))
+        if self._colorcode & 0o10:
             clr = '1;' + clr
         return clr
 

--- a/pylib/cqlshlib/test/ansi_colors.py
+++ b/pylib/cqlshlib/test/ansi_colors.py
@@ -16,6 +16,11 @@
 
 import re
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 LIGHT = 0o10
 
 ansi_CSI = '\033['

--- a/pylib/cqlshlib/test/run_cqlsh.py
+++ b/pylib/cqlshlib/test/run_cqlsh.py
@@ -103,7 +103,7 @@ def timing_out_alarm(seconds):
 if is_win():
     try:
         import eventlet
-    except ImportError, e:
+    except ImportError as e:
         sys.exit("evenlet library required to run cqlshlib tests on Windows")
 
     def timing_out(seconds):

--- a/pylib/cqlshlib/util.py
+++ b/pylib/cqlshlib/util.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -161,6 +162,6 @@ def profile_off(pr, file_name):
     ret = s.getvalue()
     if file_name:
         with open(file_name, 'w') as f:
-            print "Writing to %s\n" % (f.name, )
+            print("Writing to %s\n" % (f.name, ))
             f.write(ret)
     return ret

--- a/pylib/cqlshlib/wcwidth.py
+++ b/pylib/cqlshlib/wcwidth.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -375,4 +376,4 @@ if __name__ == "__main__":
 
     assert wcswidth(u'foobar\u200b\a') < 0
 
-    print 'tests pass.'
+    print('tests pass.')


### PR DESCRIPTION
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.