### PR TITLE
Fix snapshot name with special character for Path CASSANDRA-15297

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0
+ * nodetool can not create snapshot with snapshot name that have special character (CASSANDRA-15297)
  * Inaccurate exception message with nodetool snapshot (CASSANDRA-15287)
  * Fix InternodeOutboundMetrics overloaded bytes/count mixup (CASSANDRA-15186)
  * Enhance & reenable RepairTest with compression=off and compression=on (CASSANDRA-15272)

--- a/src/java/org/apache/cassandra/tools/nodetool/Snapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Snapshot.java
@@ -22,7 +22,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
-
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,6 +61,11 @@ public class Snapshot extends NodeToolCmd
 
             Map<String, String> options = new HashMap<String,String>();
             options.put("skipFlush", Boolean.toString(skipFlush));
+            if (!snapshotName.isEmpty() && snapshotName.contains(File.separator)) 
+            {
+                throw new IOException(
+                        "Snapshot name should not contains Special characters like " + File.separator );
+            }
 
             // Create a separate path for kclist to avoid breaking of already existing scripts
             if (null != ktList && !ktList.isEmpty())


### PR DESCRIPTION
nodetool can not create snapshot with snapshot name that have special character, when user make snapshot with name contains "/", then an exception is thrown