### PR TITLE
Add auditlogviewer and fqltool into rpmbuild spec file for  CASSANDRA-15300

### DIFF
--- a/redhat/cassandra.spec
+++ b/redhat/cassandra.spec
@@ -173,6 +173,8 @@ This package contains extra tools for working with Cassandra clusters.
 %attr(755,root,root) %{_bindir}/sstableofflinerelevel
 %attr(755,root,root) %{_bindir}/sstablerepairedset
 %attr(755,root,root) %{_bindir}/sstablesplit
+%attr(755,root,root) %{_bindir}/auditlogviewer
+%attr(755,root,root) %{_bindir}/fqltool
 
 
 %changelog


### PR DESCRIPTION
patch by ysakanaka; for [CASSANDRA-15300](https://issues.apache.org/jira/browse/CASSANDRA-15300)

The spec file on the current trunk branch (cassandra 4.0) is missing auditlogviewer and fqltool.
I tried rpmbuild on trunk brunch, but it failed with unpacked files error.
RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/bin/auditlogviewer
   /usr/bin/fqltool
I guess the committers will modify this file in the future because they are new features but I suggest that the following lines be added into the spec file.
 
%attr(755,root,root) %{_bindir}/auditlogviewer
%attr(755,root,root) %{_bindir}/fqltool
 