### PR TITLE
Fix cassandra.bat so it allows "legacy" usage

### DIFF
--- a/bin/cassandra.bat
+++ b/bin/cassandra.bat
@@ -137,7 +137,7 @@ if "%PRUNSRV%" == "" set PRUNSRV=%PATH_PRUNSRV%prunsrv
 echo trying to delete service if it has been created already
 "%PRUNSRV%" //DS//%SERVICE_JVM%
 rem quit if we're just going to uninstall
-if /i "%ARG%" == "UNINSTALL" goto finally
+if /i "%ARG2%" == "UNINSTALL" goto finally
 
 echo Installing %SERVICE_JVM%. If you get registry warnings, re-run as an Administrator
 "%PRUNSRV%" //IS//%SERVICE_JVM%

--- a/bin/cassandra.bat
+++ b/bin/cassandra.bat
@@ -17,6 +17,8 @@
 @echo off
 if "%OS%" == "Windows_NT" setlocal
 REM ---- Usage:  cassandra.bat [LEGACY|PS] [INSTALL|UNINSTALL]
+REM - Note1:  Does not work if any argument contains the ! or & char
+REM - Note2:  Any extra spaces in between arguments will NOT be removed
 set ARG=%1
 set ARG2=%2
 
@@ -36,7 +38,11 @@ REM ----------------------------------------------------------------------------
 :runPowerShell
 echo Detected powershell execution permissions.  Running with enhanced startup scripts.
 set errorlevel=
-powershell /file "%CASSANDRA_HOME%\bin\cassandra.ps1" %*
+setlocal ENABLEDELAYEDEXPANSION
+  set "_args=%*"
+  set "_args=!_args:*%1 =!"
+endlocal
+powershell /file "%CASSANDRA_HOME%\bin\cassandra.ps1" %_args%
 exit /b %errorlevel%
 
 REM -----------------------------------------------------------------------------

--- a/bin/cassandra.bat
+++ b/bin/cassandra.bat
@@ -16,16 +16,16 @@
 
 @echo off
 if "%OS%" == "Windows_NT" setlocal
-
+REM ---- Usage:  cassandra.bat [LEGACY|PS] [INSTALL|UNINSTALL]
 set ARG=%1
-set INSTALL="INSTALL"
-set UNINSTALL="UNINSTALL"
+set ARG2=%2
 
 pushd %~dp0..
 if NOT DEFINED CASSANDRA_HOME set CASSANDRA_HOME=%CD%
 popd
 
 if /i "%ARG%" == "LEGACY" goto runLegacy
+if /i "%ARG%" == "PS" goto runPowerShell
 REM -----------------------------------------------------------------------------
 REM See if we have access to run unsigned powershell scripts
 for /F "delims=" %%i in ('powershell Get-ExecutionPolicy') do set PERMISSION=%%i
@@ -117,8 +117,8 @@ set CASSANDRA_PARAMS=-Dcassandra -Dcassandra-foreground=yes
 set CASSANDRA_PARAMS=%CASSANDRA_PARAMS% -Dcassandra.logdir="%CASSANDRA_HOME%\logs"
 set CASSANDRA_PARAMS=%CASSANDRA_PARAMS% -Dcassandra.storagedir="%CASSANDRA_HOME%\data"
 
-if /i "%ARG%" == "INSTALL" goto doInstallOperation
-if /i "%ARG%" == "UNINSTALL" goto doInstallOperation
+if /i "%ARG2%" == "INSTALL" goto doInstallOperation
+if /i "%ARG2%" == "UNINSTALL" goto doInstallOperation
 
 echo Starting Cassandra Server
 "%JAVA_HOME%\bin\java" %JAVA_OPTS% %CASSANDRA_PARAMS% -cp %CASSANDRA_CLASSPATH% "%CASSANDRA_MAIN%"


### PR DESCRIPTION
L20-21 made no sense and created unused vars for `INSTALL` and `UNINSTALL`.   Replaced it with logic to allow user to select `LEGACY` or `PS` (PowerShell) instead of forcing PS usage for runtime execution and for service installation/uninstallation.  

Tested on W2012-R2 + Cassandra 3.0.15, W2016 + Cassandra 3.11.1 
(I don't think the code here has changed that much so patch should be forward-portable into `trunk` and back-portable to `cassandra-3.0` branches too I believe).  