### PR TITLE
[CASSANDRA-15355] Schema push/pull race on continuous schema changes

### DIFF
--- a/src/java/org/apache/cassandra/schema/MigrationManager.java
+++ b/src/java/org/apache/cassandra/schema/MigrationManager.java
@@ -124,6 +124,12 @@ public class MigrationManager
                     logger.debug("epState vanished for {}, not submitting migration task", endpoint);
                     return;
                 }
+                if (!epSchemaVersion.equals(theirVersion))
+                {
+                    logger.debug("Not submitting migration task for {} because their version " +
+                            "has changed from {} to {} since the task was scheduled", endpoint, theirVersion, epSchemaVersion);
+                    return;
+                }
                 if (Schema.instance.isSameVersion(epSchemaVersion))
                 {
                     logger.debug("Not submitting migration task for {} because our versions match ({})", endpoint, epSchemaVersion);


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/CASSANDRA-5025, pull based schema updates were scheduled 1 minute after the schema change was first visible, so as to prefer the push codepath as much as possible.

Unfortunately, this does not handle the case where there are many schema changes happening - imagine a scenario where we create a table every 5 seconds for 2 minutes - the first update tasks execute 60 seconds in and the schemas may well be out of sync between nodes at that point.

In this case, there is some chance that when the task runs, the schemas are out of sync because a subsequent schema update has occurred, and so the same push/pull race has happened.

A fix is to modify the codepath such that the scheduled task is only run if the other node's schema version is the same as when the task was scheduled. A different (later scheduled) task should run otherwise.

For us, what we see is that when we have a reasonably large number of changes, a few schema changes can have the unfortunate outcome of causing our nodes to run out of memory and crash. This change stops that.