### PR TITLE
Ignore sstables with only ttl deletions which are not currently expired.

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1993,8 +1993,8 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
     public boolean mayHaveTombstones()
     {
         // A sstable is guaranteed to have no tombstones if minLocalDeletionTime is still set to its default,
-        // Cell.NO_DELETION_TIME, which is bigger than any valid deletion times.
-        return getMinLocalDeletionTime() != Cell.NO_DELETION_TIME;
+        // Cell.NO_DELETION_TIME, which is bigger than any valid deletion times, or bigger than current time (for ttl only tombstones).
+        return getMinLocalDeletionTime() != Cell.NO_DELETION_TIME && getMinLocalDeletionTime() < System.currentTimeMillis()/1000;
     }
 
     public int getMinTTL()


### PR DESCRIPTION
When filtering SSTables in the case of time-based data and TimeWindowCompactionStrategy, we can reduce SSTables number, by filtering out those with only ttl tombstones, for which ttl has not expired yet (so there is no chance they affect the current result set).