### PR TITLE
add sample for parsed option

### DIFF
--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -23,7 +23,9 @@
 ; password = !!bang!!$
 ; keyspace = ks1
 
-
+[protocol]
+;; Specify a specific protcol version otherwise the client will default and downgrade as necessary
+; version = None
 
 [ui]
 ;; Whether or not to display query results with colors

--- a/doc/source/tools/cqlsh.rst
+++ b/doc/source/tools/cqlsh.rst
@@ -94,6 +94,12 @@ Options:
 ``--cqlshrc``
   Specify a non-default location for the ``cqlshrc`` file
 
+``--cqlversion``
+  Specify a particular CQL version, by default the highest version supported by the server will be used. Examples: "3.0.3", "3.1.0"
+
+``--protocol-version``
+  Specify a specific protcol version otherwise the client will default and downgrade as necessary.
+
 ``-e`` ``--execute``
   Execute the given statement, then exit
 


### PR DESCRIPTION
Cqlsh is parsing for section `[protocol]` option `version` which is not actually mentioned in [conf/cqlshrc.sample](https://github.com/apache/cassandra/blob/trunk/conf/cqlshrc.sample).