### PR TITLE
CASSANDRA-15380 Update command description

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ClearSnapshot.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
-@Command(name = "clearsnapshot", description = "Remove the snapshot with the given name from the given keyspaces. If no snapshotName is specified we will remove all snapshots")
+@Command(name = "clearsnapshot", description = "Remove the snapshot with the given name from the given keyspaces")
 public class ClearSnapshot extends NodeToolCmd
 {
     @Arguments(usage = "[<keyspaces>...] ", description = "Remove snapshots from the given keyspaces")


### PR DESCRIPTION
Calling ClearSnaphot without a snapshot name no longer deletes all snapshots - update command description accordingly.