### PR TITLE
CASSANDRA-15410: Improve strings encoding speed and add benchmarks

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -510,7 +510,7 @@ public abstract class QueryOptions
             if (flags.contains(Flag.TIMESTAMP))
                 dest.writeLong(options.getSpecificOptions().timestamp);
             if (flags.contains(Flag.KEYSPACE))
-                CBUtil.writeString(options.getSpecificOptions().keyspace, dest);
+                CBUtil.writeAsciiString(options.getSpecificOptions().keyspace, dest);
             if (flags.contains(Flag.NOW_IN_SECONDS))
                 dest.writeInt(options.getSpecificOptions().nowInSeconds);
 

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -539,7 +539,7 @@ public abstract class QueryOptions
             if (flags.contains(Flag.TIMESTAMP))
                 size += 8;
             if (flags.contains(Flag.KEYSPACE))
-                size += CBUtil.sizeOfString(options.getSpecificOptions().keyspace);
+                size += CBUtil.sizeOfAsciiString(options.getSpecificOptions().keyspace);
             if (flags.contains(Flag.NOW_IN_SECONDS))
                 size += 4;
 

--- a/src/java/org/apache/cassandra/cql3/ResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/ResultSet.java
@@ -469,8 +469,8 @@ public class ResultSet
                 {
                     if (globalTablesSpec)
                     {
-                        size += CBUtil.sizeOfString(m.names.get(0).ksName);
-                        size += CBUtil.sizeOfString(m.names.get(0).cfName);
+                        size += CBUtil.sizeOfAsciiString(m.names.get(0).ksName);
+                        size += CBUtil.sizeOfAsciiString(m.names.get(0).cfName);
                     }
 
                     for (int i = 0; i < m.columnCount; i++)
@@ -478,10 +478,10 @@ public class ResultSet
                         ColumnSpecification name = m.names.get(i);
                         if (!globalTablesSpec)
                         {
-                            size += CBUtil.sizeOfString(name.ksName);
-                            size += CBUtil.sizeOfString(name.cfName);
+                            size += CBUtil.sizeOfAsciiString(name.ksName);
+                            size += CBUtil.sizeOfAsciiString(name.cfName);
                         }
-                        size += CBUtil.sizeOfString(name.name.toString());
+                        size += CBUtil.sizeOfAsciiString(name.name.toString());
                         size += DataType.codec.oneSerializedSize(DataType.fromType(name.type, version), version);
                     }
                 }
@@ -661,8 +661,8 @@ public class ResultSet
                 int size = 8;
                 if (globalTablesSpec)
                 {
-                    size += CBUtil.sizeOfString(m.names.get(0).ksName);
-                    size += CBUtil.sizeOfString(m.names.get(0).cfName);
+                    size += CBUtil.sizeOfAsciiString(m.names.get(0).ksName);
+                    size += CBUtil.sizeOfAsciiString(m.names.get(0).cfName);
                 }
 
                 if (m.partitionKeyBindIndexes != null && version.isGreaterOrEqualTo(ProtocolVersion.V4))
@@ -672,10 +672,10 @@ public class ResultSet
                 {
                     if (!globalTablesSpec)
                     {
-                        size += CBUtil.sizeOfString(name.ksName);
-                        size += CBUtil.sizeOfString(name.cfName);
+                        size += CBUtil.sizeOfAsciiString(name.ksName);
+                        size += CBUtil.sizeOfAsciiString(name.cfName);
                     }
-                    size += CBUtil.sizeOfString(name.name.toString());
+                    size += CBUtil.sizeOfAsciiString(name.name.toString());
                     size += DataType.codec.oneSerializedSize(DataType.fromType(name.type, version), version);
                 }
                 return size;

--- a/src/java/org/apache/cassandra/cql3/ResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/ResultSet.java
@@ -433,8 +433,8 @@ public class ResultSet
                 {
                     if (globalTablesSpec)
                     {
-                        CBUtil.writeString(m.names.get(0).ksName, dest);
-                        CBUtil.writeString(m.names.get(0).cfName, dest);
+                        CBUtil.writeAsciiString(m.names.get(0).ksName, dest);
+                        CBUtil.writeAsciiString(m.names.get(0).cfName, dest);
                     }
 
                     for (int i = 0; i < m.columnCount; i++)
@@ -442,10 +442,10 @@ public class ResultSet
                         ColumnSpecification name = m.names.get(i);
                         if (!globalTablesSpec)
                         {
-                            CBUtil.writeString(name.ksName, dest);
-                            CBUtil.writeString(name.cfName, dest);
+                            CBUtil.writeAsciiString(name.ksName, dest);
+                            CBUtil.writeAsciiString(name.cfName, dest);
                         }
-                        CBUtil.writeString(name.name.toString(), dest);
+                        CBUtil.writeAsciiString(name.name.toString(), dest);
                         DataType.codec.writeOne(DataType.fromType(name.type, version), dest, version);
                     }
                 }
@@ -639,18 +639,18 @@ public class ResultSet
 
                 if (globalTablesSpec)
                 {
-                    CBUtil.writeString(m.names.get(0).ksName, dest);
-                    CBUtil.writeString(m.names.get(0).cfName, dest);
+                    CBUtil.writeAsciiString(m.names.get(0).ksName, dest);
+                    CBUtil.writeAsciiString(m.names.get(0).cfName, dest);
                 }
 
                 for (ColumnSpecification name : m.names)
                 {
                     if (!globalTablesSpec)
                     {
-                        CBUtil.writeString(name.ksName, dest);
-                        CBUtil.writeString(name.cfName, dest);
+                        CBUtil.writeAsciiString(name.ksName, dest);
+                        CBUtil.writeAsciiString(name.cfName, dest);
                     }
-                    CBUtil.writeString(name.name.toString(), dest);
+                    CBUtil.writeAsciiString(name.name.toString(), dest);
                     DataType.codec.writeOne(DataType.fromType(name.type, version), dest, version);
                 }
             }

--- a/src/java/org/apache/cassandra/transport/CBUtil.java
+++ b/src/java/org/apache/cassandra/transport/CBUtil.java
@@ -140,7 +140,6 @@ public abstract class CBUtil
      * Write US-ASCII strings. It does not work if containing any char > 0x007F (127)
      * @param str, satisfies {@link org.apache.cassandra.db.marshal.AsciiType},
      *             i.e. seven-bit ASCII, a.k.a. ISO646-US
-     * @throws ProtocolException, when the input {@param str} cannot satisfy the encoding.
      */
     public static void writeAsciiString(String str, ByteBuf cb)
     {
@@ -158,6 +157,16 @@ public abstract class CBUtil
     public static int sizeOfString(String str)
     {
         return 2 + TypeSizes.encodedUTF8Length(str);
+    }
+
+    /**
+     * Returns the ecoding size of a US-ASCII string. It does not work if containing any char > 0x007F (127)
+     * @param str, satisfies {@link org.apache.cassandra.db.marshal.AsciiType},
+     *             i.e. seven-bit ASCII, a.k.a. ISO646-US
+     */
+    public static int sizeOfAsciiString(String str)
+    {
+        return 2 + str.length();
     }
 
     public static String readLongString(ByteBuf cb)
@@ -282,7 +291,7 @@ public abstract class CBUtil
 
     public static <T extends Enum<T>> int sizeOfEnumValue(T enumValue)
     {
-        return sizeOfString(enumValue.toString());
+        return sizeOfAsciiString(enumValue.toString());
     }
 
     public static UUID readUUID(ByteBuf cb)

--- a/src/java/org/apache/cassandra/transport/DataType.java
+++ b/src/java/org/apache/cassandra/transport/DataType.java
@@ -160,7 +160,7 @@ public enum DataType
                 break;
             case UDT:
                 UserType udt = (UserType)value;
-                CBUtil.writeString(udt.keyspace, cb);
+                CBUtil.writeAsciiString(udt.keyspace, cb);
                 CBUtil.writeString(UTF8Type.instance.compose(udt.name), cb);
                 cb.writeShort(udt.size());
                 for (int i = 0; i < udt.size(); i++)

--- a/src/java/org/apache/cassandra/transport/DataType.java
+++ b/src/java/org/apache/cassandra/transport/DataType.java
@@ -200,7 +200,7 @@ public enum DataType
             case UDT:
                 UserType udt = (UserType)value;
                 int size = 0;
-                size += CBUtil.sizeOfString(udt.keyspace);
+                size += CBUtil.sizeOfAsciiString(udt.keyspace);
                 size += CBUtil.sizeOfString(UTF8Type.instance.compose(udt.name));
                 size += 2;
                 for (int i = 0; i < udt.size(); i++)

--- a/src/java/org/apache/cassandra/transport/Event.java
+++ b/src/java/org/apache/cassandra/transport/Event.java
@@ -363,26 +363,26 @@ public abstract class Event
                 if (version.isGreaterOrEqualTo(ProtocolVersion.V4))
                     return CBUtil.sizeOfEnumValue(change)
                                + CBUtil.sizeOfEnumValue(target)
-                               + CBUtil.sizeOfString(keyspace)
-                               + CBUtil.sizeOfString(name)
+                               + CBUtil.sizeOfAsciiString(keyspace)
+                               + CBUtil.sizeOfAsciiString(name)
                                + CBUtil.sizeOfStringList(argTypes);
                 if (version.isGreaterOrEqualTo(ProtocolVersion.V3))
                     return CBUtil.sizeOfEnumValue(Change.UPDATED)
                            + CBUtil.sizeOfEnumValue(Target.KEYSPACE)
-                           + CBUtil.sizeOfString(keyspace);
+                           + CBUtil.sizeOfAsciiString(keyspace);
                 return CBUtil.sizeOfEnumValue(Change.UPDATED)
-                       + CBUtil.sizeOfString(keyspace)
-                       + CBUtil.sizeOfString("");
+                       + CBUtil.sizeOfAsciiString(keyspace)
+                       + CBUtil.sizeOfAsciiString("");
             }
 
             if (version.isGreaterOrEqualTo(ProtocolVersion.V3))
             {
                 int size = CBUtil.sizeOfEnumValue(change)
                          + CBUtil.sizeOfEnumValue(target)
-                         + CBUtil.sizeOfString(keyspace);
+                         + CBUtil.sizeOfAsciiString(keyspace);
 
                 if (target != Target.KEYSPACE)
-                    size += CBUtil.sizeOfString(name);
+                    size += CBUtil.sizeOfAsciiString(name);
 
                 return size;
             }
@@ -391,12 +391,12 @@ public abstract class Event
                 if (target == Target.TYPE)
                 {
                     return CBUtil.sizeOfEnumValue(Change.UPDATED)
-                         + CBUtil.sizeOfString(keyspace)
-                         + CBUtil.sizeOfString("");
+                         + CBUtil.sizeOfAsciiString(keyspace)
+                         + CBUtil.sizeOfAsciiString("");
                 }
                 return CBUtil.sizeOfEnumValue(change)
-                     + CBUtil.sizeOfString(keyspace)
-                     + CBUtil.sizeOfString(target == Target.KEYSPACE ? "" : name);
+                     + CBUtil.sizeOfAsciiString(keyspace)
+                     + CBUtil.sizeOfAsciiString(target == Target.KEYSPACE ? "" : name);
             }
         }
 

--- a/src/java/org/apache/cassandra/transport/Event.java
+++ b/src/java/org/apache/cassandra/transport/Event.java
@@ -313,8 +313,8 @@ public abstract class Event
                     // available since protocol version 4
                     CBUtil.writeEnumValue(change, dest);
                     CBUtil.writeEnumValue(target, dest);
-                    CBUtil.writeString(keyspace, dest);
-                    CBUtil.writeString(name, dest);
+                    CBUtil.writeAsciiString(keyspace, dest);
+                    CBUtil.writeAsciiString(name, dest);
                     CBUtil.writeStringList(argTypes, dest);
                 }
                 else
@@ -323,8 +323,8 @@ public abstract class Event
                     CBUtil.writeEnumValue(Change.UPDATED, dest);
                     if (version.isGreaterOrEqualTo(ProtocolVersion.V3))
                         CBUtil.writeEnumValue(Target.KEYSPACE, dest);
-                    CBUtil.writeString(keyspace, dest);
-                    CBUtil.writeString("", dest);
+                    CBUtil.writeAsciiString(keyspace, dest);
+                    CBUtil.writeAsciiString("", dest);
                 }
                 return;
             }
@@ -333,9 +333,9 @@ public abstract class Event
             {
                 CBUtil.writeEnumValue(change, dest);
                 CBUtil.writeEnumValue(target, dest);
-                CBUtil.writeString(keyspace, dest);
+                CBUtil.writeAsciiString(keyspace, dest);
                 if (target != Target.KEYSPACE)
-                    CBUtil.writeString(name, dest);
+                    CBUtil.writeAsciiString(name, dest);
             }
             else
             {
@@ -344,14 +344,14 @@ public abstract class Event
                     // For the v1/v2 protocol, we have no way to represent type changes, so we simply say the keyspace
                     // was updated.  See CASSANDRA-7617.
                     CBUtil.writeEnumValue(Change.UPDATED, dest);
-                    CBUtil.writeString(keyspace, dest);
-                    CBUtil.writeString("", dest);
+                    CBUtil.writeAsciiString(keyspace, dest);
+                    CBUtil.writeAsciiString("", dest);
                 }
                 else
                 {
                     CBUtil.writeEnumValue(change, dest);
-                    CBUtil.writeString(keyspace, dest);
-                    CBUtil.writeString(target == Target.KEYSPACE ? "" : name, dest);
+                    CBUtil.writeAsciiString(keyspace, dest);
+                    CBUtil.writeAsciiString(target == Target.KEYSPACE ? "" : name, dest);
                 }
             }
         }

--- a/src/java/org/apache/cassandra/transport/messages/AuthenticateMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/AuthenticateMessage.java
@@ -44,7 +44,7 @@ public class AuthenticateMessage extends Message.Response
 
         public int encodedSize(AuthenticateMessage msg, ProtocolVersion version)
         {
-            return CBUtil.sizeOfString(msg.authenticator);
+            return CBUtil.sizeOfAsciiString(msg.authenticator);
         }
     };
 

--- a/src/java/org/apache/cassandra/transport/messages/AuthenticateMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/AuthenticateMessage.java
@@ -38,7 +38,8 @@ public class AuthenticateMessage extends Message.Response
 
         public void encode(AuthenticateMessage msg, ByteBuf dest, ProtocolVersion version)
         {
-            CBUtil.writeString(msg.authenticator, dest);
+            // Safe to skip. `msg.authenticator` is a FQCN string. All characters are ASCII encoded.
+            CBUtil.writeAsciiString(msg.authenticator, dest);
         }
 
         public int encodedSize(AuthenticateMessage msg, ProtocolVersion version)

--- a/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
@@ -257,7 +257,7 @@ public class ErrorMessage extends Message.Response
                         RequestFailureException rfe = (RequestFailureException)err;
                         boolean isWrite = err.code() == ExceptionCode.WRITE_FAILURE;
                         size += CBUtil.sizeOfConsistencyLevel(rfe.consistency) + 4 + 4 + 4;
-                        size += isWrite ? CBUtil.sizeOfString(((WriteFailureException)rfe).writeType.toString()) : 1;
+                        size += isWrite ? CBUtil.sizeOfAsciiString(((WriteFailureException)rfe).writeType.toString()) : 1;
 
                         if (version.isGreaterOrEqualTo(ProtocolVersion.V5))
                         {
@@ -274,12 +274,12 @@ public class ErrorMessage extends Message.Response
                     RequestTimeoutException rte = (RequestTimeoutException)err;
                     boolean isWrite = err.code() == ExceptionCode.WRITE_TIMEOUT;
                     size += CBUtil.sizeOfConsistencyLevel(rte.consistency) + 8;
-                    size += isWrite ? CBUtil.sizeOfString(((WriteTimeoutException)rte).writeType.toString()) : 1;
+                    size += isWrite ? CBUtil.sizeOfAsciiString(((WriteTimeoutException)rte).writeType.toString()) : 1;
                     break;
                 case FUNCTION_FAILURE:
                     FunctionExecutionException fee = (FunctionExecutionException)msg.error;
-                    size += CBUtil.sizeOfString(fee.functionName.keyspace);
-                    size += CBUtil.sizeOfString(fee.functionName.name);
+                    size += CBUtil.sizeOfAsciiString(fee.functionName.keyspace);
+                    size += CBUtil.sizeOfAsciiString(fee.functionName.name);
                     size += CBUtil.sizeOfStringList(fee.argTypes);
                     break;
                 case UNPREPARED:
@@ -288,8 +288,8 @@ public class ErrorMessage extends Message.Response
                     break;
                 case ALREADY_EXISTS:
                     AlreadyExistsException aee = (AlreadyExistsException)err;
-                    size += CBUtil.sizeOfString(aee.ksName);
-                    size += CBUtil.sizeOfString(aee.cfName);
+                    size += CBUtil.sizeOfAsciiString(aee.ksName);
+                    size += CBUtil.sizeOfAsciiString(aee.cfName);
                     break;
             }
             return size;

--- a/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
@@ -204,7 +204,7 @@ public class ErrorMessage extends Message.Response
                         }
 
                         if (isWrite)
-                            CBUtil.writeString(((WriteFailureException)rfe).writeType.toString(), dest);
+                            CBUtil.writeAsciiString(((WriteFailureException)rfe).writeType.toString(), dest);
                         else
                             dest.writeByte((byte)(((ReadFailureException)rfe).dataPresent ? 1 : 0));
                     }
@@ -218,14 +218,14 @@ public class ErrorMessage extends Message.Response
                     dest.writeInt(rte.received);
                     dest.writeInt(rte.blockFor);
                     if (isWrite)
-                        CBUtil.writeString(((WriteTimeoutException)rte).writeType.toString(), dest);
+                        CBUtil.writeAsciiString(((WriteTimeoutException)rte).writeType.toString(), dest);
                     else
                         dest.writeByte((byte)(((ReadTimeoutException)rte).dataPresent ? 1 : 0));
                     break;
                 case FUNCTION_FAILURE:
                     FunctionExecutionException fee = (FunctionExecutionException)msg.error;
-                    CBUtil.writeString(fee.functionName.keyspace, dest);
-                    CBUtil.writeString(fee.functionName.name, dest);
+                    CBUtil.writeAsciiString(fee.functionName.keyspace, dest);
+                    CBUtil.writeAsciiString(fee.functionName.name, dest);
                     CBUtil.writeStringList(fee.argTypes, dest);
                     break;
                 case UNPREPARED:
@@ -234,8 +234,8 @@ public class ErrorMessage extends Message.Response
                     break;
                 case ALREADY_EXISTS:
                     AlreadyExistsException aee = (AlreadyExistsException)err;
-                    CBUtil.writeString(aee.ksName, dest);
-                    CBUtil.writeString(aee.cfName, dest);
+                    CBUtil.writeAsciiString(aee.ksName, dest);
+                    CBUtil.writeAsciiString(aee.cfName, dest);
                     break;
             }
         }

--- a/src/java/org/apache/cassandra/transport/messages/PrepareMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/PrepareMessage.java
@@ -79,7 +79,7 @@ public class PrepareMessage extends Message.Request
                 // If we have a keyspace, we'd write it out. Otherwise, we'd write nothing.
                 size += msg.keyspace == null
                     ? 0
-                    : CBUtil.sizeOfString(msg.keyspace);
+                    : CBUtil.sizeOfAsciiString(msg.keyspace);
             }
             return size;
         }

--- a/src/java/org/apache/cassandra/transport/messages/PrepareMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/PrepareMessage.java
@@ -63,7 +63,7 @@ public class PrepareMessage extends Message.Request
                     dest.writeInt(0x0);
                 else {
                     dest.writeInt(0x1);
-                    CBUtil.writeString(msg.keyspace, dest);
+                    CBUtil.writeAsciiString(msg.keyspace, dest);
                 }
             }
         }

--- a/src/java/org/apache/cassandra/transport/messages/ResultMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ResultMessage.java
@@ -158,7 +158,7 @@ public abstract class ResultMessage extends Message.Response
             public int encodedSize(ResultMessage msg, ProtocolVersion version)
             {
                 assert msg instanceof SetKeyspace;
-                return CBUtil.sizeOfString(((SetKeyspace)msg).keyspace);
+                return CBUtil.sizeOfAsciiString(((SetKeyspace)msg).keyspace);
             }
         };
 

--- a/src/java/org/apache/cassandra/transport/messages/ResultMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ResultMessage.java
@@ -152,7 +152,7 @@ public abstract class ResultMessage extends Message.Response
             public void encode(ResultMessage msg, ByteBuf dest, ProtocolVersion version)
             {
                 assert msg instanceof SetKeyspace;
-                CBUtil.writeString(((SetKeyspace)msg).keyspace, dest);
+                CBUtil.writeAsciiString(((SetKeyspace)msg).keyspace, dest);
             }
 
             public int encodedSize(ResultMessage msg, ProtocolVersion version)

--- a/test/microbench/org/apache/cassandra/test/microbench/StringsEncodeBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/StringsEncodeBench.java
@@ -113,4 +113,16 @@ public class StringsEncodeBench
         ByteBuf cb = Unpooled.buffer(longTextEncodeSize);
         CBUtil.writeAsciiString(longText, cb);
     }
+
+    @Benchmark
+    public int sizeOfString()
+    {
+        return CBUtil.sizeOfString(longText);
+    }
+
+    @Benchmark
+    public int sizeOfAsciiString()
+    {
+        return CBUtil.sizeOfAsciiString(longText);
+    }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/StringsEncodeBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/StringsEncodeBench.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 6, time = 20)
 @Fork(value = 1,jvmArgsAppend = { "-Xmx256M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @State(Scope.Benchmark)
-public class Utf8StringEncodeBench
+public class StringsEncodeBench
 {
     private String shortText = "abcdefghijk";
     private String longText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
@@ -75,6 +75,13 @@ public class Utf8StringEncodeBench
     }
 
     @Benchmark
+    public void writeShortTextAsASCII()
+    {
+        ByteBuf cb = Unpooled.buffer(shortTextEncodeSize);
+        CBUtil.writeAsciiString(shortText, cb);
+    }
+
+    @Benchmark
     public int writeLongText() // expecting resize
     {
         ByteBuf cb = Unpooled.buffer(longTextEncodeSize);
@@ -100,4 +107,10 @@ public class Utf8StringEncodeBench
         return ByteBufUtil.reserveAndWriteUtf8(cb, longText, size);
     }
 
+    @Benchmark
+    public void writeLongTextAsASCII()
+    {
+        ByteBuf cb = Unpooled.buffer(longTextEncodeSize);
+        CBUtil.writeAsciiString(longText, cb);
+    }
 }

--- a/test/microbench/org/apache/cassandra/test/microbench/Utf8StringEncodeBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/Utf8StringEncodeBench.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import java.util.concurrent.TimeUnit;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.transport.CBUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 6, time = 20)
+@Fork(value = 1,jvmArgsAppend = { "-Xmx256M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@State(Scope.Benchmark)
+public class Utf8StringEncodeBench
+{
+    private String shortText = "abcdefghijk";
+    private String longText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+    private int shortTextEncodeSize = CBUtil.sizeOfString(shortText);
+    private int longTextEncodeSize = CBUtil.sizeOfString(longText);
+
+    @Benchmark
+    public int writeShortText() // expecting resize
+    {
+        ByteBuf cb = Unpooled.buffer(shortTextEncodeSize);
+        cb.writeShort(0); // field for str length
+        return ByteBufUtil.writeUtf8(cb, shortText);
+    }
+
+    @Benchmark
+    public int writeShortTextWithExactSize() // no resize
+    {
+        ByteBuf cb = Unpooled.buffer(shortTextEncodeSize);
+        int size = TypeSizes.encodedUTF8Length(shortText);
+        cb.writeShort(size); // field for str length
+        return ByteBufUtil.reserveAndWriteUtf8(cb, shortText, size);
+    }
+
+    @Benchmark
+    public int writeShortTextWithExactSizeSkipCalc() // no resize; from the encodeSize, we already know the amount of bytes required.
+    {
+        ByteBuf cb = Unpooled.buffer(shortTextEncodeSize);
+        cb.writeShort(0); // field for str length
+        int size = cb.capacity() - cb.writerIndex(); // leverage the pre-calculated encodeSize
+        return ByteBufUtil.reserveAndWriteUtf8(cb, shortText, size);
+    }
+
+    @Benchmark
+    public int writeLongText() // expecting resize
+    {
+        ByteBuf cb = Unpooled.buffer(longTextEncodeSize);
+        cb.writeShort(0); // field for str length
+        return ByteBufUtil.writeUtf8(cb, longText);
+    }
+
+    @Benchmark
+    public int writeLongTextWithExactSize() // no resize
+    {
+        ByteBuf cb = Unpooled.buffer(longTextEncodeSize);
+        int size = TypeSizes.encodedUTF8Length(longText);
+        cb.writeShort(size); // field for str length
+        return ByteBufUtil.reserveAndWriteUtf8(cb, longText, size);
+    }
+
+    @Benchmark
+    public int writeLongTextWithExactSizeSkipCalc() // no resize
+    {
+        ByteBuf cb = Unpooled.buffer(longTextEncodeSize);
+        cb.writeShort(0); // field for str length
+        int size = cb.capacity() - cb.writerIndex(); // leverage the pre-calculated encodeSize
+        return ByteBufUtil.reserveAndWriteUtf8(cb, longText, size);
+    }
+
+}

--- a/test/unit/org/apache/cassandra/transport/CBUtilTest.java
+++ b/test/unit/org/apache/cassandra/transport/CBUtilTest.java
@@ -65,4 +65,27 @@ public class CBUtilTest
         Assert.assertEquals(text, CBUtil.readLongString(buf));
         Assert.assertEquals(buf.writerIndex(), buf.readerIndex());
     }
+
+    @Test
+    public void writeAndReadAsciiString()
+    {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i < 128; i++)
+            sb.append((char) i);
+        String write = sb.toString();
+        int size = CBUtil.sizeOfString(write);
+        buf = allocator.heapBuffer(size);
+        CBUtil.writeAsciiString(write, buf);
+        String read = CBUtil.readString(buf);
+        Assert.assertEquals(write, read);
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void writeAndReadAsciiStringFailedWithNonAscii()
+    {
+        String invalidAsciiStr = "\u0080 \u0123 \u0321"; // a valid string contains no char > 0x007F
+        int size = CBUtil.sizeOfString(invalidAsciiStr);
+        buf = allocator.heapBuffer(size);
+        CBUtil.writeAsciiString(invalidAsciiStr, buf);
+    }
 }

--- a/test/unit/org/apache/cassandra/transport/CBUtilTest.java
+++ b/test/unit/org/apache/cassandra/transport/CBUtilTest.java
@@ -80,12 +80,15 @@ public class CBUtilTest
         Assert.assertEquals(write, read);
     }
 
-    @Test(expected = ProtocolException.class)
-    public void writeAndReadAsciiStringFailedWithNonAscii()
+    @Test
+    public void writeAndReadAsciiStringMismatchWithNonUSAscii()
     {
         String invalidAsciiStr = "\u0080 \u0123 \u0321"; // a valid string contains no char > 0x007F
         int size = CBUtil.sizeOfString(invalidAsciiStr);
         buf = allocator.heapBuffer(size);
         CBUtil.writeAsciiString(invalidAsciiStr, buf);
+        Assert.assertNotEquals("Characters (> 0x007F) is considered as 2 bytes in sizeOfString, meanwhile writeAsciiString writes just 1 byte",
+                               size,
+                               buf.writerIndex());
     }
 }

--- a/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
@@ -114,7 +114,9 @@ public class ErrorMessageTest
 
     private ErrorMessage serializeAndGetDeserializedErrorMessage(ErrorMessage message, ProtocolVersion version)
     {
-        ByteBuf buffer = Unpooled.buffer(ErrorMessage.codec.encodedSize(message, version));
+        int size = ErrorMessage.codec.encodedSize(message, version);
+        // cap the maxCapticity of buffer so that the correctness of the calculated encodeSize is examed.
+        ByteBuf buffer = Unpooled.buffer(size, size);
         ErrorMessage.codec.encode(message, buffer, version);
         return ErrorMessage.codec.decode(buffer, version);
     }

--- a/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
@@ -25,19 +25,18 @@ import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.WriteType;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.WriteFailureException;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.transport.messages.EncodeAndDecodeTestBase;
 import org.apache.cassandra.transport.messages.ErrorMessage;
 
 import static org.junit.Assert.assertEquals;
 
-public class ErrorMessageTest
+public class ErrorMessageTest extends EncodeAndDecodeTestBase<ErrorMessage>
 {
     private static Map<InetAddressAndPort, RequestFailureReason> failureReasonMap1;
     private static Map<InetAddressAndPort, RequestFailureReason> failureReasonMap2;
@@ -63,7 +62,7 @@ public class ErrorMessageTest
         boolean dataPresent = false;
         ReadFailureException rfe = new ReadFailureException(consistencyLevel, receivedBlockFor, receivedBlockFor, dataPresent, failureReasonMap1);
 
-        ErrorMessage deserialized = serializeAndGetDeserializedErrorMessage(ErrorMessage.fromException(rfe), ProtocolVersion.V5);
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromException(rfe), ProtocolVersion.V5);
         ReadFailureException deserializedRfe = (ReadFailureException) deserialized.error;
 
         assertEquals(failureReasonMap1, deserializedRfe.failureReasonByEndpoint);
@@ -81,7 +80,7 @@ public class ErrorMessageTest
         WriteType writeType = WriteType.SIMPLE;
         WriteFailureException wfe = new WriteFailureException(consistencyLevel, receivedBlockFor, receivedBlockFor, writeType, failureReasonMap2);
 
-        ErrorMessage deserialized = serializeAndGetDeserializedErrorMessage(ErrorMessage.fromException(wfe), ProtocolVersion.V5);
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromException(wfe), ProtocolVersion.V5);
         WriteFailureException deserializedWfe = (WriteFailureException) deserialized.error;
 
         assertEquals(failureReasonMap2, deserializedWfe.failureReasonByEndpoint);
@@ -112,12 +111,8 @@ public class ErrorMessageTest
         assertEquals(failureReasonMap1, wfe.failureReasonByEndpoint);
     }
 
-    private ErrorMessage serializeAndGetDeserializedErrorMessage(ErrorMessage message, ProtocolVersion version)
+    protected Message.Codec<ErrorMessage> getCodec()
     {
-        int size = ErrorMessage.codec.encodedSize(message, version);
-        // cap the maxCapticity of buffer so that the correctness of the calculated encodeSize is examed.
-        ByteBuf buffer = Unpooled.buffer(size, size);
-        ErrorMessage.codec.encode(message, buffer, version);
-        return ErrorMessage.codec.decode(buffer, version);
+        return ErrorMessage.codec;
     }
 }

--- a/test/unit/org/apache/cassandra/transport/messages/AuthenticateMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/messages/AuthenticateMessageTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport.messages;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.auth.PasswordAuthenticator;
+import org.apache.cassandra.transport.Message;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+public class AuthenticateMessageTest extends EncodeAndDecodeTestBase<AuthenticateMessage>
+{
+    @Test
+    public void testEncodeAndDecode()
+    {
+        AuthenticateMessage origin = new AuthenticateMessage(PasswordAuthenticator.class.getName());
+        AuthenticateMessage newMessage = encodeThenDecode(origin, ProtocolVersion.V5);
+        Assert.assertEquals(origin.toString(), newMessage.toString());
+    }
+
+    protected Message.Codec<AuthenticateMessage> getCodec()
+    {
+        return AuthenticateMessage.codec;
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/messages/EncodeAndDecodeTestBase.java
+++ b/test/unit/org/apache/cassandra/transport/messages/EncodeAndDecodeTestBase.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport.messages;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.cassandra.transport.Message;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+public abstract class EncodeAndDecodeTestBase<T extends Message>
+{
+    protected abstract Message.Codec<T> getCodec();
+
+    protected T encodeThenDecode(T message, ProtocolVersion version)
+    {
+        int size = getCodec().encodedSize(message, version);
+        ByteBuf buffer = Unpooled.buffer(size, size);
+        getCodec().encode(message, buffer, version);
+        return getCodec().decode(buffer, version);
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/messages/PrepareMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/messages/PrepareMessageTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport.messages;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.transport.Message;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+public class PrepareMessageTest extends EncodeAndDecodeTestBase<PrepareMessage>
+{
+    @Test
+    public void testEncodeThenDecode()
+    {
+        PrepareMessage origin = new PrepareMessage("SELECT * FROM keyspace.tbl WHERE name='ßètæ'", "keyspace");
+        PrepareMessage newMessage = encodeThenDecode(origin, ProtocolVersion.V5);
+        Assert.assertEquals(origin.toString(), newMessage.toString());
+    }
+
+    protected Message.Codec<PrepareMessage> getCodec()
+    {
+        return PrepareMessage.codec;
+    }
+}


### PR DESCRIPTION
Given the fact that the `encodeSize` was calculated already when encoding, we can leverage the size and safely reserve the remaining capacity for writing to avoid resizing. 

A set of benchmarks were taken to show the difference. For the long text, the change halves the string encoding time from 571.9 ns to 216.1 ns. The time is almost halves for the short text as well. 

The improvement is because of avoiding the unnecessary resizing and data copy. 

```
[java] Benchmark                                                  Mode  Cnt    Score    Error  Units
[java] Utf8StringEncodeBench.writeLongText                        avgt    6  571.949 ± 19.791  ns/op
[java] Utf8StringEncodeBench.writeLongTextWithExactSize           avgt    6  459.932 ± 27.790  ns/op
[java] Utf8StringEncodeBench.writeLongTextWithExactSizeSkipCalc   avgt    6  216.085 ±  3.480  ns/op
[java] Utf8StringEncodeBench.writeShortText                       avgt    6   62.775 ±  6.159  ns/op
[java] Utf8StringEncodeBench.writeShortTextWithExactSize          avgt    6   44.071 ±  5.645  ns/op
[java] Utf8StringEncodeBench.writeShortTextWithExactSizeSkipCalc  avgt    6   36.358 ±  5.135  ns/op
````

- writeLongText: the original implementation that calls `ByteBufUtils.writeUtf8`. It over-estimates the size of string that causes resizing the buffer.
- writeLongTextWithExactSize: calls `TypeSizes.encodeUTF8Length` to reserve the exact size of bytes to write.
- writeLongTextWithExactSizeSkipCalc: optimize by removing calculating the UTF8 length. Because we calculated the encodeSize before encode for messages. Therefore, the size of the final bytes is known, we can leverage this information to just reserve using the remaining capacity.