### PR TITLE
CASSANDRA-15402 Make incremental backup configurable per keyspace and table.

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
@@ -275,6 +277,7 @@ public class Config
     public ParameterizedClass hints_compression;
 
     public volatile boolean incremental_backups = false;
+    public volatile Multimap<String, String> incrementalbackupKsTbs = HashMultimap.<String, String>create();
     public boolean trickle_fsync = false;
     public int trickle_fsync_interval_in_kb = 10240;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 
@@ -2312,6 +2313,25 @@ public class DatabaseDescriptor
     public static void setIncrementalBackupsEnabled(boolean value)
     {
         conf.incremental_backups = value;
+    }
+    
+    public static void setIncrementalBackupsKSTBs(Multimap<String, String> ksTbs)
+    {
+        conf.incrementalbackupKsTbs = ksTbs;
+    }
+    
+    public static Multimap<String, String> getIncrementalBackupsKSTBs()
+    {
+        return conf.incrementalbackupKsTbs;
+    }
+    
+    public static boolean incrementalBackupForKSTB(String keyspace, String table)
+    {
+        if (conf.incrementalbackupKsTbs.containsEntry(keyspace, table))
+        {
+            return true;
+        }
+        return false;
     }
 
     public static int getFileCacheSizeInMB()

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -389,7 +389,8 @@ public class Tracker
 
     public void maybeIncrementallyBackup(final Iterable<SSTableReader> sstables)
     {
-        if (!DatabaseDescriptor.isIncrementalBackupsEnabled())
+        if (!DatabaseDescriptor.isIncrementalBackupsEnabled() || 
+                (DatabaseDescriptor.isIncrementalBackupsEnabled() && !DatabaseDescriptor.incrementalBackupForKSTB(cfstore.metadata().keyspace, cfstore.metadata().name)))
             return;
 
         for (SSTableReader sstable : sstables)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1495,6 +1495,15 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return DatabaseDescriptor.getIncrementalBackupsKSTBs();
     }
 
+    /**
+     * Set the incremental backup status with the specified keyspace and table
+     * 
+     * @param value if set true then means incremental backup is turn on for the keyspace/table.
+     *        If the value set false, that means incremental backup should be turn off for the keyspace/table.
+     * @param ksTbStringList the array of the string with the format keyspace.table, This means the keyspace/table
+     *        that should turn on/off incremental backup. All keyspace/table will be set when this variable is null  
+     *          
+     * */
     public void setIncrementalBackupsEnabled(boolean value, String ... ksTbStringList) throws IOException, IllegalArgumentException
     {
         Multimap<String, String> incrementalbackupKsTbs;

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -33,6 +33,7 @@ import javax.management.openmbean.TabularData;
 
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import com.google.common.collect.Multimap;
 
 public interface StorageServiceMBean extends NotificationEmitter
 {
@@ -587,7 +588,8 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void setConcurrentViewBuilders(int value);
 
     public boolean isIncrementalBackupsEnabled();
-    public void setIncrementalBackupsEnabled(boolean value);
+    public void setIncrementalBackupsEnabled(boolean value, String ... ksTbStringList) throws IOException, IllegalArgumentException;
+    public Multimap<String, String> getIncrementalBackupsKSTBs();
 
     /**
      * Initiate a process of streaming data for which we are responsible from other nodes. It is similar to bootstrap

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -763,14 +763,19 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.getAutoCompactionStatus(ks, tableNames);
     }
 
-    public void setIncrementalBackupsEnabled(boolean enabled)
+    public void setIncrementalBackupsEnabled(boolean enabled, String ... ksTbStringList) throws IllegalArgumentException, IOException
     {
-        ssProxy.setIncrementalBackupsEnabled(enabled);
+        ssProxy.setIncrementalBackupsEnabled(enabled, ksTbStringList);
     }
 
     public boolean isIncrementalBackupsEnabled()
     {
         return ssProxy.isIncrementalBackupsEnabled();
+    }
+    
+    public  Multimap<String, String> getIncrementalBackupsKSTBs()
+    {
+        return ssProxy.getIncrementalBackupsKSTBs();
     }
 
     public void setCacheCapacities(int keyCacheCapacity, int rowCacheCapacity, int counterCacheCapacity)

--- a/src/java/org/apache/cassandra/tools/nodetool/DisableBackup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/DisableBackup.java
@@ -18,16 +18,40 @@
 package org.apache.cassandra.tools.nodetool;
 
 import io.airlift.airline.Command;
-
+import io.airlift.airline.Option;
+import java.io.IOException;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
-@Command(name = "disablebackup", description = "Disable incremental backup")
+@Command(name = "disablebackup", description = "Disable incremental backup with specified keyspace and table")
 public class DisableBackup extends NodeToolCmd
 {
+    @Option(title = "ktlist", name = { "-kt", "--kt-list" }, description = "The list of Keyspace.table connected by ',' to take incremental backup. All table will take backup if not set. ")
+    private String ktList = null;
+    
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.setIncrementalBackupsEnabled(false);
+        try 
+        {
+            System.out.printf("%s%n", "Requested disable encremental backup for :");
+            
+            if (null != ktList && !ktList.isEmpty())
+            {
+                ktList = ktList.replace(" ", "");
+                probe.setIncrementalBackupsEnabled(false, ktList.split(","));
+                System.out.printf("    %s", probe.getIncrementalBackupsKSTBs());
+            }
+            else 
+            {
+                probe.setIncrementalBackupsEnabled(false); 
+                System.out.printf("    %s", "All keyspaces");
+            }
+            
+        }
+        catch (IOException | IllegalArgumentException e) 
+        {
+            throw new RuntimeException("Error during diable incremental backup.", e);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/EnableBackup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/EnableBackup.java
@@ -18,16 +18,38 @@
 package org.apache.cassandra.tools.nodetool;
 
 import io.airlift.airline.Command;
-
+import io.airlift.airline.Option;
+import java.io.IOException;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
-@Command(name = "enablebackup", description = "Enable incremental backup")
+@Command(name = "enablebackup", description = "Enable incremental backup with specified keyspace and table")
 public class EnableBackup extends NodeToolCmd
-{
+{   
+    @Option(title = "ktlist", name = { "-kt", "--kt-list" }, description = "The list of Keyspace.table connected by ',' to take incremental backup. All table will take backup if not set. ")
+    private String ktList = null;
+    
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.setIncrementalBackupsEnabled(true);
+        try 
+        {
+            System.out.printf("%s%n", "Requested enable encremental backup for :");
+            if (null != ktList && !ktList.isEmpty())
+            {
+                ktList = ktList.replace(" ", "");
+                probe.setIncrementalBackupsEnabled(true, ktList.split(","));
+                System.out.printf("    %s", probe.getIncrementalBackupsKSTBs());
+            }
+            else 
+            {
+                probe.setIncrementalBackupsEnabled(true);
+                System.out.printf("    %s", "All keyspaces");
+            }
+        }
+        catch (IOException | IllegalArgumentException e) 
+        {
+            throw new RuntimeException("Error during enable incremental backup.", e);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/StatusBackup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StatusBackup.java
@@ -28,9 +28,16 @@ public class StatusBackup extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        System.out.println(
-                probe.isIncrementalBackupsEnabled()
-                ? "running"
-                : "not running");
+        System.out.printf("%s%n", "Incremental backup status:");
+        
+        if (!probe.isIncrementalBackupsEnabled())
+        {
+            System.out.printf("    %s", "Not running");
+        }
+        else 
+        {
+            System.out.printf("    %s%n", "Runinng, backup keyspace and table are :");
+            System.out.printf("    %s", probe.getIncrementalBackupsKSTBs());
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreTest.java
@@ -18,27 +18,26 @@
 */
 package org.apache.cassandra.db;
 
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
-
-import org.junit.Before;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import com.google.common.collect.Iterators;
-import org.apache.cassandra.*;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
-import org.apache.cassandra.db.rows.*;
-import org.apache.cassandra.db.partitions.*;
-import org.apache.cassandra.db.marshal.*;
+import org.apache.cassandra.db.partitions.FilteredPartition;
+import org.apache.cassandra.db.rows.Cell;
+import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
@@ -50,7 +49,14 @@ import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.WrappedRunnable;
-import static junit.framework.Assert.assertNotNull;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Multimap;
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class ColumnFamilyStoreTest
 {
@@ -87,6 +93,13 @@ public class ColumnFamilyStoreTest
         // Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_SUPER1).truncateBlocking();
 
         Keyspace.open(KEYSPACE2).getColumnFamilyStore(CF_STANDARD1).truncateBlocking();
+        
+        Multimap<String, String> incrementalbackupKsTbs = HashMultimap.<String, String>create();
+        Keyspace.all().forEach(keyspace -> 
+            {
+                keyspace.getMetadata().tables.forEach(table -> incrementalbackupKsTbs.put(table.keyspace, table.name));
+            });
+        DatabaseDescriptor.setIncrementalBackupsKSTBs(incrementalbackupKsTbs);
     }
 
     @Test


### PR DESCRIPTION
I just add the feature of incremental backup configurable per keyspace and table . 
First of all , all the table will be added to a map at startup when the incremental_backup flag is set to true, which means all the table will take off incremental backup. 

Through nodetool of enablebackup /disablebackup we can enable backup and disable backup for the specified keyspace and table.Also the commadn of statusbackup will show the status of keyspace/table that turn on incremental backup.

