### PR TITLE
fix an error in ALTER TABLE doc when adding or dropping multiple columns

### DIFF
--- a/doc/source/cql/ddl.rst
+++ b/doc/source/cql/ddl.rst
@@ -721,8 +721,10 @@ Altering an existing table uses the ``ALTER TABLE`` statement:
 
 .. productionlist::
    alter_table_statement: ALTER TABLE `table_name` `alter_table_instruction`
-   alter_table_instruction: ADD `column_name` `cql_type` ( ',' `column_name` `cql_type` )*
-                          : | DROP `column_name` ( `column_name` )*
+   alter_table_instruction: ADD `column_name` `cql_type`
+                          : | ADD '(' `column_name` `cql_type` ( ',' `column_name` `cql_type`)* ')'
+                          : | DROP `column_name`
+                          : | DROP '(' `column_name` (',' `column_name` )* ')'
                           : | WITH `options`
 
 For instance::


### PR DESCRIPTION
This PR sync the ALTER TABLE doc with the actual functionality.
In practice (as tested with 3.1.11) both add and drop of multiple columns requires parentheses around the columns list

```
create table test_alter( a int primary key) ;
alter table test_alter add b int; // one column - works
alter table test_alter add c int , d int; // two colmns with out parentheses - does not work
SyntaxException: line 1:33 mismatched input ',' expecting EOF (...table test_alter add c int [,] d...)
alter table test_alter add (c int , d int); // two colmns with parentheses - works
```  
