### PR TITLE
[CASSANDRA-15437] Decommission fails with "Unable to stream hints since no live endpoints seen" even if no hints need to be sent.

### DIFF
--- a/src/java/org/apache/cassandra/hints/HintsService.java
+++ b/src/java/org/apache/cassandra/hints/HintsService.java
@@ -393,4 +393,8 @@ public final class HintsService implements HintsServiceMBean
     {
         return isShutDown;
     }
-}
+    
+    public boolean hasHints()
+    {
+        return catalog.hasFiles();
+    }}


### PR DESCRIPTION
I add a check step in unbootstrap: If there is no hints in hintsservice, just skip streaming hints and continue the decommission process.