### PR TITLE
CASSANDRA-15470 Adding validations on several fields in DatabaseDescr…

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -503,24 +503,24 @@ public class DatabaseDescriptor
         checkForLowestAcceptedTimeouts(conf);
 
         if (conf.native_transport_max_frame_size_in_mb <= 0 || conf.native_transport_max_frame_size_in_mb >= 2048)
-            throw new ConfigurationException("native_transport_max_frame_size_in_mb must be positive value < 2KiB, but was "
+            throw new ConfigurationException("native_transport_max_frame_size_in_mb must be positive value < 2048, but was "
                                              + conf.native_transport_max_frame_size_in_mb, false);
 
         if (conf.column_index_size_in_kb <= 0 || conf.column_index_size_in_kb >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("column_index_size_in_kb must be positive value < 2MiB " +
-                                             "but was " + conf.column_index_size_in_kb, false);
+            throw new ConfigurationException("column_index_size_in_kb must be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + conf.column_index_size_in_kb, false);
 
         if (conf.column_index_cache_size_in_kb <= 0 || conf.column_index_cache_size_in_kb >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("column_index_cache_size_in_kb must be positive value < 2 MiB, " +
-                                             "but was " + conf.column_index_cache_size_in_kb, false);
+            throw new ConfigurationException("column_index_cache_size_in_kb must be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + conf.column_index_cache_size_in_kb, false);
 
         if (conf.batch_size_warn_threshold_in_kb <= 0 || conf.batch_size_warn_threshold_in_kb >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("batch_size_warn_threshold_in_kb must be positive value < 2MiB but was "
-                                             + conf.batch_size_warn_threshold_in_kb, false);
+            throw new ConfigurationException("batch_size_warn_threshold_in_kb must be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + conf.batch_size_warn_threshold_in_kb, false);
 
         if (conf.native_transport_frame_block_size_in_kb <= 0 || conf.native_transport_frame_block_size_in_kb >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("native_transport_frame_block_size_in_kb must be positive value < 2MiB, " +
-                                             "but was " + conf.native_transport_frame_block_size_in_kb, false);
+            throw new ConfigurationException("native_transport_frame_block_size_in_kb must be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + conf.native_transport_frame_block_size_in_kb, false);
 
         if (conf.native_transport_max_negotiable_protocol_version != null)
             logger.warn("The configuration option native_transport_max_negotiable_protocol_version has been deprecated " +
@@ -1394,8 +1394,8 @@ public class DatabaseDescriptor
     public static void setColumnIndexSize(int val)
     {
         if (val <= 0 || val >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("set column_index_size_in_kb value should be positive value < 2MiB " +
-                                             "but was " + val);
+            throw new ConfigurationException("set column_index_size_in_kb value should be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + val);
         conf.column_index_size_in_kb = val;
     }
 
@@ -1408,8 +1408,8 @@ public class DatabaseDescriptor
     public static void setColumnIndexCacheSize(int val)
     {
         if (val <= 0 || val >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("column_index_cache_size_in_kb value should be positive value < 2MiB " +
-                                             "but was " + val);
+            throw new ConfigurationException("column_index_cache_size_in_kb value should be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + val);
 
         conf.column_index_cache_size_in_kb = val;
     }
@@ -1442,8 +1442,8 @@ public class DatabaseDescriptor
     public static void setBatchSizeWarnThresholdInKB(int threshold)
     {
         if (threshold <= 0 || threshold >= TWO_MEBI_BYTES)
-            throw new ConfigurationException("set batch_size_warn_threshold_in_kb value should be positive value < 2MiB " +
-                                             "but was " + threshold);
+            throw new ConfigurationException("set batch_size_warn_threshold_in_kb value should be positive value < " + TWO_MEBI_BYTES +
+                                             ", but was " + threshold);
 
         conf.batch_size_warn_threshold_in_kb = threshold;
     }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -499,10 +499,38 @@ public class DatabaseDescriptor
         checkForLowestAcceptedTimeouts(conf);
 
         if (conf.native_transport_max_frame_size_in_mb <= 0)
-            throw new ConfigurationException("native_transport_max_frame_size_in_mb must be positive, but was " + conf.native_transport_max_frame_size_in_mb, false);
+            throw new ConfigurationException("native_transport_max_frame_size_in_mb must be positive, but was "
+                                             + conf.native_transport_max_frame_size_in_mb, false);
         else if (conf.native_transport_max_frame_size_in_mb >= 2048)
             throw new ConfigurationException("native_transport_max_frame_size_in_mb must be smaller than 2048, but was "
                     + conf.native_transport_max_frame_size_in_mb, false);
+
+        if (conf.column_index_size_in_kb <= 0)
+            throw new ConfigurationException("column_index_size_in_kb must be positive, but was " + conf.column_index_size_in_kb, false);
+        else if (conf.column_index_size_in_kb >= 2 * 1024 * 1024)
+            throw new ConfigurationException("column_index_size_in_kb must be smaller than 2GiB, but was "
+                                             + conf.column_index_size_in_kb, false);
+
+        if (conf.column_index_cache_size_in_kb <= 0)
+            throw new ConfigurationException("column_index_cache_size_in_kb must be positive, but was "
+                                             + conf.column_index_cache_size_in_kb, false);
+        else if (conf.column_index_cache_size_in_kb >= 2 * 1024 * 1024)
+            throw new ConfigurationException("column_index_cache_size_in_kb must be smaller than 2GiB, but was "
+                                             + conf.column_index_cache_size_in_kb, false);
+
+        if (conf.batch_size_warn_threshold_in_kb <= 0)
+            throw new ConfigurationException("batch_size_warn_threshold_in_kb must be positive, but was "
+                                             + conf.batch_size_warn_threshold_in_kb, false);
+        else if (conf.native_transport_max_frame_size_in_mb >= 2 * 1024 * 1024)
+            throw new ConfigurationException("batch_size_warn_threshold_in_kb must be smaller than 2GiB, but was "
+                                             + conf.batch_size_warn_threshold_in_kb, false);
+
+        if (conf.native_transport_frame_block_size_in_kb <= 0)
+            throw new ConfigurationException("native_transport_frame_block_size_in_kb must be positive, but was "
+                                             + conf.native_transport_frame_block_size_in_kb, false);
+        else if (conf.native_transport_frame_block_size_in_kb >= 2 * 1024 * 1024)
+            throw new ConfigurationException("native_transport_frame_block_size_in_kb must be smaller than 2GiB, but was "
+                                             + conf.native_transport_frame_block_size_in_kb, false);
 
         if (conf.native_transport_max_negotiable_protocol_version != null)
             logger.warn("The configuration option native_transport_max_negotiable_protocol_version has been deprecated " +
@@ -1375,6 +1403,11 @@ public class DatabaseDescriptor
     @VisibleForTesting
     public static void setColumnIndexSize(int val)
     {
+        if (val <= 0)
+            throw new ConfigurationException("Cannot set column_index_size_in_kb to " + val + " <= 0 KiB");
+        else if (val >= 2 * 1024 * 1024)
+            throw new ConfigurationException("A column_index_size_in_kb " + val + " KiB will cause integer overflow");
+
         conf.column_index_size_in_kb = val;
     }
 
@@ -1386,6 +1419,12 @@ public class DatabaseDescriptor
     @VisibleForTesting
     public static void setColumnIndexCacheSize(int val)
     {
+        if (val <= 0)
+            throw new ConfigurationException("Cannot set column_index_cache_size_in_kb to " + val + " <= 0 KiB");
+        else if (val >= 2 * 1024 * 1024)
+            throw new ConfigurationException("A column_index_cache_size_in_kb " + val +
+                                             " KiB will cause integer overflow");
+
         conf.column_index_cache_size_in_kb = val;
     }
 
@@ -1416,6 +1455,13 @@ public class DatabaseDescriptor
 
     public static void setBatchSizeWarnThresholdInKB(int threshold)
     {
+        if (threshold <= 0)
+            throw new ConfigurationException("Cannot set batch_size_warn_threshold_in_kb to " + threshold +
+                                             " <= 0 KiB");
+        else if (threshold >= 2 * 1024 * 1024)
+            throw new ConfigurationException("A batch_size_warn_threshold_in_kb " + threshold +
+                                             " kiB will cause integer overflow");
+
         conf.batch_size_warn_threshold_in_kb = threshold;
     }
 

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -214,6 +214,57 @@ public class DatabaseDescriptorTest
     }
 
     @Test
+    public void testExceptionsForInvalidConfigValues() {
+        try
+        {
+            DatabaseDescriptor.setColumnIndexCacheSize(0);
+            fail("Should have received a ConfigurationException column_index_cache_size_in_kb = 0");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(2048, DatabaseDescriptor.getColumnIndexCacheSize());
+
+        try
+        {
+            DatabaseDescriptor.setColumnIndexCacheSize(2 * 1024 * 1024);
+            fail("Should have received a ConfigurationException column_index_cache_size_in_kb = 2TiB");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(2048, DatabaseDescriptor.getColumnIndexCacheSize());
+
+        try
+        {
+            DatabaseDescriptor.setColumnIndexSize(0);
+            fail("Should have received a ConfigurationException column_index_size_in_kb = 0");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize());
+
+        try
+        {
+            DatabaseDescriptor.setColumnIndexSize(2 * 1024 * 1024);
+            fail("Should have received a ConfigurationException column_index_size_in_kb = 2TiB");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize());
+
+        try
+        {
+            DatabaseDescriptor.setBatchSizeWarnThresholdInKB(0);
+            fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = 0");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
+
+        try
+        {
+            DatabaseDescriptor.setBatchSizeWarnThresholdInKB(2 * 1024 * 1024);
+            fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = 2TiB");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize());
+    }
+
+    @Test
     public void testLowestAcceptableTimeouts() throws ConfigurationException
     {
         Config testConfig = new Config();

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -226,7 +226,7 @@ public class DatabaseDescriptorTest
         try
         {
             DatabaseDescriptor.setColumnIndexCacheSize(2 * 1024 * 1024);
-            fail("Should have received a ConfigurationException column_index_cache_size_in_kb = 2TiB");
+            fail("Should have received a ConfigurationException column_index_cache_size_in_kb = 2GiB");
         }
         catch (ConfigurationException ignored) { }
         Assert.assertEquals(2048, DatabaseDescriptor.getColumnIndexCacheSize());
@@ -242,7 +242,7 @@ public class DatabaseDescriptorTest
         try
         {
             DatabaseDescriptor.setColumnIndexSize(2 * 1024 * 1024);
-            fail("Should have received a ConfigurationException column_index_size_in_kb = 2TiB");
+            fail("Should have received a ConfigurationException column_index_size_in_kb = 2GiB");
         }
         catch (ConfigurationException ignored) { }
         Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize());
@@ -258,7 +258,7 @@ public class DatabaseDescriptorTest
         try
         {
             DatabaseDescriptor.setBatchSizeWarnThresholdInKB(2 * 1024 * 1024);
-            fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = 2TiB");
+            fail("Should have received a ConfigurationException batch_size_warn_threshold_in_kb = 2GiB");
         }
         catch (ConfigurationException ignored) { }
         Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize());


### PR DESCRIPTION
…iptor that have the potential to overflow

DatabaseDescriptor has several functions that convert between user supplied sizes in KB/MB and bytes. Taking the validation path to avoid integer overflows.