### PR TITLE
Fix NoSuchElementException issue reappearing when iterator is exhausted

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/Operation.java
+++ b/tools/stress/src/org/apache/cassandra/stress/Operation.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.stress;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 
 import org.apache.cassandra.stress.report.Timer;
 import org.apache.cassandra.stress.settings.SettingsLog;
@@ -75,6 +76,10 @@ public abstract class Operation
             {
                 success = run.run();
                 break;
+            }
+            catch (NoSuchElementException e) {
+                // Pass thru iterator exhaustion exception
+                throw e;
             }
             catch (Exception e)
             {

--- a/tools/stress/src/org/apache/cassandra/stress/StressAction.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressAction.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+import java.util.NoSuchElementException;
 
 import org.apache.cassandra.stress.operations.OpDistribution;
 import org.apache.cassandra.stress.operations.OpDistributionFactory;
@@ -472,7 +473,10 @@ public class StressAction implements Runnable
                                 throw new IllegalStateException();
                         }
                     }
-                    catch (Exception e)
+                    catch (NoSuchElementException e)
+                    {
+                        // Silently reiterate when iterator is exhausted
+                    } catch (Exception e)
                     {
                         if (output == null)
                             System.err.println(e.getMessage());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-15034

I see too many messages like this when network error happens:
	at org.apache.cassandra.stress.generate.PartitionIterator$MultiRowIterator.next(PartitionIterator.java:689)
	at org.apache.cassandra.stress.generate.PartitionIterator$MultiRowIterator.next(PartitionIterator.java:187)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.bind(CASQuery.java:163)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.access$200(CASQuery.java:57)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery$JavaDriverRun.run(CASQuery.java:147)
	at org.apache.cassandra.stress.Operation.timeWithRetry(Operation.java:76)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.run(CASQuery.java:157)
	at org.apache.cassandra.stress.StressAction$Consumer.run(StressAction.java:466)
java.util.NoSuchElementException
	at org.apache.cassandra.stress.generate.PartitionIterator$MultiRowIterator.next(PartitionIterator.java:689)
	at org.apache.cassandra.stress.generate.PartitionIterator$MultiRowIterator.next(PartitionIterator.java:187)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.bind(CASQuery.java:163)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.access$200(CASQuery.java:57)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery$JavaDriverRun.run(CASQuery.java:147)
	at org.apache.cassandra.stress.Operation.timeWithRetry(Operation.java:76)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.run(CASQuery.java:157)
	at org.apache.cassandra.stress.StressAction$Consumer.run(StressAction.java:466)
java.util.NoSuchElementException
	at org.apache.cassandra.stress.generate.PartitionIterator$MultiRowIterator.next(PartitionIterator.java:689)
	at org.apache.cassandra.stress.generate.PartitionIterator$MultiRowIterator.next(PartitionIterator.java:187)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.bind(CASQuery.java:163)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.access$200(CASQuery.java:57)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery$JavaDriverRun.run(CASQuery.java:147)
	at org.apache.cassandra.stress.Operation.timeWithRetry(Operation.java:76)
	at org.apache.cassandra.stress.operations.userdefined.CASQuery.run(CASQuery.java:157)
	at org.apache.cassandra.stress.StressAction$Consumer.run(StressAction.java:466)