### PR TITLE
CASSANDRA-15598 fix(StressProfile.java): fix c-s failing when profile table is extended with set<set<>> column

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsErrors.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsErrors.java
@@ -34,12 +34,14 @@ public class SettingsErrors implements Serializable
     public final boolean ignore;
     public final int tries;
     public final boolean skipReadValidation;
+    public final boolean skipUnsupportedColumns;
 
     public SettingsErrors(Options options)
     {
         ignore = options.ignore.setByUser();
         this.tries = Math.max(1, Integer.parseInt(options.retries.value()) + 1);
         skipReadValidation = options.skipReadValidation.setByUser();
+        skipUnsupportedColumns = options.skipUnsupportedColumns.setByUser();
     }
 
     // Option Declarations
@@ -49,10 +51,11 @@ public class SettingsErrors implements Serializable
         final OptionSimple retries = new OptionSimple("retries=", "[0-9]+", "9", "Number of tries to perform for each operation before failing", false);
         final OptionSimple ignore = new OptionSimple("ignore", "", null, "Do not fail on errors", false);
         final OptionSimple skipReadValidation = new OptionSimple("skip-read-validation", "", null, "Skip read validation and message output", false);
+        final OptionSimple skipUnsupportedColumns = new OptionSimple("skip-unsupported-columns", "", null, "Skip unsupported columns, such as maps and embedded collections, when generating data for a user profile.", false);
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(retries, ignore, skipReadValidation);
+            return Arrays.asList(retries, ignore, skipReadValidation, skipUnsupportedColumns);
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-15598

Reason:
c-s reads metadata from database, and build column generator from it.
But this logic is build in a way so that it does not support generator recursion, which is necessary to support embedded collections.

Fix:
This fix is simple exclude this type of columns from being processed.

Steps to reproduce:

- docker run -d --name cassandra cassandra:latest
- cassandra-stress user profile=/tmp/fail_anyway.yaml ops'(insert=1)' cl=ONE n=20 -pop seq=1..10000000 -port jmx=6868 -mode cql3 native -rate threads=2 -node x.x.x.x
java.lang.NullPointerException
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:760)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:800)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:800)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:755)
	at org.apache.cassandra.stress.StressProfile$GeneratorFactory.get(StressProfile.java:733)
	at org.apache.cassandra.stress.StressProfile$GeneratorFactory.newGenerator(StressProfile.java:726)
	at org.apache.cassandra.stress.StressProfile.newGenerator(StressProfile.java:696)
	at org.apache.cassandra.stress.StressProfile.printSettings(StressProfile.java:126)
	at org.apache.cassandra.stress.settings.StressSettings.lambda$printSettings$1(StressSettings.java:311)
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
	at org.apache.cassandra.stress.settings.StressSettings.printSettings(StressSettings.java:311)
	at org.apache.cassandra.stress.Stress.run(Stress.java:95)
	at org.apache.cassandra.stress.Stress.main(Stress.java:62)

- cassandra-stress user profile=/tmp/fail_if_no_skip.yaml ops'(insert=1)' cl=ONE n=20 -pop seq=1..10000000 -port jmx=6868 -mode cql3 native -rate threads=2 -node x.x.x.x
java.lang.UnsupportedOperationException: Because of this name: aux_map if you removed it from the yaml and are still seeing this, make sure to drop table
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:804)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:755)
	at org.apache.cassandra.stress.StressProfile$GeneratorFactory.get(StressProfile.java:733)
	at org.apache.cassandra.stress.StressProfile$GeneratorFactory.newGenerator(StressProfile.java:726)
	at org.apache.cassandra.stress.StressProfile.newGenerator(StressProfile.java:696)
	at org.apache.cassandra.stress.StressProfile.printSettings(StressProfile.java:126)
	at org.apache.cassandra.stress.settings.StressSettings.lambda$printSettings$1(StressSettings.java:311)
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
	at org.apache.cassandra.stress.settings.StressSettings.printSettings(StressSettings.java:311)
	at org.apache.cassandra.stress.Stress.run(Stress.java:95)
	at org.apache.cassandra.stress.Stress.main(Stress.java:62)

[user_profiles.zip](https://github.com/apache/cassandra/files/4379378/user_profiles.zip)
