### PR TITLE
CASSANDRA-15565 Use result size for index built test

### DIFF
--- a/test/unit/org/apache/cassandra/index/internal/CassandraIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/internal/CassandraIndexTest.java
@@ -495,17 +495,22 @@ public class CassandraIndexTest extends CQLTester
         String tableName = createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a, b))");
         createIndex(String.format("CREATE INDEX %s ON %%s(c)", indexName));
         waitForIndex(KEYSPACE, tableName, indexName);
-        // check that there are no other rows in the built indexes table
-        assertRows(execute(String.format("SELECT * FROM %s.\"%s\"", SchemaConstants.SYSTEM_KEYSPACE_NAME, SystemKeyspace.BUILT_INDEXES)),
-                   row(KEYSPACE, indexName, null));
+        String selectBuiltIndexesQuery = String.format("SELECT * FROM %s.\"%s\"",
+                                                             SchemaConstants.SYSTEM_KEYSPACE_NAME,
+                                                             SystemKeyspace.BUILT_INDEXES);
+
+        UntypedResultSet rs = execute(selectBuiltIndexesQuery);
+        int initialSize = rs.size();
+        assertRowsIgnoringOrderAndExtra(rs, row(KEYSPACE, indexName, null));
 
         // rebuild the index and verify the built status table
         getCurrentColumnFamilyStore().rebuildSecondaryIndex(indexName);
         waitForIndex(KEYSPACE, tableName, indexName);
 
-        // check that there are no other rows in the built indexes table
-        assertRows(execute(String.format("SELECT * FROM %s.\"%s\"", SchemaConstants.SYSTEM_KEYSPACE_NAME, SystemKeyspace.BUILT_INDEXES)),
-                   row(KEYSPACE, indexName, null ));
+        // check that there are no new rows in the built indexes table
+        rs = execute(selectBuiltIndexesQuery);
+        assertEquals(initialSize, rs.size());
+        assertRowsIgnoringOrderAndExtra(rs, row(KEYSPACE, indexName, null));
     }
 
 


### PR DESCRIPTION
Use a before and after size comparison to avoid failing as a result of another test failure.