### PR TITLE
Fix CASSANDRA-15557 using client state timestamps

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -395,7 +395,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
         // DROP
         private final List<ColumnMetadata.Raw> droppedColumns = new ArrayList<>();
-        private long timestamp = FBUtilities.timestampMicros();
+        private Long timestamp;
 
         // RENAME
         private final Map<ColumnMetadata.Raw, ColumnMetadata.Raw> renamedColumns = new HashMap<>();
@@ -412,12 +412,14 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         {
             String keyspaceName = name.hasKeyspace() ? name.getKeyspace() : state.getKeyspace();
             String tableName = name.getName();
-
             switch (kind)
             {
                 case   ALTER_COLUMN: return new AlterColumn(keyspaceName, tableName);
                 case    ADD_COLUMNS: return new AddColumns(keyspaceName, tableName, addedColumns);
-                case   DROP_COLUMNS: return new DropColumns(keyspaceName, tableName, droppedColumns, timestamp);
+                case   DROP_COLUMNS: return new DropColumns(keyspaceName,
+                                                            tableName,
+                                                            droppedColumns,
+                                                            timestamp == null ? state.getTimestamp() : timestamp);
                 case RENAME_COLUMNS: return new RenameColumns(keyspaceName, tableName, renamedColumns);
                 case  ALTER_OPTIONS: return new AlterOptions(keyspaceName, tableName, attrs);
             }


### PR DESCRIPTION
This should also fix https://issues.apache.org/jira/browse/CASSANDRA-15303 and re-enables the behavior from https://issues.apache.org/jira/browse/CASSANDRA-12997 which was removed as part of https://issues.apache.org/jira/browse/CASSANDRA-13426

Note this leaves a problem with precision where the extra microseconds added by ClientState.getTimestamp() will be dropped on save due to lack of precision see https://issues.apache.org/jira/browse/CASSANDRA-15626