### PR TITLE
CASSANDRA-15623: cqlsh return non-zero status when STDIN CQL fails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.11.7
+ * cqlsh return non-zero status when STDIN CQL fails (CASSANDRA-15623)
  * Allow sstableloader to use SSL on the native port (CASSANDRA-14904)
 Merged from 3.0:
 =======

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -548,6 +548,10 @@ class Shell(cmd.Cmd):
         self.single_statement = single_statement
 
     @property
+    def batch_mode(self):
+        return not self.tty
+
+    @property
     def is_using_utf8(self):
         # utf8 encodings from https://docs.python.org/{2,3}/library/codecs.html
         return self.encoding.replace('-', '_').lower() in ['utf', 'utf_8', 'u8', 'utf8', CP65001]
@@ -2430,8 +2434,7 @@ def main(options, hostname, port):
 
     shell.cmdloop()
     save_history()
-    batch_mode = options.file or options.execute
-    if batch_mode and shell.statement_error:
+    if shell.batch_mode and shell.statement_error:
         sys.exit(2)
 
 


### PR DESCRIPTION
This is a backport of [CASSANDRA-15623](https://github.com/apache/cassandra/pull/468) to cassandra-3.11, please see the linked PR for more details.