### PR TITLE
CASSANDRA-15623: cqlsh return non-zero status when STDIN CQL fails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha4
+ * cqlsh return non-zero status when STDIN CQL fails (CASSANDRA-15623)
  * Added Virtual Table exposing Cassandra relevant system properties (CASSANDRA-15616)
  * Add data modeling introduction (CASSANDRA-15481)
  * Improve the algorithmic token allocation in case racks = RF (CASSANDRA-15600)

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -539,6 +539,10 @@ class Shell(cmd.Cmd):
         self.is_subshell = is_subshell
 
     @property
+    def batch_mode(self):
+        return not self.tty
+
+    @property
     def is_using_utf8(self):
         # utf8 encodings from https://docs.python.org/{2,3}/library/codecs.html
         return self.encoding.replace('-', '_').lower() in ['utf', 'utf_8', 'u8', 'utf8', CP65001]
@@ -2465,9 +2469,7 @@ def main(options, hostname, port):
 
     shell.cmdloop()
     save_history()
-
-    batch_mode = options.file or options.execute
-    if batch_mode and shell.statement_error:
+    if shell.batch_mode and shell.statement_error:
         sys.exit(2)
 
 


### PR DESCRIPTION
I believe currently it can be safely assumed that
any `Shell` instance without a TTY (i.e. `Shell.tty
== False`) is in a "batch mode". With this in mind,
the two following changes were applied.

First, while we could just use the `Shell.tty`
attribute directly, to be semantically clear and to
provide room for future enhancement on what is
considered a "batch mode", we will add a respective
property instead.

Second, with the new `Shell.batch_mode` property at
hand, it makes no more sense to check any options
implying a "batch mode", it is perfectly enough to
just check this property.

patch by Jacob Becker a.k.a. plastikat;
reviewed by Jordan West for CASSANDRA-15623