### PR TITLE
CASSANDRA-15526 Fix testConcurrentMemtableReadsAndWrites UT

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha4
+ * Fixed empty check in TrieMemIndex due to potential state inconsistency in ConcurrentSkipListMap (CASSANDRA-15526)
  * Added Virtual Table exposing Cassandra relevant system properties (CASSANDRA-15616)
  * Add data modeling introduction (CASSANDRA-15481)
  * Improve the algorithmic token allocation in case racks = RF (CASSANDRA-15600)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha4
+ * Fixed empty check in TrieMemIndex due to potential state inconsistency in ConcurrentSkipListMap (CASSANDRA-15526)
  * Add compaction allocation measurement test (CASSANDRA-15388)
  * Added UnleveledSSTables global and table level metric (CASSANDRA-15620)
  * Added Virtual Table exposing Cassandra relevant system properties (CASSANDRA-15616, CASSANDRA-15643)

--- a/src/java/org/apache/cassandra/index/sasi/memory/TrieMemIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/memory/TrieMemIndex.java
@@ -146,8 +146,10 @@ public class TrieMemIndex extends MemIndex
             RangeUnionIterator.Builder<Long, Token> builder = RangeUnionIterator.builder();
             for (ConcurrentSkipListSet<DecoratedKey> keys : search)
             {
-                if (!keys.isEmpty())
+                if (keys.size() > 0)
+                {
                     builder.add(new KeyRangeIterator(keys));
+                }
             }
 
             return builder.build();


### PR DESCRIPTION
EDIT
Closed in favor of #478

----------
The implementation of ConcurrentSkipListMap changed significantly from Java v8 to v11. In v8, ConcurrentSkipListMap#size iterates over the elements in the map and counts them as it goes. But in v11, ConcurrentSkipListMap holds an internal LongAdder instance, which is incremented as new elements are added.
In both versions, isEmpty will return false if it's able to find the head node.
The issue is that in v11 there's a potential race condition in which the head node may have been initialized, but the LongAdder hasn't been incremented yet, which leaves it briefly in an inconsistent state.

https://issues.apache.org/jira/browse/CASSANDRA-15526?focusedCommentId=17049522&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17049522