### PR TITLE
Python has no RuntimeException, use RuntimeError

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,7 @@ cassandra_build_file = '../../build.xml'
 with open(cassandra_build_file) as f:
     m = re.search("name=\"base\.version\" value=\"([^\"]+)\"", f.read())
     if not m or m.lastindex != 1:
-        raise RuntimeException("Problem finding version in build.xml file, this shouldn't happen.")
+        raise RuntimeError("Problem finding version in build.xml file, this shouldn't happen.")
     cassandra_version = m.group(1)
 
 def setup(sphinx):


### PR DESCRIPTION
Undefined name: Python has no `RuntimeException`, so use `RuntimeError` instead.  The current code will raise `NameError` because `RuntimeException` is an undefined name.  
https://stackoverflow.com/questions/56529207/difference-between-runtimeexception-and-exception-in-python
https://docs.python.org/3/library/exceptions.html