### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/doc/convert_yaml_to_rst.py
+++ b/doc/convert_yaml_to_rst.py
@@ -23,8 +23,10 @@ Usage:
     convert_yaml_to_rest.py conf/cassandra.yaml docs/source/conf.rst
 """
 
-import sys
+from __future__ import print_function
+
 import re
+import sys
 
 # Detects options, whether commented or uncommented.
 # Group 1 will be non-empty if the option is commented out.
@@ -137,7 +139,7 @@ def write_complex_option(lines, outfile):
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print >> sys.stderr, "Usage: %s <yaml source file> <rst dest file>" % (sys.argv[0],)
+        print("Usage: %s <yaml source file> <rst dest file>" % (sys.argv[0],), file=sys.stderr)
         sys.exit(1)
 
     yaml_file = sys.argv[1]


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.