### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -414,7 +414,7 @@ def insert_driver_hooks():
 
 class Shell(cmd.Cmd):
     custom_prompt = os.getenv('CQLSH_PROMPT', '')
-    if custom_prompt is not '':
+    if custom_prompt != '':
         custom_prompt += "\n"
     default_prompt = custom_prompt + "cqlsh> "
     continue_prompt = "   ... "


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% python3.8
```
>>> 'nt' is 'nt'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
>>> nt = 'n'
>>> nt += 't'
>>> nt == 'nt'
True
>>> nt is 'nt'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```