### PR TITLE
CASSANDRA-15679 Don't use bytearray for blobs in copyutil.py 4.0

### DIFF
--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -1933,7 +1933,10 @@ class ImportConversion(object):
             return converters.get(t.typename, convert_unknown)(v, ct=t)
 
         def convert_blob(v, **_):
-            return bytearray.fromhex(v[2:])
+            if sys.version_info.major >= 3:
+                return bytes.fromhex(v[2:])
+            else:
+                return v[2:].decode("hex")
 
         def convert_text(v, **_):
             return ensure_str(v)


### PR DESCRIPTION
* Use str in Python 2
* Use bytes in Python 3

https://issues.apache.org/jira/browse/CASSANDRA-15679