### PR TITLE
CASSANDRA-15706: Mark system_views / system_virtual_schema as system keyspaces for cqlsh

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha4
+ * Mark system_views / system_virtual_schema as system keyspaces for cqlsh (CASSANDRA-15706)
  * Repair history tables should have TTL and TWCS (CASSANDRA-12701)
  * Fix cqlsh erroring out on Python 3.7 due to webbrowser module being absent (CASSANDRA-15572)
  * Fix IMH#acquireCapacity() to return correct Outcome when endpoint reserve runs out (CASSANDRA-15607)

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -34,7 +34,7 @@ class UnexpectedTableStructure(UserWarning):
         return 'Unexpected table structure; may not translate correctly to CQL. ' + self.msg
 
 
-SYSTEM_KEYSPACES = ('system', 'system_schema', 'system_traces', 'system_auth', 'system_distributed')
+SYSTEM_KEYSPACES = ('system', 'system_schema', 'system_traces', 'system_auth', 'system_distributed', 'system_views', 'system_virtual_schema')
 NONALTERBALE_KEYSPACES = ('system', 'system_schema')
 
 


### PR DESCRIPTION
This is so that those keyspaces don't show up in tab completions. This
also fixes the cqlsh completion tests.