### PR TITLE
CASSANDRA-15623: cqlsh return non-zero status when STDIN CQL fails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.0.21
+ * cqlsh return non-zero status when STDIN CQL fails (CASSANDRA-15623)
  * Memtable memory allocations may deadlock (CASSANDRA-15367)
  * Run evictFromMembership in GossipStage (CASSANDRA-15592)
 Merged from 2.2:

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -814,6 +814,10 @@ class Shell(cmd.Cmd):
         self.single_statement = single_statement
 
     @property
+    def batch_mode(self):
+        return not self.tty
+
+    @property
     def is_using_utf8(self):
         # utf8 encodings from https://docs.python.org/{2,3}/library/codecs.html
         return self.encoding.replace('-', '_').lower() in ['utf', 'utf_8', 'u8', 'utf8', CP65001]
@@ -2681,8 +2685,7 @@ def main(options, hostname, port):
 
     shell.cmdloop()
     save_history()
-    batch_mode = options.file or options.execute
-    if batch_mode and shell.statement_error:
+    if shell.batch_mode and shell.statement_error:
         sys.exit(2)
 
 


### PR DESCRIPTION
This is a backport of [CASSANDRA-15623](https://github.com/apache/cassandra/pull/468) to cassandra-3.0, please see the linked PR for more details.