### PR TITLE
CASSANDRA-15735 fix(tools/stress/*): Add serial consistency option and regular and serial consistency into profile yaml

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/StressYaml.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressYaml.java
@@ -43,9 +43,17 @@ public class StressYaml
     {
         public String cql;
         public String fields;
+        public String consistencyLevel;
+        public String serialConsistencyLevel;
         public String getConfigAsString()
         {
-            return String.format("CQL:%s;Fields:%s;", cql, fields);
+            String output = String.format("CQL:%s;Fields:%s;",
+                    cql, fields, consistencyLevel, serialConsistencyLevel);
+            if (consistencyLevel != null)
+                output += String.format("consistencyLevel:%s;", consistencyLevel);
+            if (serialConsistencyLevel != null)
+                output += String.format("serialConsistencyLevel:%s;", serialConsistencyLevel);
+            return output;
         }
     }
 

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
@@ -277,7 +277,11 @@ public abstract class CqlOperation<V> extends PredefinedOperation
         public <V> V execute(String query, ByteBuffer key, List<Object> queryParams, ResultHandler<V> handler)
         {
             String formattedQuery = formatCqlQuery(query, queryParams);
-            return handler.javaDriverHandler().apply(client.execute(formattedQuery, settings.command.consistencyLevel));
+            return handler.javaDriverHandler().apply(
+                    client.execute(
+                            formattedQuery,
+                            settings.command.consistencyLevel,
+                            settings.command.serialConsistencyLevel));
         }
 
         @Override
@@ -287,7 +291,8 @@ public abstract class CqlOperation<V> extends PredefinedOperation
                     client.executePrepared(
                             (PreparedStatement) preparedStatement,
                             queryParams,
-                            settings.command.consistencyLevel));
+                            settings.command.consistencyLevel,
+                            settings.command.serialConsistencyLevel));
         }
 
         @Override

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/CASQuery.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/CASQuery.java
@@ -62,10 +62,10 @@ public class CASQuery extends SchemaStatement
 
     private PreparedStatement casReadConditionStatement;
 
-    public CASQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, PreparedStatement statement, ConsistencyLevel cl, ArgSelect argSelect, final String tableName)
+    public CASQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, PreparedStatement statement, ArgSelect argSelect, final String tableName)
     {
         super(timer, settings, new DataSpec(generator, seedManager, new DistributionFixed(1), settings.insert.rowPopulationRatio.get(), argSelect == SchemaStatement.ArgSelect.MULTIROW ? statement.getVariables().size() : 1), statement,
-              statement.getVariables().asList().stream().map(ColumnDefinitions.Definition::getName).collect(Collectors.toList()), cl);
+              statement.getVariables().asList().stream().map(ColumnDefinitions.Definition::getName).collect(Collectors.toList()));
 
         if (argSelect != SchemaStatement.ArgSelect.SAMEROW)
             throw new IllegalArgumentException("CAS is supported only for type 'samerow'");

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaInsert.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaInsert.java
@@ -46,9 +46,9 @@ public class SchemaInsert extends SchemaStatement
     private final String insertStatement;
     private final BatchStatement.Type batchType;
 
-    public SchemaInsert(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, Distribution batchSize, RatioDistribution useRatio, RatioDistribution rowPopulation, PreparedStatement statement, ConsistencyLevel cl, BatchStatement.Type batchType)
+    public SchemaInsert(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, Distribution batchSize, RatioDistribution useRatio, RatioDistribution rowPopulation, PreparedStatement statement, BatchStatement.Type batchType)
     {
-        super(timer, settings, new DataSpec(generator, seedManager, batchSize, useRatio, rowPopulation), statement, statement.getVariables().asList().stream().map(d -> d.getName()).collect(Collectors.toList()), cl);
+        super(timer, settings, new DataSpec(generator, seedManager, batchSize, useRatio, rowPopulation), statement, statement.getVariables().asList().stream().map(d -> d.getName()).collect(Collectors.toList()));
         this.batchType = batchType;
         this.insertStatement = null;
         this.tableSchema = null;
@@ -59,7 +59,7 @@ public class SchemaInsert extends SchemaStatement
      */
     public SchemaInsert(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, RatioDistribution useRatio, RatioDistribution rowPopulation, String statement, String tableSchema)
     {
-        super(timer, settings, new DataSpec(generator, seedManager, new DistributionFixed(1), useRatio, rowPopulation), null, generator.getColumnNames(), ConsistencyLevel.ONE);
+        super(timer, settings, new DataSpec(generator, seedManager, new DistributionFixed(1), useRatio, rowPopulation), null, generator.getColumnNames());
         this.batchType = BatchStatement.Type.UNLOGGED;
         this.insertStatement = statement;
         this.tableSchema = tableSchema;
@@ -97,10 +97,8 @@ public class SchemaInsert extends SchemaStatement
                 else
                 {
                     BatchStatement batch = new BatchStatement(batchType);
-                    if (cl.isSerialConsistency())
-                        batch.setSerialConsistencyLevel(JavaDriverClient.from(cl));
-                    else
-                        batch.setConsistencyLevel(JavaDriverClient.from(cl));
+                    batch.setConsistencyLevel(statement.getConsistencyLevel());
+                    batch.setSerialConsistencyLevel(statement.getSerialConsistencyLevel());
                     batch.addAll(substmts);
                     stmt = batch;
                 }

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaQuery.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaQuery.java
@@ -40,10 +40,10 @@ public class SchemaQuery extends SchemaStatement
     final Object[][] randomBuffer;
     final Random random = new Random();
 
-    public SchemaQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, PreparedStatement statement, ConsistencyLevel cl, ArgSelect argSelect)
+    public SchemaQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, PreparedStatement statement, ArgSelect argSelect)
     {
         super(timer, settings, new DataSpec(generator, seedManager, new DistributionFixed(1), settings.insert.rowPopulationRatio.get(), argSelect == SchemaStatement.ArgSelect.MULTIROW ? statement.getVariables().size() : 1), statement,
-              statement.getVariables().asList().stream().map(d -> d.getName()).collect(Collectors.toList()), cl);
+              statement.getVariables().asList().stream().map(d -> d.getName()).collect(Collectors.toList()));
         this.argSelect = argSelect;
         randomBuffer = new Object[argumentIndex.length][argumentIndex.length];
     }

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaStatement.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaStatement.java
@@ -45,31 +45,21 @@ public abstract class SchemaStatement extends PartitionOperation
     }
 
     final PreparedStatement statement;
-    final ConsistencyLevel cl;
     final int[] argumentIndex;
     final Object[] bindBuffer;
     final ColumnDefinitions definitions;
 
     public SchemaStatement(Timer timer, StressSettings settings, DataSpec spec,
-                           PreparedStatement statement, List<String> bindNames, ConsistencyLevel cl)
+                           PreparedStatement statement, List<String> bindNames)
     {
         super(timer, settings, spec);
         this.statement = statement;
-        this.cl = cl;
         argumentIndex = new int[bindNames.size()];
         bindBuffer = new Object[argumentIndex.length];
         definitions = statement != null ? statement.getVariables() : null;
         int i = 0;
         for (String name : bindNames)
             argumentIndex[i++] = spec.partitionGenerator.indexOf(name);
-
-        if (statement != null)
-        {
-            if (cl.isSerialConsistency())
-                statement.setSerialConsistencyLevel(JavaDriverClient.from(cl));
-            else
-                statement.setConsistencyLevel(JavaDriverClient.from(cl));
-        }
     }
 
     BoundStatement bindRow(Row row)

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/ValidatingSchemaQuery.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/ValidatingSchemaQuery.java
@@ -48,7 +48,7 @@ public class ValidatingSchemaQuery extends PartitionOperation
     final int[] argumentIndex;
     final Object[] bindBuffer;
 
-    private ValidatingSchemaQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, ValidatingStatement[] statements, ConsistencyLevel cl, int clusteringComponents)
+    private ValidatingSchemaQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, ValidatingStatement[] statements, ConsistencyLevel cl, ConsistencyLevel serialCl, int clusteringComponents)
     {
         super(timer, settings, new DataSpec(generator, seedManager, new DistributionFixed(1), settings.insert.rowPopulationRatio.get(), 1));
         this.statements = statements;
@@ -61,10 +61,10 @@ public class ValidatingSchemaQuery extends PartitionOperation
 
         for (ValidatingStatement statement : statements)
         {
-            if (cl.isSerialConsistency())
-                statement.statement.setSerialConsistencyLevel(JavaDriverClient.from(cl));
-            else
+            if(statement.statement.getConsistencyLevel() == null)
                 statement.statement.setConsistencyLevel(JavaDriverClient.from(cl));
+            if(statement.statement.getSerialConsistencyLevel() == null)
+                statement.statement.setSerialConsistencyLevel(JavaDriverClient.from(serialCl));
         }
         this.clusteringComponents = clusteringComponents;
     }
@@ -176,9 +176,9 @@ public class ValidatingSchemaQuery extends PartitionOperation
             this.clusteringComponents = clusteringComponents;
         }
 
-        public ValidatingSchemaQuery create(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, ConsistencyLevel cl)
+        public ValidatingSchemaQuery create(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, ConsistencyLevel cl, ConsistencyLevel serialCl)
         {
-            return new ValidatingSchemaQuery(timer, settings, generator, seedManager, statements, cl, clusteringComponents);
+            return new ValidatingSchemaQuery(timer, settings, generator, seedManager, statements, cl, serialCl, clusteringComponents);
         }
     }
 

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommand.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommand.java
@@ -50,6 +50,7 @@ public abstract class SettingsCommand implements Serializable
     public final boolean noWarmup;
     public final TruncateWhen truncate;
     public final ConsistencyLevel consistencyLevel;
+    public final ConsistencyLevel serialConsistencyLevel;
     public final double targetUncertainty;
     public final int minimumUncertaintyMeasurements;
     public final int maximumUncertaintyMeasurements;
@@ -69,6 +70,7 @@ public abstract class SettingsCommand implements Serializable
     {
         this.type = type;
         this.consistencyLevel = ConsistencyLevel.valueOf(options.consistencyLevel.value().toUpperCase());
+        this.serialConsistencyLevel = ConsistencyLevel.valueOf(options.serialConsistencyLevel.value().toUpperCase());
         this.noWarmup = options.noWarmup.setByUser();
         this.truncate = TruncateWhen.valueOf(options.truncate.value().toUpperCase());
 
@@ -124,6 +126,7 @@ public abstract class SettingsCommand implements Serializable
         final OptionSimple noWarmup = new OptionSimple("no-warmup", "", null, "Do not warmup the process", false);
         final OptionSimple truncate = new OptionSimple("truncate=", "never|once|always", "never", "Truncate the table: never, before performing any work, or before each iteration", false);
         final OptionSimple consistencyLevel = new OptionSimple("cl=", "ONE|QUORUM|LOCAL_QUORUM|EACH_QUORUM|ALL|ANY|TWO|THREE|LOCAL_ONE|SERIAL|LOCAL_SERIAL", "LOCAL_ONE", "Consistency level to use", false);
+        final OptionSimple serialConsistencyLevel = new OptionSimple("serial-cl=", "SERIAL|LOCAL_SERIAL", "SERIAL", "Serial consistency level to use", false);
     }
 
     static class Count extends Options
@@ -132,7 +135,7 @@ public abstract class SettingsCommand implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(count, noWarmup, truncate, consistencyLevel);
+            return Arrays.asList(count, noWarmup, truncate, consistencyLevel, serialConsistencyLevel);
         }
     }
 
@@ -142,7 +145,7 @@ public abstract class SettingsCommand implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(duration, noWarmup, truncate, consistencyLevel);
+            return Arrays.asList(duration, noWarmup, truncate, consistencyLevel, serialConsistencyLevel);
         }
     }
 
@@ -154,7 +157,7 @@ public abstract class SettingsCommand implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(uncertainty, minMeasurements, maxMeasurements, noWarmup, truncate, consistencyLevel);
+            return Arrays.asList(uncertainty, minMeasurements, maxMeasurements, noWarmup, truncate, consistencyLevel, serialConsistencyLevel);
         }
     }
 
@@ -186,6 +189,7 @@ public abstract class SettingsCommand implements Serializable
         }
         out.printf("  No Warmup: %s%n", noWarmup);
         out.printf("  Consistency Level: %s%n", consistencyLevel.toString());
+        out.printf("  Serial Consistency Level: %s%n", serialConsistencyLevel.toString());
         if (targetUncertainty != -1)
         {
             out.printf("  Target Uncertainty: %.3f%n", targetUncertainty);

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -186,24 +186,32 @@ public class JavaDriverClient
     public ResultSet execute(String query, org.apache.cassandra.db.ConsistencyLevel consistency)
     {
         SimpleStatement stmt = new SimpleStatement(query);
+        stmt.setConsistencyLevel(JavaDriverClient.from(consistency));
+        return getSession().execute(stmt);
+    }
 
-        if (consistency.isSerialConsistency())
-            stmt.setSerialConsistencyLevel(from(consistency));
-        else
-            stmt.setConsistencyLevel(from(consistency));
+    public ResultSet execute(String query, org.apache.cassandra.db.ConsistencyLevel consistency, org.apache.cassandra.db.ConsistencyLevel serialConsistency)
+    {
+        SimpleStatement stmt = new SimpleStatement(query);
+        stmt.setConsistencyLevel(JavaDriverClient.from(consistency));
+        stmt.setSerialConsistencyLevel(JavaDriverClient.from(serialConsistency));
         return getSession().execute(stmt);
     }
 
     public ResultSet executePrepared(PreparedStatement stmt, List<Object> queryParams, org.apache.cassandra.db.ConsistencyLevel consistency)
     {
-        if (consistency.isSerialConsistency())
-        {
-            stmt.setSerialConsistencyLevel(from(consistency));
-        }
-        else
-        {
-            stmt.setConsistencyLevel(from(consistency));
-        }
+        if(stmt.getConsistencyLevel() == null)
+            stmt.setConsistencyLevel(JavaDriverClient.from(consistency));
+        BoundStatement bstmt = stmt.bind((Object[]) queryParams.toArray(new Object[queryParams.size()]));
+        return getSession().execute(bstmt);
+    }
+
+    public ResultSet executePrepared(PreparedStatement stmt, List<Object> queryParams, org.apache.cassandra.db.ConsistencyLevel consistency, org.apache.cassandra.db.ConsistencyLevel serialConsistency)
+    {
+        if(stmt.getConsistencyLevel() == null)
+            stmt.setConsistencyLevel(JavaDriverClient.from(consistency));
+        if(stmt.getSerialConsistencyLevel() == null)
+            stmt.setSerialConsistencyLevel(JavaDriverClient.from(serialConsistency));
         BoundStatement bstmt = stmt.bind((Object[]) queryParams.toArray(new Object[queryParams.size()]));
         return getSession().execute(bstmt);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-15735

   Needed to be done in order to be able to control serial consistency and regular consistency levels separately
   For instance, it was not possible to set serial consistency to LOCAL_SERIAL and regular consistency to QUORUM.
   Now it is possible, and also it is possible to specify consistency in yaml file per query, in case you want to stress with different consistency levels.