### PR TITLE
CASSANDRA-15734: Fix python codestyle warning

### DIFF
--- a/pylib/cqlshlib/saferscanner.py
+++ b/pylib/cqlshlib/saferscanner.py
@@ -98,5 +98,6 @@ class Py38SaferScanner(SaferScannerBase):
         self.p = p
         self.scanner = re.sre_compile.compile(p)
 
+
 SaferScanner = Py36SaferScanner if six.PY3 else Py2SaferScanner
 SaferScanner = Py38SaferScanner if version_info >= (3, 8) else SaferScanner


### PR DESCRIPTION
This should fix https://ci-cassandra.apache.org/job/Cassandra-trunk/75/testReport/cqlsh_tests.test_cqlsh/TestCqlsh/test_pycodestyle_compliance/