### PR TITLE
CASSANDRA-15730 Batch statement preparation fails if multiple tables and parameters are used

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha4
+ * Fix batch statment preparation when multiple tables and parameters are used (CASSANDRA-15730)
  * Correct Visibility and Improve Safety of Methods in LatencyMetrics (CASSANDRA-15597)
  * Allow cqlsh to run with Python2.7/Python3.6+ (CASSANDRA-15659,CASSANDRA-15573)
  * Improve logging around incremental repair (CASSANDRA-15599)

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -141,7 +141,7 @@ public class BatchStatement implements CQLStatement
     public short[] getPartitionKeyBindVariableIndexes()
     {
         boolean affectsMultipleTables =
-            !statements.isEmpty() && statements.stream().map(s -> s.metadata().id).allMatch(isEqual(statements.get(0).metadata().id));
+            !statements.isEmpty() && !statements.stream().map(s -> s.metadata().id).allMatch(isEqual(statements.get(0).metadata().id));
 
         // Use the TableMetadata of the first statement for partition key bind indexes.  If the statements affect
         // multiple tables, we won't send partition key bind indexes.

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/BatchTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/BatchTest.java
@@ -168,6 +168,26 @@ public class BatchTest extends CQLTester
     }
 
     @Test
+    public void testBatchMultipleTablePrepare() throws Throwable
+    {
+        String tbl1 = KEYSPACE + "." + createTableName();
+        String tbl2 = KEYSPACE + "." + createTableName();
+
+        schemaChange(String.format("CREATE TABLE %s (k1 int PRIMARY KEY, v1 int)", tbl1));
+        schemaChange(String.format("CREATE TABLE %s (k2 int PRIMARY KEY, v2 int)", tbl2));
+
+        String query = "BEGIN BATCH " +
+                   String.format("UPDATE %s SET v1 = 1 WHERE k1 = ?;", tbl1) +
+                   String.format("UPDATE %s SET v2 = 2 WHERE k2 = ?;", tbl2) +
+                   "APPLY BATCH;";
+        prepare(query);
+        execute(query, 0, 0);
+
+        assertRows(execute(String.format("SELECT * FROM %s", tbl1)), row(0, 1));
+        assertRows(execute(String.format("SELECT * FROM %s", tbl2)), row(0, 2));
+    }
+
+    @Test
     public void testBatchWithInRestriction() throws Throwable
     {
         createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY (a,b))");


### PR DESCRIPTION
The logic for detecting if a batch statement affects multiple tables in BatchStatement#getPartitionKeyBindVariableIndexes is inverted.
BatchTest#testBatchMultipleTablePrepare has been added to demonstrate the issue.