### PR TITLE
Generate compiler options file to support Java11 in IDEA.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2136,6 +2136,13 @@
                    match="name=&quot;VM_PARAMETERS&quot; value=&quot;(.*)&quot;"
                    replace="name=&quot;VM_PARAMETERS&quot; value=&quot;\1 ${java11-jvmargs}&quot;"
                    byline="true"/>
+
+      <echo file=".idea/compiler.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_STRING" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED" />
+  </component>
+</project>]]></echo>
   </target>
 
   <!-- Generate IDEA project description files -->


### PR DESCRIPTION
The change to JMX in CASSANDRA-15653 prevents the IDEA project from
compiling under JDK11.  This change adds the required compiler flag
when the project is upgraded from Java1.8 to Java11.

Patch by Jon Meredith; Reviewed by ? for CASSANDRA-15738