### PR TITLE
Add support for lazy NoSpamLogger argument evaluation

### DIFF
--- a/src/java/org/apache/cassandra/net/InboundSink.java
+++ b/src/java/org/apache/cassandra/net/InboundSink.java
@@ -30,6 +30,8 @@ import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.index.IndexNotAvailableException;
 import org.apache.cassandra.utils.NoSpamLogger;
 
+import static org.apache.cassandra.utils.NoSpamLogger.params;
+
 /**
  * A message sink that all inbound messages go through.
  *
@@ -96,8 +98,10 @@ public class InboundSink implements InboundMessageHandlers.MessageConsumer
         {
             fail(message.header, t);
 
-            if (t instanceof TombstoneOverwhelmingException || t instanceof IndexNotAvailableException)
-                noSpamLogger.error(t.getMessage());
+            if (t instanceof TombstoneOverwhelmingException)
+                noSpamLogger.error("Tombstone overwhelming while receiving message: {}", () -> params(t.getMessage()));
+            else if (t instanceof IndexNotAvailableException)
+                noSpamLogger.error("Index not available while receiving message: {}", () -> params(t.getMessage()));
             else if (t instanceof RuntimeException)
                 throw (RuntimeException) t;
             else

--- a/src/java/org/apache/cassandra/utils/NoSpamLogger.java
+++ b/src/java/org/apache/cassandra/utils/NoSpamLogger.java
@@ -344,9 +344,9 @@ public class NoSpamLogger
 
     public NoSpamLogStatement getStatement(String key, String s, long minIntervalNanos)
     {
-        return lastMessage.computeIfAbsent(key, x -> new NoSpamLogStatement(s, minIntervalNanos));
+        return lastMessage.computeIfAbsent(key, k -> new NoSpamLogStatement(s, minIntervalNanos));
     }
-    
+
     // Syntactic sugar for making supplier of params
     public static Object[] params(Object... objects) {
         return objects;

--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -23,6 +23,7 @@ import java.lang.ref.ReferenceQueue;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Queue;
 import java.util.Set;
@@ -51,6 +52,7 @@ import org.apache.cassandra.utils.concurrent.Ref;
 import static com.google.common.collect.ImmutableList.of;
 import static org.apache.cassandra.utils.ExecutorUtils.*;
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
+import static org.apache.cassandra.utils.NoSpamLogger.params;
 import static org.apache.cassandra.utils.memory.MemoryUtil.isExactlyDirect;
 
 /**
@@ -218,6 +220,8 @@ public class BufferPool
             return chunks.poll();
         }
 
+
+
         /**
          * This method might be called by multiple threads and that's fine if we add more
          * than one chunk at the same time as long as we don't exceed the MEMORY_USAGE_THRESHOLD.
@@ -232,8 +236,8 @@ public class BufferPool
                     if (MEMORY_USAGE_THRESHOLD > 0)
                     {
                         noSpamLogger.info("Maximum memory usage reached ({}), cannot allocate chunk of {}",
-                                          prettyPrintMemory(MEMORY_USAGE_THRESHOLD),
-                                          prettyPrintMemory(MACRO_CHUNK_SIZE));
+                                          () -> params(prettyPrintMemory(MEMORY_USAGE_THRESHOLD),
+                                                       prettyPrintMemory(MACRO_CHUNK_SIZE)));
                     }
                     return null;
                 }
@@ -252,9 +256,9 @@ public class BufferPool
                 noSpamLogger.error("Buffer pool failed to allocate chunk of {}, current size {} ({}). " +
                                    "Attempting to continue; buffers will be allocated in on-heap memory which can degrade performance. " +
                                    "Make sure direct memory size (-XX:MaxDirectMemorySize) is large enough to accommodate off-heap memtables and caches.",
-                                   prettyPrintMemory(MACRO_CHUNK_SIZE),
-                                   prettyPrintMemory(sizeInBytes()),
-                                   oom.toString());
+                                   () -> params(prettyPrintMemory(MACRO_CHUNK_SIZE),
+                                                prettyPrintMemory(sizeInBytes()),
+                                                oom.toString()));
                 return null;
             }
 

--- a/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
+++ b/test/unit/org/apache/cassandra/utils/NoSpamLoggerTest.java
@@ -320,16 +320,4 @@ public class NoSpamLoggerTest
         assertTrue(nospamStatement.error(lazyParams));
         checkSupplierMock(Level.ERROR, now);
     }
-
-    @Test
-    public void simpleLog()
-    {
-        NoSpamLogger.log(mock, Level.INFO, 1, TimeUnit.NANOSECONDS, "{}", "param");
-    }
-
-    @Test
-    public void paramLog()
-    {
-        NoSpamLogger.log(mock, Level.INFO, 1, TimeUnit.NANOSECONDS, "{}", () -> params("param"));
-    }
 }


### PR DESCRIPTION
NoSpamLogger is use in hot logging paths.  To get the greatest benefit
calling should be as cheap as possible.  This patch adds a variant to
NoSpamLogger.log and friends to lazily supply the formatting parameters.

It also introduces a params() helper function to make constructing the
parameter array supplier cleaner.

Fixed up existing call sites to use params where it made sense and
altered the logging for org.apache.cassandra.net.InboundSink#accept
so that log statements for tombstones and indices would be output
correctly. The previous getMessage format string included info on
keys, tables and queries that would vary between calls.

Patch by Jon Meredith; reviewed by ? for CASSANDRA-15766.