### PR TITLE
curl redirect for KEYS

### DIFF
--- a/doc/source/getting_started/installing.rst
+++ b/doc/source/getting_started/installing.rst
@@ -187,7 +187,7 @@ Installing the Debian packages
 
 ::
 
-   $ curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
+   $ curl -L https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100  266k  100  266k    0     0   320k      0 --:--:-- --:--:-- --:--:--  320k


### PR DESCRIPTION
current curl command for registering keys fails because:

 ```
$ curl https://www.apache.org/dist/cassandra/KEYS 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://downloads.apache.org/cassandra/KEYS">here</a>.</p>
</body></html>
```


we want

    curl -L https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
