### PR TITLE
change the command to get linux system memory

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -18,7 +18,7 @@ calculate_heap_sizes()
 {
     case "`uname`" in
         Linux)
-            system_memory_in_mb=`free -m | awk '/:/ {print $2;exit}'`
+            system_memory_in_mb=`free -m | awk '{print $2;}' | sed -n '2, 1p'`
             system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
         ;;
         FreeBSD)


### PR DESCRIPTION
for some language like Chinese, the output for `free -m` command has no character ':', so the command `free -m | awk '/:/ {print $2;exit}'` will return nothing. and then, the cassandra can not start up.
this pr fixed the issue using a different way to get system memory with no dependency of a specific character.

<pre><font color="#4E9A06"><b>➜  </b></font><font color="#06989A"><b>~</b></font> free -m
              总计         已用        空闲      共享    缓冲/缓存    可用
内存：       32110        4268       22069         261        5772       27137
交换：       61034           0       61034
<font color="#4E9A06"><b>➜  </b></font><font color="#06989A"><b>~</b></font> free -m | awk &apos;/:/ {print $2;exit}&apos;
<font color="#4E9A06"><b>➜  </b></font><font color="#06989A"><b>~</b></font> free -m | awk &apos;{print $2;}&apos; | sed -n &apos;2, 1p&apos;
32110
</pre>