### PR TITLE
CASSANDRA-15834 Bloom false positive rate includes true negatives

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 3.0.21
+ * Fix bloom filter false ratio calculation by including true negatives (CASSANDRA-15834)
  * Rely on snapshotted session infos on StreamResultFuture.maybeComplete to avoid race conditions (CASSANDRA-15667)
  * EmptyType doesn't override writeValue so could attempt to write bytes when expected not to (CASSANDRA-15790)
  * Fix index queries on partition key columns when some partitions contains only static data (CASSANDRA-13666)

--- a/src/java/org/apache/cassandra/io/sstable/BloomFilterTracker.java
+++ b/src/java/org/apache/cassandra/io/sstable/BloomFilterTracker.java
@@ -23,8 +23,10 @@ public class BloomFilterTracker
 {
     private final AtomicLong falsePositiveCount = new AtomicLong(0);
     private final AtomicLong truePositiveCount = new AtomicLong(0);
+    private final AtomicLong trueNegativeCount = new AtomicLong(0);
     private long lastFalsePositiveCount = 0L;
     private long lastTruePositiveCount = 0L;
+    private long lastTrueNegativeCount = 0L;
 
     public void addFalsePositive()
     {
@@ -34,6 +36,11 @@ public class BloomFilterTracker
     public void addTruePositive()
     {
         truePositiveCount.incrementAndGet();
+    }
+
+    public void addTrueNegative()
+    {
+        trueNegativeCount.incrementAndGet();
     }
 
     public long getFalsePositiveCount()
@@ -69,6 +76,24 @@ public class BloomFilterTracker
         finally
         {
             lastTruePositiveCount = tpc;
+        }
+    }
+
+    public long getTrueNegativeCount()
+    {
+        return trueNegativeCount.get();
+    }
+
+    public long getRecentTrueNegativeCount()
+    {
+        long tnc = getTrueNegativeCount();
+        try
+        {
+            return (tnc - lastTrueNegativeCount);
+        }
+        finally
+        {
+            lastTrueNegativeCount = tnc;
         }
     }
 }

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1853,6 +1853,16 @@ public abstract class SSTableReader extends SSTable implements SelfRefCounted<SS
         return bloomFilterTracker.getRecentTruePositiveCount();
     }
 
+    public long getBloomFilterTrueNegativeCount()
+    {
+        return bloomFilterTracker.getTrueNegativeCount();
+    }
+
+    public long getRecentBloomFilterTrueNegativeCount()
+    {
+        return bloomFilterTracker.getRecentTrueNegativeCount();
+    }
+
     public InstrumentingCache<KeyCacheKey, RowIndexEntry> getKeyCache()
     {
         return keyCache;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -145,6 +145,7 @@ public class BigTableReader extends SSTableReader
             {
                 listener.onSSTableSkipped(this, SkippingReason.BLOOM_FILTER);
                 Tracing.trace("Bloom filter allows skipping sstable {}", descriptor.generation);
+                bloomFilterTracker.addTrueNegative();
                 return null;
             }
         }

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -483,68 +483,76 @@ public class TableMetrics
         {
             public Double getValue()
             {
-                long falseCount = 0L;
-                long trueCount = 0L;
+                long falsePositiveCount = 0L;
+                long truePositiveCount = 0L;
+                long trueNegativeCount = 0L;
                 for (SSTableReader sstable : cfs.getSSTables(SSTableSet.LIVE))
                 {
-                    falseCount += sstable.getBloomFilterFalsePositiveCount();
-                    trueCount += sstable.getBloomFilterTruePositiveCount();
+                    falsePositiveCount += sstable.getBloomFilterFalsePositiveCount();
+                    truePositiveCount += sstable.getBloomFilterTruePositiveCount();
+                    trueNegativeCount += sstable.getBloomFilterTrueNegativeCount();
                 }
-                if (falseCount == 0L && trueCount == 0L)
+                if (falsePositiveCount == 0L && truePositiveCount == 0L)
                     return 0d;
-                return (double) falseCount / (trueCount + falseCount);
+                return (double) falsePositiveCount / (truePositiveCount + falsePositiveCount + trueNegativeCount);
             }
         }, new Gauge<Double>() // global gauge
         {
             public Double getValue()
             {
-                long falseCount = 0L;
-                long trueCount = 0L;
+                long falsePositiveCount = 0L;
+                long truePositiveCount = 0L;
+                long trueNegativeCount = 0L;
                 for (Keyspace keyspace : Keyspace.all())
                 {
                     for (SSTableReader sstable : keyspace.getAllSSTables(SSTableSet.LIVE))
                     {
-                        falseCount += sstable.getBloomFilterFalsePositiveCount();
-                        trueCount += sstable.getBloomFilterTruePositiveCount();
+                        falsePositiveCount += sstable.getBloomFilterFalsePositiveCount();
+                        truePositiveCount += sstable.getBloomFilterTruePositiveCount();
+                        trueNegativeCount += sstable.getBloomFilterTrueNegativeCount();
                     }
                 }
-                if (falseCount == 0L && trueCount == 0L)
+                if (falsePositiveCount == 0L && truePositiveCount == 0L)
                     return 0d;
-                return (double) falseCount / (trueCount + falseCount);
+                return (double) falsePositiveCount / (truePositiveCount + falsePositiveCount + trueNegativeCount);
             }
         });
         recentBloomFilterFalseRatio = createTableGauge("RecentBloomFilterFalseRatio", new Gauge<Double>()
         {
             public Double getValue()
             {
-                long falseCount = 0L;
-                long trueCount = 0L;
+                long falsePositiveCount = 0L;
+                long truePositiveCount = 0L;
+                long trueNegativeCount = 0L;
                 for (SSTableReader sstable: cfs.getSSTables(SSTableSet.LIVE))
                 {
-                    falseCount += sstable.getRecentBloomFilterFalsePositiveCount();
-                    trueCount += sstable.getRecentBloomFilterTruePositiveCount();
+                    falsePositiveCount += sstable.getRecentBloomFilterFalsePositiveCount();
+                    truePositiveCount += sstable.getRecentBloomFilterTruePositiveCount();
+                    trueNegativeCount += sstable.getRecentBloomFilterTrueNegativeCount();
                 }
-                if (falseCount == 0L && trueCount == 0L)
+                if (falsePositiveCount == 0L && truePositiveCount == 0L)
                     return 0d;
-                return (double) falseCount / (trueCount + falseCount);
+                return (double) falsePositiveCount / (truePositiveCount + falsePositiveCount + trueNegativeCount);
             }
         }, new Gauge<Double>() // global gauge
         {
             public Double getValue()
             {
-                long falseCount = 0L;
-                long trueCount = 0L;
+                long falsePositiveCount = 0L;
+                long truePositiveCount = 0L;
+                long trueNegativeCount = 0L;
                 for (Keyspace keyspace : Keyspace.all())
                 {
                     for (SSTableReader sstable : keyspace.getAllSSTables(SSTableSet.LIVE))
                     {
-                        falseCount += sstable.getRecentBloomFilterFalsePositiveCount();
-                        trueCount += sstable.getRecentBloomFilterTruePositiveCount();
+                        falsePositiveCount += sstable.getRecentBloomFilterFalsePositiveCount();
+                        truePositiveCount += sstable.getRecentBloomFilterTruePositiveCount();
+                        trueNegativeCount += sstable.getRecentBloomFilterTrueNegativeCount();
                     }
                 }
-                if (falseCount == 0L && trueCount == 0L)
+                if (falsePositiveCount == 0L && truePositiveCount == 0L)
                     return 0d;
-                return (double) falseCount / (trueCount + falseCount);
+                return (double) falsePositiveCount / (truePositiveCount + falsePositiveCount + trueNegativeCount);
             }
         });
         bloomFilterDiskSpaceUsed = createTableGauge("BloomFilterDiskSpaceUsed", new Gauge<Long>()


### PR DESCRIPTION
Before this change the bloom filter false positive rate was calculated
without true negatives which resulted in high rates. In an extreme case,
where all queries return no data, the false positive rate could go up to
1.0.

This change includes true negatives in [recent] bloom filter false ratio.