### PR TITLE
Fix cqlshrc default path in docs

### DIFF
--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -15,7 +15,7 @@
 ; specific language governing permissions and limitations
 ; under the License.
 ;
-; Sample ~/.cqlshrc file.
+; Sample ~/.cassandra/cqlshrc file.
 
 [authentication]
 ;; If Cassandra has auth enabled, fill out these options

--- a/doc/source/tools/cqlsh.rst
+++ b/doc/source/tools/cqlsh.rst
@@ -42,7 +42,7 @@ cqlshrc
 ^^^^^^^
 
 The ``cqlshrc`` file holds configuration options for cqlsh.  By default this is in the user's home directory at
-``~/.cassandra/cqlsh``, but a custom location can be specified with the ``--cqlshrc`` option.
+``~/.cassandra/cqlshrc``, but a custom location can be specified with the ``--cqlshrc`` option.
 
 Example config values and documentation can be found in the ``conf/cqlshrc.sample`` file of a tarball installation.  You
 can also view the latest version of `cqlshrc online <https://github.com/apache/cassandra/blob/trunk/conf/cqlshrc.sample>`__.


### PR DESCRIPTION
The default config file gets set to '~/.cassandra/cqlshrc' in bin/cqlsh.py:

![image](https://user-images.githubusercontent.com/6944615/84039173-25f71500-a9a1-11ea-89b5-af1304ca36f9.png)
