### PR TITLE
CASSANDRA-15888 DOC - Installation pages, curl command for retrieving keys

### DIFF
--- a/doc/source/getting_started/installing.rst
+++ b/doc/source/getting_started/installing.rst
@@ -180,14 +180,14 @@ Installing the Debian packages
 
 ::
 
-   $ echo "deb http://www.apache.org/dist/cassandra/debian 40x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-   deb http://www.apache.org/dist/cassandra/debian 40x main
+   $ echo "deb http://downloads.apache.org/cassandra/debian 40x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+   deb http://downloads.apache.org/cassandra/debian 40x main
 
 3. Add the Apache Cassandra repository keys to the list of trusted keys on the server:
 
 ::
 
-   $ curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
+   $ curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100  266k  100  266k    0     0   320k      0 --:--:-- --:--:-- --:--:--  320k


### PR DESCRIPTION
On the **getting_started/installing** page in the Debian section the curl command for retrieving the cassandra GPG KEYS did not work as the URL gets redirected but curl did not follow the redirection.

This PR changes the URLs from `www.apache.com` to `downloads.apache.org`. Adding `-L` to curl would also fix this problem, but the installation steps for RPM packages also use `downloads.apache.org` and so I think it is more consistent to use this URL here as well.