### PR TITLE
DOC: broken url for adding respository keys

### DIFF
--- a/doc/source/getting_started/installing.rst
+++ b/doc/source/getting_started/installing.rst
@@ -187,7 +187,7 @@ Installing the Debian packages
 
 ::
 
-   $ curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -
+   $ curl curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                     Dload  Upload   Total   Spent    Left  Speed
    100  266k  100  266k    0     0   320k      0 --:--:-- --:--:-- --:--:--  320k


### PR DESCRIPTION
the functionality at https://www.apache.org/dist/cassandra/KEYS has now been moved to https://downloads.apache.org/cassandra/KEYS.
However,the documentation refers to the old path.