### PR TITLE
Fix upgrade failures when using the EC2Snitch in legacy mode

### DIFF
--- a/src/java/org/apache/cassandra/locator/Ec2Snitch.java
+++ b/src/java/org/apache/cassandra/locator/Ec2Snitch.java
@@ -178,10 +178,11 @@ public class Ec2Snitch extends AbstractNetworkTopologySnitch
             // Further, we can't make any assumptions of what that suffix might be by looking at this node's
             // datacenterSuffix as conceivably their could be many different suffixes in play for a given region.
             //
-            // Thus, the best we can do is make sure the region name follows
-            // the basic region naming pattern: "us-east-1<custom-suffix>"
-            boolean dcUsesLegacyFormat = !dc.matches("[a-z]+-[a-z].+-[\\d].*");
-            if (dcUsesLegacyFormat != usingLegacyNaming)
+            // It is impossible to distinguish standard and legacy names for datacenters in some cases
+            // as the format didn't change for some regions (us-west-2 for example).
+            // We can still identify as legacy the dc names without a number as a suffix like us-east"
+            boolean dcUsesLegacyFormat = dc.matches("^[a-z]+-[a-z]+$");
+            if (dcUsesLegacyFormat && !usingLegacyNaming)
                 valid = false;
         }
 

--- a/test/unit/org/apache/cassandra/locator/EC2SnitchTest.java
+++ b/test/unit/org/apache/cassandra/locator/EC2SnitchTest.java
@@ -140,7 +140,7 @@ public class EC2SnitchTest
     {
         Set<String> datacenters = new HashSet<>();
         datacenters.add("us-east-1");
-        Assert.assertFalse(Ec2Snitch.validate(datacenters, Collections.emptySet(), true));
+        Assert.assertTrue(Ec2Snitch.validate(datacenters, Collections.emptySet(), true));
     }
 
     @Test
@@ -205,6 +205,33 @@ public class EC2SnitchTest
         Set<String> racks = new HashSet<>();
         racks.add("us-east-1a");
         Assert.assertTrue(Ec2Snitch.validate(datacenters, racks, false));
+    }
+
+    /**
+     * Validate upgrades in legacy mode for regions that didn't change name between the standard and legacy modes.
+     */
+    @Test
+    public void validate_RequiresLegacy_DCValidStandardAndLegacy()
+    {
+        Set<String> datacenters = new HashSet<>();
+        datacenters.add("us-west-2");
+        Set<String> racks = new HashSet<>();
+        racks.add("2a");
+        racks.add("2b");
+        Assert.assertTrue(Ec2Snitch.validate(datacenters, racks, true));
+    }
+
+    /**
+     * Check that racks names are enough to detect a mismatch in naming conventions.
+     */
+    @Test
+    public void validate_RequiresLegacy_RackInvalidForLegacy()
+    {
+        Set<String> datacenters = new HashSet<>();
+        datacenters.add("us-west-2");
+        Set<String> racks = new HashSet<>();
+        racks.add("us-west-2a");
+        Assert.assertFalse(Ec2Snitch.validate(datacenters, racks, true));
     }
 
     @AfterClass


### PR DESCRIPTION
Legacy naming conventions for AWS regions were allowing datacenter names such as us-west and us-west-2, which in the new standard mode become us-west-1 and us-west-2.
As us-west-2 can match both the standard and legacy mode, checking the DC name cannot be reliably used to detect mixed modes being used as it would fail in case of an upgrade from pre-4.0 clusters in a region such as us-west-2.
The rack check should be enough as rack names in the standard mode now includes the region name, which can be easily identified.