### PR TITLE
CASSANDRA-13701 Updated default num_tokens from 256 to 16

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha5
+ * Updated default num_tokens from 256 to 16 with associated allocate_tokens_for_local_replication_factor (CASSANDRA-13701)
  * Prune expired messages less frequently in internode messaging (CASSANDRA-15700)
  * Fix Ec2Snitch handling of legacy mode for dc names matching both formats, eg "us-west-2" (CASSANDRA-15878)
  * Add support for server side DESCRIBE statements (CASSANDRA-14825)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -251,14 +251,14 @@ Upgrading
       four digits need to be prefixed with a plus or minus sign.
     - cqlsh now returns a non-zero code in case of errors. This is a backward incompatible change so it may
       break existing scripts that rely on the current behavior. See CASSANDRA-15623 for more details.
-    - CASSANDRA-13701 To give a better out of the box experience, the default 'num_tokens'
-      value has been changed from 256 to 16 for reasons described in
-      https://cassandra.apache.org/doc/latest/getting_started/production.html#tokens
+    - To give a better out of the box experience, the default 'num_tokens' value has been changed from 256
+      to 16 for reasons described in https://cassandra.apache.org/doc/latest/getting_started/production.html#tokens
       'allocate_tokens_for_local_replication_factor' is also uncommented and set to 3.
       Please note when upgrading that if the 'num_tokens' value is different than what you have
       configured, the upgraded node will refuse to start. Also note that if a new node joining
       the cluster has a different value for 'num_tokens' than the rest of the datacenter,
       the new node will be responsible for a different amount of data than the rest of the datacenter.
+      See CASSANDRA-13701 for details.
 
 
 Deprecation

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -251,6 +251,14 @@ Upgrading
       four digits need to be prefixed with a plus or minus sign.
     - cqlsh now returns a non-zero code in case of errors. This is a backward incompatible change so it may
       break existing scripts that rely on the current behavior. See CASSANDRA-15623 for more details.
+    - CASSANDRA-13701 To give a better out of the box experience, the default 'num_tokens'
+      value has been changed from 256 to 16 for reasons described in
+      https://cassandra.apache.org/doc/latest/getting_started/production.html#tokens
+      'allocate_tokens_for_local_replication_factor' is also uncommented and set to 3.
+      Please note when upgrading that if the 'num_tokens' value is different than what you have
+      configured, the upgraded node will refuse to start. Also note that if a new node joining
+      the cluster has a different value for 'num_tokens' than the rest of the datacenter,
+      the new node will be responsible for a different amount of data than the rest of the datacenter.
 
 
 Deprecation

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -20,7 +20,10 @@ cluster_name: 'Test Cluster'
 # Specifying initial_token will override this setting on the node's initial start,
 # on subsequent starts, this setting will apply even if initial token is set.
 #
-num_tokens: 256
+# See https://cassandra.apache.org/doc/latest/getting_started/production.html#tokens for
+# best practice information about num_tokens.
+#
+num_tokens: 16
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over
@@ -37,7 +40,7 @@ num_tokens: 256
 
 # Replica factor is explicitly set, regardless of keyspace or datacenter.
 # This is the replica factor within the datacenter, like NTS.
-# allocate_tokens_for_local_replication_factor: 3
+allocate_tokens_for_local_replication_factor: 3
 
 # initial_token allows you to specify tokens manually.  While you can use it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 


### PR DESCRIPTION
Updated default num_tokens from 256 to 16 with associated allocate_tokens_for_local_replication_factor.  Also added some information about upgrading in NEWS.txt.