### PR TITLE
Fixed setting USING_G1 (CASSANDRA-15931)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0-alpha5
+ * USING_G1 is incorrectly set in cassandra-env.sh if G1 is explicitly disabled with -UseG1GC (CASSANDRA-15931)
  * Prune expired messages less frequently in internode messaging (CASSANDRA-15700)
  * Fix Ec2Snitch handling of legacy mode for dc names matching both formats, eg "us-west-2" (CASSANDRA-15878)
  * Add support for server side DESCRIBE statements (CASSANDRA-14825)

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -120,7 +120,7 @@ echo $JVM_OPTS | grep -q Xms
 DEFINED_XMS=$?
 echo $JVM_OPTS | grep -q UseConcMarkSweepGC
 USING_CMS=$?
-echo $JVM_OPTS | grep -q UseG1GC
+echo $JVM_OPTS | grep -q +UseG1GC
 USING_G1=$?
 
 # Override these to set the amount of memory to allocate to the JVM at


### PR DESCRIPTION
Made the grep when setting USING_G1 check explicitly for enabling G1 (+UseG1GC).