### PR TITLE
CASSANDRA-17488 allow users to change cqlsh history location using env variable

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -247,7 +247,7 @@ optvalues = optparse.Values()
 (options, arguments) = parser.parse_args(sys.argv[1:], values=optvalues)
 
 # BEGIN history/config definition
-HISTORY_DIR = os.path.expanduser(os.path.join('~', '.cassandra'))
+HISTORY_DIR = os.getenv('CQL_HISTORY',os.path.expanduser(os.path.join('~', '.cassandra')))
 
 if hasattr(options, 'cqlshrc'):
     CONFIG_FILE = options.cqlshrc


### PR DESCRIPTION
Good day. 

I just started using cassandra and found that it creates history folder in my home directory. I personally don't like it and all my folders follow XDG standard. I found stackoverflow [question](https://stackoverflow.com/questions/35708522/how-can-i-change-the-cqlsh-cqlsh-history-log-file-location) related to it which says that it's not possible to do without configuring source code of cqlsh.py. 

In this pull request I added a feature to choose history directory using environment variable. The name of variable is **CQL_HISTORY**. Why ? Because postgres and node-repl use approximately the same convention (NODE_REPL_HISTORY,PSQL_HISTORY). If you want I can change the name.

Please review this idea I think a lot of people would like to have it (P.S I am not sure if this information should be added to README if so then I can do it )