### PR TITLE
Backport CASSANDRA-15857 Freeze raw tuple unconditionally

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/CreateAggregateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CreateAggregateStatement.java
@@ -141,7 +141,7 @@ public final class CreateAggregateStatement extends SchemaAlteringStatement
 
     private AbstractType<?> prepareType(String typeName, CQL3Type.Raw rawType)
     {
-        if (rawType.isFrozen())
+        if (!rawType.isTuple() && rawType.isFrozen())
             throw new InvalidRequestException(String.format("The function %s should not be frozen; remove the frozen<> modifier", typeName));
 
         // UDT are not supported non frozen but we do not allow the frozen keyword for argument. So for the moment we

--- a/src/java/org/apache/cassandra/cql3/statements/CreateFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CreateFunctionStatement.java
@@ -170,7 +170,7 @@ public final class CreateFunctionStatement extends SchemaAlteringStatement
 
     private AbstractType<?> prepareType(String typeName, CQL3Type.Raw rawType)
     {
-        if (rawType.isFrozen())
+        if (!rawType.isTuple() && rawType.isFrozen())
             throw new InvalidRequestException(String.format("The function %s should not be frozen; remove the frozen<> modifier", typeName));
 
         // UDT are not supported non frozen but we do not allow the frozen keyword for argument. So for the moment we

--- a/src/java/org/apache/cassandra/cql3/statements/DropAggregateStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/DropAggregateStatement.java
@@ -139,7 +139,7 @@ public final class DropAggregateStatement extends SchemaAlteringStatement
 
     private AbstractType<?> prepareType(String typeName, CQL3Type.Raw rawType)
     {
-        if (rawType.isFrozen())
+        if (!rawType.isTuple() && rawType.isFrozen())
             throw new InvalidRequestException(String.format("The function %s should not be frozen; remove the frozen<> modifier", typeName));
 
         // UDT are not supported non frozen but we do not allow the frozen keyword for argument. So for the moment we

--- a/src/java/org/apache/cassandra/cql3/statements/DropFunctionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/DropFunctionStatement.java
@@ -70,7 +70,7 @@ public final class DropFunctionStatement extends SchemaAlteringStatement
             argTypes = new ArrayList<>(argRawTypes.size());
             for (CQL3Type.Raw rawType : argRawTypes)
             {
-                if (rawType.isFrozen())
+                if (!rawType.isTuple() && rawType.isFrozen())
                     throw new InvalidRequestException("The function arguments should not be frozen; remove the frozen<> modifier");
 
                 // UDT are not supported non frozen but we do not allow the frozen keyword for argument. So for the moment we

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UFTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UFTest.java
@@ -110,6 +110,19 @@ public class UFTest extends CQLTester
         assertLastSchemaChange(Event.SchemaChange.Change.DROPPED, Event.SchemaChange.Target.FUNCTION,
                                KEYSPACE, parseFunctionName(f).name,
                                "double", "double");
+
+        // The function with nested tuple should be created without throwing InvalidRequestException. See CASSANDRA-15857
+        String f1 = createFunction(KEYSPACE,
+                                   "list<tuple<int, int>>, double",
+                                   "CREATE OR REPLACE FUNCTION %s(state list<tuple<int, int>>, val double) " +
+                                   "RETURNS NULL ON NULL INPUT " +
+                                   "RETURNS double " +
+                                   "LANGUAGE javascript " +
+                                   "AS '\"string\";';");
+
+        assertLastSchemaChange(Event.SchemaChange.Change.CREATED, Event.SchemaChange.Target.FUNCTION,
+                               KEYSPACE, parseFunctionName(f1).name,
+                               "list<frozen<tuple<int, int>>>", "double"); // CASSANDRA-14825: remove frozen from param
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UFTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UFTypesTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import com.datastax.driver.core.Row;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.transport.Event;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.UUIDGen;
 
@@ -452,19 +453,20 @@ public class UFTypesTest extends CQLTester
         execute("INSERT INTO %s (a, b) VALUES (?, ?)", 2, tuple(4, 5));
         execute("INSERT INTO %s (a, b) VALUES (?, ?)", 3, tuple(7, 8));
 
-        assertInvalidMessage("The function arguments should not be frozen",
-                             "CREATE OR REPLACE FUNCTION " + KEYSPACE + ".withFrozenArg(values frozen<tuple<int, int>>) " +
-                             "CALLED ON NULL INPUT " +
-                             "RETURNS text " +
-                             "LANGUAGE java\n" +
-                             "AS 'return values.toString();';");
-
-        assertInvalidMessage("The function return type should not be frozen",
-                             "CREATE OR REPLACE FUNCTION " + KEYSPACE + ".frozenReturnType(values tuple<int, int>) " +
-                             "CALLED ON NULL INPUT " +
-                             "RETURNS frozen<tuple<int, int>> " +
-                             "LANGUAGE java\n" +
-                             "AS 'return values;';");
+        // Tuples are always frozen. Both 'tuple' and 'frozen tuple' have the same effect.
+        // So allows to create function with explicit frozen tuples as argument and return types.
+        String toDrop = createFunction(KEYSPACE,
+                                       "frozen<tuple<int, int>>",
+                                       "CREATE FUNCTION %s (values frozen<tuple<int, int>>) " +
+                                       "CALLED ON NULL INPUT " +
+                                       "RETURNS frozen<tuple<int, int>> " +
+                                       "LANGUAGE java\n" +
+                                       "AS 'return values;';");
+        // Same as above, dropping a function with explicity frozen tuple should be allowed.
+        schemaChange("DROP FUNCTION " + toDrop + "(frozen<tuple<int, int>>);");
+        assertLastSchemaChange(Event.SchemaChange.Change.DROPPED, Event.SchemaChange.Target.FUNCTION,
+                               KEYSPACE, shortFunctionName(toDrop),
+                               "frozen<tuple<int, int>>");
 
         String functionName = createFunction(KEYSPACE,
                                              "tuple<int, int>",
@@ -490,8 +492,10 @@ public class UFTypesTest extends CQLTester
         assertRows(execute("SELECT a FROM %s WHERE b = " + functionName + "(?)", tuple(1, 2)),
                    row(1));
 
-        assertInvalidMessage("The function arguments should not be frozen",
-                             "DROP FUNCTION " + functionName + "(frozen<tuple<int, int>>);");
+        schemaChange("DROP FUNCTION " + functionName + "(frozen<tuple<int, int>>);");
+        assertLastSchemaChange(Event.SchemaChange.Change.DROPPED, Event.SchemaChange.Target.FUNCTION,
+                               KEYSPACE, shortFunctionName(functionName),
+                               "frozen<tuple<int, int>>");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AggregationTest.java
@@ -459,6 +459,26 @@ public class AggregationTest extends CQLTester
         assertLastSchemaChange(Event.SchemaChange.Change.DROPPED, Event.SchemaChange.Target.AGGREGATE,
                                KEYSPACE, parseFunctionName(a).name,
                                "double");
+
+        // The aggregate with nested tuple should be created without throwing InvalidRequestException. See CASSANDRA-15857
+        String f1 = createFunction(KEYSPACE,
+                                   "double, double",
+                                   "CREATE OR REPLACE FUNCTION %s(state double, val list<tuple<int, int>>) " +
+                                   "RETURNS NULL ON NULL INPUT " +
+                                   "RETURNS double " +
+                                   "LANGUAGE javascript " +
+                                   "AS '\"string\";';");
+
+        String a1 = createAggregate(KEYSPACE,
+                                    "list<tuple<int, int>>",
+                                    "CREATE OR REPLACE AGGREGATE %s(list<tuple<int, int>>) " +
+                                    "SFUNC " + shortFunctionName(f1) + " " +
+                                    "STYPE double " +
+                                    "INITCOND 0");
+
+        assertLastSchemaChange(Event.SchemaChange.Change.CREATED, Event.SchemaChange.Target.AGGREGATE,
+                               KEYSPACE, parseFunctionName(a1).name,
+                               "list<frozen<tuple<int, int>>>"); // CASSANDRA-14825: remove frozen from param
     }
 
     @Test
@@ -1618,12 +1638,20 @@ public class AggregationTest extends CQLTester
                                        "LANGUAGE java " +
                                        "AS 'return state;'");
 
-        assertInvalidMessage("The function state type should not be frozen",
-                             "CREATE AGGREGATE %s(tuple<int, int>) " +
-                             "SFUNC " + parseFunctionName(fState).name + ' ' +
-                             "STYPE frozen<tuple<int, int>> " +
-                             "FINALFUNC " + parseFunctionName(fFinal).name + ' ' +
-                             "INITCOND null");
+        // Tuples are always frozen. Both 'tuple' and 'frozen tuple' have the same effect.
+        // So allows to create aggregate with explicit frozen tuples as argument and state types.
+        String toDrop = createAggregate(KEYSPACE,
+                                        "frozen<tuple<int, int>>",
+                                        "CREATE AGGREGATE %s(frozen<tuple<int, int>>) " +
+                                        "SFUNC " + parseFunctionName(fState).name + ' ' +
+                                        "STYPE frozen<tuple<int, int>> " +
+                                        "FINALFUNC " + parseFunctionName(fFinal).name + ' ' +
+                                        "INITCOND null");
+        // Same as above, dropping a function with explicity frozen tuple should be allowed.
+        schemaChange("DROP AGGREGATE " + toDrop + "(frozen<tuple<int, int>>);");
+        assertLastSchemaChange(Event.SchemaChange.Change.DROPPED, Event.SchemaChange.Target.AGGREGATE,
+                               KEYSPACE, shortFunctionName(toDrop),
+                               "frozen<tuple<int, int>>");
 
         String aggregation = createAggregate(KEYSPACE,
                                              "tuple<int, int>",
@@ -1636,8 +1664,10 @@ public class AggregationTest extends CQLTester
         assertRows(execute("SELECT " + aggregation + "(b) FROM %s"),
                    row(tuple(7, 8)));
 
-        assertInvalidMessage("The function arguments should not be frozen",
-                             "DROP AGGREGATE %s (frozen<tuple<int, int>>);");
+        schemaChange("DROP AGGREGATE " + aggregation + "(frozen<tuple<int, int>>);");
+        assertLastSchemaChange(Event.SchemaChange.Change.DROPPED, Event.SchemaChange.Target.AGGREGATE,
+                               KEYSPACE, shortFunctionName(aggregation),
+                               "frozen<tuple<int, int>>");
     }
 
     @Test


### PR DESCRIPTION
1. `CQLSSTableWriterTest` uses JUnit Rule, which is not exist in 4.6. I added a separate commit to "Backport CASSANDRA-13360 Upgrade junit from 4.6 to 4.12 "
2. `testSchemaChange` in `AggregationTest` and `UFTest` are adopted since in 3.11 branch we do not have CASSANDRA-14825, which removes `frozen` from param