### PR TITLE
CASSANDRA-15975 SEP.shutdownAndWait does not wait for termination and SEPExecutor.awa…

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/SEPWorker.java
+++ b/src/java/org/apache/cassandra/concurrent/SEPWorker.java
@@ -77,8 +77,15 @@ final class SEPWorker extends AtomicReference<SEPWorker.Work> implements Runnabl
         {
             while (true)
             {
-                if (pool.shuttingDown)
+                // On the first iteration of the outer loop of a worker created by SEPExecutor.maybeSchedule(),
+                // the work and task permit has been taken from the scheduler before entering this loop.  Go
+                // through the outer loop at least once to execute the task and then exit so that the task
+                // accounting is correct and will trigger the shutdown signal correctly and correctly return
+                // the correct list of aborted tasks from SEPExecutor.shutdownNow()
+                if (pool.shuttingDown && get().assigned == null)
+                {
                     return;
+                }
 
                 if (isSpinning() && !selfAssign())
                 {

--- a/src/java/org/apache/cassandra/concurrent/SharedExecutorPool.java
+++ b/src/java/org/apache/cassandra/concurrent/SharedExecutorPool.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.concurrent;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -123,13 +124,14 @@ public class SharedExecutorPool
     public synchronized void shutdownAndWait(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException
     {
         shuttingDown = true;
-        for (SEPExecutor executor : executors)
+        ArrayList<SEPExecutor> toShutdown = new ArrayList<>(executors);
+        for (SEPExecutor executor : toShutdown)
             executor.shutdownNow();
 
         terminateWorkers();
 
         long until = System.nanoTime() + unit.toNanos(timeout);
-        for (SEPExecutor executor : executors)
+        for (SEPExecutor executor : toShutdown)
         {
             executor.shutdown.await(until - System.nanoTime(), TimeUnit.NANOSECONDS);
             if (!executor.isTerminated())


### PR DESCRIPTION
…itTermination may hang

Fixes a couple of issues with the shared executor pool.

SharedExecutorPool.shutdownAndWait calls shutdownNow on the executors it owns,
which has the side effect of removing the executor from the list, then uses the
same emptied list to try and wait for them to complete shutting down, exiting
immediately.

This exposed a follow on issue that if a SEPExecutor is shutdown immediately
after maybeSchedule creates a new SEPWorker, but before the SEPWorker is able
to execute the first task it would exit immediately on entering the work loop
with a work and task permit reserved for it, but did not return them on exit.

Ensure at least one trip around the outer loop to pick up the initially assigned
executor, execute the task and then release the work and task permits correctly,
so that shutdown.signalAll is called and the SEPExecutor.shutdownNow() task
list is correct.

Patch by Jon Meredith; reviewed by ? for CASSANDRA-15975