### PR TITLE
CASSANDRA-15983 Fixed incorrect CREATE SCHEMA command in README.asc

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -57,7 +57,7 @@ offer, and 'quit;' or 'exit;' when you've had enough fun. But lets try
 something slightly more interesting:
 
 ----
-cqlsh> CREATE SCHEMA schema1 
+cqlsh> CREATE KEYSPACE schema1 
        WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
 cqlsh> USE schema1;
 cqlsh:Schema1> CREATE TABLE users (
@@ -72,7 +72,7 @@ cqlsh:Schema1> SELECT * FROM users;
  user_id | age | first | last
 ---------+-----+-------+-------
   jsmith |  42 |  john | smith
- cqlsh:Schema1> 
+cqlsh:Schema1> 
 ----
 
 If your session looks similar to what's above, congrats, your single node


### PR DESCRIPTION
Replaced `CREATE SCHEMA` with `CREATE KEYSPACE`. Issue with `README.asc` [reported in ASF Slack by Theodore](https://the-asf.slack.com/archives/CJZLTM05A/p1595748695132600).