### PR TITLE
CASSANDRA-16008 Fix ExceptionInInitializerError when data_file_direct…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.19
+ * Fix ExceptionInInitializerError when data_file_directories is not set (CASSANDRA-16008)
+
+
 2.2.18
  * Fix CQL parsing of collections when the column type is reversed (CASSANDRA-15814)
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -561,7 +561,7 @@ public class DatabaseDescriptor
                 throw new ConfigurationException("saved_caches_directory is missing and -Dcassandra.storagedir is not set", false);
             conf.saved_caches_directory += File.separator + "saved_caches";
         }
-        if (conf.data_file_directories == null)
+        if (conf.data_file_directories == null || conf.data_file_directories.length == 0)
         {
             String defaultDataDir = System.getProperty("cassandra.storagedir", null);
             if (defaultDataDir == null)


### PR DESCRIPTION
…ories is not set

Commit `257fb03` changed `Config.java`:

```
-    public String[] data_file_directories;
+    public String[] data_file_directories = new String[0];
```

which broke `DatabaseDescriptor.java`. This PR is to commit the fix to C* 3.0/3.11 by CASSANDRA-7066.