### PR TITLE
Fix ExceptionInInitializerError when data_file_directories is not set (CASSANDRA-16008)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.19
+ * Fix ExceptionInInitializerError when data_file_directories is not set (CASSANDRA-16008)
+
+
 2.2.18
  * Fix CQL parsing of collections when the column type is reversed (CASSANDRA-15814)
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -561,7 +561,7 @@ public class DatabaseDescriptor
                 throw new ConfigurationException("saved_caches_directory is missing and -Dcassandra.storagedir is not set", false);
             conf.saved_caches_directory += File.separator + "saved_caches";
         }
-        if (conf.data_file_directories == null)
+        if (conf.data_file_directories == null || conf.data_file_directories.length == 0)
         {
             String defaultDataDir = System.getProperty("cassandra.storagedir", null);
             if (defaultDataDir == null)


### PR DESCRIPTION
Applied C* 3.0/3.11 fix to `DatabaseDescriptor.java` in CASSANDRA-7066 broken by commit `257fb03`.