### PR TITLE
CASSANDRA-16178 ByteBufferAccessor throws ClassCastException when trying to query system_views.local_read_latency

### DIFF
--- a/src/java/org/apache/cassandra/db/virtual/SimpleDataSet.java
+++ b/src/java/org/apache/cassandra/db/virtual/SimpleDataSet.java
@@ -18,8 +18,11 @@
 package org.apache.cassandra.db.virtual;
 
 import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 
 import com.google.common.collect.Iterables;
 
@@ -27,7 +30,6 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.marshal.AbstractType;
-import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.CompositeType;
 import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -84,7 +86,7 @@ public class SimpleDataSet extends AbstractVirtualTable.AbstractDataSet
     {
         ByteBuffer partitionKey = partitionKeyValues.length == 1
                                 ? decompose(metadata.partitionKeyType, partitionKeyValues[0])
-                                : ((CompositeType) metadata.partitionKeyType).decompose(ByteBufferAccessor.instance, partitionKeyValues);
+                                : ((CompositeType) metadata.partitionKeyType).decompose(partitionKeyValues);
         return metadata.partitioner.decorateKey(partitionKey);
     }
 

--- a/test/unit/org/apache/cassandra/db/virtual/SimpleDataSetTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SimpleDataSetTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.DataRange;
+import org.apache.cassandra.db.marshal.CompositeType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimpleDataSetTest
+{
+    @Test
+    public void shouldDecomposeCompositePartitionKey()
+    {
+        TableMetadata metadata = TableMetadata.builder("simple_data_set", "composite_pk")
+                                              .kind(TableMetadata.Kind.VIRTUAL)
+                                              .addPartitionKeyColumn("k1", UTF8Type.instance)
+                                              .addPartitionKeyColumn("k2", UTF8Type.instance)
+                                              .addRegularColumn("value", Int32Type.instance)
+                                              .partitioner(Murmur3Partitioner.instance)
+                                              .build();
+        
+        SimpleDataSet data = new SimpleDataSet(metadata).row("first", "second");
+        ByteBuffer expected = ((CompositeType) metadata.partitionKeyType).decompose("first", "second");
+        
+        Iterator<AbstractVirtualTable.Partition> partitions = data.getPartitions(DataRange.allData(Murmur3Partitioner.instance));
+        assertEquals(expected, partitions.next().key().getKey());
+    }
+}


### PR DESCRIPTION
stop passing the accessor as the first var arg to CompositeType#decompose() when building virtual table datasets