### PR TITLE
CASSANDRA-16206 - Eliminate gen-doc template warning and unused (problematic) import

### DIFF
--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -1,5 +1,12 @@
-{% extends "defindex.html" %}
-{% block tables %}
+{% extends "layout.html" %}
+{%- block htmltitle -%}
+<title>{{ html_title }}</title>
+{%- endblock -%}
+{% block body %}
+  <h1>{{ docstitle|e }}</h1>
+  <p>
+  {% trans %}Welcome! This is the documentation for Apache Cassandra {{ version }}.{% endtrans %}
+  </p>
 <div id="wipwarning">This documentation is a work-in-progress.
     <a href="{{ pathto("bugs") }}">Contributions</a> are welcome.</div>
 

--- a/doc/source/_util/cql.py
+++ b/doc/source/_util/cql.py
@@ -26,7 +26,6 @@ from pygments.lexer import Lexer, RegexLexer, do_insertions, bygroups, words
 from pygments.token import Punctuation, Whitespace, Error, \
     Text, Comment, Operator, Keyword, Name, String, Number, Generic, Literal
 from pygments.lexers import get_lexer_by_name, ClassNotFound
-from pygments.util import iteritems
 
 __all__ = [ 'CQLLexer' ]
 


### PR DESCRIPTION
When running 'sphinx-build -b html -d build/doctrees   source build/html'
on Linux we get the following warning:
     [exec] generating indices... genindex
     [exec] WARNING: Now base template defindex.html is deprecated.
     [exec] writing additional pages... index search

on FreeBSD this causes gen-doc to fail:
     [exec] writing additional pages...  indexfailed
     [exec]
     [exec] Theme error:
     [exec] An error happened in rendering the page index.
     [exec] Reason: UndefinedError("'warn' is undefined")
     [exec] *** Error code 2

The patch to doc/source/_util/cql.py removes the unused iteritems import, preventing errors on versions of pygments 2.6.0+:
     [exec] Running Sphinx v3.2.1
     [exec]
     [exec] Exception occurred:
     [exec]   File "/wrkdirs/usr/ports/databases/cassandra4/work/apache-cassandra-4.0-beta2-src/doc/source/_util/cql.py", line 29, in <module>
     [exec]     from pygments.util import iteritems
     [exec] ImportError: cannot import name 'iteritems' from 'pygments.util' (/usr/local/lib/python3.7/site-packages/pygments/util.py)

The patch has been tested in the following environments:
FreeBSD 12.1-RELEASE-p7
    Python 3.7.9
    Sphinx 3.2.1
    pygments 2.7.1

Ubuntu 18.04.1
    Python 3.7.5
    Sphinx 1.6.7
    pygments 2.2.0

Ubuntu 18.04.1
    Python 2.7.17
    Sphinx 1.6.7
    pygments 2.5.2
