### PR TITLE
CASSANDRA-14477 - trunk - the check of num_tokens against the length of initial_token in the cassandra.yaml triggers unexpectedly

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1087,7 +1087,10 @@ public class DatabaseDescriptor
             Collection<String> tokens = tokensFromString(conf.initial_token);
             if (conf.num_tokens == null)
             {
-                throw new ConfigurationException("initial_token was set but num_tokens is not!", false);
+                if (tokens.size() == 1)
+                    conf.num_tokens = 1;
+                else
+                    throw new ConfigurationException("initial_token was set but num_tokens is not!", false);
             }
 
             if (tokens.size() != conf.num_tokens)

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -504,7 +504,7 @@ public class DatabaseDescriptorTest
     }
 
     @Test
-    public void testApplyInitialTokensInitialTokensSetNumTokensSetAndDoesMatch()
+    public void testApplyTokensConfigInitialTokensSetNumTokensSetAndDoesMatch()
     {
         Config config = DatabaseDescriptor.loadConfig();
         config.initial_token = "0,256,1024";
@@ -523,7 +523,7 @@ public class DatabaseDescriptorTest
     }
 
     @Test
-    public void testApplyInitialTokensInitialTokensSetNumTokensSetAndDoesntMatch()
+    public void testApplyTokensConfigInitialTokensSetNumTokensSetAndDoesntMatch()
     {
         Config config = DatabaseDescriptor.loadConfig();
         config.initial_token = "0,256,1024";
@@ -533,7 +533,7 @@ public class DatabaseDescriptorTest
         {
             DatabaseDescriptor.applyTokensConfig(config);
 
-            Assert.fail("initial_token = 0,256,1024 and num_tokens = 10 but applyInitialTokens() did not fail!");
+            Assert.fail("initial_token = 0,256,1024 and num_tokens = 10 but applyTokensConfig() did not fail!");
         }
         catch (ConfigurationException ex)
         {
@@ -543,7 +543,7 @@ public class DatabaseDescriptorTest
     }
 
     @Test
-    public void testApplyInitialTokensInitialTokensSetNumTokensNotSet()
+    public void testApplyTokensConfigInitialTokensSetNumTokensNotSet()
     {
         Config config = DatabaseDescriptor.loadConfig();
         config.initial_token = "0,256,1024";
@@ -560,7 +560,7 @@ public class DatabaseDescriptorTest
     }
 
     @Test
-    public void testApplyInitialTokensInitialTokensNotSetNumTokensSet()
+    public void testApplyTokensConfigInitialTokensNotSetNumTokensSet()
     {
         Config config = DatabaseDescriptor.loadConfig();
         config.num_tokens = 3;
@@ -572,12 +572,25 @@ public class DatabaseDescriptorTest
     }
 
     @Test
-    public void testApplyInitialTokensInitialTokensNotSetNumTokensNotSet()
+    public void testApplyTokensConfigInitialTokensNotSetNumTokensNotSet()
     {
         Config config = DatabaseDescriptor.loadConfig();
         DatabaseDescriptor.applyTokensConfig(config);
 
         Assert.assertEquals(Integer.valueOf(1), config.num_tokens);
         Assert.assertTrue(DatabaseDescriptor.tokensFromString(config.initial_token).isEmpty());
+    }
+
+    @Test
+    public void testApplyTokensConfigInitialTokensOneNumTokensNotSet()
+    {
+        Config config = DatabaseDescriptor.loadConfig();
+        config.initial_token = "123";
+        config.num_tokens = null;
+
+        DatabaseDescriptor.applyTokensConfig(config);
+
+        Assert.assertEquals(Integer.valueOf(1), config.num_tokens);
+        Assert.assertEquals(1, DatabaseDescriptor.tokensFromString(config.initial_token).size());
     }
 }


### PR DESCRIPTION
https://ci-cassandra.apache.org/view/patches/job/Cassandra-devbranch/167/