### PR TITLE
Correct header for STCS documentation.

### DIFF
--- a/doc/source/operating/compaction/stcs.rst
+++ b/doc/source/operating/compaction/stcs.rst
@@ -17,7 +17,7 @@
 
 .. _STCS:
 
-Leveled Compaction Strategy
+Size Tiered Compaction Strategy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The basic idea of ``SizeTieredCompactionStrategy`` (STCS) is to merge sstables of approximately the same size. All


### PR DESCRIPTION
In the STCS documentation switch the header "Levelled Compaction Strategy" to the corrected "Size Tiered Compaction Strategy" to make this documentation easier to find via search. 

Fixes the documentation issue referenced at [this Jira](https://issues.apache.org/jira/browse/CASSANDRA-16282). (Apologies, the Jira ticket was probably overkill for such a small change. I'm a first time contributor on this project.)