### PR TITLE
CASSANDRA-16406 Move merkle tree mismatch debug loggings to trace level

### DIFF
--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -300,7 +300,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
         // We need to difference all trees one against another
         DifferenceHolder diffHolder = new DifferenceHolder(trees);
 
-        logger.debug("diffs = {}", diffHolder);
+        logger.trace("diffs = {}", diffHolder);
         PreferedNodeFilter preferSameDCFilter = (streaming, candidates) ->
                                                 candidates.stream()
                                                           .filter(node -> getDC.apply(streaming)
@@ -325,7 +325,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
                     List<Range<Token>> toFetch = new ArrayList<>(streamsFor.get(fetchFrom));
                     assert !toFetch.isEmpty();
 
-                    logger.debug("{} is about to fetch {} from {}", address, toFetch, fetchFrom);
+                    logger.trace("{} is about to fetch {} from {}", address, toFetch, fetchFrom);
                     SyncTask task;
                     if (address.equals(local))
                     {
@@ -342,7 +342,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             }
             else
             {
-                logger.debug("Node {} has nothing to stream", address);
+                logger.trace("Node {} has nothing to stream", address);
             }
         }
         logger.info("Created {} optimised sync tasks based on {} merkle tree responses for {} (took: {}ms)",

--- a/src/java/org/apache/cassandra/utils/MerkleTree.java
+++ b/src/java/org/apache/cassandra/utils/MerkleTree.java
@@ -216,15 +216,15 @@ public class MerkleTree
         {
             if (lnode instanceof Leaf || rnode instanceof Leaf)
             {
-                logger.debug("Digest mismatch detected among leaf nodes {}, {}", lnode, rnode);
+                logger.trace("Digest mismatch detected among leaf nodes {}, {}", lnode, rnode);
                 diff.add(active);
             }
             else
             {
-                logger.debug("Digest mismatch detected, traversing trees [{}, {}]", ltree, rtree);
+                logger.trace("Digest mismatch detected, traversing trees [{}, {}]", ltree, rtree);
                 if (FULLY_INCONSISTENT == differenceHelper(ltree, rtree, diff, active))
                 {
-                    logger.debug("Range {} fully inconsistent", active);
+                    logger.trace("Range {} fully inconsistent", active);
                     diff.add(active);
                 }
             }
@@ -253,13 +253,13 @@ public class MerkleTree
         {
             // If the midpoint equals either the left or the right, we have a range that's too small to split - we'll simply report the
             // whole range as inconsistent
-            logger.debug("({}) No sane midpoint ({}) for range {} , marking whole range as inconsistent", active.depth, midpoint, active);
+            logger.trace("({}) No sane midpoint ({}) for range {} , marking whole range as inconsistent", active.depth, midpoint, active);
             return FULLY_INCONSISTENT;
         }
 
         TreeRange left = new TreeRange(active.left, midpoint, active.depth + 1);
         TreeRange right = new TreeRange(midpoint, active.right, active.depth + 1);
-        logger.debug("({}) Hashing sub-ranges [{}, {}] for {} divided by midpoint {}", active.depth, left, right, active, midpoint);
+        logger.trace("({}) Hashing sub-ranges [{}, {}] for {} divided by midpoint {}", active.depth, left, right, active, midpoint);
         Node lnode, rnode;
 
         // see if we should recurse left
@@ -269,7 +269,7 @@ public class MerkleTree
         Difference ldiff = CONSISTENT;
         if (null != lnode && null != rnode && lnode.hashesDiffer(rnode))
         {
-            logger.debug("({}) Inconsistent digest on left sub-range {}: [{}, {}]", active.depth, left, lnode, rnode);
+            logger.trace("({}) Inconsistent digest on left sub-range {}: [{}, {}]", active.depth, left, lnode, rnode);
 
             if (lnode instanceof Leaf)
                 ldiff = FULLY_INCONSISTENT;
@@ -278,7 +278,7 @@ public class MerkleTree
         }
         else if (null == lnode || null == rnode)
         {
-            logger.debug("({}) Left sub-range fully inconsistent {}", active.depth, left);
+            logger.trace("({}) Left sub-range fully inconsistent {}", active.depth, left);
             ldiff = FULLY_INCONSISTENT;
         }
 
@@ -289,7 +289,7 @@ public class MerkleTree
         Difference rdiff = CONSISTENT;
         if (null != lnode && null != rnode && lnode.hashesDiffer(rnode))
         {
-            logger.debug("({}) Inconsistent digest on right sub-range {}: [{}, {}]", active.depth, right, lnode, rnode);
+            logger.trace("({}) Inconsistent digest on right sub-range {}: [{}, {}]", active.depth, right, lnode, rnode);
 
             if (rnode instanceof Leaf)
                 rdiff = FULLY_INCONSISTENT;
@@ -298,29 +298,29 @@ public class MerkleTree
         }
         else if (null == lnode || null == rnode)
         {
-            logger.debug("({}) Right sub-range fully inconsistent {}", active.depth, right);
+            logger.trace("({}) Right sub-range fully inconsistent {}", active.depth, right);
             rdiff = FULLY_INCONSISTENT;
         }
 
         if (ldiff == FULLY_INCONSISTENT && rdiff == FULLY_INCONSISTENT)
         {
             // both children are fully inconsistent
-            logger.debug("({}) Fully inconsistent range [{}, {}]", active.depth, left, right);
+            logger.trace("({}) Fully inconsistent range [{}, {}]", active.depth, left, right);
             return FULLY_INCONSISTENT;
         }
         else if (ldiff == FULLY_INCONSISTENT)
         {
-            logger.debug("({}) Adding left sub-range to diff as fully inconsistent {}", active.depth, left);
+            logger.trace("({}) Adding left sub-range to diff as fully inconsistent {}", active.depth, left);
             diff.add(left);
             return PARTIALLY_INCONSISTENT;
         }
         else if (rdiff == FULLY_INCONSISTENT)
         {
-            logger.debug("({}) Adding right sub-range to diff as fully inconsistent {}", active.depth, right);
+            logger.trace("({}) Adding right sub-range to diff as fully inconsistent {}", active.depth, right);
             diff.add(right);
             return PARTIALLY_INCONSISTENT;
         }
-        logger.debug("({}) Range {} partially inconstent", active.depth, active);
+        logger.trace("({}) Range {} partially inconstent", active.depth, active);
         return PARTIALLY_INCONSISTENT;
     }
 


### PR DESCRIPTION
Debug logging being enabled by default in Cassandra, too many logger.debug() calls in the Merkle trees comparisons ended up having a significant impact on repair performance.
Such loggings are useful for Cassandra developers mostly and they were moved to trace level to avoid impacting production clusters.