### PR TITLE
CASSANDRA-16450 MigrationCoordinatorTest#testWeKeepSendingRequests() Failing Sporadically

### DIFF
--- a/test/unit/org/apache/cassandra/service/MigrationCoordinatorTest.java
+++ b/test/unit/org/apache/cassandra/service/MigrationCoordinatorTest.java
@@ -56,7 +56,6 @@ public class MigrationCoordinatorTest
     private static final UUID LOCAL_VERSION = UUID.randomUUID();
     private static final UUID V1 = UUID.randomUUID();
     private static final UUID V2 = UUID.randomUUID();
-    private static final UUID V3 = UUID.randomUUID();
 
     static
     {
@@ -256,7 +255,7 @@ public class MigrationCoordinatorTest
     }
 
     @Test
-    public void testWeKeepSendingRequests()
+    public void testWeKeepSendingRequests() throws Exception
     {
         InstrumentedCoordinator coordinator = new InstrumentedCoordinator();
 
@@ -283,7 +282,7 @@ public class MigrationCoordinatorTest
                 Assert.fail(String.format("Not expecting prev %s to be equal to next %s", prev.endpoint, next.endpoint));
 
             // should send a new request
-            next.fail();
+            next.fail().get();
             prev = next;
             Assert.assertFalse(coordinator.awaitSchemaRequests(1));
 


### PR DESCRIPTION
ensure that MigrationCoordinatorTest.testWeKeepSendingRequests waits for callback failure to complete before asserting that a new request has been sent