### PR TITLE
CASSANDRA-16505: Update python2 doc references to point to py3

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -201,7 +201,7 @@ parser.add_option("-C", "--color", action='store_true', dest='color',
 parser.add_option("--no-color", action='store_false', dest='color',
                   help='Never use color output')
 parser.add_option("--browser", dest='browser', help="""The browser to use to display CQL help, where BROWSER can be:
-                                                    - one of the supported browsers in https://docs.python.org/2/library/webbrowser.html.
+                                                    - one of the supported browsers in https://docs.python.org/3/library/webbrowser.html.
                                                     - browser path followed by %s, example: /usr/bin/google-chrome-stable %s""")
 parser.add_option('--ssl', action='store_true', help='Use SSL', default=False)
 parser.add_option("-u", "--username", help="Authenticate as user.")

--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -52,7 +52,7 @@
 ; default browser (specifying 'browser = default' does not work).
 ;
 ; Supported browsers are those supported by the Python webbrowser module.
-; (https://docs.python.org/2/library/webbrowser.html).
+; (https://docs.python.org/3/library/webbrowser.html).
 ;
 ; Hint: to use Google Chome, use
 ; 'browser = open -a /Applications/Google\ Chrome.app %s' on Mac OS X and

--- a/doc/source/tools/cqlsh.rst
+++ b/doc/source/tools/cqlsh.rst
@@ -65,7 +65,7 @@ Options:
 
 ``--browser``
   Specify the browser to use for displaying cqlsh help.  This can be one of the `supported browser names
-  <https://docs.python.org/2/library/webbrowser.html>`__ (e.g. ``firefox``) or a browser path followed by ``%s`` (e.g.
+  <https://docs.python.org/3/library/webbrowser.html>`__ (e.g. ``firefox``) or a browser path followed by ``%s`` (e.g.
   ``/usr/bin/google-chrome-stable %s``).
 
 ``--ssl``

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -2033,7 +2033,7 @@ class ImportConversion(object):
                     raise ValueError("can't interpret %r as a date with format %s or as int" % (val,
                                                                                                 self.date_time_format))
 
-            # https://docs.python.org/2/library/time.html#time.struct_time
+            # https://docs.python.org/3/library/time.html#time.struct_time
             tval = time.struct_time((int(m.group(1)), int(m.group(2)), int(m.group(3)),  # year, month, day
                                     int(m.group(4)) if m.group(4) else 0,  # hour
                                     int(m.group(5)) if m.group(5) else 0,  # minute


### PR DESCRIPTION
Python 2 has been deprecated; update the corresponding references to
point to Python 3 urls.

I verified all these URLs continue to work as expected, no dead links
etc.