### PR TITLE
CASSANDRA-16506: Drop unittest2 import

### DIFF
--- a/pylib/cqlshlib/test/basecase.py
+++ b/pylib/cqlshlib/test/basecase.py
@@ -14,21 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import sys
-import logging
+import unittest
 
 from os.path import dirname, join, normpath
 
 cqlshlog = logging.getLogger('test_cqlsh')
-
-try:
-    # a backport of python2.7 unittest features, so we can test against older
-    # pythons as necessary. python2.7 users who don't care about testing older
-    # versions need not install.
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 rundir = dirname(__file__)
 cqlshdir = normpath(join(rundir, '..', '..', '..', 'bin'))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-16506

`cqlsh` has a dependency on `unittest2`. As noted in the code comment,
this is only useful for testing against python versions < 2.7 because
newer versions of python auto-include these features in the version of
`unittest` shipped with the standard library.

Given that support for Python 2.7 is itself now deprecated in favor of
Python 3, we certainly don't need to keep supporting python's < 2.7, so
no need to include the `unittest2` import...