### PR TITLE
CASSANDRA-16509: Bump the version of cqlsh

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -45,7 +45,7 @@ UTF8 = 'utf-8'
 CP65001 = 'cp65001'  # Win utf-8 variant
 
 description = "CQL Shell for Apache Cassandra"
-version = "5.0.1"
+version = "6.0.0"
 
 readline = None
 try:


### PR DESCRIPTION
Bump the version of `cqlsh` so that when users report which version of `cqlsh` they're using, it actually means something, along with the protocol/server version.

It's been `5.0.1` for the cassandra 3.x series, so `6.0.0` probably makes sense as matching cassandra `4.0` because there are possible breaking changes depending on how [CASSANDRA-16508](https://issues.apache.org/jira/browse/CASSANDRA-16508) is resolved.

Before this change, if a user says they're using `cqlsh` 5.0.1, we have no idea which release they're actually using because that version number hasn't been incremented for several releases of the Cassandra 3.x series, even though the code within `cqlsh` is occasionally changing.