### PR TITLE
CASSANDRA-15892 Fix deadlock on network flush failure

### DIFF
--- a/src/java/org/apache/cassandra/streaming/StreamSession.java
+++ b/src/java/org/apache/cassandra/streaming/StreamSession.java
@@ -314,7 +314,11 @@ public class StreamSession implements IEndpointStateChangeSubscriber
         if (!messageSender.hasControlChannel() && isControlChannel)
             messageSender.injectControlMessageChannel(channel);
 
-        channel.closeFuture().addListener(ignored -> onChannelClose(channel));
+        channel.closeFuture().addListener(ignored ->
+            ScheduledExecutors.nonPeriodicTasks.submit(() ->
+                onChannelClose(channel)
+            )
+        );
         return channels.putIfAbsent(channel.id(), channel) == null;
     }
 
@@ -328,7 +332,11 @@ public class StreamSession implements IEndpointStateChangeSubscriber
     {
         failIfFinished();
 
-        channel.closeFuture().addListener(ignored -> onChannelClose(channel));
+        channel.closeFuture().addListener(ignored ->
+            ScheduledExecutors.nonPeriodicTasks.submit(() ->
+                onChannelClose(channel)
+            )
+        );
         return channels.putIfAbsent(channel.id(), channel) == null;
     }
 


### PR DESCRIPTION
Handle `StreamSession#onChannelClose` in a different thread to avoid deadlocking when the session is closed due to a failure while a network flush is in progress.