### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -226,7 +226,7 @@
    Apache License version 2.
 
    This product bundles a file (VIntCoding.java) from Protocol Buffers
-   copyright Google Inc., which is available under an BSD license.
+   copyright Google Inc., which is available under n BSD license.
 
    Thus product bundles material adapted from Cassandra, The Definitive Guide.
    Published by O'Reilly Media, Inc. Copyright Jeff Carpenter and Eben Hewitt 
@@ -236,5 +236,5 @@
    Huckleberry Finn, Complete by Mark Twain (Samuel Clemens), which is in
    the public domain.
    
-   This product bundles code (internalOffer) is written by Doug Lea and
+   This product bundles code (internalOffer) that is written by Doug Lea and
    Martin Buchholz available under a Creative Commons zero license.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -202,8 +202,39 @@
    limitations under the License.
 
 
-THIRD-PARTY DEPENDENCIES
-========================
-Convenience copies of some third-party dependencies are distributed with
-Apache Cassandra as Java jar files in lib/. Licensing information for
-these files can be found in the lib/licenses directory.
+   APACHE CASSANDRA SUBCOMPONENTS:
+
+   Apache Cassandra includes a number of subcomponents with
+   separate copyright notices and license terms. Your use of the source
+   code for these subcomponents is subject to the terms and
+   conditions of the following licenses.
+
+   This product bundles a file (AbstractIterator.java) from Chronicle-Bytes,
+   copyright higherfrequencytrading.com, which is available under an
+   Apache License version 2.
+
+   This product bundles a file (AbstractIterator.java) from Guava,
+   copyright The Guava Authors, which is available under an
+   Apache License version 2.
+
+   This product bundles a file (LongTimSort.java) from Android libcore,
+   copyright The Android Open Source Project, which is available under an
+   Apache License version 2.
+
+   This product bundles several files (LongTimSort.java) from PATRICIA Trie
+   copyright Roger Kapsi and Sam Berlin, which is available under an
+   Apache License version 2.
+
+   This product bundles a file (VIntCoding.java) from Protocol Buffers
+   copyright Google Inc., which is available under an BSD license.
+
+   Thus product bundles material adapted from Cassandra, The Definitive Guide.
+   Published by O'Reilly Media, Inc. Copyright Jeff Carpenter and Eben Hewitt 
+   and used with their permission.
+
+   This product bundles The Project Gutenberg EBook of Adventures of
+   Huckleberry Finn, Complete by Mark Twain (Samuel Clemens), which is in
+   the public domain.
+   
+   This product bundles code (internalOffer) is written by Doug Lea and
+   Martin Buchholz available under a Creative Commons zero license.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -226,7 +226,7 @@
    Apache License version 2.
 
    This product bundles a file (VIntCoding.java) from Protocol Buffers
-   copyright Google Inc., which is available under an BSD license.
+   copyright Google Inc., which is available under a BSD license.
 
    Thus product bundles material adapted from Cassandra, The Definitive Guide.
    Published by O'Reilly Media, Inc. Copyright Jeff Carpenter and Eben Hewitt 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -226,7 +226,7 @@
    Apache License version 2.
 
    This product bundles a file (VIntCoding.java) from Protocol Buffers
-   copyright Google Inc., which is available under n BSD license.
+   copyright Google Inc., which is available under an BSD license.
 
    Thus product bundles material adapted from Cassandra, The Definitive Guide.
    Published by O'Reilly Media, Inc. Copyright Jeff Carpenter and Eben Hewitt 


### PR DESCRIPTION
We don't specifically identify the licenses of a number of bundled components included with the source distro of Apache Cassandra in our License file in accordance with (https://infra.apache.org/licensing-howto.html). Specifically:

1. src/java/org/apache/cassandra/index/sasi/utils/AbstractIterator.java
2. src/java/org/apache/cassandra/utils/LongTimSort.java
3. src/java/org/apache/cassandra/index/sasi/utils/trie/Cursor.java
4. test/resources/tokenization/adventures_of_huckleberry_finn_mark_twain.txt
5. content in doc/source/data_modeling/

Note: src/java/org/apache/cassandra/utils/vint/VIntCoding.java makes reference of borrowing ideas from Google Protocol Buffers.

I'm not sure if this is code, concepts or a reference to the concepts in the documentation for an understanding of the idea. I've included it as its a compatible licenses to be on the safe side.  

I've also removed the reference to the lib/ folder as this license (as I understand) currently applies to the source release rather than convenience binaries. 

