### PR TITLE
CASSANDRA-16404. Provide a nodetool way of invalidating auth caches.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.1
+ * Provide a nodetool way of invalidating auth caches (CASSANDRA-16404)
  * Background schedule to clean up orphaned hints files (CASSANDRA-16815)
  * Modify SecondaryIndexManager#indexPartition() to retrieve only columns for which indexes are actually being built (CASSANDRA-16776)
  * Batch the token metadata update to improve the speed (CASSANDRA-15291)

--- a/src/java/org/apache/cassandra/auth/AuthCache.java
+++ b/src/java/org/apache/cassandra/auth/AuthCache.java
@@ -38,7 +38,7 @@ public class AuthCache<K, V> implements AuthCacheMBean
 {
     private static final Logger logger = LoggerFactory.getLogger(AuthCache.class);
 
-    private static final String MBEAN_NAME_BASE = "org.apache.cassandra.auth:type=";
+    public static final String MBEAN_NAME_BASE = "org.apache.cassandra.auth:type=";
 
     /**
      * Underlying cache. LoadingCache will call underlying load function on {@link #get} if key is not present

--- a/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
+++ b/src/java/org/apache/cassandra/auth/AuthenticatedUser.java
@@ -40,7 +40,7 @@ public class AuthenticatedUser
 
     // User-level permissions cache.
     private static final PermissionsCache permissionsCache = new PermissionsCache(DatabaseDescriptor.getAuthorizer());
-    private static final NetworkAuthCache networkAuthCache = new NetworkAuthCache(DatabaseDescriptor.getNetworkAuthorizer());
+    private static final NetworkPermissionsCache networkPermissionsCache = new NetworkPermissionsCache(DatabaseDescriptor.getNetworkAuthorizer());
 
     private final String name;
     // primary Role of the logged in user
@@ -136,7 +136,7 @@ public class AuthenticatedUser
      */
     public boolean hasLocalAccess()
     {
-        return networkAuthCache.get(this.getPrimaryRole()).canAccess(Datacenters.thisDatacenter());
+        return networkPermissionsCache.get(this.getPrimaryRole()).canAccess(Datacenters.thisDatacenter());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/auth/INetworkAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/INetworkAuthorizer.java
@@ -46,7 +46,7 @@ public interface INetworkAuthorizer
     void setRoleDatacenters(RoleResource role, DCPermissions permissions);
 
     /**
-     * Called when a role is deleted, so any corresponding network auth
+     * Called when a role is deleted, so any corresponding network permissions
      * data can also be cleaned up
      */
     void drop(RoleResource role);

--- a/src/java/org/apache/cassandra/auth/NetworkAuthCacheMBean.java
+++ b/src/java/org/apache/cassandra/auth/NetworkAuthCacheMBean.java
@@ -18,25 +18,9 @@
 
 package org.apache.cassandra.auth;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-
-public class NetworkAuthCache extends AuthCache<RoleResource, DCPermissions> implements NetworkAuthCacheMBean
+public interface NetworkAuthCacheMBean extends AuthCacheMBean
 {
-    public NetworkAuthCache(INetworkAuthorizer authorizer)
-    {
-        super(CACHE_NAME,
-              DatabaseDescriptor::setRolesValidity,
-              DatabaseDescriptor::getRolesValidity,
-              DatabaseDescriptor::setRolesUpdateInterval,
-              DatabaseDescriptor::getRolesUpdateInterval,
-              DatabaseDescriptor::setRolesCacheMaxEntries,
-              DatabaseDescriptor::getRolesCacheMaxEntries,
-              authorizer::authorize,
-              () -> DatabaseDescriptor.getAuthenticator().requireAuthentication());
-    }
+    public static final String CACHE_NAME = "NetworkAuthCache";
 
-    public void invalidateNetworkAuths(String roleName)
-    {
-        invalidate(RoleResource.role(roleName));
-    }
+    public void invalidateNetworkAuths(String roleName);
 }

--- a/src/java/org/apache/cassandra/auth/NetworkPermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/NetworkPermissionsCache.java
@@ -20,9 +20,9 @@ package org.apache.cassandra.auth;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 
-public class NetworkAuthCache extends AuthCache<RoleResource, DCPermissions> implements NetworkAuthCacheMBean
+public class NetworkPermissionsCache extends AuthCache<RoleResource, DCPermissions> implements NetworkPermissionsCacheMBean
 {
-    public NetworkAuthCache(INetworkAuthorizer authorizer)
+    public NetworkPermissionsCache(INetworkAuthorizer authorizer)
     {
         super(CACHE_NAME,
               DatabaseDescriptor::setRolesValidity,
@@ -35,7 +35,7 @@ public class NetworkAuthCache extends AuthCache<RoleResource, DCPermissions> imp
               () -> DatabaseDescriptor.getAuthenticator().requireAuthentication());
     }
 
-    public void invalidateNetworkAuths(String roleName)
+    public void invalidateNetworkPermissions(String roleName)
     {
         invalidate(RoleResource.role(roleName));
     }

--- a/src/java/org/apache/cassandra/auth/NetworkPermissionsCacheMBean.java
+++ b/src/java/org/apache/cassandra/auth/NetworkPermissionsCacheMBean.java
@@ -18,9 +18,9 @@
 
 package org.apache.cassandra.auth;
 
-public interface NetworkAuthCacheMBean extends AuthCacheMBean
+public interface NetworkPermissionsCacheMBean extends AuthCacheMBean
 {
-    public static final String CACHE_NAME = "NetworkAuthCache";
+    public static final String CACHE_NAME = "NetworkPermissionsCache";
 
-    public void invalidateNetworkAuths(String roleName);
+    public void invalidateNetworkPermissions(String roleName);
 }

--- a/src/java/org/apache/cassandra/auth/NetworkPermissionsCacheMBean.java
+++ b/src/java/org/apache/cassandra/auth/NetworkPermissionsCacheMBean.java
@@ -20,7 +20,9 @@ package org.apache.cassandra.auth;
 
 public interface NetworkPermissionsCacheMBean extends AuthCacheMBean
 {
-    public static final String CACHE_NAME = "NetworkPermissionsCache";
+    // Ideally it should be called 'NetworkPermissionsCache', hovewer, the original name is preserved for backward
+    // compatibility
+    public static final String CACHE_NAME = "NetworkAuthCache";
 
     public void invalidateNetworkPermissions(String roleName);
 }

--- a/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -103,11 +104,10 @@ public class PasswordAuthenticator implements IAuthenticator
     {
         try
         {
-            ResultMessage.Rows rows =
-            authenticateStatement.execute(QueryState.forInternalCalls(),
-                                            QueryOptions.forInternalCalls(consistencyForRole(username),
-                                                                          Lists.newArrayList(ByteBufferUtil.bytes(username))),
-                                            System.nanoTime());
+            QueryOptions options = QueryOptions.forInternalCalls(consistencyForRole(username),
+                    Lists.newArrayList(ByteBufferUtil.bytes(username)));
+
+            ResultMessage.Rows rows = select(authenticateStatement, options);
 
             // If either a non-existent role name was supplied, or no credentials
             // were found for that role we don't want to cache the result so we throw
@@ -125,6 +125,12 @@ public class PasswordAuthenticator implements IAuthenticator
         {
             throw new AuthenticationException("Unable to perform authentication: " + e.getMessage(), e);
         }
+    }
+
+    @VisibleForTesting
+    ResultMessage.Rows select(SelectStatement statement, QueryOptions options)
+    {
+        return statement.execute(QueryState.forInternalCalls(), options, System.nanoTime());
     }
 
     public Set<DataResource> protectedResources()

--- a/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
@@ -243,7 +243,7 @@ public class PasswordAuthenticator implements IAuthenticator
     {
         private CredentialsCache(PasswordAuthenticator authenticator)
         {
-            super("CredentialsCache",
+            super(CACHE_NAME,
                   DatabaseDescriptor::setCredentialsValidity,
                   DatabaseDescriptor::getCredentialsValidity,
                   DatabaseDescriptor::setCredentialsUpdateInterval,
@@ -262,6 +262,8 @@ public class PasswordAuthenticator implements IAuthenticator
 
     public static interface CredentialsCacheMBean extends AuthCacheMBean
     {
+        public static final String CACHE_NAME = "CredentialsCache";
+
         public void invalidateCredentials(String roleName);
     }
 }

--- a/src/java/org/apache/cassandra/auth/PermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/PermissionsCache.java
@@ -23,10 +23,11 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.utils.Pair;
 
 public class PermissionsCache extends AuthCache<Pair<AuthenticatedUser, IResource>, Set<Permission>>
+        implements PermissionsCacheMBean
 {
     public PermissionsCache(IAuthorizer authorizer)
     {
-        super("PermissionsCache",
+        super(CACHE_NAME,
               DatabaseDescriptor::setPermissionsValidity,
               DatabaseDescriptor::getPermissionsValidity,
               DatabaseDescriptor::setPermissionsUpdateInterval,
@@ -40,5 +41,10 @@ public class PermissionsCache extends AuthCache<Pair<AuthenticatedUser, IResourc
     public Set<Permission> getPermissions(AuthenticatedUser user, IResource resource)
     {
         return get(Pair.create(user, resource));
+    }
+
+    public void invalidatePermissions(String userName, String resourceName)
+    {
+        invalidate(Pair.create(new AuthenticatedUser(userName), Resources.fromName(resourceName)));
     }
 }

--- a/src/java/org/apache/cassandra/auth/PermissionsCacheMBean.java
+++ b/src/java/org/apache/cassandra/auth/PermissionsCacheMBean.java
@@ -18,25 +18,9 @@
 
 package org.apache.cassandra.auth;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-
-public class NetworkAuthCache extends AuthCache<RoleResource, DCPermissions> implements NetworkAuthCacheMBean
+public interface PermissionsCacheMBean extends AuthCacheMBean
 {
-    public NetworkAuthCache(INetworkAuthorizer authorizer)
-    {
-        super(CACHE_NAME,
-              DatabaseDescriptor::setRolesValidity,
-              DatabaseDescriptor::getRolesValidity,
-              DatabaseDescriptor::setRolesUpdateInterval,
-              DatabaseDescriptor::getRolesUpdateInterval,
-              DatabaseDescriptor::setRolesCacheMaxEntries,
-              DatabaseDescriptor::getRolesCacheMaxEntries,
-              authorizer::authorize,
-              () -> DatabaseDescriptor.getAuthenticator().requireAuthentication());
-    }
+    public static final String CACHE_NAME = "PermissionsCache";
 
-    public void invalidateNetworkAuths(String roleName)
-    {
-        invalidate(RoleResource.role(roleName));
-    }
+    public void invalidatePermissions(String userName, String resourceName);
 }

--- a/src/java/org/apache/cassandra/auth/RolesCache.java
+++ b/src/java/org/apache/cassandra/auth/RolesCache.java
@@ -23,11 +23,11 @@ import java.util.stream.Collectors;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 
-public class RolesCache extends AuthCache<RoleResource, Set<Role>>
+public class RolesCache extends AuthCache<RoleResource, Set<Role>> implements RolesCacheMBean
 {
     public RolesCache(IRoleManager roleManager, BooleanSupplier enableCache)
     {
-        super("RolesCache",
+        super(CACHE_NAME,
               DatabaseDescriptor::setRolesValidity,
               DatabaseDescriptor::getRolesValidity,
               DatabaseDescriptor::setRolesUpdateInterval,
@@ -61,5 +61,10 @@ public class RolesCache extends AuthCache<RoleResource, Set<Role>>
     Set<Role> getRoles(RoleResource primaryRole)
     {
         return get(primaryRole);
+    }
+
+    public void invalidateRoles(String roleName)
+    {
+        invalidate(RoleResource.role(roleName));
     }
 }

--- a/src/java/org/apache/cassandra/auth/RolesCacheMBean.java
+++ b/src/java/org/apache/cassandra/auth/RolesCacheMBean.java
@@ -18,25 +18,9 @@
 
 package org.apache.cassandra.auth;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-
-public class NetworkAuthCache extends AuthCache<RoleResource, DCPermissions> implements NetworkAuthCacheMBean
+public interface RolesCacheMBean extends AuthCacheMBean
 {
-    public NetworkAuthCache(INetworkAuthorizer authorizer)
-    {
-        super(CACHE_NAME,
-              DatabaseDescriptor::setRolesValidity,
-              DatabaseDescriptor::getRolesValidity,
-              DatabaseDescriptor::setRolesUpdateInterval,
-              DatabaseDescriptor::getRolesUpdateInterval,
-              DatabaseDescriptor::setRolesCacheMaxEntries,
-              DatabaseDescriptor::getRolesCacheMaxEntries,
-              authorizer::authorize,
-              () -> DatabaseDescriptor.getAuthenticator().requireAuthentication());
-    }
+    public static final String CACHE_NAME = "RolesCache";
 
-    public void invalidateNetworkAuths(String roleName)
-    {
-        invalidate(RoleResource.role(roleName));
-    }
+    void invalidateRoles(String primaryRoleName);
 }

--- a/src/java/org/apache/cassandra/auth/RolesCacheMBean.java
+++ b/src/java/org/apache/cassandra/auth/RolesCacheMBean.java
@@ -22,5 +22,5 @@ public interface RolesCacheMBean extends AuthCacheMBean
 {
     public static final String CACHE_NAME = "RolesCache";
 
-    void invalidateRoles(String primaryRoleName);
+    void invalidateRoles(String roleName);
 }

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -182,7 +182,7 @@ public class AuthorizationProxy implements InvocationHandler
      *             as an invocation of a method on the MBeanServer.
      */
     @VisibleForTesting
-    boolean authorize(Subject subject, String methodName, Object[] args)
+    public boolean authorize(Subject subject, String methodName, Object[] args)
     {
         logger.trace("Authorizing JMX method invocation {} for {}",
                      methodName,

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -477,10 +477,11 @@ public class AuthorizationProxy implements InvocationHandler
     }
 
     private static final class JMXPermissionsCache extends AuthCache<RoleResource, Set<PermissionDetails>>
+        implements JMXPermissionsCacheMBean
     {
         protected JMXPermissionsCache()
         {
-            super("JMXPermissionsCache",
+            super(CACHE_NAME,
                   DatabaseDescriptor::setPermissionsValidity,
                   DatabaseDescriptor::getPermissionsValidity,
                   DatabaseDescriptor::setPermissionsUpdateInterval,
@@ -490,5 +491,17 @@ public class AuthorizationProxy implements InvocationHandler
                   AuthorizationProxy::loadPermissions,
                   () -> true);
         }
+
+        public void invalidatePermissions(String roleName)
+        {
+            invalidate(RoleResource.role(roleName));
+        }
+    }
+
+    public static interface JMXPermissionsCacheMBean extends AuthCacheMBean
+    {
+        public static final String CACHE_NAME = "JMXPermissionsCache";
+
+        public void invalidatePermissions(String roleName);
     }
 }

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -500,6 +500,8 @@ public class AuthorizationProxy implements InvocationHandler
 
     public static interface JmxPermissionsCacheMBean extends AuthCacheMBean
     {
+        // Ideally it should be called 'JmxPermissionsCache', hovewer, the original name is preserved for backward
+        // compatibility
         public static final String CACHE_NAME = "JMXPermissionsCache";
 
         public void invalidatePermissions(String roleName);

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -103,7 +103,7 @@ public class AuthorizationProxy implements InvocationHandler
                                                                       "registerMBean",
                                                                       "unregisterMBean");
 
-    private static final JMXPermissionsCache permissionsCache = new JMXPermissionsCache();
+    private static final JmxPermissionsCache permissionsCache = new JmxPermissionsCache();
     private MBeanServer mbs;
 
     /*
@@ -476,10 +476,10 @@ public class AuthorizationProxy implements InvocationHandler
                                                  .collect(Collectors.toSet());
     }
 
-    private static final class JMXPermissionsCache extends AuthCache<RoleResource, Set<PermissionDetails>>
-        implements JMXPermissionsCacheMBean
+    private static final class JmxPermissionsCache extends AuthCache<RoleResource, Set<PermissionDetails>>
+        implements JmxPermissionsCacheMBean
     {
-        protected JMXPermissionsCache()
+        protected JmxPermissionsCache()
         {
             super(CACHE_NAME,
                   DatabaseDescriptor::setPermissionsValidity,
@@ -498,7 +498,7 @@ public class AuthorizationProxy implements InvocationHandler
         }
     }
 
-    public static interface JMXPermissionsCacheMBean extends AuthCacheMBean
+    public static interface JmxPermissionsCacheMBean extends AuthCacheMBean
     {
         public static final String CACHE_NAME = "JMXPermissionsCache";
 

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -56,8 +56,8 @@ import javax.management.remote.JMXServiceURL;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import org.apache.cassandra.auth.AuthCache;
-import org.apache.cassandra.auth.NetworkAuthCache;
-import org.apache.cassandra.auth.NetworkAuthCacheMBean;
+import org.apache.cassandra.auth.NetworkPermissionsCache;
+import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
 import org.apache.cassandra.auth.PasswordAuthenticator;
 import org.apache.cassandra.auth.PermissionsCache;
 import org.apache.cassandra.auth.PermissionsCacheMBean;
@@ -143,8 +143,8 @@ public class NodeProbe implements AutoCloseable
     protected BatchlogManagerMBean bmProxy;
     protected ActiveRepairServiceMBean arsProxy;
     protected PasswordAuthenticator.CredentialsCacheMBean ccProxy;
-    protected AuthorizationProxy.JMXPermissionsCacheMBean jpcProxy;
-    protected NetworkAuthCacheMBean nacProxy;
+    protected AuthorizationProxy.JmxPermissionsCacheMBean jpcProxy;
+    protected NetworkPermissionsCacheMBean npcProxy;
     protected PermissionsCacheMBean pcProxy;
     protected RolesCacheMBean rcProxy;
     protected Output output;
@@ -255,10 +255,10 @@ public class NodeProbe implements AutoCloseable
             arsProxy = JMX.newMBeanProxy(mbeanServerConn, name, ActiveRepairServiceMBean.class);
             name = new ObjectName(AuthCache.MBEAN_NAME_BASE + PasswordAuthenticator.CredentialsCacheMBean.CACHE_NAME);
             ccProxy = JMX.newMBeanProxy(mbeanServerConn, name, PasswordAuthenticator.CredentialsCacheMBean.class);
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + AuthorizationProxy.JMXPermissionsCacheMBean.CACHE_NAME);
-            jpcProxy = JMX.newMBeanProxy(mbeanServerConn, name, AuthorizationProxy.JMXPermissionsCacheMBean.class);
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + NetworkAuthCache.CACHE_NAME);
-            nacProxy = JMX.newMBeanProxy(mbeanServerConn, name, NetworkAuthCacheMBean.class);
+            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + AuthorizationProxy.JmxPermissionsCacheMBean.CACHE_NAME);
+            jpcProxy = JMX.newMBeanProxy(mbeanServerConn, name, AuthorizationProxy.JmxPermissionsCacheMBean.class);
+            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + NetworkPermissionsCache.CACHE_NAME);
+            npcProxy = JMX.newMBeanProxy(mbeanServerConn, name, NetworkPermissionsCacheMBean.class);
             name = new ObjectName(AuthCache.MBEAN_NAME_BASE + PermissionsCache.CACHE_NAME);
             pcProxy = JMX.newMBeanProxy(mbeanServerConn, name, PermissionsCacheMBean.class);
             name = new ObjectName(AuthCache.MBEAN_NAME_BASE + RolesCache.CACHE_NAME);
@@ -521,14 +521,14 @@ public class NodeProbe implements AutoCloseable
         cacheService.invalidateKeyCache();
     }
 
-    public void invalidateNetworkAuthCache()
+    public void invalidateNetworkPermissionsCache()
     {
-        nacProxy.invalidate();
+        npcProxy.invalidate();
     }
 
-    public void invalidateNetworkAuthCache(String resourceName)
+    public void invalidateNetworkPermissionsCache(String roleName)
     {
-        nacProxy.invalidateNetworkAuths(resourceName);
+        npcProxy.invalidateNetworkPermissions(roleName);
     }
 
     public void invalidatePermissionsCache()
@@ -546,9 +546,9 @@ public class NodeProbe implements AutoCloseable
         rcProxy.invalidate();
     }
 
-    public void invalidateRolesCache(String primaryRoleName)
+    public void invalidateRolesCache(String roleName)
     {
-        rcProxy.invalidateRoles(primaryRoleName);
+        rcProxy.invalidateRoles(roleName);
     }
 
     public void invalidateRowCache()

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -33,7 +33,6 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOError;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -143,7 +142,7 @@ public class NodeTool
                 InvalidateCredentialsCache.class,
                 InvalidateJmxPermissionsCache.class,
                 InvalidateKeyCache.class,
-                InvalidateNetworkAuthCache.class,
+                InvalidateNetworkPermissionsCache.class,
                 InvalidatePermissionsCache.class,
                 InvalidateRolesCache.class,
                 InvalidateRowCache.class,

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -139,9 +139,14 @@ public class NodeTool
                 GetMaxHintWindow.class,
                 GossipInfo.class,
                 Import.class,
-                InvalidateKeyCache.class,
-                InvalidateRowCache.class,
                 InvalidateCounterCache.class,
+                InvalidateCredentialsCache.class,
+                InvalidateJmxPermissionsCache.class,
+                InvalidateKeyCache.class,
+                InvalidateNetworkAuthCache.class,
+                InvalidatePermissionsCache.class,
+                InvalidateRolesCache.class,
+                InvalidateRowCache.class,
                 Join.class,
                 Move.class,
                 PauseHandoff.class,
@@ -470,29 +475,6 @@ public class NodeTool
         {
             return cmdArgs.size() <= 1 ? EMPTY_STRING_ARRAY : toArray(cmdArgs.subList(1, cmdArgs.size()), String.class);
         }
-    }
-
-    public static SortedMap<String, SetHostStat> getOwnershipByDc(NodeProbe probe, boolean resolveIp,
-                                                                  Map<String, String> tokenToEndpoint,
-                                                                  Map<InetAddress, Float> ownerships)
-    {
-        SortedMap<String, SetHostStat> ownershipByDc = Maps.newTreeMap();
-        EndpointSnitchInfoMBean epSnitchInfo = probe.getEndpointSnitchInfoProxy();
-        try
-        {
-            for (Entry<String, String> tokenAndEndPoint : tokenToEndpoint.entrySet())
-            {
-                String dc = epSnitchInfo.getDatacenter(tokenAndEndPoint.getValue());
-                if (!ownershipByDc.containsKey(dc))
-                    ownershipByDc.put(dc, new SetHostStat(resolveIp));
-                ownershipByDc.get(dc).add(tokenAndEndPoint.getKey(), tokenAndEndPoint.getValue(), ownerships);
-            }
-        }
-        catch (UnknownHostException e)
-        {
-            throw new RuntimeException(e);
-        }
-        return ownershipByDc;
     }
 
     public static SortedMap<String, SetHostStatWithPort> getOwnershipByDcWithPort(NodeProbe probe, boolean resolveIp,

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCache.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "invalidatecredentialscache", description = "Invalidate the credentials cache")
+public class InvalidateCredentialsCache extends NodeToolCmd
+{
+    @Arguments(usage = "[<role>...]", description = "List of roles to invalidate. By default, all roles")
+    private List<String> args = new ArrayList<>();
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        if (args.isEmpty())
+        {
+            probe.invalidateCredentialsCache();
+        }
+        else
+        {
+            for (String roleName : args)
+            {
+                probe.invalidateCredentialsCache(roleName);
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCache.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "invalidatejmxpermissionscache", description = "Invalidate the JMX permissions cache")
+public class InvalidateJmxPermissionsCache extends NodeToolCmd
+{
+    @Arguments(usage = "[<role>...]", description = "List of roles to invalidate. By default, all roles")
+    private List<String> args = new ArrayList<>();
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        if (args.isEmpty())
+        {
+            probe.invalidateJmxPermissionsCache();
+        } else
+        {
+            for (String roleName : args)
+            {
+                probe.invalidateJmxPermissionsCache(roleName);
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidateNetworkAuthCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidateNetworkAuthCache.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "invalidatenetworkauthcache", description = "Invalidate the network auth cache")
+public class InvalidateNetworkAuthCache extends NodeToolCmd
+{
+    @Arguments(usage = "[<role>...]", description = "List of roles to invalidate. By default, all roles")
+    private List<String> args = new ArrayList<>();
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        if (args.isEmpty()) {
+            probe.invalidateNetworkAuthCache();
+        } else {
+            for (String roleName : args) {
+                probe.invalidateNetworkAuthCache(roleName);
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCache.java
@@ -25,8 +25,8 @@ import io.airlift.airline.Command;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
-@Command(name = "invalidatenetworkauthcache", description = "Invalidate the network auth cache")
-public class InvalidateNetworkAuthCache extends NodeToolCmd
+@Command(name = "invalidatenetworkpermissionscache", description = "Invalidate the network permissions cache")
+public class InvalidateNetworkPermissionsCache extends NodeToolCmd
 {
     @Arguments(usage = "[<role>...]", description = "List of roles to invalidate. By default, all roles")
     private List<String> args = new ArrayList<>();
@@ -34,11 +34,15 @@ public class InvalidateNetworkAuthCache extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        if (args.isEmpty()) {
-            probe.invalidateNetworkAuthCache();
-        } else {
-            for (String roleName : args) {
-                probe.invalidateNetworkAuthCache(roleName);
+        if (args.isEmpty())
+        {
+            probe.invalidateNetworkPermissionsCache();
+        }
+        else
+        {
+            for (String roleName : args)
+            {
+                probe.invalidateNetworkPermissionsCache(roleName);
             }
         }
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+@Command(name = "invalidatepermissionscache", description = "Invalidate the permissions cache")
+public class InvalidatePermissionsCache extends NodeToolCmd
+{
+    @Arguments(usage = "[<user> <resource>...]", description = "The user followed by one or many resources. By default, all users")
+    private List<String> args = new ArrayList<>();
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        if (args.isEmpty())
+        {
+            probe.invalidatePermissionsCache();
+        }
+        else
+        {
+            checkArgument(args.size() >= 2, "invalidatepermissionscache requires user and at least one resource args");
+
+            String userName = args.get(0);
+            for (String resourceName : args.subList(1, args.size()))
+            {
+                probe.invalidatePermissionsCache(userName, resourceName);
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
@@ -168,7 +168,7 @@ public class InvalidatePermissionsCache extends NodeToolCmd
             return FunctionResource.fromName("functions/" + functionsInKeyspace + '/' + function).getName();
         } catch (ConfigurationException e)
         {
-            throw new IllegalArgumentException("Unknown function argument type is passed");
+            throw new IllegalArgumentException("An error was encountered when looking up function definition; " + e.getMessage());
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
@@ -20,8 +20,15 @@ package org.apache.cassandra.tools.nodetool;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.FunctionResource;
+import org.apache.cassandra.auth.JMXResource;
+import org.apache.cassandra.auth.RoleResource;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
@@ -30,25 +37,127 @@ import static com.google.common.base.Preconditions.checkArgument;
 @Command(name = "invalidatepermissionscache", description = "Invalidate the permissions cache")
 public class InvalidatePermissionsCache extends NodeToolCmd
 {
-    @Arguments(usage = "[<user> <resource>...]", description = "The user followed by one or many resources. By default, all users")
+    @Arguments(usage = "[<user>]", description = "A specific user for whom permissions need to be invalidated")
     private List<String> args = new ArrayList<>();
+
+    // Data Resources
+    @Option(title = "all-keyspaces",
+            name = {"--all-keyspaces"},
+            description = "Invalidate permissions for 'ALL KEYSPACES'")
+    private boolean allKeyspaces;
+
+    @Option(title = "keyspace",
+            name = {"--keyspace"},
+            description = "Keyspace to invalidate permissions for")
+    private String keyspace;
+
+    @Option(title = "table",
+            name = {"--table"},
+            description = "Table to invalidate permissions for (you must specify --keyspace for using this option)")
+    private String table;
+
+    // Roles Resources
+    @Option(title = "all-roles",
+            name = {"--all-roles"},
+            description = "Invalidate permissions for 'ALL ROLES'")
+    private boolean allRoles;
+
+    @Option(title = "role",
+            name = {"--role"},
+            description = "Role to invalidate permissions for")
+    private String role;
+
+    // Functions Resources
+    @Option(title = "all-functions",
+            name = {"--all-functions"},
+            description = "Invalidate permissions for 'ALL FUNCTIONS'")
+    private boolean allFunctions;
+
+    @Option(title = "functions-in-keyspace",
+            name = {"--functions-in-keyspace"},
+            description = "Keyspace to invalidate permissions for")
+    private String functionsInKeyspace;
+
+    @Option(title = "function",
+            name = {"--function"},
+            description = "Function to invalidate permissions for (you must specify --functions-in-keyspace for using " +
+                    "this option; function format: name[arg1^..^agrN], for example: foo[Int32Type^DoubleType])")
+    private String function;
+
+    // MBeans Resources
+    @Option(title = "all-mbeans",
+            name = {"--all-mbeans"},
+            description = "Invalidate permissions for 'ALL MBEANS'")
+    private boolean allMBeans;
+
+    @Option(title = "mbean",
+            name = {"--mbean"},
+            description = "MBean to invalidate permissions for")
+    private String mBean;
 
     @Override
     public void execute(NodeProbe probe)
     {
         if (args.isEmpty())
         {
+            checkArgument(!allKeyspaces && StringUtils.isEmpty(keyspace) && StringUtils.isEmpty(table)
+                    && !allRoles && StringUtils.isEmpty(role)
+                    && !allFunctions && StringUtils.isEmpty(functionsInKeyspace) && StringUtils.isEmpty(function)
+                    && !allMBeans && StringUtils.isEmpty(mBean),
+                    "No options allowed without a <user> being specified");
+
             probe.invalidatePermissionsCache();
         }
         else
         {
-            checkArgument(args.size() >= 2, "invalidatepermissionscache requires user and at least one resource args");
+            checkArgument(args.size() == 1,
+                    "A single <user> is only supported / you have a typo in the options spelling");
+            List<String> resourceNames = new ArrayList<>();
+
+            // Data Resources
+            if (allKeyspaces)
+                resourceNames.add(DataResource.root().getName());
+
+            if (StringUtils.isNotEmpty(table))
+                if (StringUtils.isNotEmpty(keyspace))
+                    resourceNames.add(DataResource.table(keyspace, table).getName());
+                else
+                    throw new IllegalArgumentException("--table option should be passed along with --keyspace option");
+            else
+                if (StringUtils.isNotEmpty(keyspace))
+                    resourceNames.add(DataResource.keyspace(keyspace).getName());
+
+            // Roles Resources
+            if (allRoles)
+                resourceNames.add(RoleResource.root().getName());
+
+            if (StringUtils.isNotEmpty(role))
+                resourceNames.add(RoleResource.role(role).getName());
+
+            // Function Resources
+            if (allFunctions)
+                resourceNames.add(FunctionResource.root().getName());
+
+            if (StringUtils.isNotEmpty(function))
+                if (StringUtils.isNotEmpty(functionsInKeyspace))
+                    resourceNames.add("functions/" + functionsInKeyspace + '/' + function);
+                else
+                    throw new IllegalArgumentException("--function option should be passed along with --functions-in-keyspace option");
+            else
+                if (StringUtils.isNotEmpty(functionsInKeyspace))
+                    resourceNames.add(FunctionResource.keyspace(functionsInKeyspace).getName());
+
+            // MBeans Resources
+            if (allMBeans)
+                resourceNames.add(JMXResource.root().getName());
+
+            if (StringUtils.isNotEmpty(mBean))
+                resourceNames.add(JMXResource.mbean(mBean).getName());
 
             String userName = args.get(0);
-            for (String resourceName : args.subList(1, args.size()))
-            {
+
+            for (String resourceName : resourceNames)
                 probe.invalidatePermissionsCache(userName, resourceName);
-            }
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCache.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.FunctionResource;
 import org.apache.cassandra.auth.JMXResource;
 import org.apache.cassandra.auth.RoleResource;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
@@ -140,7 +141,7 @@ public class InvalidatePermissionsCache extends NodeToolCmd
 
             if (StringUtils.isNotEmpty(function))
                 if (StringUtils.isNotEmpty(functionsInKeyspace))
-                    resourceNames.add("functions/" + functionsInKeyspace + '/' + function);
+                    resourceNames.add(constructFunctionResource(functionsInKeyspace, function));
                 else
                     throw new IllegalArgumentException("--function option should be passed along with --functions-in-keyspace option");
             else
@@ -158,6 +159,16 @@ public class InvalidatePermissionsCache extends NodeToolCmd
 
             for (String resourceName : resourceNames)
                 probe.invalidatePermissionsCache(userName, resourceName);
+        }
+    }
+
+    private String constructFunctionResource(String functionsInKeyspace, String function) {
+        try
+        {
+            return FunctionResource.fromName("functions/" + functionsInKeyspace + '/' + function).getName();
+        } catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException("Unknown function argument type is passed");
         }
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/InvalidateRolesCache.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/InvalidateRolesCache.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "invalidaterolescache", description = "Invalidate the roles cache")
+public class InvalidateRolesCache extends NodeToolCmd
+{
+
+    @Arguments(usage = "[<role>...]", description = "List of roles to invalidate. By default, all roles")
+    private List<String> args = new ArrayList<>();
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        if (args.isEmpty())
+        {
+            probe.invalidateRolesCache();
+        }
+        else
+        {
+            for (String roleName : args)
+            {
+                probe.invalidateRolesCache(roleName);
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
+++ b/test/unit/org/apache/cassandra/auth/CassandraRoleManagerTest.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 
-import static org.apache.cassandra.auth.RoleTestUtils.*;
+import static org.apache.cassandra.auth.AuthTestUtils.*;
 import static org.junit.Assert.assertEquals;
 
 public class CassandraRoleManagerTest
@@ -80,9 +80,9 @@ public class CassandraRoleManagerTest
 
     private void fetchRolesAndCheckReadCount(IRoleManager roleManager, RoleResource primaryRole)
     {
-        long before = getReadCount();
+        long before = getRolesReadCount();
         Set<Role> granted = roleManager.getRoleDetails(primaryRole);
-        long after = getReadCount();
+        long after = getRolesReadCount();
         assertEquals(granted.size(), after - before);
     }
 }

--- a/test/unit/org/apache/cassandra/auth/RolesTest.java
+++ b/test/unit/org/apache/cassandra/auth/RolesTest.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 
-import static org.apache.cassandra.auth.RoleTestUtils.*;
+import static org.apache.cassandra.auth.AuthTestUtils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -57,39 +57,39 @@ public class RolesTest
     public void superuserStatusIsCached()
     {
         boolean hasSuper = Roles.hasSuperuserStatus(ROLE_A);
-        long count = getReadCount();
+        long count = getRolesReadCount();
 
         assertEquals(hasSuper, Roles.hasSuperuserStatus(ROLE_A));
-        assertEquals(count, getReadCount());
+        assertEquals(count, getRolesReadCount());
     }
 
     @Test
     public void loginPrivilegeIsCached()
     {
         boolean canLogin = Roles.canLogin(ROLE_A);
-        long count = getReadCount();
+        long count = getRolesReadCount();
 
         assertEquals(canLogin, Roles.canLogin(ROLE_A));
-        assertEquals(count, getReadCount());
+        assertEquals(count, getRolesReadCount());
     }
 
     @Test
     public void grantedRoleDetailsAreCached()
     {
         Iterable<Role> granted = Roles.getRoleDetails(ROLE_A);
-        long count = getReadCount();
+        long count = getRolesReadCount();
 
         assertTrue(Iterables.elementsEqual(granted, Roles.getRoleDetails(ROLE_A)));
-        assertEquals(count, getReadCount());
+        assertEquals(count, getRolesReadCount());
     }
 
     @Test
     public void grantedRoleResourcesAreCached()
     {
         Set<RoleResource> granted = Roles.getRoles(ROLE_A);
-        long count = getReadCount();
+        long count = getRolesReadCount();
 
         assertEquals(granted, Roles.getRoles(ROLE_A));
-        assertEquals(count, getReadCount());
+        assertEquals(count, getRolesReadCount());
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.datastax.driver.core.EndPoint;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.auth.AuthTestUtils;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.IAuthenticator;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
+import static org.apache.cassandra.auth.AuthTestUtils.getRolesReadCount;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class InvalidateCredentialsCacheTest extends CQLTester
+{
+    private static IAuthenticator.SaslNegotiator roleANegotiator;
+    private static IAuthenticator.SaslNegotiator roleBNegotiator;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        AuthTestUtils.LocalCassandraRoleManager roleManager = new AuthTestUtils.LocalCassandraRoleManager();
+        PasswordAuthenticator authenticator = new AuthTestUtils.LocalPasswordAuthenticator();
+        SchemaLoader.setupAuth(roleManager,
+                authenticator,
+                new AuthTestUtils.LocalCassandraAuthorizer(),
+                new AuthTestUtils.LocalCassandraNetworkAuthorizer());
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_A, AuthTestUtils.getLoginRoleOprions());
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOprions());
+
+        roleANegotiator = authenticator.newSaslNegotiator(null);
+        roleANegotiator.evaluateResponse(new PlainTextAuthProvider(ROLE_A.getRoleName(), "ignored")
+                .newAuthenticator((EndPoint) null, null)
+                .initialResponse());
+        roleBNegotiator = authenticator.newSaslNegotiator(null);
+        roleBNegotiator.evaluateResponse(new PlainTextAuthProvider(ROLE_B.getRoleName(), "ignored")
+                .newAuthenticator((EndPoint) null, null)
+                .initialResponse());
+
+        startJMXServer();
+    }
+
+    @Test
+    @SuppressWarnings("SingleCharacterStringConcatenation")
+    public void testMaybeChangeDocs()
+    {
+        // If you added, modified options or help, please update docs if necessary
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("help", "invalidatecredentialscache");
+        tool.assertOnCleanExit();
+
+        String help =   "NAME\n" +
+                        "        nodetool invalidatecredentialscache - Invalidate the credentials cache\n" +
+                        "\n" +
+                        "SYNOPSIS\n" +
+                        "        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]\n" +
+                        "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
+                        "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
+                        "                [(-u <username> | --username <username>)] invalidatecredentialscache\n" +
+                        "                [--] [<role>...]\n" +
+                        "\n" +
+                        "OPTIONS\n" +
+                        "        -h <host>, --host <host>\n" +
+                        "            Node hostname or ip address\n" +
+                        "\n" +
+                        "        -p <port>, --port <port>\n" +
+                        "            Remote jmx agent port number\n" +
+                        "\n" +
+                        "        -pp, --print-port\n" +
+                        "            Operate in 4.0 mode with hosts disambiguated by port number\n" +
+                        "\n" +
+                        "        -pw <password>, --password <password>\n" +
+                        "            Remote jmx agent password\n" +
+                        "\n" +
+                        "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
+                        "            Path to the JMX password file\n" +
+                        "\n" +
+                        "        -u <username>, --username <username>\n" +
+                        "            Remote jmx agent username\n" +
+                        "\n" +
+                        "        --\n" +
+                        "            This option can be used to separate command-line options from the\n" +
+                        "            list of argument, (useful when arguments might be mistaken for\n" +
+                        "            command-line options\n" +
+                        "\n" +
+                        "        [<role>...]\n" +
+                        "            List of roles to invalidate. By default, all roles\n" +
+                        "\n" +
+                        "\n";
+        assertThat(tool.getStdout(), equalTo(help));
+    }
+
+    @Test
+    public void testInvalidateSingleCredential()
+    {
+        // cache credential
+        roleANegotiator.getAuthenticatedUser();
+        long originalReadsCount = getRolesReadCount();
+
+        // enure credential is cached
+        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
+        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+
+        // invalidate credential
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatecredentialscache", ROLE_A.getRoleName());
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure credential is reloaded
+        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
+        assertThat(originalReadsCount, lessThan(getRolesReadCount()));
+    }
+
+    @Test
+    public void testInvalidateAllCredentials()
+    {
+        // cache credentials
+        roleANegotiator.getAuthenticatedUser();
+        roleBNegotiator.getAuthenticatedUser();
+        long originalReadsCount = getRolesReadCount();
+
+        // enure credentials are cached
+        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
+        assertThat(roleBNegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_B.getRoleName())));
+        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+
+        // invalidate both credentials
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatecredentialscache");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure credential for roleA is reloaded
+        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
+        long readsCountAfterFirstReLoad = getRolesReadCount();
+        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+
+        // ensure credential for roleB is reloaded
+        assertThat(roleBNegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_B.getRoleName())));
+        long readsCountAfterSecondReLoad = getRolesReadCount();
+        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
@@ -36,10 +36,7 @@ import org.apache.cassandra.tools.ToolRunner;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getRolesReadCount;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class InvalidateCredentialsCacheTest extends CQLTester
@@ -119,7 +116,7 @@ public class InvalidateCredentialsCacheTest extends CQLTester
                         "            List of roles to invalidate. By default, all roles\n" +
                         "\n" +
                         "\n";
-        assertThat(tool.getStdout(), equalTo(help));
+        assertThat(tool.getStdout()).isEqualTo(help);
     }
 
     @Test
@@ -130,17 +127,17 @@ public class InvalidateCredentialsCacheTest extends CQLTester
         long originalReadsCount = getRolesReadCount();
 
         // enure credential is cached
-        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
-        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+        assertThat(roleANegotiator.getAuthenticatedUser()).isEqualTo(new AuthenticatedUser(ROLE_A.getRoleName()));
+        assertThat(originalReadsCount).isEqualTo(getRolesReadCount());
 
         // invalidate credential
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatecredentialscache", ROLE_A.getRoleName());
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure credential is reloaded
-        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
-        assertThat(originalReadsCount, lessThan(getRolesReadCount()));
+        assertThat(roleANegotiator.getAuthenticatedUser()).isEqualTo(new AuthenticatedUser(ROLE_A.getRoleName()));
+        assertThat(originalReadsCount).isLessThan(getRolesReadCount());
     }
 
     @Test
@@ -152,23 +149,23 @@ public class InvalidateCredentialsCacheTest extends CQLTester
         long originalReadsCount = getRolesReadCount();
 
         // enure credentials are cached
-        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
-        assertThat(roleBNegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_B.getRoleName())));
-        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+        assertThat(roleANegotiator.getAuthenticatedUser()).isEqualTo(new AuthenticatedUser(ROLE_A.getRoleName()));
+        assertThat(roleBNegotiator.getAuthenticatedUser()).isEqualTo(new AuthenticatedUser(ROLE_B.getRoleName()));
+        assertThat(originalReadsCount).isEqualTo(getRolesReadCount());
 
         // invalidate both credentials
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatecredentialscache");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure credential for roleA is reloaded
-        assertThat(roleANegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_A.getRoleName())));
+        assertThat(roleANegotiator.getAuthenticatedUser()).isEqualTo(new AuthenticatedUser(ROLE_A.getRoleName()));
         long readsCountAfterFirstReLoad = getRolesReadCount();
-        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+        assertThat(originalReadsCount).isLessThan(readsCountAfterFirstReLoad);
 
         // ensure credential for roleB is reloaded
-        assertThat(roleBNegotiator.getAuthenticatedUser(), equalTo(new AuthenticatedUser(ROLE_B.getRoleName())));
+        assertThat(roleBNegotiator.getAuthenticatedUser()).isEqualTo(new AuthenticatedUser(ROLE_B.getRoleName()));
         long readsCountAfterSecondReLoad = getRolesReadCount();
-        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+        assertThat(readsCountAfterFirstReLoad).isLessThan(readsCountAfterSecondReLoad);
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
@@ -39,11 +39,7 @@ import org.apache.cassandra.tools.ToolRunner;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getRolePermissionsReadCount;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class InvalidateJmxPermissionsCacheTest extends CQLTester
@@ -120,7 +116,7 @@ public class InvalidateJmxPermissionsCacheTest extends CQLTester
                         "            List of roles to invalidate. By default, all roles\n" +
                         "\n" +
                         "\n";
-        assertThat(tool.getStdout(), equalTo(help));
+        assertThat(tool.getStdout()).isEqualTo(help);
     }
 
     @Test
@@ -133,17 +129,17 @@ public class InvalidateJmxPermissionsCacheTest extends CQLTester
         long originalReadsCount = getRolePermissionsReadCount();
 
         // enure role permission is cached
-        assertTrue(authorizationProxy.authorize(userSubject, "queryNames", null));
-        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+        assertThat(authorizationProxy.authorize(userSubject, "queryNames", null)).isTrue();
+        assertThat(originalReadsCount).isEqualTo(getRolePermissionsReadCount());
 
         // invalidate role permission
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatejmxpermissionscache", ROLE_A.getRoleName());
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure role permission is reloaded
-        assertTrue(authorizationProxy.authorize(userSubject, "queryNames", null));
-        assertThat(originalReadsCount, lessThan(getRolePermissionsReadCount()));
+        assertThat(authorizationProxy.authorize(userSubject, "queryNames", null)).isTrue();
+        assertThat(originalReadsCount).isLessThan(getRolePermissionsReadCount());
     }
 
     @Test
@@ -158,24 +154,24 @@ public class InvalidateJmxPermissionsCacheTest extends CQLTester
         long originalReadsCount = getRolePermissionsReadCount();
 
         // enure role permissions are cached
-        assertTrue(authorizationProxy.authorize(roleASubject, "queryNames", null));
-        assertTrue(authorizationProxy.authorize(roleBSubject, "queryNames", null));
-        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+        assertThat(authorizationProxy.authorize(roleASubject, "queryNames", null)).isTrue();
+        assertThat(authorizationProxy.authorize(roleBSubject, "queryNames", null)).isTrue();
+        assertThat(originalReadsCount).isEqualTo(getRolePermissionsReadCount());
 
         // invalidate both role permissions
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatejmxpermissionscache");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure role permission for roleA is reloaded
-        assertTrue(authorizationProxy.authorize(roleASubject, "queryNames", null));
+        assertThat(authorizationProxy.authorize(roleASubject, "queryNames", null)).isTrue();
         long readsCountAfterFirstReLoad = getRolePermissionsReadCount();
-        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+        assertThat(originalReadsCount).isLessThan(readsCountAfterFirstReLoad);
 
         // ensure role permission for roleB is reloaded
-        assertTrue(authorizationProxy.authorize(roleBSubject, "queryNames", null));
+        assertThat(authorizationProxy.authorize(roleBSubject, "queryNames", null)).isTrue();
         long readsCountAfterSecondReLoad = getRolePermissionsReadCount();
-        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+        assertThat(readsCountAfterFirstReLoad).isLessThan(readsCountAfterSecondReLoad);
     }
 
     private static Subject subject(String roleName)

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.Set;
+import javax.security.auth.Subject;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.auth.AuthTestUtils;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.CassandraPrincipal;
+import org.apache.cassandra.auth.JMXResource;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
+import static org.apache.cassandra.auth.AuthTestUtils.getRolePermissionsReadCount;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class InvalidateJmxPermissionsCacheTest extends CQLTester
+{
+    private static final AuthorizationProxy authorizationProxy = new NoAuthSetupAuthorizationProxy();
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        AuthTestUtils.LocalCassandraRoleManager roleManager = new AuthTestUtils.LocalCassandraRoleManager();
+        AuthTestUtils.LocalCassandraAuthorizer authorizer = new AuthTestUtils.LocalCassandraAuthorizer();
+        SchemaLoader.setupAuth(roleManager,
+                new AuthTestUtils.LocalPasswordAuthenticator(),
+                authorizer,
+                new AuthTestUtils.LocalCassandraNetworkAuthorizer());
+
+        JMXResource rootJmxResource = JMXResource.root();
+        Set<Permission> jmxPermissions = rootJmxResource.applicablePermissions();
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_A, AuthTestUtils.getLoginRoleOprions());
+        authorizer.grant(AuthenticatedUser.SYSTEM_USER, jmxPermissions, rootJmxResource, ROLE_A);
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOprions());
+        authorizer.grant(AuthenticatedUser.SYSTEM_USER, jmxPermissions, rootJmxResource, ROLE_B);
+
+        startJMXServer();
+    }
+
+    @Test
+    @SuppressWarnings("SingleCharacterStringConcatenation")
+    public void testMaybeChangeDocs()
+    {
+        // If you added, modified options or help, please update docs if necessary
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("help", "invalidatejmxpermissionscache");
+        tool.assertOnCleanExit();
+
+        String help =   "NAME\n" +
+                        "        nodetool invalidatejmxpermissionscache - Invalidate the JMX permissions\n" +
+                        "        cache\n" +
+                        "\n" +
+                        "SYNOPSIS\n" +
+                        "        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]\n" +
+                        "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
+                        "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
+                        "                [(-u <username> | --username <username>)] invalidatejmxpermissionscache\n" +
+                        "                [--] [<role>...]\n" +
+                        "\n" +
+                        "OPTIONS\n" +
+                        "        -h <host>, --host <host>\n" +
+                        "            Node hostname or ip address\n" +
+                        "\n" +
+                        "        -p <port>, --port <port>\n" +
+                        "            Remote jmx agent port number\n" +
+                        "\n" +
+                        "        -pp, --print-port\n" +
+                        "            Operate in 4.0 mode with hosts disambiguated by port number\n" +
+                        "\n" +
+                        "        -pw <password>, --password <password>\n" +
+                        "            Remote jmx agent password\n" +
+                        "\n" +
+                        "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
+                        "            Path to the JMX password file\n" +
+                        "\n" +
+                        "        -u <username>, --username <username>\n" +
+                        "            Remote jmx agent username\n" +
+                        "\n" +
+                        "        --\n" +
+                        "            This option can be used to separate command-line options from the\n" +
+                        "            list of argument, (useful when arguments might be mistaken for\n" +
+                        "            command-line options\n" +
+                        "\n" +
+                        "        [<role>...]\n" +
+                        "            List of roles to invalidate. By default, all roles\n" +
+                        "\n" +
+                        "\n";
+        assertThat(tool.getStdout(), equalTo(help));
+    }
+
+    @Test
+    public void testInvalidateSingleJMXPermission()
+    {
+        Subject userSubject = subject(ROLE_A.getRoleName());
+
+        // cache role permission
+        authorizationProxy.authorize(userSubject, "queryNames", null);
+        long originalReadsCount = getRolePermissionsReadCount();
+
+        // enure role permission is cached
+        assertTrue(authorizationProxy.authorize(userSubject, "queryNames", null));
+        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+
+        // invalidate role permission
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatejmxpermissionscache", ROLE_A.getRoleName());
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure role permission is reloaded
+        assertTrue(authorizationProxy.authorize(userSubject, "queryNames", null));
+        assertThat(originalReadsCount, lessThan(getRolePermissionsReadCount()));
+    }
+
+    @Test
+    public void testInvalidateAllJMXPermissions()
+    {
+        Subject roleASubject = subject(ROLE_A.getRoleName());
+        Subject roleBSubject = subject(ROLE_B.getRoleName());
+
+        // cache role permissions
+        authorizationProxy.authorize(roleASubject, "queryNames", null);
+        authorizationProxy.authorize(roleBSubject, "queryNames", null);
+        long originalReadsCount = getRolePermissionsReadCount();
+
+        // enure role permissions are cached
+        assertTrue(authorizationProxy.authorize(roleASubject, "queryNames", null));
+        assertTrue(authorizationProxy.authorize(roleBSubject, "queryNames", null));
+        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+
+        // invalidate both role permissions
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatejmxpermissionscache");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure role permission for roleA is reloaded
+        assertTrue(authorizationProxy.authorize(roleASubject, "queryNames", null));
+        long readsCountAfterFirstReLoad = getRolePermissionsReadCount();
+        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+
+        // ensure role permission for roleB is reloaded
+        assertTrue(authorizationProxy.authorize(roleBSubject, "queryNames", null));
+        long readsCountAfterSecondReLoad = getRolePermissionsReadCount();
+        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+    }
+
+    private static Subject subject(String roleName)
+    {
+        Subject subject = new Subject();
+        subject.getPrincipals().add(new CassandraPrincipal(roleName));
+        return subject;
+    }
+
+    private static class NoAuthSetupAuthorizationProxy extends AuthorizationProxy
+    {
+        public NoAuthSetupAuthorizationProxy()
+        {
+            super();
+            this.isAuthSetupComplete = () -> true;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.auth.AuthTestUtils;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
+import static org.apache.cassandra.auth.AuthTestUtils.getNetworkPermissionsReadCount;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class InvalidateNetworkPermissionsCacheTest extends CQLTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        AuthTestUtils.LocalCassandraRoleManager roleManager = new AuthTestUtils.LocalCassandraRoleManager();
+        SchemaLoader.setupAuth(roleManager,
+                new AuthTestUtils.LocalPasswordAuthenticator(),
+                new AuthTestUtils.LocalCassandraAuthorizer(),
+                new AuthTestUtils.LocalCassandraNetworkAuthorizer());
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_A, AuthTestUtils.getLoginRoleOprions());
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOprions());
+
+        startJMXServer();
+    }
+
+    @Test
+    @SuppressWarnings("SingleCharacterStringConcatenation")
+    public void testMaybeChangeDocs()
+    {
+        // If you added, modified options or help, please update docs if necessary
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("help", "invalidatenetworkpermissionscache");
+        tool.assertOnCleanExit();
+
+        String help =   "NAME\n" +
+                        "        nodetool invalidatenetworkpermissionscache - Invalidate the network\n" +
+                        "        permissions cache\n" +
+                        "\n" +
+                        "SYNOPSIS\n" +
+                        "        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]\n" +
+                        "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
+                        "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
+                        "                [(-u <username> | --username <username>)]\n" +
+                        "                invalidatenetworkpermissionscache [--] [<role>...]\n" +
+                        "\n" +
+                        "OPTIONS\n" +
+                        "        -h <host>, --host <host>\n" +
+                        "            Node hostname or ip address\n" +
+                        "\n" +
+                        "        -p <port>, --port <port>\n" +
+                        "            Remote jmx agent port number\n" +
+                        "\n" +
+                        "        -pp, --print-port\n" +
+                        "            Operate in 4.0 mode with hosts disambiguated by port number\n" +
+                        "\n" +
+                        "        -pw <password>, --password <password>\n" +
+                        "            Remote jmx agent password\n" +
+                        "\n" +
+                        "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
+                        "            Path to the JMX password file\n" +
+                        "\n" +
+                        "        -u <username>, --username <username>\n" +
+                        "            Remote jmx agent username\n" +
+                        "\n" +
+                        "        --\n" +
+                        "            This option can be used to separate command-line options from the\n" +
+                        "            list of argument, (useful when arguments might be mistaken for\n" +
+                        "            command-line options\n" +
+                        "\n" +
+                        "        [<role>...]\n" +
+                        "            List of roles to invalidate. By default, all roles\n" +
+                        "\n" +
+                        "\n";
+        assertThat(tool.getStdout(), equalTo(help));
+    }
+
+    @Test
+    public void testInvalidateSingleNetworkPermission()
+    {
+        AuthenticatedUser role = new AuthenticatedUser(ROLE_A.getRoleName());
+
+        // cache network permission
+        role.hasLocalAccess();
+        long originalReadsCount = getNetworkPermissionsReadCount();
+
+        // enure network permission is cached
+        assertTrue(role.hasLocalAccess());
+        assertThat(originalReadsCount, equalTo(getNetworkPermissionsReadCount()));
+
+        // invalidate network permission
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatenetworkpermissionscache", ROLE_A.getRoleName());
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure network permission is reloaded
+        assertTrue(role.hasLocalAccess());
+        assertThat(originalReadsCount, lessThan(getNetworkPermissionsReadCount()));
+    }
+
+    @Test
+    public void testInvalidateAllNetworkPermissions()
+    {
+        AuthenticatedUser roleA = new AuthenticatedUser(ROLE_A.getRoleName());
+        AuthenticatedUser roleB = new AuthenticatedUser(ROLE_B.getRoleName());
+
+        // cache network permissions
+        roleA.hasLocalAccess();
+        roleB.hasLocalAccess();
+        long originalReadsCount = getNetworkPermissionsReadCount();
+
+        // enure network permissions are cached
+        assertTrue(roleA.hasLocalAccess());
+        assertTrue(roleB.hasLocalAccess());
+        assertThat(originalReadsCount, equalTo(getNetworkPermissionsReadCount()));
+
+        // invalidate both network permissions
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatenetworkpermissionscache");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure network permission for roleA is reloaded
+        assertTrue(roleA.hasLocalAccess());
+        long readsCountAfterFirstReLoad = getNetworkPermissionsReadCount();
+        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+
+        // ensure network permission for roleB is reloaded
+        assertTrue(roleB.hasLocalAccess());
+        long readsCountAfterSecondReLoad = getNetworkPermissionsReadCount();
+        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
@@ -32,11 +32,7 @@ import org.apache.cassandra.tools.ToolRunner;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getNetworkPermissionsReadCount;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class InvalidateNetworkPermissionsCacheTest extends CQLTester
@@ -104,7 +100,7 @@ public class InvalidateNetworkPermissionsCacheTest extends CQLTester
                         "            List of roles to invalidate. By default, all roles\n" +
                         "\n" +
                         "\n";
-        assertThat(tool.getStdout(), equalTo(help));
+        assertThat(tool.getStdout()).isEqualTo(help);
     }
 
     @Test
@@ -117,17 +113,17 @@ public class InvalidateNetworkPermissionsCacheTest extends CQLTester
         long originalReadsCount = getNetworkPermissionsReadCount();
 
         // enure network permission is cached
-        assertTrue(role.hasLocalAccess());
-        assertThat(originalReadsCount, equalTo(getNetworkPermissionsReadCount()));
+        assertThat(role.hasLocalAccess()).isTrue();
+        assertThat(originalReadsCount).isEqualTo(getNetworkPermissionsReadCount());
 
         // invalidate network permission
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatenetworkpermissionscache", ROLE_A.getRoleName());
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure network permission is reloaded
-        assertTrue(role.hasLocalAccess());
-        assertThat(originalReadsCount, lessThan(getNetworkPermissionsReadCount()));
+        assertThat(role.hasLocalAccess()).isTrue();
+        assertThat(originalReadsCount).isLessThan(getNetworkPermissionsReadCount());
     }
 
     @Test
@@ -142,23 +138,23 @@ public class InvalidateNetworkPermissionsCacheTest extends CQLTester
         long originalReadsCount = getNetworkPermissionsReadCount();
 
         // enure network permissions are cached
-        assertTrue(roleA.hasLocalAccess());
-        assertTrue(roleB.hasLocalAccess());
-        assertThat(originalReadsCount, equalTo(getNetworkPermissionsReadCount()));
+        assertThat(roleA.hasLocalAccess()).isTrue();
+        assertThat(roleB.hasLocalAccess()).isTrue();
+        assertThat(originalReadsCount).isEqualTo(getNetworkPermissionsReadCount());
 
         // invalidate both network permissions
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatenetworkpermissionscache");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure network permission for roleA is reloaded
-        assertTrue(roleA.hasLocalAccess());
+        assertThat(roleA.hasLocalAccess()).isTrue();
         long readsCountAfterFirstReLoad = getNetworkPermissionsReadCount();
-        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+        assertThat(originalReadsCount).isLessThan(readsCountAfterFirstReLoad);
 
         // ensure network permission for roleB is reloaded
-        assertTrue(roleB.hasLocalAccess());
+        assertThat(roleB.hasLocalAccess()).isTrue();
         long readsCountAfterSecondReLoad = getNetworkPermissionsReadCount();
-        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+        assertThat(readsCountAfterFirstReLoad).isLessThan(readsCountAfterSecondReLoad);
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
@@ -207,7 +207,7 @@ public class InvalidatePermissionsCacheTest extends CQLTester
                 KEYSPACE, "--function", "f[x]");
         assertThat(tool.getExitCode()).isEqualTo(1);
         assertThat(tool.getStdout())
-                .isEqualTo(wrapByDefaultNodetoolMessage("Unknown function argument type is passed"));
+                .isEqualTo(wrapByDefaultNodetoolMessage("An error was encountered when looking up function definition; Unable to find abstract-type class 'org.apache.cassandra.db.marshal.x'"));
         assertThat(tool.getStderr()).isEmpty();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
@@ -36,10 +36,7 @@ import org.apache.cassandra.tools.ToolRunner;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getRolePermissionsReadCount;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class InvalidatePermissionsCacheTest extends CQLTester
@@ -113,7 +110,7 @@ public class InvalidatePermissionsCacheTest extends CQLTester
                         "            The user followed by one or many resources. By default, all users\n" +
                         "\n" +
                         "\n";
-        assertThat(tool.getStdout(), equalTo(help));
+        assertThat(tool.getStdout()).isEqualTo(help);
     }
 
     @Test
@@ -129,18 +126,18 @@ public class InvalidatePermissionsCacheTest extends CQLTester
         long originalReadsCount = getRolePermissionsReadCount();
 
         // enure permission is cached
-        assertThat(role.getPermissions(rootDataResource), equalTo(dataPermissions));
-        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+        assertThat(role.getPermissions(rootDataResource)).isEqualTo(dataPermissions);
+        assertThat(originalReadsCount).isEqualTo(getRolePermissionsReadCount());
 
         // invalidate permission
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatepermissionscache",
                 ROLE_A.getRoleName(), "data");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure permission is reloaded
-        assertThat(role.getPermissions(rootDataResource), equalTo(dataPermissions));
-        assertThat(originalReadsCount, lessThan(getRolePermissionsReadCount()));
+        assertThat(role.getPermissions(rootDataResource)).isEqualTo(dataPermissions);
+        assertThat(originalReadsCount).isLessThan(getRolePermissionsReadCount());
     }
 
     @Test
@@ -158,23 +155,23 @@ public class InvalidatePermissionsCacheTest extends CQLTester
         long originalReadsCount = getRolePermissionsReadCount();
 
         // enure permissions are cached
-        assertThat(roleA.getPermissions(rootDataResource), equalTo(dataPermissions));
-        assertThat(roleB.getPermissions(rootDataResource), equalTo(dataPermissions));
-        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+        assertThat(roleA.getPermissions(rootDataResource)).isEqualTo(dataPermissions);
+        assertThat(roleB.getPermissions(rootDataResource)).isEqualTo(dataPermissions);
+        assertThat(originalReadsCount).isEqualTo(getRolePermissionsReadCount());
 
         // invalidate both permissions
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatepermissionscache");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure permission for roleA is reloaded
-        assertThat(roleA.getPermissions(rootDataResource), equalTo(dataPermissions));
+        assertThat(roleA.getPermissions(rootDataResource)).isEqualTo(dataPermissions);
         long readsCountAfterFirstReLoad = getRolePermissionsReadCount();
-        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+        assertThat(originalReadsCount).isLessThan(readsCountAfterFirstReLoad);
 
         // ensure permission for roleB is reloaded
-        assertThat(roleB.getPermissions(rootDataResource), equalTo(dataPermissions));
+        assertThat(roleB.getPermissions(rootDataResource)).isEqualTo(dataPermissions);
         long readsCountAfterSecondReLoad = getRolePermissionsReadCount();
-        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+        assertThat(readsCountAfterFirstReLoad).isLessThan(readsCountAfterSecondReLoad);
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
@@ -202,6 +202,13 @@ public class InvalidatePermissionsCacheTest extends CQLTester
         assertThat(tool.getStdout())
                 .isEqualTo(wrapByDefaultNodetoolMessage("--function option should be passed along with --functions-in-keyspace option"));
         assertThat(tool.getStderr()).isEmpty();
+
+        tool = ToolRunner.invokeNodetool("invalidatepermissionscache", "user1", "--functions-in-keyspace",
+                KEYSPACE, "--function", "f[x]");
+        assertThat(tool.getExitCode()).isEqualTo(1);
+        assertThat(tool.getStdout())
+                .isEqualTo(wrapByDefaultNodetoolMessage("Unknown function argument type is passed"));
+        assertThat(tool.getStderr()).isEmpty();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.auth.AuthTestUtils;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
+import static org.apache.cassandra.auth.AuthTestUtils.getRolePermissionsReadCount;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class InvalidatePermissionsCacheTest extends CQLTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        AuthTestUtils.LocalCassandraRoleManager roleManager = new AuthTestUtils.LocalCassandraRoleManager();
+        AuthTestUtils.LocalCassandraAuthorizer authorizer = new AuthTestUtils.LocalCassandraAuthorizer();
+        SchemaLoader.setupAuth(roleManager,
+                new AuthTestUtils.LocalPasswordAuthenticator(),
+                authorizer,
+                new AuthTestUtils.LocalCassandraNetworkAuthorizer());
+
+        DataResource rootDataResource = DataResource.root();
+        Set<Permission> dataPermissions = rootDataResource.applicablePermissions();
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_A, AuthTestUtils.getLoginRoleOprions());
+        authorizer.grant(AuthenticatedUser.SYSTEM_USER, dataPermissions, rootDataResource, ROLE_A);
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOprions());
+        authorizer.grant(AuthenticatedUser.SYSTEM_USER, dataPermissions, rootDataResource, ROLE_B);
+
+        startJMXServer();
+    }
+
+    @Test
+    @SuppressWarnings("SingleCharacterStringConcatenation")
+    public void testMaybeChangeDocs()
+    {
+        // If you added, modified options or help, please update docs if necessary
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("help", "invalidatepermissionscache");
+        tool.assertOnCleanExit();
+
+        String help =   "NAME\n" +
+                        "        nodetool invalidatepermissionscache - Invalidate the permissions cache\n" +
+                        "\n" +
+                        "SYNOPSIS\n" +
+                        "        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]\n" +
+                        "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
+                        "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
+                        "                [(-u <username> | --username <username>)] invalidatepermissionscache\n" +
+                        "                [--] [<user> <resource>...]\n" +
+                        "\n" +
+                        "OPTIONS\n" +
+                        "        -h <host>, --host <host>\n" +
+                        "            Node hostname or ip address\n" +
+                        "\n" +
+                        "        -p <port>, --port <port>\n" +
+                        "            Remote jmx agent port number\n" +
+                        "\n" +
+                        "        -pp, --print-port\n" +
+                        "            Operate in 4.0 mode with hosts disambiguated by port number\n" +
+                        "\n" +
+                        "        -pw <password>, --password <password>\n" +
+                        "            Remote jmx agent password\n" +
+                        "\n" +
+                        "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
+                        "            Path to the JMX password file\n" +
+                        "\n" +
+                        "        -u <username>, --username <username>\n" +
+                        "            Remote jmx agent username\n" +
+                        "\n" +
+                        "        --\n" +
+                        "            This option can be used to separate command-line options from the\n" +
+                        "            list of argument, (useful when arguments might be mistaken for\n" +
+                        "            command-line options\n" +
+                        "\n" +
+                        "        [<user> <resource>...]\n" +
+                        "            The user followed by one or many resources. By default, all users\n" +
+                        "\n" +
+                        "\n";
+        assertThat(tool.getStdout(), equalTo(help));
+    }
+
+    @Test
+    public void testInvalidateSinglePermission()
+    {
+        DataResource rootDataResource = DataResource.root();
+        Set<Permission> dataPermissions = rootDataResource.applicablePermissions();
+
+        AuthenticatedUser role = new AuthenticatedUser(ROLE_A.getRoleName());
+
+        // cache permission
+        role.getPermissions(rootDataResource);
+        long originalReadsCount = getRolePermissionsReadCount();
+
+        // enure permission is cached
+        assertThat(role.getPermissions(rootDataResource), equalTo(dataPermissions));
+        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+
+        // invalidate permission
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatepermissionscache",
+                ROLE_A.getRoleName(), "data");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure permission is reloaded
+        assertThat(role.getPermissions(rootDataResource), equalTo(dataPermissions));
+        assertThat(originalReadsCount, lessThan(getRolePermissionsReadCount()));
+    }
+
+    @Test
+    public void testInvalidateAllPermissions()
+    {
+        DataResource rootDataResource = DataResource.root();
+        Set<Permission> dataPermissions = rootDataResource.applicablePermissions();
+
+        AuthenticatedUser roleA = new AuthenticatedUser(ROLE_A.getRoleName());
+        AuthenticatedUser roleB = new AuthenticatedUser(ROLE_B.getRoleName());
+
+        // cache permissions
+        roleA.getPermissions(rootDataResource);
+        roleB.getPermissions(rootDataResource);
+        long originalReadsCount = getRolePermissionsReadCount();
+
+        // enure permissions are cached
+        assertThat(roleA.getPermissions(rootDataResource), equalTo(dataPermissions));
+        assertThat(roleB.getPermissions(rootDataResource), equalTo(dataPermissions));
+        assertThat(originalReadsCount, equalTo(getRolePermissionsReadCount()));
+
+        // invalidate both permissions
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidatepermissionscache");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure permission for roleA is reloaded
+        assertThat(roleA.getPermissions(rootDataResource), equalTo(dataPermissions));
+        long readsCountAfterFirstReLoad = getRolePermissionsReadCount();
+        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+
+        // ensure permission for roleB is reloaded
+        assertThat(roleB.getPermissions(rootDataResource), equalTo(dataPermissions));
+        long readsCountAfterSecondReLoad = getRolePermissionsReadCount();
+        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
@@ -32,11 +32,7 @@ import org.apache.cassandra.tools.ToolRunner;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
 import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getRolesReadCount;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(OrderedJUnit4ClassRunner.class)
 public class InvalidateRolesCacheTest extends CQLTester
@@ -103,7 +99,7 @@ public class InvalidateRolesCacheTest extends CQLTester
                         "            List of roles to invalidate. By default, all roles\n" +
                         "\n" +
                         "\n";
-        assertThat(tool.getStdout(), equalTo(help));
+        assertThat(tool.getStdout()).isEqualTo(help);
     }
 
     @Test
@@ -116,17 +112,17 @@ public class InvalidateRolesCacheTest extends CQLTester
         long originalReadsCount = getRolesReadCount();
 
         // enure role is cached
-        assertTrue(role.canLogin());
-        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+        assertThat(role.canLogin()).isTrue();
+        assertThat(originalReadsCount).isEqualTo(getRolesReadCount());
 
         // invalidate role
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidaterolescache", ROLE_A.getRoleName());
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure role is reloaded
-        assertTrue(role.canLogin());
-        assertThat(originalReadsCount, lessThan(getRolesReadCount()));
+        assertThat(role.canLogin()).isTrue();
+        assertThat(originalReadsCount).isLessThan(getRolesReadCount());
     }
 
     @Test
@@ -141,23 +137,23 @@ public class InvalidateRolesCacheTest extends CQLTester
         long originalReadsCount = getRolesReadCount();
 
         // enure roles are cached
-        assertTrue(roleA.canLogin());
-        assertTrue(roleB.canLogin());
-        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+        assertThat(roleA.canLogin()).isTrue();
+        assertThat(roleB.canLogin()).isTrue();
+        assertThat(originalReadsCount).isEqualTo(getRolesReadCount());
 
         // invalidate both roles
         ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidaterolescache");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout(), emptyString());
+        assertThat(tool.getStdout()).isEmpty();
 
         // ensure role for roleA is reloaded
-        assertTrue(roleA.canLogin());
+        assertThat(roleA.canLogin()).isTrue();
         long readsCountAfterFirstReLoad = getRolesReadCount();
-        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+        assertThat(originalReadsCount).isLessThan(readsCountAfterFirstReLoad);
 
         // ensure role for roleB is reloaded
-        assertTrue(roleB.canLogin());
+        assertThat(roleB.canLogin()).isTrue();
         long readsCountAfterSecondReLoad = getRolesReadCount();
-        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+        assertThat(readsCountAfterFirstReLoad).isLessThan(readsCountAfterSecondReLoad);
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.OrderedJUnit4ClassRunner;
+import org.apache.cassandra.SchemaLoader;
+import org.apache.cassandra.auth.AuthTestUtils;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_A;
+import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
+import static org.apache.cassandra.auth.AuthTestUtils.getRolesReadCount;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(OrderedJUnit4ClassRunner.class)
+public class InvalidateRolesCacheTest extends CQLTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        SchemaLoader.prepareServer();
+        AuthTestUtils.LocalCassandraRoleManager roleManager = new AuthTestUtils.LocalCassandraRoleManager();
+        SchemaLoader.setupAuth(roleManager,
+                new AuthTestUtils.LocalPasswordAuthenticator(),
+                new AuthTestUtils.LocalCassandraAuthorizer(),
+                new AuthTestUtils.LocalCassandraNetworkAuthorizer());
+
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_A, AuthTestUtils.getLoginRoleOprions());
+        roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOprions());
+
+        startJMXServer();
+    }
+
+    @Test
+    @SuppressWarnings("SingleCharacterStringConcatenation")
+    public void testMaybeChangeDocs()
+    {
+        // If you added, modified options or help, please update docs if necessary
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("help", "invalidaterolescache");
+        tool.assertOnCleanExit();
+
+        String help =   "NAME\n" +
+                        "        nodetool invalidaterolescache - Invalidate the roles cache\n" +
+                        "\n" +
+                        "SYNOPSIS\n" +
+                        "        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]\n" +
+                        "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
+                        "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
+                        "                [(-u <username> | --username <username>)] invalidaterolescache [--]\n" +
+                        "                [<role>...]\n" +
+                        "\n" +
+                        "OPTIONS\n" +
+                        "        -h <host>, --host <host>\n" +
+                        "            Node hostname or ip address\n" +
+                        "\n" +
+                        "        -p <port>, --port <port>\n" +
+                        "            Remote jmx agent port number\n" +
+                        "\n" +
+                        "        -pp, --print-port\n" +
+                        "            Operate in 4.0 mode with hosts disambiguated by port number\n" +
+                        "\n" +
+                        "        -pw <password>, --password <password>\n" +
+                        "            Remote jmx agent password\n" +
+                        "\n" +
+                        "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
+                        "            Path to the JMX password file\n" +
+                        "\n" +
+                        "        -u <username>, --username <username>\n" +
+                        "            Remote jmx agent username\n" +
+                        "\n" +
+                        "        --\n" +
+                        "            This option can be used to separate command-line options from the\n" +
+                        "            list of argument, (useful when arguments might be mistaken for\n" +
+                        "            command-line options\n" +
+                        "\n" +
+                        "        [<role>...]\n" +
+                        "            List of roles to invalidate. By default, all roles\n" +
+                        "\n" +
+                        "\n";
+        assertThat(tool.getStdout(), equalTo(help));
+    }
+
+    @Test
+    public void testInvalidateSingleRole()
+    {
+        AuthenticatedUser role = new AuthenticatedUser(ROLE_A.getRoleName());
+
+        // cache role
+        role.canLogin();
+        long originalReadsCount = getRolesReadCount();
+
+        // enure role is cached
+        assertTrue(role.canLogin());
+        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+
+        // invalidate role
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidaterolescache", ROLE_A.getRoleName());
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure role is reloaded
+        assertTrue(role.canLogin());
+        assertThat(originalReadsCount, lessThan(getRolesReadCount()));
+    }
+
+    @Test
+    public void testInvalidateAllRoles()
+    {
+        AuthenticatedUser roleA = new AuthenticatedUser(ROLE_A.getRoleName());
+        AuthenticatedUser roleB = new AuthenticatedUser(ROLE_B.getRoleName());
+
+        // cache roles
+        roleA.canLogin();
+        roleB.canLogin();
+        long originalReadsCount = getRolesReadCount();
+
+        // enure roles are cached
+        assertTrue(roleA.canLogin());
+        assertTrue(roleB.canLogin());
+        assertThat(originalReadsCount, equalTo(getRolesReadCount()));
+
+        // invalidate both roles
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("invalidaterolescache");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout(), emptyString());
+
+        // ensure role for roleA is reloaded
+        assertTrue(roleA.canLogin());
+        long readsCountAfterFirstReLoad = getRolesReadCount();
+        assertThat(originalReadsCount, lessThan(readsCountAfterFirstReLoad));
+
+        // ensure role for roleB is reloaded
+        assertTrue(roleB.canLogin());
+        long readsCountAfterSecondReLoad = getRolesReadCount();
+        assertThat(readsCountAfterFirstReLoad, lessThan(readsCountAfterSecondReLoad));
+    }
+}


### PR DESCRIPTION
References: https://issues.apache.org/jira/browse/CASSANDRA-16404

### Summary of the changes
* Added commands for auth caches invalidation to `NodeTool`
* Added necessary MBean interfaces for auth caches to support "single key cache invalidation/eviction"
* Added tests for the new commands
* Renamed `NetworkAuth` to `NetworkPermissions`

### Open questions
1. I can see that `Roles` cache has some hierarchical logic for getting roles and role resources by primary role. Currently I do invalidate everything for a given (single) role. It is under discussion whether we ever need to support the roles hierarchy.
2. Are there any concerns on backward compatibility after renaming of `NetworkAuth` to `NetworkPermissions`?