### PR TITLE
CASSANDRA-16645. Added a benchmark for checksum calculation.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1254,7 +1254,7 @@
               <include name="jopt*.jar"/>
               <include name="commons*.jar"/>
           </zipgroupfileset>
-          <zipgroupfileset dir="{build.lib}" includes="*.jar"/>
+          <zipgroupfileset dir="${build.lib}" includes="*.jar"/>
       </jar>
       <jar jarfile="${build.test.dir}/benchmarks.jar">
           <manifest>

--- a/test/microbench/org/apache/cassandra/test/microbench/AutoBoxingBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/AutoBoxingBench.java
@@ -38,7 +38,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 6, time = 20)
-@Fork(value = 1,jvmArgsAppend = { "-Xmx256M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Fork(value = 1, jvmArgsAppend = { "-Xmx256M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @Threads(4) // make sure this matches the number of _physical_cores_
 @State(Scope.Benchmark)
 public class AutoBoxingBench

--- a/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
@@ -69,7 +69,7 @@ import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
 @Threads(1)
 @State(Scope.Benchmark)
 public class BatchStatementBench

--- a/test/microbench/org/apache/cassandra/test/microbench/ChecksumBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ChecksumBench.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.test.microbench;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Longs;
+import org.apache.cassandra.utils.ChecksumType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.xerial.snappy.PureJavaCrc32C;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Threads(4) // make sure this matches the number of _physical_cores_
+@State(Scope.Benchmark)
+public class ChecksumBench
+{
+    private static final Random random = new Random(12345678);
+
+    // intentionally not on power-of-2 values
+    @Param({ "31", "131", "517", "2041" })
+    private int bufferSize;
+
+    private byte[] array;
+
+    @Setup
+    public void setup() throws NoSuchAlgorithmException
+    {
+        array = new byte[bufferSize];
+        random.nextBytes(array);
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchCrc32()
+    {
+        return Longs.toByteArray(ChecksumType.CRC32.of(array, 0, array.length));
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+            "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseCRC32Intrinsics",
+    })
+    public byte[] benchCrc32NoIntrinsic()
+    {
+        return Longs.toByteArray(ChecksumType.CRC32.of(array, 0, array.length));
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchHasherCrc32c()
+    {
+        Hasher crc32cHasher = Hashing.crc32c().newHasher();
+        crc32cHasher.putBytes(array);
+        return crc32cHasher.hash().asBytes();
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+    })
+    public byte[] benchPureJavaCrc32c()
+    {
+        PureJavaCrc32C pureJavaCrc32C = new PureJavaCrc32C();
+        pureJavaCrc32C.update(array, 0, array.length);
+        return Longs.toByteArray(pureJavaCrc32C.getValue());
+    }
+
+    // Below benchmarks are commented because CRC32C is unavailable in Java 8.
+//    @Benchmark
+//    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+//            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+//    })
+//    public byte[] benchCrc32c()
+//    {
+//        CRC32C crc32C = new CRC32C();
+//        crc32C.update(array);
+//        return Longs.toByteArray(crc32C.getValue());
+//    }
+//
+//    @Benchmark
+//    @Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM",
+//            "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor",
+//            "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseCRC32CIntrinsics",
+//    })
+//    public byte[] benchCrc32cNoIntrinsic()
+//    {
+//        CRC32C crc32C = new CRC32C();
+//        crc32C.update(array);
+//        return Longs.toByteArray(crc32C.getValue());
+//    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/DirectorySizerBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/DirectorySizerBench.java
@@ -35,7 +35,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 1)
 @Measurement(iterations = 30)
-@Fork(value = 1,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
 @Threads(1)
 @State(Scope.Benchmark)
 public class DirectorySizerBench

--- a/test/microbench/org/apache/cassandra/test/microbench/FastThreadLocalBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/FastThreadLocalBench.java
@@ -38,7 +38,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = {"-Xmx512M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Fork(value = 1, jvmArgsAppend = {"-Xmx512M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @Threads(4) // make sure this matches the number of _physical_cores_
 @State(Scope.Benchmark)
 public class FastThreadLocalBench

--- a/test/microbench/org/apache/cassandra/test/microbench/HashingBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/HashingBench.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @Threads(4) // make sure this matches the number of _physical_cores_
 @State(Scope.Benchmark)
 public class HashingBench

--- a/test/microbench/org/apache/cassandra/test/microbench/LatencyTrackingBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/LatencyTrackingBench.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Fork(value = 1, jvmArgsAppend = { "-Xmx512M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @Threads(4) // make sure this matches the number of _physical_cores_
 @State(Scope.Benchmark)
 public class LatencyTrackingBench

--- a/test/microbench/org/apache/cassandra/test/microbench/MessageOutBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/MessageOutBench.java
@@ -54,7 +54,7 @@ import static org.apache.cassandra.net.Verb.ECHO_REQ;
 @State(Scope.Thread)
 @Warmup(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 8, time = 4, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.SampleTime)
 public class MessageOutBench

--- a/test/microbench/org/apache/cassandra/test/microbench/OutputStreamBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/OutputStreamBench.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 3, jvmArgsAppend = "-Xmx512M")
 @Threads(1)
 @State(Scope.Benchmark)
 public class OutputStreamBench

--- a/test/microbench/org/apache/cassandra/test/microbench/PendingRangesBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/PendingRangesBench.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 50, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 3, jvmArgsAppend = "-Xmx512M")
 @Threads(1)
 @State(Scope.Benchmark)
 public class PendingRangesBench

--- a/test/microbench/org/apache/cassandra/test/microbench/PreaggregatedByteBufsBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/PreaggregatedByteBufsBench.java
@@ -37,7 +37,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Thread)
 @Warmup(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 8, time = 4, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.SampleTime)
 public class PreaggregatedByteBufsBench

--- a/test/microbench/org/apache/cassandra/test/microbench/Sample.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/Sample.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 1,jvmArgsAppend = "-Xmx512M")
+@Fork(value = 1, jvmArgsAppend = "-Xmx512M")
 @Threads(1)
 @State(Scope.Benchmark)
 public class Sample

--- a/test/microbench/org/apache/cassandra/test/microbench/StringsEncodeBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/StringsEncodeBench.java
@@ -39,7 +39,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 6, time = 20)
-@Fork(value = 1,jvmArgsAppend = { "-Xmx256M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
+@Fork(value = 1, jvmArgsAppend = { "-Xmx256M", "-Djmh.executor=CUSTOM", "-Djmh.executor.class=org.apache.cassandra.test.microbench.FastThreadExecutor"})
 @State(Scope.Benchmark)
 public class StringsEncodeBench
 {


### PR DESCRIPTION
References: https://issues.apache.org/jira/browse/CASSANDRA-16645

### Context
There is an open discussion in https://issues.apache.org/jira/browse/CASSANDRA-16360 ticket. It looks like such a benchmark would be helpful for further development and changes in checksum calculation logic.

### Summary of the changes
* Added `ChecksumBench` for benachmarking of checksum calculation
* Fixed formatting in other benchmarks classes
* Fixed `build-jmh` target in `build.xml`

### Open questions
1. Currently there are two benchmarks commented, but that's done for a purpose with a corresponding comment. I feel it is better to have them commented than every time to recover them. Please, let me know if I need to remove the commented part.
