### PR TITLE
CASSANDRA-16591 Improvement for some debug-logging guards

### DIFF
--- a/src/java/org/apache/cassandra/db/monitoring/MonitoringTask.java
+++ b/src/java/org/apache/cassandra/db/monitoring/MonitoringTask.java
@@ -147,13 +147,12 @@ class MonitoringTask
         AggregatedOperations failedOperations = failedOperationsQueue.popOperations();
         if (!failedOperations.isEmpty())
         {
-            long elapsedNanos = nowNanos - approxLastLogTimeNanos;
             noSpamLogger.warn("Some operations timed out, details available at debug level (debug.log)");
 
             if (logger.isDebugEnabled())
                 logger.debug("{} operations timed out in the last {} msecs:{}{}",
                             failedOperations.num(),
-                             NANOSECONDS.toMillis(elapsedNanos),
+                             NANOSECONDS.toMillis(nowNanos - approxLastLogTimeNanos),
                             LINE_SEPARATOR,
                             failedOperations.getLogMessage());
             return true;
@@ -168,13 +167,12 @@ class MonitoringTask
         AggregatedOperations slowOperations = slowOperationsQueue.popOperations();
         if (!slowOperations.isEmpty())
         {
-            long approxElapsedNanos = approxCurrentTimeNanos - approxLastLogTimeNanos;
             noSpamLogger.info("Some operations were slow, details available at debug level (debug.log)");
 
             if (logger.isDebugEnabled())
                 logger.debug("{} operations were slow in the last {} msecs:{}{}",
                              slowOperations.num(),
-                             NANOSECONDS.toMillis(approxElapsedNanos),
+                             NANOSECONDS.toMillis(approxCurrentTimeNanos - approxLastLogTimeNanos),
                              LINE_SEPARATOR,
                              slowOperations.getLogMessage());
             return true;

--- a/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAck2VerbHandler.java
@@ -40,8 +40,7 @@ public class GossipDigestAck2VerbHandler extends GossipVerbHandler<GossipDigestA
         }
         if (!Gossiper.instance.isEnabled())
         {
-            if (logger.isTraceEnabled())
-                logger.trace("Ignoring GossipDigestAck2Message because gossip is disabled");
+            logger.trace("Ignoring GossipDigestAck2Message because gossip is disabled");
             return;
         }
         Map<InetAddressAndPort, EndpointState> remoteEpStateMap = message.payload.getEndpointStateMap();

--- a/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestAckVerbHandler.java
@@ -43,8 +43,7 @@ public class GossipDigestAckVerbHandler extends GossipVerbHandler<GossipDigestAc
             logger.trace("Received a GossipDigestAckMessage from {}", from);
         if (!Gossiper.instance.isEnabled() && !Gossiper.instance.isInShadowRound())
         {
-            if (logger.isTraceEnabled())
-                logger.trace("Ignoring GossipDigestAckMessage because gossip is disabled");
+            logger.trace("Ignoring GossipDigestAckMessage because gossip is disabled");
             return;
         }
 

--- a/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
+++ b/src/java/org/apache/cassandra/gms/GossipDigestSynVerbHandler.java
@@ -46,8 +46,7 @@ public class GossipDigestSynVerbHandler extends GossipVerbHandler<GossipDigestSy
             logger.trace("Received a GossipDigestSynMessage from {}", from);
         if (!Gossiper.instance.isEnabled() && !Gossiper.instance.isInShadowRound())
         {
-            if (logger.isTraceEnabled())
-                logger.trace("Ignoring GossipDigestSynMessage because gossip is disabled");
+            logger.trace("Ignoring GossipDigestSynMessage because gossip is disabled");
             return;
         }
 

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -956,8 +956,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     @VisibleForTesting
     void doStatusCheck()
     {
-        if (logger.isTraceEnabled())
-            logger.trace("Performing status check ...");
+        logger.trace("Performing status check ...");
 
         long now = System.currentTimeMillis();
         long nowNano = System.nanoTime();

--- a/src/java/org/apache/cassandra/service/LoadBroadcaster.java
+++ b/src/java/org/apache/cassandra/service/LoadBroadcaster.java
@@ -89,8 +89,7 @@ public class LoadBroadcaster implements IEndpointStateChangeSubscriber
             {
                 if (!Gossiper.instance.isEnabled())
                     return;
-                if (logger.isTraceEnabled())
-                    logger.trace("Disseminating load info ...");
+                logger.trace("Disseminating load info ...");
                 Gossiper.instance.addLocalApplicationState(ApplicationState.LOAD,
                                                            StorageService.instance.valueFactory.load(StorageMetrics.load.getCount()));
             }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3876,8 +3876,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         for (String keyspace : keyspaces)
             Keyspace.clearSnapshot(tag, keyspace);
 
-        if (logger.isDebugEnabled())
-            logger.debug("Cleared out snapshot directories");
+        logger.debug("Cleared out snapshot directories");
     }
 
     public Map<String, TabularData> getSnapshotDetails()


### PR DESCRIPTION
- Removing some unnecessary debug-logging guards, since the guarded logging statements are only string literal
- Moving some statements into the adjacent logging guards, since these statements are only used by the following logging calls