### PR TITLE
CASSANDRA-16350: Adds autocomplete, errors for provide_overlapping_tombstones

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+Add autocomplete and error messages for provide_overlapping_tombstones (CASSANDRA-16350)
+patch by bhouse99@protonmail.com; reviewed by ... for CASSANDRA-16350
+
 3.11.11
  * Add StorageServiceMBean.getKeyspaceReplicationInfo(keyspaceName) (CASSANDRA-16447)
  * Upgrade jackson-databind to 2.9.10.8 (CASSANDRA-16462)

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -59,7 +59,7 @@ class Cql3ParsingRuleSet(CqlParsingRuleSet):
         # (CQL3 option name, schema_columnfamilies column name (or None if same),
         #  list of known map keys)
         ('compaction', 'compaction_strategy_options',
-            ('class', 'max_threshold', 'tombstone_compaction_interval', 'tombstone_threshold', 'enabled', 'unchecked_tombstone_compaction', 'only_purge_repaired_tombstones')),
+            ('class', 'max_threshold', 'tombstone_compaction_interval', 'tombstone_threshold', 'enabled', 'unchecked_tombstone_compaction', 'only_purge_repaired_tombstones', 'provide_overlapping_tombstones')),
         ('compression', 'compression_parameters',
             ('sstable_compression', 'chunk_length_kb', 'crc_check_chance')),
         ('caching', None,

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -639,7 +639,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      'tombstone_compaction_interval',
                                      'tombstone_threshold',
                                      'unchecked_tombstone_compaction',
-                                     'only_purge_repaired_tombstones'])
+                                     'only_purge_repaired_tombstones',
+                                     'provide_overlapping_tombstones'])
         self.trycompletions(prefix + " new_table (col_a int PRIMARY KEY) WITH compaction = "
                             + "{'class': 'SizeTieredCompactionStrategy'}",
                             choices=[';', 'AND'])
@@ -660,14 +661,15 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      'timestamp_resolution', 'min_threshold', 'class', 'max_threshold',
                                      'tombstone_compaction_interval', 'tombstone_threshold',
                                      'enabled', 'unchecked_tombstone_compaction',
-                                     'max_window_size_seconds', 'only_purge_repaired_tombstones'])
+                                     'max_window_size_seconds',
+                                     'only_purge_repaired_tombstones', 'provide_overlapping_tombstones'])
         self.trycompletions(prefix + " new_table (col_a int PRIMARY KEY) WITH compaction = "
                             + "{'class': 'TimeWindowCompactionStrategy', '",
                             choices=['compaction_window_unit', 'compaction_window_size',
                                      'timestamp_resolution', 'min_threshold', 'class', 'max_threshold',
                                      'tombstone_compaction_interval', 'tombstone_threshold',
                                      'enabled', 'unchecked_tombstone_compaction',
-                                     'only_purge_repaired_tombstones'])
+                                     'only_purge_repaired_tombstones','provide_overlapping_tombstones'])
 
     def test_complete_in_create_columnfamily(self):
         self.trycompletions('CREATE C', choices=['COLUMNFAMILY', 'CUSTOM'])

--- a/src/java/org/apache/cassandra/schema/CompactionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompactionParams.java
@@ -18,9 +18,11 @@
 package org.apache.cassandra.schema;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
@@ -60,6 +62,12 @@ public final class CompactionParams
         NONE,
         ROW,
         CELL;
+
+        private static final TombstoneOption[] copyOfValues = values();
+
+        public static Optional<TombstoneOption> forName(String name) {
+            return Arrays.stream(copyOfValues).filter(x -> x.name().equals(name)).findFirst();
+        }
     }
 
     public static final int DEFAULT_MIN_THRESHOLD = 4;
@@ -94,8 +102,15 @@ public final class CompactionParams
         boolean isEnabled = options.containsKey(Option.ENABLED.toString())
                           ? Boolean.parseBoolean(options.get(Option.ENABLED.toString()))
                           : DEFAULT_ENABLED;
-        TombstoneOption tombstoneOption = TombstoneOption.valueOf(options.getOrDefault(Option.PROVIDE_OVERLAPPING_TOMBSTONES.toString(),
-                                                                                       DEFAULT_PROVIDE_OVERLAPPING_TOMBSTONES.toString()).toUpperCase());
+        String overlappingTombstoneParm = options.getOrDefault(Option.PROVIDE_OVERLAPPING_TOMBSTONES.toString(),
+                                                        DEFAULT_PROVIDE_OVERLAPPING_TOMBSTONES.toString()).toUpperCase();
+        Optional<TombstoneOption> tombstoneOptional = TombstoneOption.forName(overlappingTombstoneParm);
+        if (!tombstoneOptional.isPresent()) {
+            throw new ConfigurationException(format("Invalid value %s for 'provide_overlapping_tombstones' compaction sub-option - must be one of the following [%s].",
+                                                    overlappingTombstoneParm,
+                                                    StringUtils.join(TombstoneOption.values(), ", ")));
+        }
+        TombstoneOption tombstoneOption = tombstoneOptional.get();
 
         Map<String, String> allOptions = new HashMap<>(options);
         if (supportsThresholdParams(klass))


### PR DESCRIPTION
CASSANDRA-16350: Adds autocomplete, errors for provide_overlapping_tombstones

Adds autocomplete in CQLSH and error handling for provide_overlapping_tombstones for a better user experience.