### PR TITLE
CASSANDRA-15669. Fixed ArrayIndexOutOfBoundsException in LCS for L8 compaction.

### DIFF
--- a/doc/source/operating/compaction/lcs.rst
+++ b/doc/source/operating/compaction/lcs.rst
@@ -36,7 +36,8 @@ cover the full range. We also can't compact all L0 sstables with all L1 sstables
 use too much memory.
 
 When deciding which level to compact LCS checks the higher levels first (with LCS, a "higher" level is one with a higher
-number, L0 being the lowest one) and if the level is behind a compaction will be started in that level.
+number: L0 is the lowest one, L8 is the highest one) and if the level is behind a compaction will be started
+in that level.
 
 Major compaction
 ~~~~~~~~~~~~~~~~

--- a/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
@@ -72,7 +72,7 @@ class LeveledGenerations
 
     Set<SSTableReader> get(int level)
     {
-        if (level >= levelCount() || level < 0)
+        if (level > levelCount() - 1 || level < 0)
             throw new ArrayIndexOutOfBoundsException("Invalid generation " + level + " - maximum is " + (levelCount() - 1));
         if (level == 0)
             return l0;
@@ -140,7 +140,7 @@ class LeveledGenerations
                 after != null && after.first.compareTo(sstable.last) <= 0)
             {
                 if (strictLCSChecksTest) // we can only assert this in tests since this is normal when for example moving sstables from unrepaired to repaired
-                    throw new AssertionError("Got unexpected overlap in level " + sstable.getSSTableLevel());
+                    throw new AssertionError("Got unexpected overlap in level "+sstable.getSSTableLevel());
                 sendToL0(sstable);
             }
             else
@@ -220,17 +220,16 @@ class LeveledGenerations
      * given a level with sstables with first tokens [0, 10, 20, 30] and a lastCompactedSSTable with last = 15, we will
      * return an Iterator over [20, 30, 0, 10].
      */
-    Iterator<SSTableReader> wrappingIterator(int level, SSTableReader lastCompactedSSTable)
+    Iterator<SSTableReader> wrappingIterator(int lvl, SSTableReader lastCompactedSSTable)
     {
-        assert level > 0; // only makes sense in L1+
-        TreeSet<SSTableReader> sstables = levels[level - 1];
-        if (sstables.isEmpty())
+        assert lvl > 0; // only makes sense in L1+
+        TreeSet<SSTableReader> level = levels[lvl - 1];
+        if (level.isEmpty())
             return Collections.emptyIterator();
         if (lastCompactedSSTable == null)
-            return sstables.iterator();
+            return level.iterator();
 
-        PeekingIterator<SSTableReader> tail = Iterators.peekingIterator(
-                sstables.tailSet(lastCompactedSSTable).iterator());
+        PeekingIterator<SSTableReader> tail = Iterators.peekingIterator(level.tailSet(lastCompactedSSTable).iterator());
         SSTableReader pivot = null;
         // then we need to make sure that the first token of the pivot is greater than the last token of the lastCompactedSSTable
         while (tail.hasNext())
@@ -245,9 +244,9 @@ class LeveledGenerations
         }
 
         if (pivot == null)
-            return sstables.iterator();
+            return level.iterator();
 
-        return Iterators.concat(tail, sstables.headSet(pivot, false).iterator());
+        return Iterators.concat(tail, level.headSet(pivot, false).iterator());
     }
 
     void logDistribution()

--- a/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledGenerations.java
@@ -49,11 +49,8 @@ class LeveledGenerations
 {
     private static final Logger logger = LoggerFactory.getLogger(LeveledGenerations.class);
     private final boolean strictLCSChecksTest = Boolean.getBoolean(Config.PROPERTY_PREFIX + "test.strict_lcs_checks");
-    // Allocate enough generations to handle about 95 TB of data, with a 1-MB sstable size and default fanout size
-    // (10). (Note that if maxSSTableSize is updated, we will still have sstables of the older, potentially smaller
-    // size. So don't make this dependent on maxSSTableSize). Max level count actually includes L0 and finally, we
-    // support [L0 - L8] levels with the current implementation.
-    static final int MAX_LEVEL_COUNT = (int) Math.log10(1000 * 1000 * 1000);
+    // It includes L0, i.e. we support [L0 - L8] levels
+    static final int MAX_LEVEL_COUNT = 9;
 
     private final Set<SSTableReader> l0 = new HashSet<>();
     private static long lastOverlapCheck = System.nanoTime();

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -242,11 +242,17 @@ public class LeveledManifest
             // we want to calculate score excluding compacting ones
             Set<SSTableReader> sstablesInLevel = Sets.newHashSet(sstables);
             Set<SSTableReader> remaining = Sets.difference(sstablesInLevel, cfs.getTracker().getCompacting());
-            double score = (double) SSTableReader.getTotalBytes(remaining) / (double)maxBytesForLevel(i, maxSSTableSizeInBytes);
+            long remainingBytesForLevel = SSTableReader.getTotalBytes(remaining);
+            long maxBytesForLevel = maxBytesForLevel(i, maxSSTableSizeInBytes);
+            double score = (double) remainingBytesForLevel / (double) maxBytesForLevel;
             logger.trace("Compaction score for level {} is {}", i, score);
 
             if (score > 1.001)
             {
+                // the highest level should not ever exceed its maximum size
+                if (i == generations.levelCount() - 1)
+                    throw new RuntimeException("L" + i + " should not exceed its maximum size (" + maxBytesForLevel + "), but it has " + remainingBytesForLevel + " bytes");
+
                 // before proceeding with a higher level, let's see if L0 is far enough behind to warrant STCS
                 if (l0Compaction != null)
                     return l0Compaction;

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -249,10 +249,14 @@ public class LeveledManifest
 
             if (score > 1.001)
             {
-                // the highest level should not ever exceed its maximum size
+                // the highest level should not ever exceed its maximum size under normal curcumstaces,
+                // but if it happens we warn about it
                 if (i == generations.levelCount() - 1)
-                    throw new RuntimeException("L" + i + " (maximum supported level) should not exceed its maximum "
-                            + "size (" + maxBytesForLevel + "), but it has " + remainingBytesForLevel + " bytes");
+                {
+                    logger.warn("L" + i + " (maximum supported level) has " + remainingBytesForLevel + " bytes while "
+                            + "its maximum size is supposed to be " + maxBytesForLevel + " bytes");
+                    continue;
+                }
 
                 // before proceeding with a higher level, let's see if L0 is far enough behind to warrant STCS
                 if (l0Compaction != null)

--- a/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledManifest.java
@@ -251,7 +251,8 @@ public class LeveledManifest
             {
                 // the highest level should not ever exceed its maximum size
                 if (i == generations.levelCount() - 1)
-                    throw new RuntimeException("L" + i + " should not exceed its maximum size (" + maxBytesForLevel + "), but it has " + remainingBytesForLevel + " bytes");
+                    throw new RuntimeException("L" + i + " (maximum supported level) should not exceed its maximum "
+                            + "size (" + maxBytesForLevel + "), but it has " + remainingBytesForLevel + " bytes");
 
                 // before proceeding with a higher level, let's see if L0 is far enough behind to warrant STCS
                 if (l0Compaction != null)

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -67,6 +67,7 @@ import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -824,7 +825,7 @@ public class LeveledCompactionStrategyTest
         assertEquals(new HashSet<>(l1), new HashSet<>(l2));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testErrorWhenMoreDataThanSupportedExistOnHighestLevel()
     {
         int fanoutSize = 2; // to generate less sstables
@@ -838,6 +839,8 @@ public class LeveledCompactionStrategyTest
         List<SSTableReader> sstables = Collections.singletonList(MockSchema.sstableWithLevel( 1, sstablesSizeForHighestLevel, highestLevel, cfs));
         lm.addSSTables(sstables);
 
-        lm.getCompactionCandidates();
+        assertThatThrownBy(lm::getCompactionCandidates)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("L8 (maximum supported level) should not exceed its maximum size (268435456), but it has 268703892 bytes");
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -108,7 +108,7 @@ public class LeveledCompactionStrategyTest
      * Since we use StandardLeveled CF for every test, we want to clean up after the test.
      */
     @After
-    public void truncateStandardLeveled()
+    public void truncateSTandardLeveled()
     {
         cfs.truncateBlocking();
     }
@@ -663,7 +663,7 @@ public class LeveledCompactionStrategyTest
     }
 
     @Test
-    public void testSingleTokenSSTable()
+    public void singleTokenSSTableTest()
     {
         ColumnFamilyStore cfs = MockSchema.newCFS();
         LeveledManifest lm = new LeveledManifest(cfs, 10, 10, new SizeTieredCompactionStrategyOptions());
@@ -696,7 +696,7 @@ public class LeveledCompactionStrategyTest
     }
 
     @Test
-    public void testRandomMultiLevelAdd()
+    public void randomMultiLevelAddTest()
     {
         int iterations = 100;
         int levelCount = 9;

--- a/test/unit/org/apache/cassandra/schema/MockSchema.java
+++ b/test/unit/org/apache/cassandra/schema/MockSchema.java
@@ -97,6 +97,11 @@ public class MockSchema
         return sstable(generation, 0, false, firstToken, lastToken, level, cfs);
     }
 
+    public static SSTableReader sstableWithLevel(int generation, int size, int level, ColumnFamilyStore cfs)
+    {
+        return sstable(generation, size, false, generation, generation, level, cfs);
+    }
+
     public static SSTableReader sstable(int generation, int size, boolean keepRef, long firstToken, long lastToken, ColumnFamilyStore cfs)
     {
         return sstable(generation, size, keepRef, firstToken, lastToken, 0, cfs);


### PR DESCRIPTION
References: https://issues.apache.org/jira/browse/CASSANDRA-15669

### Summary of the changes
* Fixed the comment explaining data size estimates for 1-MB sstables
* Added handling for a situation where there is more data on the highest level than it supports
* Slightly updated tests and documentation
