### PR TITLE
CASSANDRA-16199: Defines cassandra.logdir for nodetool

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -108,6 +108,7 @@ fi
 "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE \
         -XX:ParallelGCThreads=1 \
         -Dcassandra.storagedir="$cassandra_storagedir" \
+        -Dcassandra.logdir="$CASSANDRA_LOG_DIR" \
         -Dlogback.configurationFile=logback-tools.xml \
         $JVM_ARGS \
         org.apache.cassandra.tools.NodeTool -p $JMX_PORT $ARGS


### PR DESCRIPTION
Maps $CASSANDRA_LOG_DIR  (set during call to cassandra_env.sh call) to cassandra.logdir java property when executing nodetool.

