### PR TITLE
CASSANDRA-16661 (4.0): Fix typo: Alterting -> Altering

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -193,7 +193,7 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
 
         UserType apply(KeyspaceMetadata keyspace, UserType userType)
         {
-            throw ire("Alterting field types is no longer supported");
+            throw ire("Altering field types is no longer supported");
         }
     }
 


### PR DESCRIPTION
Fix a typo in the response message when trying to alter a type of an UDT field.