### PR TITLE
Fix typo in commit log archive page

### DIFF
--- a/doc/source/configuration/cass_cl_archive_file.rst
+++ b/doc/source/configuration/cass_cl_archive_file.rst
@@ -1,9 +1,9 @@
 .. _cassandra-cl-archive:
 
-commitlog-archiving.properties file 
+commitlog_archiving.properties file
 ================================
 
-The ``commitlog-archiving.properties`` configuration file can optionally set commands that are executed when archiving or restoring a commitlog segment. 
+The ``commitlog_archiving.properties`` configuration file can optionally set commands that are executed when archiving or restoring a commitlog segment.
 
 ===========================
 Options


### PR DESCRIPTION
The file `commitlog-archiving.properties` doesn't exist which I think it is actually referring to `commitlog_archiving.properties`.

https://github.com/apache/cassandra/blob/trunk/conf/commitlog_archiving.properties