### PR TITLE
Fix queries on empty partitions with static data (CASSANDRA-16686)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -133,7 +133,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -305,10 +305,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -403,7 +403,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -513,7 +513,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -632,10 +632,10 @@ jobs:
   j8_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -727,10 +727,10 @@ jobs:
   j11_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -823,10 +823,10 @@ jobs:
   j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -919,10 +919,10 @@ jobs:
   j11_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1015,10 +1015,10 @@ jobs:
   j8_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1110,10 +1110,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1208,7 +1208,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1353,7 +1353,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1472,10 +1472,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1568,10 +1568,10 @@ jobs:
   j11_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1667,10 +1667,10 @@ jobs:
   j8_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1743,10 +1743,10 @@ jobs:
   j8_upgradetests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1885,7 +1885,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2200,10 +2200,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2354,7 +2354,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2527,10 +2527,10 @@ jobs:
   j8_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2603,10 +2603,10 @@ jobs:
   j11_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2699,10 +2699,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2906,10 +2906,10 @@ jobs:
   j8_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3001,10 +3001,10 @@ jobs:
   j8_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3162,7 +3162,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3385,10 +3385,10 @@ jobs:
   j11_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3487,7 +3487,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3596,7 +3596,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -835,6 +835,32 @@ public final class StatementRestrictions
     {
         return hasRegularColumnsRestrictions;
     }
+
+    /**
+     * Checks if the query is a full partitions selection.
+     * @return {@code true} if the query is a full partitions selection, {@code false} otherwise.
+     */
+    private boolean queriesFullPartitions()
+    {
+        return !hasClusteringColumnsRestrictions() && !hasRegularColumnsRestrictions();
+    }
+
+    /**
+     * Determines if the query should return the static content when a partition without rows is returned (as a
+     * result set row with null for all other regular columns.)
+     *
+     * @return {@code true} if the query should return the static content when a partition without rows is returned, {@code false} otherwise.
+     */
+    public boolean returnStaticContentOnPartitionWithNoRows()
+    {
+        if (table.isStaticCompactTable())
+            return true;
+
+        // The general rational is that if some rows are specifically selected by the query (have clustering or
+        // regular columns restrictions), we ignore partitions that are empty outside of static content, but if it's a full partition
+        // query, then we include that content.
+        return queriesFullPartitions();
+    }
     
     @Override
     public String toString()

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -849,16 +849,17 @@ public final class StatementRestrictions
      * Determines if the query should return the static content when a partition without rows is returned (as a
      * result set row with null for all other regular columns.)
      *
-     * @return {@code true} if the query should return the static content when a partition without rows is returned, {@code false} otherwise.
+     * @return {@code true} if the query should return the static content when a partition without rows is returned,
+     * {@code false} otherwise.
      */
     public boolean returnStaticContentOnPartitionWithNoRows()
     {
         if (table.isStaticCompactTable())
             return true;
 
-        // The general rational is that if some rows are specifically selected by the query (have clustering or
-        // regular columns restrictions), we ignore partitions that are empty outside of static content, but if it's a full partition
-        // query, then we include that content.
+        // The general rationale is that if some rows are specifically selected by the query (have clustering or
+        // regular columns restrictions), we ignore partitions that are empty outside of static content, but if it's
+        // a full partition query, then we include that content.
         return queriesFullPartitions();
     }
     

--- a/src/java/org/apache/cassandra/cql3/selection/ColumnFilterFactory.java
+++ b/src/java/org/apache/cassandra/cql3/selection/ColumnFilterFactory.java
@@ -46,9 +46,10 @@ abstract class ColumnFilterFactory
     public static ColumnFilterFactory fromColumns(TableMetadata table,
                                                   List<ColumnMetadata> selectedColumns,
                                                   Set<ColumnMetadata> orderingColumns,
-                                                  Set<ColumnMetadata> nonPKRestrictedColumns)
+                                                  Set<ColumnMetadata> nonPKRestrictedColumns,
+                                                  boolean returnStaticContentOnPartitionWithNoRows)
     {
-        ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(table);
+        ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(table, returnStaticContentOnPartitionWithNoRows);
         builder.addAll(selectedColumns);
         builder.addAll(orderingColumns);
         // we'll also need to fetch any column on which we have a restriction (so we can apply said restriction)
@@ -62,17 +63,19 @@ abstract class ColumnFilterFactory
      * @param table the table metadata
      * @param factories the {@code SelectorFactories}
      * @param orderingColumns the columns used for ordering
-     * @param nonPKRestrictedColumns the non primary key columns that have been resticted in the WHERE clause
+     * @param nonPKRestrictedColumns the non primary key columns that have been restricted in the WHERE clause
+     * @param returnStaticContentOnPartitionWithNoRows {@code true} if the query will return the static content when the partition has no rows, {@code false} otherwise.
      * @return a new {@code ColumnFilterFactory} instance
      */
     public static ColumnFilterFactory fromSelectorFactories(TableMetadata table,
                                                             SelectorFactories factories,
                                                             Set<ColumnMetadata> orderingColumns,
-                                                            Set<ColumnMetadata> nonPKRestrictedColumns)
+                                                            Set<ColumnMetadata> nonPKRestrictedColumns,
+                                                            boolean returnStaticContentOnPartitionWithNoRows)
     {
         if (factories.areAllFetchedColumnsKnown())
         {
-            ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(table);
+            ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(table, returnStaticContentOnPartitionWithNoRows);
             factories.addFetchedColumns(builder);
             builder.addAll(orderingColumns);
             // we'll also need to fetch any column on which we have a restriction (so we can apply said restriction)
@@ -80,7 +83,7 @@ abstract class ColumnFilterFactory
             return new PrecomputedColumnFilter(builder.build());
         }
 
-        return new OnRequestColumnFilterFactory(table, nonPKRestrictedColumns);
+        return new OnRequestColumnFilterFactory(table, nonPKRestrictedColumns, returnStaticContentOnPartitionWithNoRows);
     }
 
     /**
@@ -112,17 +115,19 @@ abstract class ColumnFilterFactory
     {
         private final TableMetadata table;
         private final Set<ColumnMetadata> nonPKRestrictedColumns;
+        private final boolean returnStaticContentOnPartitionWithNoRows;
 
-        public OnRequestColumnFilterFactory(TableMetadata table, Set<ColumnMetadata> nonPKRestrictedColumns)
+        public OnRequestColumnFilterFactory(TableMetadata table, Set<ColumnMetadata> nonPKRestrictedColumns, boolean returnStaticContentOnPartitionWithNoRows)
         {
             this.table = table;
             this.nonPKRestrictedColumns = nonPKRestrictedColumns;
+            this.returnStaticContentOnPartitionWithNoRows = returnStaticContentOnPartitionWithNoRows;
         }
 
         @Override
         public ColumnFilter newInstance(List<Selector> selectors)
         {
-            ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(table);
+            ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(table, returnStaticContentOnPartitionWithNoRows);
             for (int i = 0, m = selectors.size(); i < m; i++)
                 selectors.get(i).addFetchedColumns(builder);
 

--- a/src/java/org/apache/cassandra/cql3/selection/ColumnFilterFactory.java
+++ b/src/java/org/apache/cassandra/cql3/selection/ColumnFilterFactory.java
@@ -64,7 +64,8 @@ abstract class ColumnFilterFactory
      * @param factories the {@code SelectorFactories}
      * @param orderingColumns the columns used for ordering
      * @param nonPKRestrictedColumns the non primary key columns that have been restricted in the WHERE clause
-     * @param returnStaticContentOnPartitionWithNoRows {@code true} if the query will return the static content when the partition has no rows, {@code false} otherwise.
+     * @param returnStaticContentOnPartitionWithNoRows {@code true} if the query will return the static content when the 
+     * partition has no rows, {@code false} otherwise.
      * @return a new {@code ColumnFilterFactory} instance
      */
     public static ColumnFilterFactory fromSelectorFactories(TableMetadata table,
@@ -117,7 +118,9 @@ abstract class ColumnFilterFactory
         private final Set<ColumnMetadata> nonPKRestrictedColumns;
         private final boolean returnStaticContentOnPartitionWithNoRows;
 
-        public OnRequestColumnFilterFactory(TableMetadata table, Set<ColumnMetadata> nonPKRestrictedColumns, boolean returnStaticContentOnPartitionWithNoRows)
+        public OnRequestColumnFilterFactory(TableMetadata table,
+                                            Set<ColumnMetadata> nonPKRestrictedColumns,
+                                            boolean returnStaticContentOnPartitionWithNoRows)
         {
             this.table = table;
             this.nonPKRestrictedColumns = nonPKRestrictedColumns;

--- a/src/java/org/apache/cassandra/cql3/selection/Selection.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selection.java
@@ -125,16 +125,17 @@ public abstract class Selection
         return resultMetadata;
     }
 
-    public static Selection wildcard(TableMetadata table, boolean isJson)
+    public static Selection wildcard(TableMetadata table, boolean isJson, boolean returnStaticContentOnPartitionWithNoRows)
     {
         List<ColumnMetadata> all = new ArrayList<>(table.columns().size());
         Iterators.addAll(all, table.allColumnsInSelectOrder());
-        return new SimpleSelection(table, all, Collections.emptySet(), true, isJson);
+        return new SimpleSelection(table, all, Collections.emptySet(), true, isJson, returnStaticContentOnPartitionWithNoRows);
     }
 
     public static Selection wildcardWithGroupBy(TableMetadata table,
                                                 VariableSpecifications boundNames,
-                                                boolean isJson)
+                                                boolean isJson,
+                                                boolean returnStaticContentOnPartitionWithNoRows)
     {
         return fromSelectors(table,
                              Lists.newArrayList(table.allColumnsInSelectOrder()),
@@ -142,12 +143,13 @@ public abstract class Selection
                              Collections.emptySet(),
                              Collections.emptySet(),
                              true,
-                             isJson);
+                             isJson,
+                             returnStaticContentOnPartitionWithNoRows);
     }
 
-    public static Selection forColumns(TableMetadata table, List<ColumnMetadata> columns)
+    public static Selection forColumns(TableMetadata table, List<ColumnMetadata> columns, boolean returnStaticContentOnPartitionWithNoRows)
     {
-        return new SimpleSelection(table, columns, Collections.emptySet(), false, false);
+        return new SimpleSelection(table, columns, Collections.emptySet(), false, false, returnStaticContentOnPartitionWithNoRows);
     }
 
     public void addFunctionsTo(List<Function> functions)
@@ -170,7 +172,8 @@ public abstract class Selection
                                           Set<ColumnMetadata> orderingColumns,
                                           Set<ColumnMetadata> nonPKRestrictedColumns,
                                           boolean hasGroupBy,
-                                          boolean isJson)
+                                          boolean isJson,
+                                          boolean returnStaticContentOnPartitionWithNoRows)
     {
         List<ColumnMetadata> selectedColumns = new ArrayList<>();
 
@@ -190,13 +193,15 @@ public abstract class Selection
                                           nonPKRestrictedColumns,
                                           mapping,
                                           factories,
-                                          isJson)
+                                          isJson,
+                                          returnStaticContentOnPartitionWithNoRows)
             : new SimpleSelection(table,
                                   selectedColumns,
                                   filteredOrderingColumns,
                                   nonPKRestrictedColumns,
                                   mapping,
-                                  isJson);
+                                  isJson,
+                                  returnStaticContentOnPartitionWithNoRows);
     }
 
     /**
@@ -335,6 +340,7 @@ public abstract class Selection
     {
         /**
          * Returns the {@code ColumnFilter} corresponding to those selectors
+         *
          * @return the {@code ColumnFilter} corresponding to those selectors
          */
         public ColumnFilter getColumnFilter();
@@ -385,14 +391,15 @@ public abstract class Selection
                                List<ColumnMetadata> selectedColumns,
                                Set<ColumnMetadata> orderingColumns,
                                boolean isWildcard,
-                               boolean isJson)
+                               boolean isJson,
+                               boolean returnStaticContentOnPartitionWithNoRows)
         {
             this(table,
                  selectedColumns,
                  orderingColumns,
                  SelectionColumnMapping.simpleMapping(selectedColumns),
                  isWildcard ? ColumnFilterFactory.wildcard(table)
-                            : ColumnFilterFactory.fromColumns(table, selectedColumns, orderingColumns, Collections.emptySet()),
+                            : ColumnFilterFactory.fromColumns(table, selectedColumns, orderingColumns, Collections.emptySet(), returnStaticContentOnPartitionWithNoRows),
                  isWildcard,
                  isJson);
         }
@@ -402,13 +409,14 @@ public abstract class Selection
                                Set<ColumnMetadata> orderingColumns,
                                Set<ColumnMetadata> nonPKRestrictedColumns,
                                SelectionColumnMapping mapping,
-                               boolean isJson)
+                               boolean isJson,
+                               boolean returnStaticContentOnPartitionWithNoRows)
         {
             this(table,
                  selectedColumns,
                  orderingColumns,
                  mapping,
-                 ColumnFilterFactory.fromColumns(table, selectedColumns, orderingColumns, nonPKRestrictedColumns),
+                 ColumnFilterFactory.fromColumns(table, selectedColumns, orderingColumns, nonPKRestrictedColumns, returnStaticContentOnPartitionWithNoRows),
                  false,
                  isJson);
         }
@@ -510,13 +518,14 @@ public abstract class Selection
                                        Set<ColumnMetadata> nonPKRestrictedColumns,
                                        SelectionColumnMapping metadata,
                                        SelectorFactories factories,
-                                       boolean isJson)
+                                       boolean isJson,
+                                       boolean returnStaticContentOnPartitionWithNoRows)
         {
             super(table,
                   columns,
                   orderingColumns,
                   metadata,
-                  ColumnFilterFactory.fromSelectorFactories(table, factories, orderingColumns, nonPKRestrictedColumns),
+                  ColumnFilterFactory.fromSelectorFactories(table, factories, orderingColumns, nonPKRestrictedColumns, returnStaticContentOnPartitionWithNoRows),
                   isJson);
 
             this.factories = factories;

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -593,7 +593,7 @@ public abstract class ModificationStatement implements CQLStatement
         Selection selection;
         if (columnsWithConditions == null)
         {
-            selection = Selection.wildcard(metadata, false);
+            selection = Selection.wildcard(metadata, false, false);
         }
         else
         {
@@ -605,7 +605,7 @@ public abstract class ModificationStatement implements CQLStatement
             if (isBatch)
                 Iterables.addAll(defs, metadata.primaryKeyColumns());
             Iterables.addAll(defs, columnsWithConditions);
-            selection = Selection.forColumns(metadata, new ArrayList<>(defs));
+            selection = Selection.forColumns(metadata, new ArrayList<>(defs), false);
 
         }
 

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.db.filter;
 import java.io.IOException;
 import java.util.*;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
@@ -49,17 +48,18 @@ import org.apache.cassandra.utils.CassandraVersion;
  * in its request.
  *
  * The reason for distinguishing those 2 sets is that due to the CQL semantic (see #6588 for more details), we
- * often need to internally fetch all regular columns for the queried table, but can still do some optimizations for
- * those columns that are not directly queried by the user (see #10657 for more details).
+ * often need to internally fetch all regular columns or all columns for the queried table, but can still do some
+ * optimizations for those columns that are not directly queried by the user (see #10657 for more details).
  *
  * Note that in practice:
  *   - the _queried_ columns set is always included in the _fetched_ one.
- *   - whenever those sets are different, we know 1) the _fetched_ set contains all regular columns for the table and 2)
- *     _fetched_ == _queried_ for static columns, so we don't have to record this set, we just keep a pointer to the
- *     table metadata. The only set we concretely store is thus the _queried_ one.
+ *   - whenever those sets are different, the _fetched_ columns can contains either all the regular columns and
+ *     the static columns queried by the user or all the regular and static queries. If the query is a partition level
+ *     query (no restrictions on clustering or regular columns) all the static columns will need to be fetched as
+ *     some data will need to be returned to the user if the partition has no row but some static data. For all the
+ *     other scenarios only the all the regular columns are required.
  *   - in the special case of a {@code SELECT *} query, we want to query all columns, and _fetched_ == _queried.
- *     As this is a common case, we special case it by keeping the _queried_ set {@code null} (and we retrieve
- *     the columns through the metadata pointer).
+ *     As this is a common case, we special case it by using a specific subclass for it.
  *
  * For complex columns, this class optionally allows to specify a subset of the cells to query for each column.
  * We can either select individual cells by path name, or a slice of them. Note that this is a sub-selection of
@@ -67,7 +67,7 @@ import org.apache.cassandra.utils.CassandraVersion;
  * queried and the other ones are considered fetched (and if a column has some sub-selection, it must be a queried
  * column, which is actually enforced by the Builder below).
  */
-public class ColumnFilter
+public abstract class ColumnFilter
 {
     private final static Logger logger = LoggerFactory.getLogger(ColumnFilter.class);
 
@@ -75,85 +75,139 @@ public class ColumnFilter
 
     public static final Serializer serializer = new Serializer();
 
-    // True if _fetched_ includes all regular columns (and any static in _queried_), in which case metadata must not be
-    // null. If false, then _fetched_ == _queried_ and we only store _queried_.
-    @VisibleForTesting
-    final boolean fetchAllRegulars;
-
-    // This flag can be only set when fetchAllRegulars is set. When fetchAllRegulars is set and queried==null then
-    // it is implied to be true. The flag when set allows for interpreting the column filter in the same way as it was
-    // interpreted by pre 4.0 Cassandra versions (3.4 ~ 4.0), that is, we fetch all columns (both regulars and static)
-    // but we query only some of them. This allows for proper behaviour during upgrades.
-    private final boolean fetchAllStatics;
-
-    @VisibleForTesting
-    final RegularAndStaticColumns fetched;
-
-    private final RegularAndStaticColumns queried; // can be null if fetchAllRegulars, to represent a wildcard query (all
-
-    // static and regular columns are both _fetched_ and _queried_).
-    private final SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections; // can be null
-
-    private ColumnFilter(boolean fetchAllRegulars,
-                         boolean fetchAllStatics,
-                         TableMetadata metadata,
-                         RegularAndStaticColumns queried,
-                         SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections)
-    {
-        assert !fetchAllRegulars || metadata != null;
-        assert fetchAllRegulars || queried != null;
-        assert !fetchAllStatics || fetchAllRegulars;
-        this.fetchAllRegulars = fetchAllRegulars;
-        this.fetchAllStatics = fetchAllStatics || fetchAllRegulars && queried == null;
-
-        if (fetchAllRegulars)
-        {
-            RegularAndStaticColumns all = metadata.regularAndStaticColumns();
-
-            this.fetched = (all.statics.isEmpty() || queried == null || fetchAllStatics)
-                           ? all
-                           : new RegularAndStaticColumns(queried.statics, all.regulars);
-        }
-        else
-        {
-            this.fetched = queried;
-        }
-
-        this.queried = queried;
-        this.subSelections = subSelections;
-    }
-
     /**
-     * Used on replica for deserialisation
+     * The fetching strategy for the different queries.
      */
-    private ColumnFilter(boolean fetchAllRegulars,
-                         boolean fetchAllStatics,
-                         RegularAndStaticColumns fetched,
-                         RegularAndStaticColumns queried,
-                         SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections)
+    private enum FetchingStrategy
     {
-        assert !fetchAllRegulars || fetched != null;
-        assert fetchAllRegulars || queried != null;
-        assert !fetchAllStatics || fetchAllRegulars;
-        this.fetchAllRegulars = fetchAllRegulars;
-        this.fetchAllStatics = fetchAllStatics || fetchAllRegulars && queried == null;
-        this.fetched = fetchAllRegulars ? fetched : queried;
-        this.queried = queried;
-        this.subSelections = subSelections;
+        /**
+         * This strategy will fetch all the regular and static columns.
+         *
+         * <p>According to the CQL semantic a partition exist if has at least one row or one of its static columns not null.
+         * For queries that have no restrictions on the clustering or regular columns, C* returns will return some data for
+         * the partition even if it does not contains any row as long as one of the static columns contains data.
+         * To be able to ensure those queries all columns need to be fetched.</p>
+         *
+         * <p>This strategy is also used, instead of the ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS one, in mixed version clusters
+         * where some nodes have a version lower than 4.0. To ensure backward compatibility with those version that interpret the
+         * _fetchAll_ serialization flag as a true fetch all request.</p>
+         */
+        ALL_COLUMNS
+        {
+            @Override
+            boolean fetchesAllColumns(boolean isStatic)
+            {
+                return true;
+            }
+
+            @Override
+            RegularAndStaticColumns getFetchedColumns(TableMetadata metadata, RegularAndStaticColumns queried)
+            {
+                return metadata.regularAndStaticColumns();
+            }
+        },
+
+        /**
+         * This strategy will fetch all the regular and selected static columns.
+         *
+         * <p>According to the CQL semantic a row exist if has at least one of its columns is not null.
+         * To ensure that we need to fetch all regular columns.</p>
+         */
+        ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS
+        {
+            @Override
+            boolean fetchesAllColumns(boolean isStatic)
+            {
+                return !isStatic;
+            }
+
+            @Override
+            RegularAndStaticColumns getFetchedColumns(TableMetadata metadata, RegularAndStaticColumns queried)
+            {
+                return new RegularAndStaticColumns(queried.statics, metadata.regularColumns());
+            }
+        },
+
+        /**
+         * Fetch only the columns that have been selected.
+         *
+         * <p>With this strategy _queried_ == _fetched_. This strategy is only used for internal queries.</p>
+         */
+        ONLY_QUERIED_COLUMNS
+        {
+            @Override
+            boolean fetchesAllColumns(boolean isStatic)
+            {
+                return false;
+            }
+
+            @Override
+            boolean areAllFetchedColumnsQueried()
+            {
+                return true;
+            }
+
+            @Override
+            RegularAndStaticColumns getFetchedColumns(TableMetadata metadata, RegularAndStaticColumns queried)
+            {
+                return queried;
+            }
+        };
+
+        /**
+         * Checks if the strategy fetch all the specified columns
+         *
+         * @param isStatic {@code true} is the check is for static columns, {@code false} otherwise
+         * @return {@code true} if the strategy fetch all the static columns, {@code false} otherwise.
+         */
+        abstract boolean fetchesAllColumns(boolean isStatic);
+
+        /**
+         * Checks if all the fetched columns are guaranteed to be queried
+         *
+         * @return {@code true} if all the fetched columns are guaranteed to be queried, {@code false} otherwise.
+         */
+        boolean areAllFetchedColumnsQueried()
+        {
+            return false;
+        }
+
+        /**
+         * Returns the columns that must be fetched to answer the query.
+         *
+         * @param metadata the table metadata
+         * @param queried the queried columns
+         * @return the columns that must be fetched
+         */
+        abstract RegularAndStaticColumns getFetchedColumns(TableMetadata metadata, RegularAndStaticColumns queried);
     }
 
     /**
-     * Returns true if all static columns should be fetched along with all regular columns (it only makes sense to call
-     * this method if fetchAllRegulars is going to be true and queried != null).
+     * Returns {@code true} if there are 4.0 pre-release nodes in the cluster (e.g. 4.0-rc1), {@code false} otherwise.
      *
-     * We have to apply this conversion when there are pre-4.0 nodes in the cluster because they interpret
-     * the ColumnFilter with fetchAllRegulars (translated to fetchAll in pre 4.0) and queried != null so that all
-     * the columns are fetched (both regular and static) and just some of them are queried. In 4.0+ with the same
-     * scenario, all regulars are fetched and only those statics which are queried. We need to apply the conversion
-     * so that the retrieved data is the same (note that non-queried columns may have skipped values or may not be
-     * included at all).
+     * <p>ColumnFilters from 4.0 release before RC2 wrongly assumed that fetching all regular columns and not the all
+     * the static columns was enough. That was not the case for queries that needed to return rows for empty partitions.
+     * See CASSANDRA-16686 for more details.</p>
      */
-    private static boolean shouldFetchAllStatics()
+    private static boolean isUpgradingFromVersionLowerThan40RC2()
+    {
+        if (Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0_RC2))
+        {
+            logger.trace("ColumnFilter conversion has been applied so that static columns will not be fetched because there are 4.0 pre-release nodes in the cluster");
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if there are pre-4.0 nodes in the cluster, {@code false} otherwise.
+     *
+     * <p>If there pre-4.0 nodes in the cluster all static columns should be fetched along with all regular columns.
+     * This is due to the fact that this nodes have a different understanding of the fetchAll serialization flag.
+     * Pre-4.0 the fetchAll flag meant that all the columns regular AND STATIC should be fetched whereas for 4.0
+     * nodes it meant that only the regular columns and the queried static columns should be fetched.</p>
+     */
+    private static boolean isUpgradingFromVersionLowerThan40()
     {
         if (Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0))
         {
@@ -164,17 +218,22 @@ public class ColumnFilter
     }
 
     /**
-     * Returns true if we want to consider all fetched columns as queried as well (it only makes sense to call
-     * this method if fetchAllRegulars is going to be true).
+     * Returns {@code true} if there are pre-3.4 nodes in the cluster, {@code false} otherwise.
      *
-     * We have to apply this conversion when there are pre-3.4 (in particular, pre CASSANDRA-10657) nodes in the cluster
-     * because they interpret the ColumnFilter with fetchAllRegulars (translated to fetchAll in pre 4.0) so that all
-     * fetched columns are queried. In 3.4+ with the same scenario, all the columns are fetched
-     * (though see {@link #shouldFetchAllStatics()}) but queried columns are taken into account in the way that we may
-     * skip values or whole cells when reading data. We need to apply the conversion so that the retrieved data is
-     * the same.
+     * When fetchAll is enabled on pre CASSANDRA-10657 (3.4-), queried columns are not considered at all, and it
+     * is assumed that all columns are queried. CASSANDRA-10657 (3.4+) brings back skipping values of columns
+     * which are not in queried set when fetchAll is enabled. That makes exactly the same filter being
+     * interpreted in a different way on 3.4- and 3.4+.
+     *
+     * Moreover, there is no way to convert the filter with fetchAll and queried != null so that it is
+     * interpreted the same way on 3.4- because that Cassandra version does not support such filtering.
+     *
+     * In order to avoid inconsistencies in data read by 3.4- and 3.4+ we need to avoid creation of incompatible
+     * filters when the cluster contains 3.4- nodes. We need to do that by using a wildcard query.
+     *
+     * see CASSANDRA-10657, CASSANDRA-15833, CASSANDRA-16415
      */
-    private static boolean shouldQueriedBeNull()
+    private static boolean isUpgradingFromVersionLowerThan34()
     {
         if (Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_3_4))
         {
@@ -189,7 +248,7 @@ public class ColumnFilter
      */
     public static ColumnFilter all(TableMetadata metadata)
     {
-        return new ColumnFilter(true, true, metadata, null, null);
+        return new WildCardColumnFilter(metadata.regularAndStaticColumns());
     }
 
     /**
@@ -201,16 +260,41 @@ public class ColumnFilter
      */
     public static ColumnFilter selection(RegularAndStaticColumns columns)
     {
-        return new ColumnFilter(false, false, (TableMetadata) null, columns, null);
+        return SelectionColumnFilter.newInstance(FetchingStrategy.ONLY_QUERIED_COLUMNS,
+                                                 (TableMetadata) null,
+                                                 columns,
+                                                 null);
     }
 
     /**
      * A filter that fetches all columns for the provided table, but returns
      * only the queried ones.
      */
-    public static ColumnFilter selection(TableMetadata metadata, RegularAndStaticColumns queried)
+    public static ColumnFilter selection(TableMetadata metadata,
+                                          RegularAndStaticColumns queried,
+                                          boolean returnStaticContentOnPartitionWithNoRows)
     {
-        return new ColumnFilter(true, shouldFetchAllStatics(), metadata, shouldQueriedBeNull() ? null : queried, null);
+        // pre CASSANDRA-10657 (3.4-), when fetchAll is enabled, queried columns are not considered at all, and it
+        // is assumed that all columns are queried.
+        if (isUpgradingFromVersionLowerThan34())
+        {
+            return new WildCardColumnFilter(metadata.regularAndStaticColumns());
+        }
+
+        // pre CASSANDRA-12768 (4.0-) all static columns should be fetched along with all regular columns.
+        if (isUpgradingFromVersionLowerThan40())
+        {
+            return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_COLUMNS, metadata, queried, null);
+        }
+
+        // pre CASSANDRA-16686 (4.0-RC2-) static columns where not fetched unless queried witch lead to some wrong results
+        // for some queries
+        if (isUpgradingFromVersionLowerThan40RC2() || !returnStaticContentOnPartitionWithNoRows)
+        {
+            return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS, metadata, queried, null);
+        }
+
+        return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_COLUMNS, metadata, queried, null);
     }
 
     /**
@@ -218,23 +302,17 @@ public class ColumnFilter
      *
      * @return the columns to fetch for this filter.
      */
-    public RegularAndStaticColumns fetchedColumns()
-    {
-        return fetched;
-    }
+    public abstract RegularAndStaticColumns fetchedColumns();
 
     /**
      * The columns actually queried by the user.
      * <p>
      * Note that this is in general not all the columns that are fetched internally (see {@link #fetchedColumns}).
      */
-    public RegularAndStaticColumns queriedColumns()
-    {
-        return queried == null ? fetched : queried;
-    }
+    public abstract RegularAndStaticColumns queriedColumns();
 
     /**
-     * Wether all the (regular or static) columns are fetched by this filter.
+     * Whether all the (regular or static) columns are fetched by this filter.
      * <p>
      * Note that this method is meant as an optimization but a negative return
      * shouldn't be relied upon strongly: this can return {@code false} but
@@ -246,32 +324,18 @@ public class ColumnFilter
      * the method returns if all static columns are fetched, otherwise it checks
      * regular columns.
      */
-    public boolean fetchesAllColumns(boolean isStatic)
-    {
-        return isStatic ? queried == null || fetchAllStatics : fetchAllRegulars;
-    }
+    public abstract boolean fetchesAllColumns(boolean isStatic);
 
     /**
      * Whether _fetched_ == _queried_ for this filter, and so if the {@code isQueried()} methods
      * can return {@code false} for some column/cell.
      */
-    public boolean allFetchedColumnsAreQueried()
-    {
-        return !fetchAllRegulars || queried == null;
-    }
+    public abstract boolean allFetchedColumnsAreQueried();
 
     /**
      * Whether the provided column is fetched by this filter.
      */
-    public boolean fetches(ColumnMetadata column)
-    {
-        // For statics, it is included only if it's part of _queried_, or if _queried_ is null (wildcard query).
-        if (column.isStatic())
-            return fetchAllStatics || queried == null || queried.contains(column);
-
-        // For regulars, if 'fetchAllRegulars', then it's included automatically. Otherwise, it depends on _queried_.
-        return fetchAllRegulars || queried.contains(column);
-    }
+    public abstract boolean fetches(ColumnMetadata column);
 
     /**
      * Whether the provided column, which is assumed to be _fetched_ by this filter (so the caller must guarantee
@@ -281,10 +345,7 @@ public class ColumnFilter
      * columns that this class made before using this method. If unsure, you probably want
      * to use the {@link #fetches} method.
      */
-    public boolean fetchedColumnIsQueried(ColumnMetadata column)
-    {
-        return !fetchAllRegulars || queried == null || queried.contains(column);
-    }
+    public abstract boolean fetchedColumnIsQueried(ColumnMetadata column);
 
     /**
      * Whether the provided complex cell (identified by its column and path), which is assumed to be _fetched_ by
@@ -294,48 +355,7 @@ public class ColumnFilter
      * columns that this class made before using this method. If unsure, you probably want
      * to use the {@link #fetches} method.
      */
-    public boolean fetchedCellIsQueried(ColumnMetadata column, CellPath path)
-    {
-        assert path != null;
-
-        // first verify that the column to which the cell belongs is queried
-        if (!fetchedColumnIsQueried(column))
-            return false;
-
-        if (subSelections == null)
-            return true;
-
-        SortedSet<ColumnSubselection> s = subSelections.get(column.name);
-        // No subsection for this column means everything is queried
-        if (s.isEmpty())
-            return true;
-
-        for (ColumnSubselection subSel : s)
-            if (subSel.compareInclusionOf(path) == 0)
-                return true;
-
-        return false;
-    }
-
-    /**
-     * Creates a new {@code Tester} to efficiently test the inclusion of cells of complex column
-     * {@code column}.
-     *
-     * @param column for complex column for which to create a tester.
-     * @return the created tester or {@code null} if all the cells from the provided column
-     * are queried.
-     */
-    public Tester newTester(ColumnMetadata column)
-    {
-        if (subSelections == null || !column.isComplex())
-            return null;
-
-        SortedSet<ColumnSubselection> s = subSelections.get(column.name);
-        if (s.isEmpty())
-            return null;
-
-        return new Tester(!column.isStatic() && fetchAllRegulars || column.isStatic() && fetchAllStatics, s.iterator());
-    }
+    public abstract boolean fetchedCellIsQueried(ColumnMetadata column, CellPath path);
 
     /**
      * Given an iterator on the cell of a complex column, returns an iterator that only include the cells selected by
@@ -345,22 +365,53 @@ public class ColumnFilter
      * @param cells the cells to filter.
      * @return a filtered iterator that only include the cells from {@code cells} that are included by this filter.
      */
-    public Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells)
-    {
-        Tester tester = newTester(column);
-        if (tester == null)
-            return cells;
+    public abstract Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells);
 
-        return Iterators.filter(cells, cell -> tester.fetchedCellIsQueried(cell.path()));
+    /**
+     * Creates a new {@code Tester} to efficiently test the inclusion of cells of complex column
+     * {@code column}.
+     *
+     * @param column for complex column for which to create a tester.
+     * @return the created tester or {@code null} if all the cells from the provided column
+     * are queried.
+     */
+    public abstract Tester newTester(ColumnMetadata column);
+
+    /**
+     * Checks if this {@code ColumnFilter} is for a wildcard query.
+     *
+     * @return {@code true} if this {@code ColumnFilter} is for a wildcard query, {@code false} otherwise.
+     */
+    public boolean isWildcard()
+    {
+        return false;
     }
 
     /**
-     * Returns a {@code ColumnFilter}} builder that fetches all regular columns (and queries the columns
-     * added to the builder, or everything if no column is added).
+     * Returns the CQL string corresponding to this {@code ColumnFilter}.
+     *
+     * @return the CQL string corresponding to this {@code ColumnFilter}.
      */
-    public static Builder allRegularColumnsBuilder(TableMetadata metadata)
+    public abstract String toCQLString();
+
+    /**
+     * Returns the sub-selections or {@code null} if there are none.
+     *
+     * @return the sub-selections or {@code null} if there are none
+     */
+    protected abstract SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections();
+
+    /**
+     * Returns a {@code ColumnFilter} builder that fetches all regular columns or all columns (and queries the columns
+     * added to the builder, or everything if no column is added).
+     *
+     * @param metadata the table metadata
+     * @param returnStaticContentOnPartitionWithNoRows {@code true} if the query must return static contents if the partition has no row,
+     * {@code false} otherwise.
+     */
+    public static Builder allRegularColumnsBuilder(TableMetadata metadata, boolean returnStaticContentOnPartitionWithNoRows)
     {
-        return new Builder(metadata);
+        return new Builder(metadata, returnStaticContentOnPartitionWithNoRows);
     }
 
     /**
@@ -368,7 +419,7 @@ public class ColumnFilter
      */
     public static Builder selectionBuilder()
     {
-        return new Builder(null);
+        return new Builder(null, false);
     }
 
     public static class Tester
@@ -420,31 +471,39 @@ public class ColumnFilter
      * A builder for a {@code ColumnFilter} object.
      *
      * Note that the columns added to this build are the _queried_ column. Whether or not all columns
-     * are _fetched_ depends on which constructor you've used to obtained this builder, allColumnsBuilder (all
+     * are _fetched_ depends on which constructor you've used to obtained this builder, allRegularColumnsBuilder (all
      * columns are fetched) or selectionBuilder (only the queried columns are fetched).
      *
-     * Note that for a allColumnsBuilder, if no queried columns are added, this is interpreted as querying
+     * Note that for a allRegularColumnsBuilder, if no queried columns are added, this is interpreted as querying
      * all columns, not querying none (but if you know you want to query all columns, prefer
      * {@link ColumnFilter#all(TableMetadata)}. For selectionBuilder, adding no queried columns means no column will be
      * fetched (so the builder will return {@code PartitionColumns.NONE}).
      *
-     * Also, if only a subselection of a complex column should be queried, then only the corresponding
-     * subselection method of the builder ({@link #slice} or {@link #select}) should be called for the
+     * Also, if only a sub-selection of a complex column should be queried, then only the corresponding
+     * sub-selection method of the builder ({@link #slice} or {@link #select}) should be called for the
      * column, but {@link #add} shouldn't. if {@link #add} is also called, the whole column will be
-     * queried and the subselection(s) will be ignored. This is done for correctness of CQL where
+     * queried and the sub-selection(s) will be ignored. This is done for correctness of CQL where
      * if you do "SELECT m, m[2..5]", you are really querying the whole collection.
      */
     public static class Builder
     {
         private final TableMetadata metadata; // null if we don't fetch all columns
+
+        /**
+         * {@code true} if the query must return static contents if the partition has no row, {@code false} otherwise.
+         */
+        private final boolean returnStaticContentOnPartitionWithNoRows;
+
         private RegularAndStaticColumns.Builder queriedBuilder;
+
         private List<ColumnSubselection> subSelections;
 
         private Set<ColumnMetadata> fullySelectedComplexColumns;
 
-        private Builder(TableMetadata metadata)
+        private Builder(TableMetadata metadata, boolean returnStaticContentOnPartitionWithNoRows)
         {
             this.metadata = metadata;
+            this.returnStaticContentOnPartitionWithNoRows = returnStaticContentOnPartitionWithNoRows;
         }
 
         public Builder add(ColumnMetadata c)
@@ -502,149 +561,473 @@ public class ColumnFilter
             boolean isFetchAll = metadata != null;
 
             RegularAndStaticColumns queried = queriedBuilder == null ? null : queriedBuilder.build();
+
             // It's only ok to have queried == null in ColumnFilter if isFetchAll. So deal with the case of a selectionBuilder
             // with nothing selected (we can at least happen on some backward compatible queries - CASSANDRA-10471).
             if (!isFetchAll && queried == null)
                 queried = RegularAndStaticColumns.NONE;
 
-            SortedSetMultimap<ColumnIdentifier, ColumnSubselection> s = null;
-            if (subSelections != null)
+            SortedSetMultimap<ColumnIdentifier, ColumnSubselection> s = buildSubSelections();
+
+            if (isFetchAll)
             {
-                s = TreeMultimap.create(Comparator.naturalOrder(), Comparator.naturalOrder());
-                for (ColumnSubselection subSelection : subSelections)
+                // When fetchAll is enabled on pre CASSANDRA-10657 (3.4-), queried columns are not considered at all, and it
+                // is assumed that all columns are queried. CASSANDRA-10657 (3.4+) brings back skipping values of columns
+                // which are not in queried set when fetchAll is enabled. That makes exactly the same filter being
+                // interpreted in a different way on 3.4- and 3.4+.
+                //
+                // Moreover, there is no way to convert the filter with fetchAll and queried != null so that it is
+                // interpreted the same way on 3.4- because that Cassandra version does not support such filtering.
+                //
+                // In order to avoid inconsitencies in data read by 3.4- and 3.4+ we need to avoid creation of incompatible
+                // filters when the cluster contains 3.4- nodes. We do that by forcibly setting queried to null.
+                //
+                // see CASSANDRA-10657, CASSANDRA-15833, CASSANDRA-16415
+                if (queried == null || isUpgradingFromVersionLowerThan34())
                 {
-                    if (fullySelectedComplexColumns == null || !fullySelectedComplexColumns.contains(subSelection.column()))
-                        s.put(subSelection.column().name, subSelection);
+                    return new WildCardColumnFilter(metadata.regularAndStaticColumns());
                 }
+
+                // pre CASSANDRA-12768 (4.0-) all static columns should be fetched along with all regular columns.
+                if (isUpgradingFromVersionLowerThan40())
+                {
+                    return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_COLUMNS, metadata, queried, s);
+                }
+
+                // pre CASSANDRA-16686 (4.0-RC2-) static columns where not fetched unless queried witch lead to some wrong results
+                // for some queries
+                if (isUpgradingFromVersionLowerThan40RC2() || !returnStaticContentOnPartitionWithNoRows)
+                {
+                    return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS, metadata, queried, s);
+                }
+
+                return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_COLUMNS, metadata, queried, s);
             }
 
-            // When fetchAll is enabled on pre CASSANDRA-10657 (3.4-), queried columns are not considered at all, and it
-            // is assumed that all columns are queried. CASSANDRA-10657 (3.4+) brings back skipping values of columns
-            // which are not in queried set when fetchAll is enabled. That makes exactly the same filter being
-            // interpreted in a different way on 3.4- and 3.4+.
-            //
-            // Moreover, there is no way to convert the filter with fetchAll and queried != null so that it is
-            // interpreted the same way on 3.4- because that Cassandra version does not support such filtering.
-            //
-            // In order to avoid inconsitencies in data read by 3.4- and 3.4+ we need to avoid creation of incompatible
-            // filters when the cluster contains 3.4- nodes. We do that by forcibly setting queried to null.
-            //
-            // see CASSANDRA-10657, CASSANDRA-15833, CASSANDRA-16415
-            return new ColumnFilter(isFetchAll, isFetchAll && shouldFetchAllStatics(), metadata, isFetchAll && shouldQueriedBeNull() ? null : queried, s);
+            return SelectionColumnFilter.newInstance(FetchingStrategy.ONLY_QUERIED_COLUMNS, (TableMetadata) null, queried, s);
+        }
+
+        private SortedSetMultimap<ColumnIdentifier, ColumnSubselection> buildSubSelections()
+        {
+            if (subSelections == null)
+                return null;
+
+            SortedSetMultimap<ColumnIdentifier, ColumnSubselection> s = TreeMultimap.create(Comparator.naturalOrder(), Comparator.naturalOrder());
+            for (ColumnSubselection subSelection : subSelections)
+            {
+                if (fullySelectedComplexColumns == null || !fullySelectedComplexColumns.contains(subSelection.column()))
+                    s.put(subSelection.column().name, subSelection);
+            }
+
+            return s;
         }
     }
 
-    @Override
-    public boolean equals(Object other)
+    /**
+     * {@code ColumnFilter} sub-class for wildcard queries.
+     *
+     * <p>The class  does not rely on TableMetadata and expect a fix set of columns to prevent issues
+     * with Schema race propagation. See CASSANDRA-15899.</p>
+     */
+    public static class WildCardColumnFilter extends ColumnFilter
     {
-        if (other == this)
+        /**
+         * The queried and fetched columns.
+         */
+        private final RegularAndStaticColumns fetchedAndQueried;
+
+        /**
+         * Creates a {@code ColumnFilter} for wildcard queries.
+         *
+         * <p>The class  does not rely on TableMetadata and expect a fix set of columns to prevent issues
+         * with Schema race propagation. See CASSANDRA-15899.</p>
+         *
+         * @param fetchedAndQueried the fetched and queried columns
+         */
+        private WildCardColumnFilter(RegularAndStaticColumns fetchedAndQueried)
+        {
+            this.fetchedAndQueried = fetchedAndQueried;
+        }
+
+        @Override
+        public RegularAndStaticColumns fetchedColumns()
+        {
+            return fetchedAndQueried;
+        }
+
+        @Override
+        public RegularAndStaticColumns queriedColumns()
+        {
+            return fetchedAndQueried;
+        }
+
+        @Override
+        public boolean fetchesAllColumns(boolean isStatic)
+        {
             return true;
+        }
 
-        if (!(other instanceof ColumnFilter))
-            return false;
+        @Override
+        public boolean allFetchedColumnsAreQueried()
+        {
+            return true;
+        }
 
-        ColumnFilter otherCf = (ColumnFilter) other;
+        @Override
+        public boolean fetches(ColumnMetadata column)
+        {
+            return true;
+        }
 
-        return otherCf.fetchAllRegulars == this.fetchAllRegulars &&
-               otherCf.fetchAllStatics == this.fetchAllStatics &&
-               Objects.equals(otherCf.fetched, this.fetched) &&
-               Objects.equals(otherCf.queried, this.queried) &&
-               Objects.equals(otherCf.subSelections, this.subSelections);
-    }
+        @Override
+        public boolean fetchedColumnIsQueried(ColumnMetadata column)
+        {
+            return true;
+        }
 
-    @Override
-    public String toString()
-    {
-        String prefix = "";
+        @Override
+        public boolean fetchedCellIsQueried(ColumnMetadata column, CellPath path)
+        {
+            return true;
+        }
 
-        if (fetchAllRegulars && queried == null)
+        @Override
+        public Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells)
+        {
+            return cells;
+        }
+
+        @Override
+        public Tester newTester(ColumnMetadata column)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == this)
+                return true;
+
+            if (!(other instanceof WildCardColumnFilter))
+                return false;
+
+            WildCardColumnFilter w = (WildCardColumnFilter) other;
+
+            return fetchedAndQueried.equals(w.fetchedAndQueried);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(fetchedAndQueried);
+        }
+
+        @Override
+        public String toString()
+        {
             return "*/*";
-
-        if (fetchAllRegulars && fetchAllStatics)
-            prefix = "*/";
-
-        if (fetchAllRegulars && !fetchAllStatics)
-        {
-            prefix = queried.statics.isEmpty()
-                   ? "<all regulars>/"
-                   : String.format("<all regulars>+%s/", toString(queried.statics.selectOrderIterator(), false));
         }
 
-        return prefix + toString(queried.selectOrderIterator(), false);
-    }
-
-    public String toCQLString()
-    {
-        if (queried == null || queried.isEmpty())
+        public String toCQLString()
+        {
             return "*";
+        }
 
-        return toString(queried.selectOrderIterator(), true);
+        @Override
+        public boolean isWildcard()
+        {
+            return true;
+        }
+
+        @Override
+        protected SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections()
+        {
+            return null;
+        }
     }
 
-    private String toString(Iterator<ColumnMetadata> columns, boolean cql)
+    /**
+     * {@code ColumnFilter} sub-class for queries with selected columns.
+     *
+     * <p>The class  does not rely on TableMetadata and expect a fix set of fetched columns to prevent issues
+     * with Schema race propagation. See CASSANDRA-15899.</p>
+     */
+    public static class SelectionColumnFilter extends ColumnFilter
     {
-        StringJoiner joiner = cql ? new StringJoiner(", ") : new StringJoiner(", ", "[", "]");
+        public final FetchingStrategy fetchingStrategy;
 
-        while (columns.hasNext())
+        /**
+         * The selected columns
+         */
+        private final RegularAndStaticColumns queried;
+
+        /**
+         * The columns that need to be fetched to be able
+         */
+        private final RegularAndStaticColumns fetched;
+
+        private final SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections; // can be null
+
+        public static SelectionColumnFilter newInstance(FetchingStrategy fetchingStrategy,
+                                                        TableMetadata metadata,
+                                                        RegularAndStaticColumns queried,
+                                                        SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections)
         {
-            ColumnMetadata column = columns.next();
-            String columnName = cql ? column.name.toCQLString() : String.valueOf(column.name);
+            assert fetchingStrategy != FetchingStrategy.ONLY_QUERIED_COLUMNS || metadata == null;
+            assert queried != null;
 
-            SortedSet<ColumnSubselection> s = subSelections != null
-                                            ? subSelections.get(column.name)
-                                            : Collections.emptySortedSet();
-
-            if (s.isEmpty())
-                joiner.add(columnName);
-            else
-                s.forEach(subSel -> joiner.add(String.format("%s%s", columnName, subSel)));
+            return new SelectionColumnFilter(fetchingStrategy,
+                                             queried,
+                                             fetchingStrategy.getFetchedColumns(metadata, queried),
+                                             subSelections);
         }
-        return joiner.toString();
+
+        /**
+         * Creates a {@code ColumnFilter} for queries with selected columns.
+         *
+         * <p>The class  does not rely on TableMetadata and expect a fix set of columns to prevent issues
+         * with Schema race propagation. See CASSANDRA-15899.</p>
+         *
+         * @param fetchingStrategy the strategy used to select the fetched columns
+         * @param fetched the columns that must be fetched
+         * @param queried the queried columns
+         * @param subSelections the columns sub-selections
+         */
+        public SelectionColumnFilter(FetchingStrategy fetchingStrategy,
+                                     RegularAndStaticColumns queried,
+                                     RegularAndStaticColumns fetched,
+                                     SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections)
+        {
+            assert fetched.includes(queried);
+
+            this.fetchingStrategy = fetchingStrategy;
+            this.queried = queried;
+            this.fetched = fetched;
+            this.subSelections = subSelections;
+        }
+
+        @Override
+        public RegularAndStaticColumns fetchedColumns()
+        {
+            return fetched;
+        }
+
+        @Override
+        public RegularAndStaticColumns queriedColumns()
+        {
+            return queried;
+        }
+
+        @Override
+        public boolean fetchesAllColumns(boolean isStatic)
+        {
+            return fetchingStrategy.fetchesAllColumns(isStatic);
+        }
+
+        @Override
+        public boolean allFetchedColumnsAreQueried()
+        {
+            return fetchingStrategy.areAllFetchedColumnsQueried();
+        }
+
+        @Override
+        public boolean fetches(ColumnMetadata column)
+        {
+            return fetchingStrategy.fetchesAllColumns(column.isStatic()) || queried.contains(column);
+        }
+
+        @Override
+        public boolean fetchedColumnIsQueried(ColumnMetadata column)
+        {
+            return fetchingStrategy.areAllFetchedColumnsQueried() || queried.contains(column);
+        }
+
+        @Override
+        public boolean fetchedCellIsQueried(ColumnMetadata column, CellPath path)
+        {
+            assert path != null;
+
+            // first verify that the column to which the cell belongs is queried
+            if (!fetchedColumnIsQueried(column))
+                return false;
+
+            if (subSelections == null)
+                return true;
+
+            SortedSet<ColumnSubselection> s = subSelections.get(column.name);
+            // No subsection for this column means everything is queried
+            if (s.isEmpty())
+                return true;
+
+            for (ColumnSubselection subSel : s)
+                if (subSel.compareInclusionOf(path) == 0)
+                    return true;
+
+            return false;
+        }
+
+        @Override
+        public Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells)
+        {
+            Tester tester = newTester(column);
+            if (tester == null)
+                return cells;
+
+            return Iterators.filter(cells, cell -> tester.fetchedCellIsQueried(cell.path()));
+        }
+
+        @Override
+        public Tester newTester(ColumnMetadata column)
+        {
+            if (subSelections == null || !column.isComplex())
+                return null;
+
+            SortedSet<ColumnSubselection> s = subSelections.get(column.name);
+            if (s.isEmpty())
+                return null;
+
+            return new Tester(fetchingStrategy.fetchesAllColumns(column.isStatic()), s.iterator());
+        }
+
+        @Override
+        protected SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections()
+        {
+            return subSelections;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == this)
+                return true;
+
+            if (!(other instanceof SelectionColumnFilter))
+                return false;
+
+            SelectionColumnFilter otherCf = (SelectionColumnFilter) other;
+
+            return otherCf.fetchingStrategy == this.fetchingStrategy &&
+                   Objects.equals(otherCf.queried, this.queried) &&
+                   Objects.equals(otherCf.fetched, this.fetched) &&
+                   Objects.equals(otherCf.subSelections, this.subSelections);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(fetchingStrategy, queried, fetched, subSelections);
+        }
+
+        @Override
+        public String toString()
+        {
+            String prefix = "";
+
+            if (fetchingStrategy.fetchesAllColumns(true))
+                prefix = "*/";
+
+            if (fetchingStrategy == FetchingStrategy.ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS)
+            {
+                prefix = queried.statics.isEmpty()
+                       ? "<all regulars>/"
+                       : String.format("<all regulars>+%s/", toString(queried.statics.selectOrderIterator(), false));
+            }
+
+            return prefix + toString(queried.selectOrderIterator(), false);
+        }
+
+        public String toCQLString()
+        {
+            return queried.isEmpty() ? "*" : toString(queried.selectOrderIterator(), true);
+        }
+
+        private String toString(Iterator<ColumnMetadata> columns, boolean cql)
+        {
+            StringJoiner joiner = cql ? new StringJoiner(", ") : new StringJoiner(", ", "[", "]");
+
+            while (columns.hasNext())
+            {
+                ColumnMetadata column = columns.next();
+                String columnName = cql ? column.name.toCQLString() : String.valueOf(column.name);
+
+                SortedSet<ColumnSubselection> s = subSelections != null
+                                                ? subSelections.get(column.name)
+                                                : Collections.emptySortedSet();
+
+                if (s.isEmpty())
+                    joiner.add(columnName);
+                else
+                    s.forEach(subSel -> joiner.add(String.format("%s%s", columnName, subSel)));
+            }
+            return joiner.toString();
+        }
     }
 
     public static class Serializer
     {
+        // Prior to 4.0 the FETCH_ALL flag meant fetch all regular and static columns. From 4.0 onward it meant
+        // fetch all regular columns and queried static columns
         private static final int FETCH_ALL_MASK = 0x01;
         private static final int HAS_QUERIED_MASK = 0x02;
         private static final int HAS_SUB_SELECTIONS_MASK = 0x04;
+        // The FETCH_ALL_STATICS flag was added in CASSANDRA-16686 to allow 4.0 to handle queries that required
+        // to return static data for empty partitions
+        private static final int FETCH_ALL_STATICS_MASK = 0x08;
 
         private static int makeHeaderByte(ColumnFilter selection)
         {
-            return (selection.fetchAllRegulars ? FETCH_ALL_MASK : 0)
-                   | (selection.queried != null ? HAS_QUERIED_MASK : 0)
-                   | (selection.subSelections != null ? HAS_SUB_SELECTIONS_MASK : 0);
+            return (selection.fetchesAllColumns(false) ? FETCH_ALL_MASK : 0)
+                   | (!selection.isWildcard() ? HAS_QUERIED_MASK : 0)
+                   | (selection.subSelections() != null ? HAS_SUB_SELECTIONS_MASK : 0)
+                   | (selection.fetchesAllColumns(true) ? FETCH_ALL_STATICS_MASK : 0);
         }
 
         public void serialize(ColumnFilter selection, DataOutputPlus out, int version) throws IOException
         {
             out.writeByte(makeHeaderByte(selection));
 
-            if (version >= MessagingService.VERSION_3014 && selection.fetchAllRegulars)
+            if (version >= MessagingService.VERSION_3014 && selection.fetchesAllColumns(false))
             {
-                Columns.serializer.serialize(selection.fetched.statics, out);
-                Columns.serializer.serialize(selection.fetched.regulars, out);
+                serializeRegularAndStaticColumns(selection.fetchedColumns(), out);
             }
 
-            if (selection.queried != null)
+            if (!selection.isWildcard())
             {
-                Columns.serializer.serialize(selection.queried.statics, out);
-                Columns.serializer.serialize(selection.queried.regulars, out);
+                serializeRegularAndStaticColumns(selection.queriedColumns(), out);
             }
 
-            if (selection.subSelections != null)
+            serializeSubSelections(selection.subSelections(), out, version);
+        }
+
+        private void serializeSubSelections(SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections,
+                                            DataOutputPlus out,
+                                            int version) throws IOException
+        {
+            if (subSelections != null)
             {
-                out.writeUnsignedVInt(selection.subSelections.size());
-                for (ColumnSubselection subSel : selection.subSelections.values())
+                out.writeUnsignedVInt(subSelections.size());
+                for (ColumnSubselection subSel : subSelections.values())
                     ColumnSubselection.serializer.serialize(subSel, out, version);
             }
+        }
+
+        private void serializeRegularAndStaticColumns(RegularAndStaticColumns regularAndStaticColumns,
+                                                      DataOutputPlus out) throws IOException
+        {
+            Columns.serializer.serialize(regularAndStaticColumns.statics, out);
+            Columns.serializer.serialize(regularAndStaticColumns.regulars, out);
         }
 
         public ColumnFilter deserialize(DataInputPlus in, int version, TableMetadata metadata) throws IOException
         {
             int header = in.readUnsignedByte();
+            // The meaning of isFetchAll is actually different for pre-4.0 versions and for 4.0+ versions
+            // In 4.0+ it meant is fetch all regulars
             boolean isFetchAll = (header & FETCH_ALL_MASK) != 0;
             boolean hasQueried = (header & HAS_QUERIED_MASK) != 0;
             boolean hasSubSelections = (header & HAS_SUB_SELECTIONS_MASK) != 0;
+            boolean isFetchAllStatics = (header & FETCH_ALL_STATICS_MASK) != 0;
 
             RegularAndStaticColumns fetched = null;
             RegularAndStaticColumns queried = null;
@@ -653,9 +1036,7 @@ public class ColumnFilter
             {
                 if (version >= MessagingService.VERSION_3014)
                 {
-                    Columns statics = Columns.serializer.deserializeStatics(in, metadata);
-                    Columns regulars = Columns.serializer.deserializeRegulars(in, metadata);
-                    fetched = new RegularAndStaticColumns(statics, regulars);
+                    fetched = deserializeRegularAndStaticColumns(in, metadata);
                 }
                 else
                 {
@@ -665,49 +1046,99 @@ public class ColumnFilter
 
             if (hasQueried)
             {
-                Columns statics = Columns.serializer.deserializeStatics(in, metadata);
-                Columns regulars = Columns.serializer.deserializeRegulars(in, metadata);
-                queried = new RegularAndStaticColumns(statics, regulars);
+                queried = deserializeRegularAndStaticColumns(in, metadata);
             }
 
             SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections = null;
             if (hasSubSelections)
             {
-                subSelections = TreeMultimap.create(Comparator.naturalOrder(), Comparator.naturalOrder());
-                int size = (int) in.readUnsignedVInt();
-                for (int i = 0; i < size; i++)
-                {
-                    ColumnSubselection subSel = ColumnSubselection.serializer.deserialize(in, version, metadata);
-                    subSelections.put(subSel.column().name, subSel);
-                }
+                subSelections = deserializeSubSelection(in, version, metadata);
             }
 
-            return new ColumnFilter(isFetchAll, isFetchAll && shouldFetchAllStatics(), fetched, isFetchAll && shouldQueriedBeNull() ? null : queried, subSelections);
+            if (isFetchAll)
+            {
+                // pre CASSANDRA-10657 (3.4-), when fetchAll is enabled, queried columns are not considered at all, and it
+                // is assumed that all columns are queried.
+                if (!hasQueried || isUpgradingFromVersionLowerThan34())
+                {
+                    return new WildCardColumnFilter(fetched);
+                }
+
+                // pre CASSANDRA-12768 (4.0-) all static columns should be fetched along with all regular columns.
+                if (isUpgradingFromVersionLowerThan40())
+                {
+                    return new SelectionColumnFilter(FetchingStrategy.ALL_COLUMNS, queried, fetched, subSelections);
+                }
+
+                // pre CASSANDRA-16686 (4.0-RC2-) static columns where not fetched unless queried witch lead to some wrong results
+                // for some queries
+                if (isUpgradingFromVersionLowerThan40RC2() || !isFetchAllStatics)
+                {
+                    return new SelectionColumnFilter(FetchingStrategy.ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS, queried, fetched, subSelections);
+                }
+
+                return new SelectionColumnFilter(FetchingStrategy.ALL_COLUMNS, queried, fetched, subSelections);
+            }
+
+            return new SelectionColumnFilter(FetchingStrategy.ONLY_QUERIED_COLUMNS, queried, queried, subSelections);
+        }
+
+        private RegularAndStaticColumns deserializeRegularAndStaticColumns(DataInputPlus in,
+                                                                           TableMetadata metadata) throws IOException
+        {
+            Columns statics = Columns.serializer.deserializeStatics(in, metadata);
+            Columns regulars = Columns.serializer.deserializeRegulars(in, metadata);
+            return new RegularAndStaticColumns(statics, regulars);
+        }
+
+        private SortedSetMultimap<ColumnIdentifier, ColumnSubselection> deserializeSubSelection(DataInputPlus in,
+                                                                                                int version,
+                                                                                                TableMetadata metadata) throws IOException
+        {
+            SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections = TreeMultimap.create(Comparator.naturalOrder(), Comparator.naturalOrder());
+            int size = (int) in.readUnsignedVInt();
+            for (int i = 0; i < size; i++)
+            {
+                ColumnSubselection subSel = ColumnSubselection.serializer.deserialize(in, version, metadata);
+                subSelections.put(subSel.column().name, subSel);
+            }
+            return subSelections;
         }
 
         public long serializedSize(ColumnFilter selection, int version)
         {
             long size = 1; // header byte
 
-            if (version >= MessagingService.VERSION_3014 && selection.fetchAllRegulars)
+            if (version >= MessagingService.VERSION_3014 && selection.fetchesAllColumns(false))
             {
-                size += Columns.serializer.serializedSize(selection.fetched.statics);
-                size += Columns.serializer.serializedSize(selection.fetched.regulars);
+                size += regularAndStaticColumnsSerializedSize(selection.fetchedColumns());
             }
 
-            if (selection.queried != null)
+            if (!selection.isWildcard())
             {
-                size += Columns.serializer.serializedSize(selection.queried.statics);
-                size += Columns.serializer.serializedSize(selection.queried.regulars);
+                size += regularAndStaticColumnsSerializedSize(selection.queriedColumns());
             }
 
-            if (selection.subSelections != null)
-            {
+            size += subSelectionsSerializedSize(selection.subSelections(), version);
 
-                size += TypeSizes.sizeofUnsignedVInt(selection.subSelections.size());
-                for (ColumnSubselection subSel : selection.subSelections.values())
-                    size += ColumnSubselection.serializer.serializedSize(subSel, version);
-            }
+            return size;
+        }
+
+        private long regularAndStaticColumnsSerializedSize(RegularAndStaticColumns columns)
+        {
+            return Columns.serializer.serializedSize(columns.statics)
+                    + Columns.serializer.serializedSize(columns.regulars);
+        }
+
+        private long subSelectionsSerializedSize(SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections,
+                                                 int version)
+        {
+            if (subSelections == null)
+                return 0;
+
+            int size = TypeSizes.sizeofUnsignedVInt(subSelections.size());
+            for (ColumnSubselection subSel : subSelections.values())
+                size += ColumnSubselection.serializer.serializedSize(subSel, version);
 
             return size;
         }

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -22,7 +22,6 @@ import java.util.*;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.Iterators;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 
@@ -31,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.*;
-import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.CellPath;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -355,16 +353,6 @@ public abstract class ColumnFilter
      * to use the {@link #fetches} method.
      */
     public abstract boolean fetchedCellIsQueried(ColumnMetadata column, CellPath path);
-
-    /**
-     * Given an iterator on the cell of a complex column, returns an iterator that only include the cells selected by
-     * this filter.
-     *
-     * @param column the (complex) column for which the cells are.
-     * @param cells the cells to filter.
-     * @return a filtered iterator that only include the cells from {@code cells} that are included by this filter.
-     */
-    public abstract Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells);
 
     /**
      * Creates a new {@code Tester} to efficiently test the inclusion of cells of complex column
@@ -692,12 +680,6 @@ public abstract class ColumnFilter
         }
 
         @Override
-        public Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells)
-        {
-            return cells;
-        }
-
-        @Override
         public Tester newTester(ColumnMetadata column)
         {
             return null;
@@ -874,16 +856,6 @@ public abstract class ColumnFilter
                     return true;
 
             return false;
-        }
-
-        @Override
-        public Iterator<Cell<?>> filterComplexCells(ColumnMetadata column, Iterator<Cell<?>> cells)
-        {
-            Tester tester = newTester(column);
-            if (tester == null)
-                return cells;
-
-            return Iterators.filter(cells, cell -> cell != null && tester.fetchedCellIsQueried(cell.path()));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -838,6 +838,14 @@ public abstract class ColumnFilter
             return fetchingStrategy.fetchesAllColumns(column.isStatic()) || fetched.contains(column);
         }
 
+        /**
+         * Whether the provided complex cell (identified by its column and path), which is assumed to be _fetched_ by
+         * this filter, is also _queried_ by the user.
+         *
+         * !WARNING! please be sure to understand the difference between _fetched_ and _queried_
+         * columns that this class made before using this method. If unsure, you probably want
+         * to use the {@link #fetches} method.
+         */
         @Override
         public boolean fetchedColumnIsQueried(ColumnMetadata column)
         {

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -596,7 +596,7 @@ public abstract class ColumnFilter
 
                 // pre CASSANDRA-16686 (4.0-RC2-) static columns where not fetched unless queried witch lead to some wrong results
                 // for some queries
-                if (isUpgradingFromVersionLowerThan40RC2() || !returnStaticContentOnPartitionWithNoRows)
+                if (!returnStaticContentOnPartitionWithNoRows || isUpgradingFromVersionLowerThan40RC2())
                 {
                     return SelectionColumnFilter.newInstance(FetchingStrategy.ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS, metadata, queried, s);
                 }
@@ -1074,7 +1074,7 @@ public abstract class ColumnFilter
 
                 // pre CASSANDRA-16686 (4.0-RC2-) static columns where not fetched unless queried witch lead to some wrong results
                 // for some queries
-                if (isUpgradingFromVersionLowerThan40RC2() || !isFetchAllStatics)
+                if (!isFetchAllStatics || isUpgradingFromVersionLowerThan40RC2())
                 {
                     return new SelectionColumnFilter(FetchingStrategy.ALL_REGULARS_AND_QUERIED_STATICS_COLUMNS, queried, fetched, subSelections);
                 }

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -439,7 +439,7 @@ public final class SchemaKeyspace
 
         // We want to skip the 'cdc' column. A simple solution for that is based on the fact that
         // 'PartitionUpdate.fromIterator()' will ignore any columns that are marked as 'fetched' but not 'queried'.
-        ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(partition.metadata());
+        ColumnFilter.Builder builder = ColumnFilter.allRegularColumnsBuilder(partition.metadata(), false);
         for (ColumnMetadata column : filter.fetchedColumns())
         {
             if (!column.name.toString().equals("cdc"))

--- a/src/java/org/apache/cassandra/utils/CassandraVersion.java
+++ b/src/java/org/apache/cassandra/utils/CassandraVersion.java
@@ -49,6 +49,7 @@ public class CassandraVersion implements Comparable<CassandraVersion>
     private static final Pattern PATTERN = Pattern.compile(VERSION_REGEXP);
 
     public static final CassandraVersion CASSANDRA_4_0 = new CassandraVersion("4.0").familyLowerBound.get();
+    public static final CassandraVersion CASSANDRA_4_0_RC2 = new CassandraVersion(4, 0, 0, NO_HOTFIX, new String[] {"rc2"}, null);
     public static final CassandraVersion CASSANDRA_3_4 = new CassandraVersion("3.4").familyLowerBound.get();
 
     public final int major;

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
@@ -51,7 +51,7 @@ public class MixedModeReadTest extends UpgradeTestBase
             // we need to let gossip settle or the test will fail
             int attempts = 1;
             //noinspection Convert2MethodRef
-            while (!((IInvokableInstance) (cluster.get(1))).callOnInstance(() -> Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0.familyLowerBound.get()) &&
+            while (!((IInvokableInstance) (cluster.get(1))).callOnInstance(() -> Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0) &&
                                                                                  !Gossiper.instance.isUpgradingFromVersionLowerThan(new CassandraVersion(("3.0")).familyLowerBound.get())))
             {
                 if (attempts++ > 90)

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReadTest.java
@@ -51,7 +51,7 @@ public class MixedModeReadTest extends UpgradeTestBase
             // we need to let gossip settle or the test will fail
             int attempts = 1;
             //noinspection Convert2MethodRef
-            while (!((IInvokableInstance) (cluster.get(1))).callOnInstance(() -> Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0) &&
+            while (!((IInvokableInstance) cluster.get(1)).callOnInstance(() -> Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0) &&
                                                                                  !Gossiper.instance.isUpgradingFromVersionLowerThan(new CassandraVersion(("3.0")).familyLowerBound.get())))
             {
                 if (attempts++ > 90)

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CompactTableTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CompactTableTest.java
@@ -112,4 +112,21 @@ public class CompactTableTest extends CQLTester
         assertRows(execute("SELECT * FROM %s WHERE pk = ?",2),
                    row(2, 2, null, 2));
     }
+
+    @Test
+    public void testColumnDeletionWithCompactTableWithMultipleColumns() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int PRIMARY KEY, v1 int, v2 int) WITH COMPACT STORAGE");
+
+        execute("INSERT INTO %s (pk, v1, v2) VALUES (1, 1, 1) USING TIMESTAMP 1000");
+        flush();
+        execute("INSERT INTO %s (pk, v1) VALUES (1, 2) USING TIMESTAMP 2000");
+        flush();
+        execute("DELETE v1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1");
+        flush();
+
+        assertRows(execute("SELECT * FROM %s WHERE pk=1"), row(1, null, 1));
+        assertRows(execute("SELECT v1, v2 FROM %s WHERE pk=1"), row((Integer) null, 1));
+        assertRows(execute("SELECT v1 FROM %s WHERE pk=1"), row((Integer) null)); // <-fail
+    }
 }

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CompactTableTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CompactTableTest.java
@@ -126,7 +126,7 @@ public class CompactTableTest extends CQLTester
         flush();
 
         assertRows(execute("SELECT * FROM %s WHERE pk=1"), row(1, null, 1));
-        assertRows(execute("SELECT v1, v2 FROM %s WHERE pk=1"), row((Integer) null, 1));
-        assertRows(execute("SELECT v1 FROM %s WHERE pk=1"), row((Integer) null)); // <-fail
+        assertRows(execute("SELECT v1, v2 FROM %s WHERE pk=1"), row(null, 1));
+        assertRows(execute("SELECT v1 FROM %s WHERE pk=1"), row((Integer) null));
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/DeleteTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/DeleteTest.java
@@ -1462,8 +1462,10 @@ public class DeleteTest extends CQLTester
         flush();
 
         assertRows(execute("SELECT * FROM %s WHERE pk=1"), row(1, 1, null, 1, 1));
-        assertRows(execute("SELECT s1, s2 FROM %s WHERE pk=1"), row((Integer) null, 1));
+        assertRows(execute("SELECT s1, s2 FROM %s WHERE pk=1"), row(null, 1));
         assertRows(execute("SELECT s1 FROM %s WHERE pk=1"), row((Integer) null));
+        assertRows(execute("SELECT DISTINCT s1, s2 FROM %s WHERE pk=1"), row(null, 1));
+        assertRows(execute("SELECT DISTINCT s1 FROM %s WHERE pk=1"), row((Integer) null));
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/DeleteTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/DeleteTest.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQLTester;
@@ -33,7 +31,6 @@ import org.apache.cassandra.db.Keyspace;
 
 import static org.apache.cassandra.utils.ByteBufferUtil.EMPTY_BYTE_BUFFER;
 import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -1423,6 +1420,51 @@ public class DeleteTest extends CQLTester
         execute("DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 0, 2);
     }
 
+    @Test
+    public void testStaticColumnDeletionWithMultipleStaticColumns() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, s1 int static, s2 int static, v int, PRIMARY KEY(pk, ck))");
+
+        execute("INSERT INTO %s (pk, s1, s2) VALUES (1, 1, 1) USING TIMESTAMP 1000");
+        flush();
+        execute("INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000");
+        flush();
+        execute("DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1");
+        flush();
+
+        assertRows(execute("SELECT * FROM %s WHERE pk=1"), row(1, null, null, 1, null));
+        assertRows(execute("SELECT pk, s1, s2 FROM %s WHERE pk=1"), row(1, (Integer) null, 1));
+        assertRows(execute("SELECT s1, s2 FROM %s WHERE pk=1"), row((Integer) null, 1));
+        assertRows(execute("SELECT pk, s1 FROM %s WHERE pk=1"), row(1, (Integer) null)); 
+        assertRows(execute("SELECT s1 FROM %s WHERE pk=1"), row((Integer) null));
+        assertRows(execute("SELECT pk, s2 FROM %s WHERE pk=1"), row(1, 1));
+        assertRows(execute("SELECT s2 FROM %s WHERE pk=1"), row(1));
+        assertRows(execute("SELECT pk, ck FROM %s WHERE pk=1"), row(1, null));
+        assertRows(execute("SELECT ck FROM %s WHERE pk=1"), row((Integer) null));
+        assertRows(execute("SELECT DISTINCT pk, s1, s2 FROM %s WHERE pk=1"), row(1, (Integer) null, 1));
+        assertRows(execute("SELECT DISTINCT s1, s2 FROM %s WHERE pk=1"), row((Integer) null, 1));
+        assertRows(execute("SELECT DISTINCT pk, s1 FROM %s WHERE pk=1"), row(1, (Integer) null));
+        assertRows(execute("SELECT DISTINCT pk, s2 FROM %s WHERE pk=1"), row(1, 1));
+        assertRows(execute("SELECT DISTINCT s1 FROM %s WHERE pk=1"), row((Integer) null));
+        assertRows(execute("SELECT DISTINCT s2 FROM %s WHERE pk=1"), row(1));
+    }
+
+    @Test
+    public void testStaticColumnDeletionWithMultipleStaticColumnsAndRegularColumns() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, s1 int static, s2 int static, v int, PRIMARY KEY(pk, ck))");
+
+        execute("INSERT INTO %s (pk, ck, v, s2) VALUES (1, 1, 1, 1) USING TIMESTAMP 1000");
+        flush();
+        execute("INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000");
+        flush();
+        execute("DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1");
+        flush();
+
+        assertRows(execute("SELECT * FROM %s WHERE pk=1"), row(1, 1, null, 1, 1));
+        assertRows(execute("SELECT s1, s2 FROM %s WHERE pk=1"), row((Integer) null, 1));
+        assertRows(execute("SELECT s1 FROM %s WHERE pk=1"), row((Integer) null));
+    }
 
     /**
      * Checks if the memtable is empty or not

--- a/test/unit/org/apache/cassandra/db/ReadCommandTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandTest.java
@@ -328,7 +328,7 @@ public class ReadCommandTest
 
         List<ByteBuffer> buffers = new ArrayList<>(groups.length);
         int nowInSeconds = FBUtilities.nowInSeconds();
-        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata()).build();
+        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata(), false).build();
         RowFilter rowFilter = RowFilter.create();
         Slice slice = Slice.make(BufferClusteringBound.BOTTOM, BufferClusteringBound.TOP);
         ClusteringIndexSliceFilter sliceFilter = new ClusteringIndexSliceFilter(Slices.with(cfs.metadata().comparator, slice), false);
@@ -495,7 +495,7 @@ public class ReadCommandTest
 
         List<ByteBuffer> buffers = new ArrayList<>(groups.length);
         int nowInSeconds = FBUtilities.nowInSeconds();
-        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata()).build();
+        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata(), false).build();
         RowFilter rowFilter = RowFilter.create();
         Slice slice = Slice.make(BufferClusteringBound.BOTTOM, BufferClusteringBound.TOP);
         ClusteringIndexSliceFilter sliceFilter = new ClusteringIndexSliceFilter(
@@ -571,7 +571,7 @@ public class ReadCommandTest
 
         List<ByteBuffer> buffers = new ArrayList<>(groups.length);
         int nowInSeconds = FBUtilities.nowInSeconds();
-        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata()).build();
+        ColumnFilter columnFilter = ColumnFilter.allRegularColumnsBuilder(cfs.metadata(), false).build();
         RowFilter rowFilter = RowFilter.create();
         Slice slice = Slice.make(BufferClusteringBound.BOTTOM, BufferClusteringBound.TOP);
         ClusteringIndexSliceFilter sliceFilter = new ClusteringIndexSliceFilter(

--- a/test/unit/org/apache/cassandra/db/SSTableAndMemTableDigestMatchTest.java
+++ b/test/unit/org/apache/cassandra/db/SSTableAndMemTableDigestMatchTest.java
@@ -154,14 +154,16 @@ public class SSTableAndMemTableDigestMatchTest extends CQLTester
     private void testWithFilterAndStaticColumnsOnly(Function<TableMetadata, ColumnFilter> filterFactory) throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, ck int, s1 int static, s2 int static, v int, PRIMARY KEY(pk, ck))");
-        execute("INSERT INTO %s (pk, s1, s2) VALUES (1, 1, 1) USING TIMESTAMP 1000");
-        flush();
-        execute("INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000");
-        flush();
-        execute("DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1");
-        flush();
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+
+        execute("INSERT INTO %s (pk, s1, s2) VALUES (1, 1, 1) USING TIMESTAMP 1000");
+        assertDigestsAreEqualsBeforeAndAfterFlush(filterFactory.apply(cfs.metadata()));
+
+        execute("INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000");
+        assertDigestsAreEqualsBeforeAndAfterFlush(filterFactory.apply(cfs.metadata()));
+
+        execute("DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1");
         assertDigestsAreEqualsBeforeAndAfterFlush(filterFactory.apply(cfs.metadata()));
     }
 

--- a/test/unit/org/apache/cassandra/db/SSTableAndMemTableDigestMatchTest.java
+++ b/test/unit/org/apache/cassandra/db/SSTableAndMemTableDigestMatchTest.java
@@ -57,21 +57,21 @@ public class SSTableAndMemTableDigestMatchTest extends CQLTester
     public void testSelectNoColumns() throws Throwable
     {
         testWithFilter(tableMetadata ->
-                       ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.builder().build()));
+                       ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.builder().build(), false));
     }
 
     @Test
     public void testSelectEmptyColumn() throws Throwable
     {
         testWithFilter(tableMetadata ->
-                       ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("e", false)))));
+                       ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("e", false))), false));
     }
 
     @Test
     public void testSelectNonEmptyColumn() throws Throwable
     {
         testWithFilter(tableMetadata ->
-                       ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("v1", false)))));
+                       ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("v1", false))), false));
     }
 
     @Test
@@ -82,7 +82,8 @@ public class SSTableAndMemTableDigestMatchTest extends CQLTester
                                               RegularAndStaticColumns.builder()
                                                                      .add(tableMetadata.getColumn(ColumnIdentifier.getInterned("v1", false)))
                                                                      .add(tableMetadata.getColumn(ColumnIdentifier.getInterned("v2", false)))
-                                                                     .build()));
+                                                                     .build(),
+                                              false));
     }
 
     @Test
@@ -106,6 +107,39 @@ public class SSTableAndMemTableDigestMatchTest extends CQLTester
                                                                                CellPath.create(Int32Type.instance.decompose(5))).build());
     }
 
+    @Test
+    public void testSelectRegularColumnOnPartitionWithOnlyStaticData() throws Throwable
+    {
+        testWithFilterAndStaticColumnsOnly(tableMetadata ->
+                                           ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("v", false))), false));
+        testWithFilterAndStaticColumnsOnly(tableMetadata ->
+                                           ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("v", false))), true));
+    }
+
+    @Test
+    public void testSelectStaticColumnOnPartitionWithOnlyStaticData() throws Throwable
+    {
+        testWithFilterAndStaticColumnsOnly(tableMetadata ->
+                                           ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("s2", false))), false));
+        testWithFilterAndStaticColumnsOnly(tableMetadata ->
+                                           ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("s2", false))), true));
+    }
+
+    @Test
+    public void testSelectNullStaticColumnOnPartitionWithOnlyStaticData() throws Throwable
+    {
+        testWithFilterAndStaticColumnsOnly(tableMetadata ->
+                                           ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("s1", false))), false));
+        testWithFilterAndStaticColumnsOnly(tableMetadata ->
+                                           ColumnFilter.selection(tableMetadata, RegularAndStaticColumns.of(tableMetadata.getColumn(ColumnIdentifier.getInterned("s1", false))), true));
+    }
+
+    @Test
+    public void testSelectAllColumnsOnPartitionWithOnlyStaticData() throws Throwable
+    {
+        testWithFilterAndStaticColumnsOnly(tableMetadata -> ColumnFilter.all(tableMetadata));
+    }
+
     private void testWithFilter(Function<TableMetadata, ColumnFilter> filterFactory) throws Throwable
     {
         Map<Integer, Integer> m = new HashMap<>();
@@ -114,19 +148,39 @@ public class SSTableAndMemTableDigestMatchTest extends CQLTester
         execute("INSERT INTO %s (k, v1, v2, m) values (?, ?, ?, ?) USING TIMESTAMP ?", 1, 2, 3, m, writeTime);
 
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
-        ColumnFilter filter = filterFactory.apply(cfs.metadata());
-        String digest1 = getDigest(filter);
+        assertDigestsAreEqualsBeforeAndAfterFlush(filterFactory.apply(cfs.metadata()), Clustering.EMPTY);
+    }
+
+    private void testWithFilterAndStaticColumnsOnly(Function<TableMetadata, ColumnFilter> filterFactory) throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck int, s1 int static, s2 int static, v int, PRIMARY KEY(pk, ck))");
+        execute("INSERT INTO %s (pk, s1, s2) VALUES (1, 1, 1) USING TIMESTAMP 1000");
         flush();
-        String digest2 = getDigest(filter);
+        execute("INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000");
+        flush();
+        execute("DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1");
+        flush();
+
+        ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
+        assertDigestsAreEqualsBeforeAndAfterFlush(filterFactory.apply(cfs.metadata()));
+    }
+
+    private void assertDigestsAreEqualsBeforeAndAfterFlush(ColumnFilter filter, Clustering<?>... clusterings)
+    {
+        String digest1 = getDigest(filter, clusterings);
+        flush();
+        String digest2 = getDigest(filter, clusterings);
 
         assertEquals(digest1, digest2);
     }
 
-    private String getDigest(ColumnFilter filter)
+    
+    private String getDigest(ColumnFilter filter, Clustering<?>... clusterings)
     {
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
-        NavigableSet<Clustering<?>> clusterings = Sets.newTreeSet(new ClusteringComparator());
-        clusterings.add(Clustering.EMPTY);
+        NavigableSet<Clustering<?>> clusteringSet = Sets.newTreeSet(new ClusteringComparator());
+        for (Clustering<?> clustering : clusterings)
+            clusteringSet.add(clustering);
         BufferDecoratedKey key = new BufferDecoratedKey(DatabaseDescriptor.getPartitioner().getToken(Int32Type.instance.decompose(1)),
                                                         Int32Type.instance.decompose(1));
         SinglePartitionReadCommand cmd = SinglePartitionReadCommand
@@ -134,7 +188,7 @@ public class SSTableAndMemTableDigestMatchTest extends CQLTester
                                                  (int) (System.currentTimeMillis() / 1000),
                                                  key,
                                                  filter,
-                                                 new ClusteringIndexNamesFilter(clusterings, false)).copyAsDigestQuery();
+                                                 new ClusteringIndexNamesFilter(clusteringSet, false)).copyAsDigestQuery();
         cmd.setDigestVersion(MessagingService.current_version);
         ReadResponse resp;
         try (ReadExecutionController ctrl = ReadExecutionController.forCommand(cmd); UnfilteredRowIterator iterator = cmd.queryMemtableAndDisk(cfs, ctrl))

--- a/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
@@ -345,20 +345,11 @@ public class ColumnFilterTest
                 assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
             }
-            else if ("3.11".equals(clusterMinVersion))
+            else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
             {
                 assertEquals("*/[v1]", filter.toString());
                 assertEquals("v1", filter.toCQLString());
                 assertFetchedQueried(true, false, filter, s1, s2, v2);
-                assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
-                assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
-            }
-            else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
-            {
-                assertEquals("*/[v1]", filter.toString());
-                assertEquals("v1", filter.toCQLString());
-                assertFetchedQueried(true, false, filter, v2);
-                assertFetchedQueried(true, false, filter, s1, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
             }
@@ -402,22 +393,13 @@ public class ColumnFilterTest
                 assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
             }
-            else if ("3.11".equals(clusterMinVersion))
+            else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
             {
                 assertEquals("*/[s1]", filter.toString());
                 assertEquals("s1", filter.toCQLString());
                 assertFetchedQueried(true, false, filter, v1, v2, s2);
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
-            }
-            else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
-            {
-                assertEquals("*/[s1]", filter.toString());
-                assertEquals("s1", filter.toCQLString());
-                assertFetchedQueried(true, false, filter, v1, v2);
-                assertFetchedQueried(true, false, filter, s2);
-                assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
-                assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
             }
             else
             {
@@ -461,7 +443,7 @@ public class ColumnFilterTest
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
         }
-        else if ("3.11".equals(clusterMinVersion))
+        else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
         {
             assertEquals("*/[v2[1]]", filter.toString());
             assertEquals("v2[1]", filter.toCQLString());
@@ -469,16 +451,6 @@ public class ColumnFilterTest
             assertCellFetchedQueried(true, true, filter, v2, path1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
             assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
-        }
-        else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
-        {
-            assertEquals("*/[v2[1]]", filter.toString());
-            assertEquals("v2[1]", filter.toCQLString());
-            assertFetchedQueried(true, false, filter, v1);
-            assertFetchedQueried(true, false, filter, s1, s2);
-            assertCellFetchedQueried(true, true, filter, v2, path1);
-            assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
-            assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
         }
         else
         {
@@ -504,7 +476,7 @@ public class ColumnFilterTest
         testSelectStaticColumnCellWithMetadata(true);
     }
 
-    public void testSelectStaticColumnCellWithMetadata(boolean returnStaticContentOnPartitionWithNoRows)
+    private void testSelectStaticColumnCellWithMetadata(boolean returnStaticContentOnPartitionWithNoRows)
     {
         ColumnFilter filter = ColumnFilter.allRegularColumnsBuilder(metadata, returnStaticContentOnPartitionWithNoRows)
                                           .select(s2, path1)
@@ -519,22 +491,12 @@ public class ColumnFilterTest
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path1, path0, path2, path3, path4);
         }
-        else if ("3.11".equals(clusterMinVersion))
+        else if ("3.11".equals(clusterMinVersion) || (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion)))
         {
             assertEquals("*/[s2[1]]", filter.toString());
             assertEquals("s2[1]", filter.toCQLString());
             assertFetchedQueried(true, false, filter, v1, v2, s1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
-            assertCellFetchedQueried(true, true, filter, s2, path1);
-            assertCellFetchedQueried(true, false, filter, s2, path0, path2, path3, path4);
-        }
-        else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
-        {
-            assertEquals("*/[s2[1]]", filter.toString());
-            assertEquals("s2[1]", filter.toCQLString());
-            assertFetchedQueried(true, false, filter, v1, v2);
-            assertFetchedQueried(true, false, filter, s1);
-            assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path1);
             assertCellFetchedQueried(true, false, filter, s2, path0, path2, path3, path4);
         }

--- a/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
+++ b/test/unit/org/apache/cassandra/db/filter/ColumnFilterTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.db.RegularAndStaticColumns;
+
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.rows.CellPath;
@@ -85,7 +86,7 @@ public class ColumnFilterTest
     @Parameterized.Parameters(name = "{index}: clusterMinVersion={0}")
     public static Collection<Object[]> data()
     {
-        return Arrays.asList(new Object[]{ "3.0" }, new Object[]{ "3.11" }, new Object[]{ "4.0" });
+        return Arrays.asList(new Object[]{ "3.0" }, new Object[]{ "3.11" }, new Object[]{ "4.0-rc1" }, new Object[]{ "4.0" });
     }
 
     @BeforeClass
@@ -117,7 +118,8 @@ public class ColumnFilterTest
         };
 
         check.accept(ColumnFilter.all(metadata));
-        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata).build());
+        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata, false).build());
+        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata, true).build());
     }
 
     // Selections
@@ -321,6 +323,17 @@ public class ColumnFilterTest
     @Test
     public void testSelectSimpleColumnWithMetadata()
     {
+        testSelectSimpleColumnWithMetadata(false);
+    }
+
+    @Test
+    public void testSelectSimpleColumnWithMetadataAndReturnStaticContentOnPartitionWithNoRows()
+    {
+        testSelectSimpleColumnWithMetadata(true);
+    }
+
+    private void testSelectSimpleColumnWithMetadata(boolean returnStaticContentOnPartitionWithNoRows)
+    {
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
             assertFetchedQueried(true, true, filter, v1);
@@ -340,6 +353,15 @@ public class ColumnFilterTest
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
             }
+            else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
+            {
+                assertEquals("*/[v1]", filter.toString());
+                assertEquals("v1", filter.toCQLString());
+                assertFetchedQueried(true, false, filter, v2);
+                assertFetchedQueried(true, false, filter, s1, s2);
+                assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
+                assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
+            }
             else
             {
                 assertEquals("<all regulars>/[v1]", filter.toString());
@@ -351,12 +373,23 @@ public class ColumnFilterTest
             }
         };
 
-        check.accept(ColumnFilter.selection(metadata, RegularAndStaticColumns.builder().add(v1).build()));
-        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata).add(v1).build());
+        check.accept(ColumnFilter.selection(metadata, RegularAndStaticColumns.builder().add(v1).build(), returnStaticContentOnPartitionWithNoRows));
+        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata, returnStaticContentOnPartitionWithNoRows).add(v1).build());
     }
 
     @Test
     public void testSelectStaticColumnWithMetadata()
+    {
+        testSelectStaticColumnWithMetadata(false);
+    }
+
+    @Test
+    public void testSelectStaticColumnWithMetadataAndReturnStaticContentOnPartitionWithNoRows()
+    {
+        testSelectStaticColumnWithMetadata(true);
+    }
+
+    private void testSelectStaticColumnWithMetadata(boolean returnStaticContentOnPartitionWithNoRows)
     {
         Consumer<ColumnFilter> check = filter -> {
             testRoundTrips(filter);
@@ -377,6 +410,15 @@ public class ColumnFilterTest
                 assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
                 assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
             }
+            else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
+            {
+                assertEquals("*/[s1]", filter.toString());
+                assertEquals("s1", filter.toCQLString());
+                assertFetchedQueried(true, false, filter, v1, v2);
+                assertFetchedQueried(true, false, filter, s2);
+                assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
+                assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
+            }
             else
             {
                 assertEquals("<all regulars>+[s1]/[s1]", filter.toString());
@@ -388,14 +430,27 @@ public class ColumnFilterTest
             }
         };
 
-        check.accept(ColumnFilter.selection(metadata, RegularAndStaticColumns.builder().add(s1).build()));
-        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata).add(s1).build());
+        check.accept(ColumnFilter.selection(metadata, RegularAndStaticColumns.builder().add(s1).build(), returnStaticContentOnPartitionWithNoRows));
+        check.accept(ColumnFilter.allRegularColumnsBuilder(metadata, returnStaticContentOnPartitionWithNoRows).add(s1).build());
     }
 
     @Test
     public void testSelectCellWithMetadata()
     {
-        ColumnFilter filter = ColumnFilter.allRegularColumnsBuilder(metadata).select(v2, path1).build();
+        testSelectCellWithMetadata(false);
+    }
+
+    @Test
+    public void testSelectCellWithMetadataAndReturnStaticContentOnPartitionWithNoRows()
+    {
+        testSelectCellWithMetadata(true);
+    }
+
+    private void testSelectCellWithMetadata(boolean returnStaticContentOnPartitionWithNoRows)
+    {
+        ColumnFilter filter = ColumnFilter.allRegularColumnsBuilder(metadata, returnStaticContentOnPartitionWithNoRows)
+                                          .select(v2, path1)
+                                          .build();
         testRoundTrips(filter);
         assertFetchedQueried(true, true, filter, v2);
         if ("3.0".equals(clusterMinVersion))
@@ -403,8 +458,7 @@ public class ColumnFilterTest
             assertEquals("*/*", filter.toString());
             assertEquals("*", filter.toCQLString());
             assertFetchedQueried(true, true, filter, s1, s2, v1);
-            assertCellFetchedQueried(true, true, filter, v2, path1);
-            assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
+            assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path0, path1, path2, path3, path4);
         }
         else if ("3.11".equals(clusterMinVersion))
@@ -415,6 +469,16 @@ public class ColumnFilterTest
             assertCellFetchedQueried(true, true, filter, v2, path1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
             assertCellFetchedQueried(true, false, filter, s2, path0, path1, path2, path3, path4);
+        }
+        else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
+        {
+            assertEquals("*/[v2[1]]", filter.toString());
+            assertEquals("v2[1]", filter.toCQLString());
+            assertFetchedQueried(true, false, filter, v1);
+            assertFetchedQueried(true, false, filter, s1, s2);
+            assertCellFetchedQueried(true, true, filter, v2, path1);
+            assertCellFetchedQueried(true, false, filter, v2, path0, path2, path3, path4);
+            assertCellFetchedQueried(false, false, filter, s2, path0, path1, path2, path3, path4);
         }
         else
         {
@@ -431,7 +495,20 @@ public class ColumnFilterTest
     @Test
     public void testSelectStaticColumnCellWithMetadata()
     {
-        ColumnFilter filter = ColumnFilter.allRegularColumnsBuilder(metadata).select(s2, path1).build();
+        testSelectStaticColumnCellWithMetadata(false);
+    }
+
+    @Test
+    public void testSelectStaticColumnCellWithMetadataAndReturnStaticContentOnPartitionWithNoRows()
+    {
+        testSelectStaticColumnCellWithMetadata(true);
+    }
+
+    public void testSelectStaticColumnCellWithMetadata(boolean returnStaticContentOnPartitionWithNoRows)
+    {
+        ColumnFilter filter = ColumnFilter.allRegularColumnsBuilder(metadata, returnStaticContentOnPartitionWithNoRows)
+                                          .select(s2, path1)
+                                          .build();
         testRoundTrips(filter);
         assertFetchedQueried(true, true, filter, s2);
         if ("3.0".equals(clusterMinVersion))
@@ -440,8 +517,7 @@ public class ColumnFilterTest
             assertEquals("*", filter.toCQLString());
             assertFetchedQueried(true, true, filter, v1, v2, s1);
             assertCellFetchedQueried(true, true, filter, v2, path0, path1, path2, path3, path4);
-            assertCellFetchedQueried(true, true, filter, s2, path1);
-            assertCellFetchedQueried(true, false, filter, s2, path0, path2, path3, path4);  // TODO ???
+            assertCellFetchedQueried(true, true, filter, s2, path1, path0, path2, path3, path4);
         }
         else if ("3.11".equals(clusterMinVersion))
         {
@@ -449,6 +525,16 @@ public class ColumnFilterTest
             assertEquals("s2[1]", filter.toCQLString());
             assertFetchedQueried(true, false, filter, v1, v2, s1);
             assertCellFetchedQueried(true, false, filter, v2, path0, path1, path2, path3, path4);
+            assertCellFetchedQueried(true, true, filter, s2, path1);
+            assertCellFetchedQueried(true, false, filter, s2, path0, path2, path3, path4);
+        }
+        else if (returnStaticContentOnPartitionWithNoRows && "4.0".equals(clusterMinVersion))
+        {
+            assertEquals("*/[s2[1]]", filter.toString());
+            assertEquals("s2[1]", filter.toCQLString());
+            assertFetchedQueried(true, false, filter, v1, v2);
+            assertFetchedQueried(true, false, filter, s1);
+            assertCellFetchedQueried(false, false, filter, v2, path0, path1, path2, path3, path4);
             assertCellFetchedQueried(true, true, filter, s2, path1);
             assertCellFetchedQueried(true, false, filter, s2, path0, path2, path3, path4);
         }
@@ -481,13 +567,13 @@ public class ColumnFilterTest
             DataInputPlus input = new DataInputBuffer(output.buffer(), false);
             ColumnFilter deserialized = serializer.deserialize(input, version, metadata);
 
-            if (!clusterMinVersion.equals("4.0") || version != MessagingService.VERSION_30 || !columnFilter.fetchAllRegulars)
+            if (version == MessagingService.VERSION_30 && columnFilter.fetchesAllColumns(false))
             {
-                Assert.assertEquals(deserialized, columnFilter);
+                Assert.assertEquals(metadata.regularAndStaticColumns(), deserialized.fetchedColumns());
             }
             else
             {
-                Assert.assertEquals(deserialized.fetched, metadata.regularAndStaticColumns());
+                Assert.assertEquals(deserialized, columnFilter);
             }
         }
         catch (IOException e)

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
@@ -115,7 +116,7 @@ public class GossiperTest
 
         VersionedValue.VersionedValueFactory factory = new VersionedValue.VersionedValueFactory(null);
         EndpointState es = new EndpointState((HeartBeatState) null);
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion("4.0-SNAPSHOT"));
+        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
         Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.1"), es);
         Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.1"));
 


### PR DESCRIPTION
When an CQL query is done at the partition level (without clustering or regular column restrictions), if a partition does not contains any row but contains some static columns a row will be returned to the user with null values for all the clustering and regular columns.
Since CASSANDRA-12768, Cassandra fetch all the regular columns but only the static columns that have been selected by the user. By consequence, Cassandra will fetch only s1 for the SELECT s1 FROM %s WHERE pk=1 query from the description example. Due to that it will NOT attempt to fetch the s2 value and will look only at the third and second SSTables. The partition having no value for s1 Cassandra will consider the partition empty and will not return a row for it as it should. 

The patch fix the issue by adding all the static columns to the fetched columns when the query is at the partition level (without clustering or regular column restrictions). Unfortunately as 4.0-rc1 has been released we need to ensure backward compatibility with it in a mixed cluster environment. To ensure that some extra changes were required in ColumnFilter and in Gossiper.  