### PR TITLE
CASSANDRA-16663 Request-Based Native Transport Rate-Limiting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 2
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -130,10 +130,10 @@ jobs:
   repeated_jvm_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -305,10 +305,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -400,10 +400,10 @@ jobs:
   j11_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -510,10 +510,10 @@ jobs:
   repeated_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -632,10 +632,10 @@ jobs:
   j8_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -727,10 +727,10 @@ jobs:
   j11_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -823,10 +823,10 @@ jobs:
   j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -919,10 +919,10 @@ jobs:
   j11_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1015,10 +1015,10 @@ jobs:
   j8_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1110,10 +1110,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1205,10 +1205,10 @@ jobs:
   j11_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1350,10 +1350,10 @@ jobs:
   j8_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1472,10 +1472,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1568,10 +1568,10 @@ jobs:
   j11_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1667,10 +1667,10 @@ jobs:
   j8_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1743,10 +1743,10 @@ jobs:
   j8_upgradetests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1819,7 +1819,7 @@ jobs:
   utests_stress:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -1882,10 +1882,10 @@ jobs:
   j8_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1991,10 +1991,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 2
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2200,10 +2200,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2351,10 +2351,10 @@ jobs:
   j11_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2527,10 +2527,10 @@ jobs:
   j8_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2603,10 +2603,10 @@ jobs:
   j11_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2699,10 +2699,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 5
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2906,10 +2906,10 @@ jobs:
   j8_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3001,10 +3001,10 @@ jobs:
   j8_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3096,7 +3096,7 @@ jobs:
   utests_long:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3159,10 +3159,10 @@ jobs:
   utests_system_keyspace_directory:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3322,7 +3322,7 @@ jobs:
   utests_fqltool:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3385,10 +3385,10 @@ jobs:
   j11_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3484,10 +3484,10 @@ jobs:
   utests_compression:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3593,10 +3593,10 @@ jobs:
   j8_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -34,8 +34,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.audit.AuditLogOptions;
-import org.apache.cassandra.fql.FullQueryLoggerOptions;
 import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.fql.FullQueryLoggerOptions;
 
 /**
  * A class that contains configuration properties for the cassandra node it runs within.
@@ -193,6 +193,8 @@ public class Config
     public volatile boolean native_transport_allow_older_protocols = true;
     public volatile long native_transport_max_concurrent_requests_in_bytes_per_ip = -1L;
     public volatile long native_transport_max_concurrent_requests_in_bytes = -1L;
+    public volatile boolean native_transport_rate_limiting_enabled = false;
+    public volatile int native_transport_max_requests_per_second = 1000000;
     public int native_transport_receive_queue_capacity_in_bytes = 1 << 20; // 1MiB
 
     @Deprecated

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -540,6 +540,11 @@ public class DatabaseDescriptor
         {
             conf.native_transport_max_concurrent_requests_in_bytes_per_ip = Runtime.getRuntime().maxMemory() / 40;
         }
+        
+        if (conf.native_transport_rate_limiting_enabled)
+            logger.info("Native transport rate-limiting enabled at {} requests/second.", conf.native_transport_max_requests_per_second);
+        else
+            logger.info("Native transport rate-limiting disabled.");
 
         if (conf.commitlog_total_space_in_mb == null)
         {
@@ -2322,6 +2327,28 @@ public class DatabaseDescriptor
     public static void setNativeTransportMaxConcurrentRequestsInBytes(long maxConcurrentRequestsInBytes)
     {
         conf.native_transport_max_concurrent_requests_in_bytes = maxConcurrentRequestsInBytes;
+    }
+
+    public static int getNativeTransportMaxRequestsPerSecond()
+    {
+        return conf.native_transport_max_requests_per_second;
+    }
+
+    public static void setNativeTransportMaxRequestsPerSecond(int perSecond)
+    {
+        Preconditions.checkArgument(perSecond > 0, "native_transport_max_requests_per_second must be greater than zero");
+        conf.native_transport_max_requests_per_second = perSecond;
+    }
+
+    public static void setNativeTransportRateLimitingEnabled(boolean enabled)
+    {
+        logger.info("native_transport_rate_limiting_enabled set to {}", enabled);
+        conf.native_transport_rate_limiting_enabled = enabled;
+    }
+
+    public static boolean getNativeTransportRateLimitingEnabled()
+    {
+        return conf.native_transport_rate_limiting_enabled;
     }
 
     public static int getCommitLogSyncPeriod()

--- a/src/java/org/apache/cassandra/net/FrameDecoder.java
+++ b/src/java/org/apache/cassandra/net/FrameDecoder.java
@@ -191,6 +191,14 @@ public abstract class FrameDecoder extends ChannelInboundHandlerAdapter
     abstract void addLastTo(ChannelPipeline pipeline);
 
     /**
+     * @return true if we are actively decoding and processing frames
+     */
+    public boolean isActive()
+    {
+        return isActive;
+    }
+    
+    /**
      * For use by InboundMessageHandler (or other upstream handlers) that want to start receiving frames.
      */
     public void activate(FrameProcessor processor)
@@ -208,7 +216,7 @@ public abstract class FrameDecoder extends ChannelInboundHandlerAdapter
      * For use by InboundMessageHandler (or other upstream handlers) that want to resume
      * receiving frames after previously indicating that processing should be paused.
      */
-    void reactivate() throws IOException
+    public void reactivate() throws IOException
     {
         if (isActive)
             throw new IllegalStateException("Tried to reactivate an already active FrameDecoder");
@@ -282,7 +290,8 @@ public abstract class FrameDecoder extends ChannelInboundHandlerAdapter
     {
         decode(frames, bytes);
 
-        if (isActive) isActive = deliver(processor);
+        if (isActive)
+            isActive = deliver(processor);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/net/InboundMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandler.java
@@ -34,8 +34,6 @@ import org.apache.cassandra.exceptions.IncompatibleSchemaException;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message.Header;
-import org.apache.cassandra.net.FrameDecoder.Frame;
-import org.apache.cassandra.net.FrameDecoder.FrameProcessor;
 import org.apache.cassandra.net.FrameDecoder.IntactFrame;
 import org.apache.cassandra.net.FrameDecoder.CorruptFrame;
 import org.apache.cassandra.net.ResourceLimits.Limit;

--- a/src/java/org/apache/cassandra/net/ResourceLimits.java
+++ b/src/java/org/apache/cassandra/net/ResourceLimits.java
@@ -41,7 +41,7 @@ public abstract class ResourceLimits
          * Sets the total amount of permits represented by this {@link Limit} - the capacity
          *
          * If the old limit has been reached and the new limit is large enough to allow for more
-         * permits to be aqcuired, subsequent calls to {@link #allocate(long)} or {@link #tryAllocate(long)}
+         * permits to be acquired, subsequent calls to {@link #allocate(long)} or {@link #tryAllocate(long)}
          * will succeed.
          *
          * If the new limit is lower than the current amount of allocated permits then subsequent calls
@@ -163,7 +163,7 @@ public abstract class ResourceLimits
                 // possible it would require synchronizing the closing of all outbound connections
                 // and reinitializing the Concurrent limit before reopening.  For such an unlikely path
                 // (previously this was an assert), it is safer to terminate the JVM and have something external
-                // restart and get back to a known good state rather than intermittendly crashing on any of
+                // restart and get back to a known good state rather than intermittently crashing on any of
                 // the connections sharing this limit.
                 throw new UnrecoverableIllegalStateException(
                     "Internode messaging byte limits that are shared between connections is invalid (using="+using+")");

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5860,6 +5860,30 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         ClientResourceLimits.setEndpointLimit(newLimit);
     }
 
+    @Override
+    public int getNativeTransportMaxRequestsPerSecond()
+    {
+        return ClientResourceLimits.getNativeTransportMaxRequestsPerSecond();
+    }
+
+    @Override
+    public void setNativeTransportMaxRequestsPerSecond(int newPerSecond)
+    {
+        ClientResourceLimits.setNativeTransportMaxRequestsPerSecond(newPerSecond);
+    }
+
+    @Override
+    public void setNativeTransportRateLimitingEnabled(boolean enabled)
+    {
+        DatabaseDescriptor.setNativeTransportRateLimitingEnabled(enabled);
+    }
+
+    @Override
+    public boolean getNativeTransportRateLimitingEnabled()
+    {
+        return DatabaseDescriptor.getNativeTransportRateLimitingEnabled();
+    }
+
     @VisibleForTesting
     public void shutdownServer()
     {

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -35,7 +35,6 @@ import javax.management.openmbean.TabularData;
 
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.cassandra.locator.InetAddressAndPort;
 
 public interface StorageServiceMBean extends NotificationEmitter
 {
@@ -556,7 +555,10 @@ public interface StorageServiceMBean extends NotificationEmitter
     public void setNativeTransportMaxConcurrentRequestsInBytes(long newLimit);
     public long getNativeTransportMaxConcurrentRequestsInBytesPerIp();
     public void setNativeTransportMaxConcurrentRequestsInBytesPerIp(long newLimit);
-
+    public int getNativeTransportMaxRequestsPerSecond();
+    public void setNativeTransportMaxRequestsPerSecond(int newPerSecond);
+    public void setNativeTransportRateLimitingEnabled(boolean enabled);
+    public boolean getNativeTransportRateLimitingEnabled();
 
     // allows a node that have been started without joining the ring to join it
     public void joinRing() throws IOException;

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -20,7 +20,11 @@ package org.apache.cassandra.transport;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
@@ -30,15 +34,19 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.ClientResourceLimits.Overload;
 import org.apache.cassandra.transport.Flusher.FlushItem;
 import org.apache.cassandra.transport.messages.ErrorMessage;
 import org.apache.cassandra.transport.messages.EventMessage;
 import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.apache.cassandra.utils.NoSpamLogger;
 
 import static org.apache.cassandra.concurrent.SharedExecutorPool.SHARED;
 
 public class Dispatcher
 {
+    private static final Logger logger = LoggerFactory.getLogger(Dispatcher.class);
+    
     private static final LocalAwareExecutorService requestExecutor = SHARED.newExecutor(DatabaseDescriptor.getNativeTransportMaxThreads(),
                                                                                         DatabaseDescriptor::setNativeTransportMaxThreads,
                                                                                         "transport",
@@ -65,19 +73,36 @@ public class Dispatcher
         this.useLegacyFlusher = useLegacyFlusher;
     }
 
-    public void dispatch(Channel channel, Message.Request request, FlushItemConverter forFlusher)
+    public void dispatch(Channel channel, Message.Request request, FlushItemConverter forFlusher, Overload backpressure)
     {
-        requestExecutor.submit(() -> processRequest(channel, request, forFlusher));
+        requestExecutor.submit(() -> processRequest(channel, request, forFlusher, backpressure));
     }
 
     /**
      * Note: this method may be executed on the netty event loop, during initial protocol negotiation
      */
-    static Message.Response processRequest(ServerConnection connection, Message.Request request)
+    static Message.Response processRequest(ServerConnection connection, Message.Request request, Overload backpressure)
     {
         long queryStartNanoTime = System.nanoTime();
         if (connection.getVersion().isGreaterOrEqualTo(ProtocolVersion.V4))
             ClientWarn.instance.captureWarnings();
+
+        if (backpressure == Overload.REQUESTS)
+        {
+            String message = String.format("Request breached global limit of %d requests/second and triggered backpressure.",
+                                           ClientResourceLimits.getNativeTransportMaxRequestsPerSecond());
+            
+            NoSpamLogger.log(logger, NoSpamLogger.Level.INFO, 1, TimeUnit.MINUTES, message);
+            ClientWarn.instance.warn(message);
+        }
+        else if (backpressure == Overload.BYTES_IN_FLIGHT)
+        {
+            String message = String.format("Request breached limit(s) on bytes in flight (Endpoint: %d, Global: %d) and triggered backpressure.",
+                                           ClientResourceLimits.getEndpointLimit(), ClientResourceLimits.getGlobalLimit());
+            
+            NoSpamLogger.log(logger, NoSpamLogger.Level.INFO, 1, TimeUnit.MINUTES, message);
+            ClientWarn.instance.warn(message);
+        }
 
         QueryState qstate = connection.validateNewMessage(request.type, connection.getVersion());
 
@@ -94,7 +119,7 @@ public class Dispatcher
     /**
      * Note: this method is not expected to execute on the netty event loop.
      */
-    void processRequest(Channel channel, Message.Request request, FlushItemConverter forFlusher)
+    void processRequest(Channel channel, Message.Request request, FlushItemConverter forFlusher, Overload backpressure)
     {
         final Message.Response response;
         final ServerConnection connection;
@@ -103,7 +128,7 @@ public class Dispatcher
         {
             assert request.connection() instanceof ServerConnection;
             connection = (ServerConnection) request.connection();
-            response = processRequest(connection, request);
+            response = processRequest(connection, request, backpressure);
             toFlush = forFlusher.toFlushItem(channel, request, response);
             Message.logger.trace("Responding: {}, v={}", response, connection.getVersion());
         }
@@ -152,7 +177,7 @@ public class Dispatcher
      * for delivering events to registered clients is dependent on protocol version and the configuration
      * of the pipeline. For v5 and newer connections, the event message is encoded into an Envelope,
      * wrapped in a FlushItem and then delivered via the pipeline's flusher, in a similar way to
-     * a Response returned from {@link #processRequest(Channel, Message.Request, FlushItemConverter)}.
+     * a Response returned from {@link #processRequest(Channel, Message.Request, FlushItemConverter, Overload)}.
      * It's worth noting that events are not generally fired as a direct response to a client request,
      * so this flush item has a null request attribute. The dispatcher itself is created when the
      * pipeline is first configured during protocol negotiation and is attached to the channel for

--- a/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
+++ b/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.transport.ClientResourceLimits.Overload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,7 +148,7 @@ public class InitialConnectionHandler extends ByteToMessageDecoder
                         promise = new VoidChannelPromise(ctx.channel(), false);
                     }
 
-                    final Message.Response response = Dispatcher.processRequest((ServerConnection) connection, startup);
+                    final Message.Response response = Dispatcher.processRequest((ServerConnection) connection, startup, Overload.NONE);
                     outbound = response.encode(inbound.header.version);
                     ctx.writeAndFlush(outbound, promise);
                     logger.debug("Configured pipeline: {}", ctx.pipeline());

--- a/src/java/org/apache/cassandra/utils/concurrent/NonBlockingRateLimiter.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/NonBlockingRateLimiter.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Ticker;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.Math.toIntExact;
+
+/**
+ * A rate limiter implementation that allows callers to reserve permits that may only be available 
+ * in the future, delegating to them decisions about how to schedule/delay work and whether or not
+ * to block execution to do so.
+ */
+@SuppressWarnings("UnstableApiUsage")
+@ThreadSafe
+public class NonBlockingRateLimiter
+{
+    public static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+    static final long DEFAULT_BURST_NANOS = NANOS_PER_SECOND;
+
+    /** a starting time for elapsed time calculations */
+    private final long startedNanos;
+
+    /** nanoseconds from start time corresponding to the next available permit */
+    private final AtomicLong nextAvailable = new AtomicLong();
+    
+    private volatile Ticker ticker;
+    
+    private volatile int permitsPerSecond;
+    
+    /** time in nanoseconds between permits on the timeline */
+    private volatile long intervalNanos;
+
+    /**
+     * To allow the limiter to more closely adhere to the configured rate in the face of
+     * unevenly distributed permits requests, it will allow a number of permits equal to
+     * burstNanos / intervalNanos to be issued in a "burst" before reaching a steady state.
+     * 
+     * Another way to think about this is that it allows us to bring forward the permits
+     * from short periods of inactivity. This is especially useful when the upstream user
+     * of the limiter delays request processing mechanism contains overhead that is longer
+     * than the intervalNanos in duration.
+     */
+    private final long burstNanos;
+
+    public NonBlockingRateLimiter(int permitsPerSecond)
+    {
+        this(permitsPerSecond, DEFAULT_BURST_NANOS, Ticker.systemTicker());
+    }
+
+    @VisibleForTesting
+    public NonBlockingRateLimiter(int permitsPerSecond, long burstNanos, Ticker ticker)
+    {
+        this.startedNanos = ticker.read();
+        this.burstNanos = burstNanos;
+        setRate(permitsPerSecond, ticker);
+    }
+
+    public void setRate(int permitsPerSecond)
+    {
+        setRate(permitsPerSecond, Ticker.systemTicker());
+    }
+
+    @VisibleForTesting
+    public synchronized void setRate(int permitsPerSecond, Ticker ticker)
+    {
+        Preconditions.checkArgument(permitsPerSecond > 0, "permits/second must be positive");
+        Preconditions.checkArgument(permitsPerSecond <= NANOS_PER_SECOND, "permits/second cannot be greater than " + NANOS_PER_SECOND);
+
+        this.ticker = ticker;
+        this.permitsPerSecond = permitsPerSecond;
+        intervalNanos = NANOS_PER_SECOND / permitsPerSecond;
+        nextAvailable.set(nanosElapsed());
+    }
+
+    /**
+     * @return the number of available permits per second
+     */
+    public int getRate()
+    {
+        return permitsPerSecond;
+    }
+
+    /**
+     * Reserves a single permit slot on the timeline which may not yet be available.
+     *
+     * @return time until the reserved permit will be available (or zero if it already is) in the specified units
+     */
+    public long reserveAndGetDelay(TimeUnit delayUnit)
+    {
+        long nowNanos = nanosElapsed();
+
+        for (;;)
+        {
+            long prev = nextAvailable.get();
+            long interval = this.intervalNanos;
+
+            // Push the first available permit slot up to the burst window if necessary.
+            long firstAvailable = Math.max(prev, nowNanos - burstNanos);
+
+            // Advance the configured interval starting from the bounded previous permit slot.
+            if (nextAvailable.compareAndSet(prev, firstAvailable + interval))
+                // If the time now is before the first available slot, return the delay.  
+                return delayUnit.convert(Math.max(0,  firstAvailable - nowNanos), TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
+     * Reserves a single permit slot on the timeline, but only if one is available.
+     *
+     * @return true if a permit is available, false if one is not
+     */
+    public boolean tryReserve()
+    {
+        long nowNanos = nanosElapsed();
+    
+        for (;;)
+        {
+            long prev = nextAvailable.get();
+            long interval = this.intervalNanos;
+    
+            // Push the first available permit slot up to the burst window if necessary.
+            long firstAvailable = Math.max(prev, nowNanos - burstNanos);
+            
+            // If we haven't reached the time for the first available permit, we've failed to reserve. 
+            if (nowNanos < firstAvailable)
+                return false;
+    
+            // Advance the configured interval starting from the bounded previous permit slot.
+            // If another thread has already taken the next slot, retry.
+            if (nextAvailable.compareAndSet(prev, firstAvailable + interval))
+                return true;
+        }
+    }
+
+    @VisibleForTesting
+    public long getIntervalNanos()
+    {
+        return intervalNanos;
+    }
+    
+    @VisibleForTesting
+    public long getStartedNanos()
+    {
+        return startedNanos;
+    }
+
+    private long nanosElapsed()
+    {
+        return ticker.read() - startedNanos;
+    }
+
+    public static final NonBlockingRateLimiter NO_OP_LIMITER = new NonBlockingRateLimiter(toIntExact(NANOS_PER_SECOND))
+    {
+        @Override
+        public long reserveAndGetDelay(TimeUnit delayUnit) {
+            return 0;
+        }
+
+        @Override
+        public boolean tryReserve()
+        {
+            return true;
+        }
+    };
+}

--- a/test/burn/org/apache/cassandra/transport/BurnTestUtil.java
+++ b/test/burn/org/apache/cassandra/transport/BurnTestUtil.java
@@ -35,6 +35,9 @@ import org.apache.cassandra.net.AbstractMessageHandler;
 import org.apache.cassandra.net.ResourceLimits;
 import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.concurrent.NonBlockingRateLimiter;
+
+import static org.apache.cassandra.utils.concurrent.NonBlockingRateLimiter.NO_OP_LIMITER;
 
 public class BurnTestUtil
 {
@@ -143,6 +146,12 @@ public class BurnTestUtil
                     return delegate.endpointWaitQueue();
                 }
 
+                @Override
+                public NonBlockingRateLimiter requestRateLimiter()
+                {
+                    return NO_OP_LIMITER;
+                }
+                
                 public void release()
                 {
                     delegate.release();

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -50,6 +50,7 @@ import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Gauge;
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ResultSet;
@@ -63,6 +64,7 @@ import org.apache.cassandra.index.SecondaryIndexManager;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.TokenMetadata;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -90,7 +92,10 @@ import org.apache.cassandra.utils.JMXServerUtils;
 
 import static com.datastax.driver.core.SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS;
 import static com.datastax.driver.core.SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Base class for CQL tests.
@@ -939,6 +944,23 @@ public abstract class CQLTester
         Assert.assertEquals(expectedKeyspace, schemaChange.keyspace);
         Assert.assertEquals(expectedName, schemaChange.name);
         Assert.assertEquals(expectedArgTypes != null ? Arrays.asList(expectedArgTypes) : null, schemaChange.argTypes);
+    }
+
+    protected static void assertWarningsContain(Message.Response response, String message)
+    {
+        List<String> warnings = response.getWarnings();
+        Assert.assertNotNull(warnings);
+        assertTrue(warnings.stream().anyMatch(s -> s.contains(message)));
+    }
+
+    protected static void assertNoWarningContains(Message.Response response, String message)
+    {
+        List<String> warnings = response.getWarnings();
+        
+        if (warnings != null) 
+        {
+            assertFalse(warnings.stream().anyMatch(s -> s.contains(message)));
+        }
     }
 
     protected static ResultMessage schemaChange(String query)
@@ -1804,6 +1826,17 @@ public abstract class CQLTester
     {
         requireNetwork();
         return clusters.get(protocolVersion).getMetadata().newTupleType(types);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    protected static Gauge<Integer> getPausedConnectionsGauge()
+    {
+        String metricName = "org.apache.cassandra.metrics.Client.PausedConnections";
+        Map<String, Gauge> metrics = CassandraMetricsRegistry.Metrics.getGauges((name, metric) -> name.equals(metricName));
+        if (metrics.size() != 1)
+            fail(String.format("Expected a single registered metric for paused client connections, found %s",
+                               metrics.size()));
+        return metrics.get(metricName);
     }
 
     // Attempt to find an AbstracType from a value (for serialization/printing sake).

--- a/test/unit/org/apache/cassandra/net/ResourceLimitsTest.java
+++ b/test/unit/org/apache/cassandra/net/ResourceLimitsTest.java
@@ -23,9 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongFunction;
 
-import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.KillerForTests;
 import org.junit.Assert;

--- a/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.transport;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -29,9 +28,9 @@ import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import org.apache.cassandra.service.StorageService;
 import org.junit.*;
 
-import com.codahale.metrics.Gauge;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryOptions;
@@ -40,13 +39,11 @@ import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.virtual.*;
 import org.apache.cassandra.exceptions.OverloadedException;
-import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.utils.FBUtilities;
 import org.awaitility.Awaitility;
 
-import static org.apache.cassandra.Util.spinAssertEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -55,19 +52,18 @@ import static org.junit.Assert.fail;
 
 public class ClientResourceLimitsTest extends CQLTester
 {
-
     private static final long LOW_LIMIT = 600L;
     private static final long HIGH_LIMIT = 5000000000L;
 
-    private static final QueryOptions V5_DEFAULT_OPTIONS = QueryOptions.create(
-        QueryOptions.DEFAULT.getConsistency(),
-        QueryOptions.DEFAULT.getValues(),
-        QueryOptions.DEFAULT.skipMetadata(),
-        QueryOptions.DEFAULT.getPageSize(),
-        QueryOptions.DEFAULT.getPagingState(),
-        QueryOptions.DEFAULT.getSerialConsistency(),
-        ProtocolVersion.V5,
-        KEYSPACE);
+    private static final QueryOptions V5_DEFAULT_OPTIONS = 
+        QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
+                            QueryOptions.DEFAULT.getValues(),
+                            QueryOptions.DEFAULT.skipMetadata(),
+                            QueryOptions.DEFAULT.getPageSize(),
+                            QueryOptions.DEFAULT.getPagingState(),
+                            QueryOptions.DEFAULT.getSerialConsistency(),
+                            ProtocolVersion.V5,
+                            KEYSPACE);
 
     @BeforeClass
     public static void setUp()
@@ -75,7 +71,7 @@ public class ClientResourceLimitsTest extends CQLTester
         DatabaseDescriptor.setNativeTransportReceiveQueueCapacityInBytes(1);
         DatabaseDescriptor.setNativeTransportMaxConcurrentRequestsInBytesPerIp(LOW_LIMIT);
         DatabaseDescriptor.setNativeTransportMaxConcurrentRequestsInBytes(LOW_LIMIT);
-
+        
         // The driver control connections would send queries that might interfere with the tests.
         requireNetworkWithoutDriver();
     }
@@ -124,7 +120,7 @@ public class ClientResourceLimitsTest extends CQLTester
         }
     }
 
-    @SuppressWarnings("resource")
+    @SuppressWarnings({"resource", "SameParameterValue"})
     private SimpleClient client(boolean throwOnOverload, int largeMessageThreshold)
     {
         try
@@ -184,27 +180,34 @@ public class ClientResourceLimitsTest extends CQLTester
                          (provider) -> provider.endpointWaitQueue().signal());
     }
 
-    private void backPressureTest(Runnable limitLifter, Consumer<ClientResourceLimits.ResourceProvider> signaller)
-    throws Throwable
+    private void backPressureTest(Runnable limitLifter, Consumer<ClientResourceLimits.ResourceProvider> signaller) throws Throwable
     {
         final AtomicReference<Exception> error = new AtomicReference<>();
         final CountDownLatch started = new CountDownLatch(1);
         final CountDownLatch complete = new CountDownLatch(1);
-        try(SimpleClient client = client(false))
+        
+        try (SimpleClient client = client(false))
         {
-            QueryMessage queryMessage = new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)",
-                                                         V5_DEFAULT_OPTIONS);
-            client.execute(queryMessage);
+            // The first query does not trigger backpressure/pause the connection:
+            QueryMessage queryMessage = 
+                    new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)", V5_DEFAULT_OPTIONS);
+            Message.Response belowThresholdResponse = client.execute(queryMessage);
+            assertEquals(0, getPausedConnectionsGauge().getValue().intValue());
+            assertNoWarningContains(belowThresholdResponse, "bytes in flight");
+            
+            // A second query triggers backpressure but is allowed to complete...
+            Message.Response aboveThresholdResponse = client.execute(queryMessage());
+            assertEquals(1, getPausedConnectionsGauge().getValue().intValue());
+            assertWarningsContain(aboveThresholdResponse, "bytes in flight");
 
-            // There should be no paused client connections yet
-            Gauge<Integer> pausedConnections = getPausedConnectionsGauge();
-            int before = pausedConnections.getValue();
-
+            // ...and a third request is paused.
+            final AtomicReference<Message.Response> response = new AtomicReference<>();
+            
             Thread t = new Thread(() -> {
                 try
                 {
                     started.countDown();
-                    client.execute(queryMessage());
+                    response.set(client.execute(queryMessage()));
                     complete.countDown();
                 }
                 catch (Exception e)
@@ -216,19 +219,13 @@ public class ClientResourceLimitsTest extends CQLTester
             });
             t.start();
 
-            // When the client attempts to execute the second query, the backpressure
-            // mechanism should report the client connection is paused
-            assertTrue(started.await(5, TimeUnit.SECONDS));
-            spinAssertEquals("Timed out after waiting 5 seconds for paused " +
-                             "connections metric to increment due to backpressure",
-                             before + 1, pausedConnections::getValue, 5, TimeUnit.SECONDS);
-
             // verify the request hasn't completed
             assertFalse(complete.await(1, TimeUnit.SECONDS));
 
             // backpressure has been applied, if we increase the limits of the exhausted reserve and signal
             // the appropriate WaitQueue, it should be released and the client request will complete
             limitLifter.run();
+            
             // We need a ResourceProvider to get access to the WaitQueue
             ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
             ClientResourceLimits.ResourceProvider queueHandle = new ClientResourceLimits.ResourceProvider.Default(allocator);
@@ -237,8 +234,10 @@ public class ClientResourceLimitsTest extends CQLTester
             // SimpleClient has a 10 second timeout, so if we have to wait
             // longer than that assume that we're not going to receive a
             // reply. If all's well, the completion should happen immediately
-            assertTrue(complete.await(11, TimeUnit.SECONDS));
+            assertTrue(complete.await(SimpleClient.TIMEOUT_SECONDS + 1, TimeUnit.SECONDS));
             assertNull(error.get());
+            assertEquals(0, getPausedConnectionsGauge().getValue().intValue());
+            assertNoWarningContains(response.get(), "bytes in flight");
         }
     }
 
@@ -302,17 +301,6 @@ public class ClientResourceLimitsTest extends CQLTester
             query.append('a');
         query.append("')");
         return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private Gauge<Integer> getPausedConnectionsGauge()
-    {
-        String metricName = "org.apache.cassandra.metrics.Client.PausedConnections";
-        Map<String, Gauge> metrics = CassandraMetricsRegistry.Metrics.getGauges((name, metric) -> name.equals(metricName));
-        if (metrics.size() != 1)
-            fail(String.format("Expected a single registered metric for paused client connections, found %s",
-                               metrics.size()));
-        return metrics.get(metricName);
     }
 
     @Test
@@ -468,5 +456,24 @@ public class ClientResourceLimitsTest extends CQLTester
         {
             client.close();
         }
+    }
+
+    @Test
+    public void shouldChangeRequestsPerSecondAtRuntime()
+    {
+        StorageService.instance.setNativeTransportMaxRequestsPerSecond(100);
+        assertEquals(100, ClientResourceLimits.getNativeTransportMaxRequestsPerSecond(), 0);
+        assertEquals(100, ClientResourceLimits.GLOBAL_REQUEST_LIMITER.getRate(), 0);
+        assertEquals(100, StorageService.instance.getNativeTransportMaxRequestsPerSecond());
+
+        StorageService.instance.setNativeTransportMaxRequestsPerSecond(1000);
+        assertEquals(1000, ClientResourceLimits.getNativeTransportMaxRequestsPerSecond(), 0);
+        assertEquals(1000, ClientResourceLimits.GLOBAL_REQUEST_LIMITER.getRate(), 0);
+        assertEquals(1000, StorageService.instance.getNativeTransportMaxRequestsPerSecond());
+
+        StorageService.instance.setNativeTransportMaxRequestsPerSecond(500);
+        assertEquals(500, ClientResourceLimits.getNativeTransportMaxRequestsPerSecond(), 0);
+        assertEquals(500, ClientResourceLimits.GLOBAL_REQUEST_LIMITER.getRate(), 0);
+        assertEquals(500, StorageService.instance.getNativeTransportMaxRequestsPerSecond());
     }
 }

--- a/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
+++ b/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Ticker;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.service.StorageService;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.utils.Throwables;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import static org.apache.cassandra.Util.spinAssertEquals;
+import static org.apache.cassandra.transport.ProtocolVersion.V4;
+
+@SuppressWarnings("UnstableApiUsage")
+@RunWith(Parameterized.class)
+public class RateLimitingTest extends CQLTester
+{
+    public static final String BACKPRESSURE_WARNING_SNIPPET = "Request breached global limit";
+    
+    private static final int LARGE_PAYLOAD_THRESHOLD_BYTES = 1000;
+    private static final int OVERLOAD_PERMITS_PER_SECOND = 1;
+
+    @Parameterized.Parameter
+    public ProtocolVersion version;
+
+    @Parameterized.Parameters(name="{0}")
+    public static Collection<Object[]> versions()
+    {
+        return ProtocolVersion.SUPPORTED.stream()
+                                        .map(v -> new Object[]{v})
+                                        .collect(Collectors.toList());
+    }
+
+    private AtomicLong tick;
+    private Ticker ticker;
+
+    @BeforeClass
+    public static void setup()
+    {
+        // If we don't exceed the queue capacity, we won't actually use the global/endpoint 
+        // bytes-in-flight limits, and the assertions we make below around releasing them would be useless.
+        DatabaseDescriptor.setNativeTransportReceiveQueueCapacityInBytes(1);
+        
+        // The driver control connections would send queries that might interfere with the tests.
+        requireNetworkWithoutDriver();
+    }
+
+    @Before
+    public void resetLimits()
+    {
+        // Reset to the original start time in case a test advances the clock.
+        tick = new AtomicLong(ClientResourceLimits.GLOBAL_REQUEST_LIMITER.getStartedNanos());
+
+        ticker = new Ticker()
+        {
+            @Override
+            public long read()
+            {
+                return tick.get();
+            }
+        };
+
+        ClientResourceLimits.setGlobalLimit(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void shouldThrowOnOverloadSmallMessages() throws Exception
+    {
+        int payloadSize = LARGE_PAYLOAD_THRESHOLD_BYTES / 4;
+        testOverload(payloadSize, true);
+    }
+
+    @Test
+    public void shouldThrowOnOverloadLargeMessages() throws Exception
+    {
+        int payloadSize = LARGE_PAYLOAD_THRESHOLD_BYTES * 2;
+        testOverload(payloadSize, true);
+    }
+
+    @Test
+    public void shouldBackpressureSmallMessages() throws Exception
+    {
+        int payloadSize = LARGE_PAYLOAD_THRESHOLD_BYTES / 4;
+        testOverload(payloadSize, false);
+    }
+
+    @Test
+    public void shouldBackpressureLargeMessages() throws Exception
+    {
+        int payloadSize = LARGE_PAYLOAD_THRESHOLD_BYTES * 2;
+        testOverload(payloadSize, false);
+    }
+
+    @Test
+    public void shouldReleaseSmallMessageOnBytesInFlightOverload() throws Exception
+    {
+        testBytesInFlightOverload(LARGE_PAYLOAD_THRESHOLD_BYTES / 4);
+    }
+
+    @Test
+    public void shouldReleaseLargeMessageOnBytesInFlightOverload() throws Exception
+    {
+        testBytesInFlightOverload(LARGE_PAYLOAD_THRESHOLD_BYTES * 2);
+    }
+
+    private void testBytesInFlightOverload(int payloadSize) throws Exception
+    {
+        try (SimpleClient client = client().connect(false, true))
+        {
+            StorageService.instance.setNativeTransportRateLimitingEnabled(false);
+            QueryMessage queryMessage = new QueryMessage("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".atable (pk int PRIMARY KEY, v text)", queryOptions());
+            client.execute(queryMessage);
+
+            StorageService.instance.setNativeTransportRateLimitingEnabled(true);
+            ClientResourceLimits.GLOBAL_REQUEST_LIMITER.setRate(OVERLOAD_PERMITS_PER_SECOND, ticker);
+            ClientResourceLimits.setGlobalLimit(1);
+
+            try
+            {
+                // The first query takes the one available permit, but should fail on the bytes in flight limit.
+                client.execute(queryMessage(payloadSize));
+            }
+            catch (RuntimeException e)
+            {
+                assertTrue(Throwables.anyCauseMatches(e, cause -> cause instanceof OverloadedException));
+            }
+        }
+        finally
+        {
+            // Sanity check bytes in flight limiter.
+            assertEquals(0, ClientResourceLimits.getCurrentGlobalUsage());
+            StorageService.instance.setNativeTransportRateLimitingEnabled(false);
+        }
+    }
+
+    private void testOverload(int payloadSize, boolean throwOnOverload) throws Exception
+    {
+        try (SimpleClient client = client().connect(false, throwOnOverload))
+        {
+            StorageService.instance.setNativeTransportRateLimitingEnabled(false);
+            QueryMessage queryMessage = new QueryMessage("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".atable (pk int PRIMARY KEY, v text)", queryOptions());
+            client.execute(queryMessage);
+
+            StorageService.instance.setNativeTransportRateLimitingEnabled(true);
+            ClientResourceLimits.GLOBAL_REQUEST_LIMITER.setRate(OVERLOAD_PERMITS_PER_SECOND, ticker);
+
+            if (throwOnOverload)
+                testThrowOnOverload(payloadSize, client);
+            else
+            {
+                testBackpressureOnOverload(payloadSize, client);
+            }   
+        }
+        finally
+        {
+            // Sanity the check bytes in flight limiter.
+            assertEquals(0, ClientResourceLimits.getCurrentGlobalUsage());
+            StorageService.instance.setNativeTransportRateLimitingEnabled(false);
+        }
+    }
+
+    private void testBackpressureOnOverload(int payloadSize, SimpleClient client) throws Exception
+    {
+        // The first query takes the one available permit.
+        Message.Response firstResponse = client.execute(queryMessage(payloadSize));
+        assertEquals(0, getPausedConnectionsGauge().getValue().intValue());
+        assertNoWarningContains(firstResponse, BACKPRESSURE_WARNING_SNIPPET);
+        
+        // The second query activates backpressure.
+        long overloadQueryStartTime = System.currentTimeMillis();
+        Message.Response response = client.execute(queryMessage(payloadSize));
+
+        // V3 does not support client warnings, but otherwise we should get one for this query.
+        if (version.isGreaterOrEqualTo(V4))
+            assertWarningsContain(response, BACKPRESSURE_WARNING_SNIPPET);
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch complete = new CountDownLatch(1);
+        AtomicReference<Message.Response> pausedQueryResponse = new AtomicReference<>();
+        
+        Thread queryRunner = new Thread(() ->
+        {
+            try
+            {
+                started.countDown();
+                pausedQueryResponse.set(client.execute(queryMessage(payloadSize)));
+                complete.countDown();
+            }
+            catch (Throwable t)
+            {
+                error.set(t);
+            }
+        });
+
+        // Advance the rater limiter so that this query will see an available permit. This also
+        // means it should not produce a client warning, which we verify below.
+        // (Note that we advance 2 intervals for the 2 prior queries.)
+        tick.addAndGet(2 * ClientResourceLimits.GLOBAL_REQUEST_LIMITER.getIntervalNanos());
+        
+        queryRunner.start();
+
+        // ...and the request should complete without error.
+        assertTrue(complete.await(SimpleClient.TIMEOUT_SECONDS + 1, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertNoWarningContains(pausedQueryResponse.get(), BACKPRESSURE_WARNING_SNIPPET);
+
+        // At least the number of milliseconds in the permit interval should already have elapsed 
+        // since the start of the query that pauses the connection.
+        double permitIntervalMillis = (double) TimeUnit.SECONDS.toMillis(1L) / OVERLOAD_PERMITS_PER_SECOND;
+        long sinceQueryStarted = System.currentTimeMillis() - overloadQueryStartTime;
+        long remainingMillis = ((long) permitIntervalMillis) - sinceQueryStarted;
+        assertTrue("Query completed before connection unpause!", remainingMillis <= 0);
+        
+        spinAssertEquals("Timed out after waiting 5 seconds for paused connections metric to normalize.",
+                         0, () -> getPausedConnectionsGauge().getValue(), 5, TimeUnit.SECONDS);
+    }
+
+    private void testThrowOnOverload(int payloadSize, SimpleClient client)
+    {
+        // The first query takes the one available permit...
+        client.execute(queryMessage(payloadSize));
+        
+        try
+        {   
+            // ...and the second breaches the limit....
+            client.execute(queryMessage(payloadSize));
+        }
+        catch (RuntimeException e)
+        {
+            assertTrue(Throwables.anyCauseMatches(e, cause -> cause instanceof OverloadedException));
+        }
+
+        // Advance the timeline and verify that we can take a permit again.
+        // (Note that we don't take one when we throw on overload.)
+        tick.addAndGet(ClientResourceLimits.GLOBAL_REQUEST_LIMITER.getIntervalNanos());
+        client.execute(queryMessage(payloadSize));
+    }
+
+    private QueryMessage queryMessage(int length)
+    {
+        StringBuilder query = new StringBuilder("INSERT INTO " + KEYSPACE + ".atable (pk, v) VALUES (1, '");
+        
+        for (int i = 0; i < length; i++)
+        {
+            query.append('a');
+        }
+        
+        query.append("')");
+        return new QueryMessage(query.toString(), queryOptions());
+    }
+
+    private SimpleClient client()
+    {
+        return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
+                           .protocolVersion(version)
+                           .useBeta()
+                           .largeMessageThreshold(LARGE_PAYLOAD_THRESHOLD_BYTES)
+                           .build();
+    }
+
+    private QueryOptions queryOptions()
+    {
+        return QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
+                                   QueryOptions.DEFAULT.getValues(),
+                                   QueryOptions.DEFAULT.skipMetadata(),
+                                   QueryOptions.DEFAULT.getPageSize(),
+                                   QueryOptions.DEFAULT.getPagingState(),
+                                   QueryOptions.DEFAULT.getSerialConsistency(),
+                                   version,
+                                   KEYSPACE);
+    }
+}

--- a/test/unit/org/apache/cassandra/utils/concurrent/NonBlockingRateLimiterTest.java
+++ b/test/unit/org/apache/cassandra/utils/concurrent/NonBlockingRateLimiterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.concurrent;
+
+import com.google.common.base.Ticker;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("UnstableApiUsage")
+public class NonBlockingRateLimiterTest
+{
+    private static final AtomicLong CLOCK = new AtomicLong(0);
+    private static final TimeUnit DELAY_UNIT = TimeUnit.NANOSECONDS;
+
+    private static final Ticker TICKER = new Ticker()
+    {
+        @Override
+        public long read() {
+            return CLOCK.get();
+        }
+    };
+
+    @Before
+    public void resetTicker()
+    {
+        CLOCK.set(0);
+    }
+
+    @Test
+    public void testUnconditionalReservation()
+    {
+        NonBlockingRateLimiter limiter = new NonBlockingRateLimiter(4, 0, TICKER);
+        long oneSecond = DELAY_UNIT.convert(1, TimeUnit.SECONDS);
+        long oneDelay = oneSecond / 4;
+
+        // Delays should begin accumulating without any ticker movement...
+        assertEquals(0, limiter.reserveAndGetDelay(DELAY_UNIT));
+        assertEquals(oneDelay, limiter.reserveAndGetDelay(DELAY_UNIT));
+        assertEquals(oneDelay * 2, limiter.reserveAndGetDelay(DELAY_UNIT));
+        assertEquals(oneDelay * 3, limiter.reserveAndGetDelay(DELAY_UNIT));
+
+        // ...but should be gone after advancing enough to free up a permit.
+        CLOCK.addAndGet(NonBlockingRateLimiter.NANOS_PER_SECOND);
+        assertEquals(0, limiter.reserveAndGetDelay(DELAY_UNIT));
+    }
+
+    @Test
+    public void testConditionalReservation()
+    {
+        NonBlockingRateLimiter limiter = new NonBlockingRateLimiter(1, 0, TICKER);
+        
+        // Take the available permit, but then fail a subsequent attempt.
+        assertTrue(limiter.tryReserve());
+        assertFalse(limiter.tryReserve());
+
+        // We only need to advance one second, as the second attempt should not get a permit.
+        CLOCK.addAndGet(NonBlockingRateLimiter.NANOS_PER_SECOND);
+        assertTrue(limiter.tryReserve());
+    }
+
+    @Test
+    public void testBurstPermitConsumption()
+    {
+        // Create a limiter that produces 2 permits/second and allows 1-second bursts.
+        NonBlockingRateLimiter limiter = new NonBlockingRateLimiter(1, NonBlockingRateLimiter.DEFAULT_BURST_NANOS, TICKER);
+
+        // Advance the clock to create a 1-second idle period, which makes one burst permit available.
+        CLOCK.addAndGet(NonBlockingRateLimiter.NANOS_PER_SECOND);
+        
+        // Take the burst permit.
+        assertTrue(limiter.tryReserve());
+        
+        // Take the "normal" permit.
+        assertTrue(limiter.tryReserve());
+        
+        // Then fail, as we've consumed both.
+        assertFalse(limiter.tryReserve());
+
+        // Advance 1 interval again...
+        CLOCK.addAndGet(NonBlockingRateLimiter.NANOS_PER_SECOND);
+
+        // ...and only one permit should be available, as we've reached a steady state.
+        assertTrue(limiter.tryReserve());
+        assertFalse(limiter.tryReserve());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaximumRate()
+    {
+        new NonBlockingRateLimiter(Integer.MAX_VALUE, 0, Ticker.systemTicker());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMinimumRate()
+    {
+        new NonBlockingRateLimiter(-1, 0, Ticker.systemTicker());
+    }
+}


### PR DESCRIPTION
This patch adds a global rate limiter for CQL requests for the V3, V4, V5, and V6 protocols. It is configurable in `cassandra.yaml` via `native_transport_rate_limiting_enabled`/`native_transport_requests_per_second` and at runtime via `setNativeTransportRateLimitingEnabled(boolean)`/`setNativeTransportRequestsPerSecond(long)` on the `StorageServiceMBean`.

Both small and large messages are supported, and both back pressure (the default) and throwing on overload are supported.