### PR TITLE
Doc change for sstableloader.rst - Clarify that "Cassandra must be stopped" applies to the source cluster

### DIFF
--- a/doc/source/tools/sstable/sstableloader.rst
+++ b/doc/source/tools/sstable/sstableloader.rst
@@ -25,7 +25,7 @@ To avoid having the sstable files to be loaded compacted while reading them, pla
 
 ref: https://issues.apache.org/jira/browse/CASSANDRA-1278
 
-Cassandra must be stopped before this tool is executed, or unexpected results will occur. Note: the script does not verify that Cassandra is stopped.
+If loading direct from a source cluster, Cassandra must be stopped on the source cluster before this tool is executed, or unexpected results will occur. Note: the script does not verify that Cassandra is stopped.
 
 Usage
 ^^^^^


### PR DESCRIPTION
Clarify that "Cassandra must be stopped" applies to the source cluster