### PR TITLE
CASSANDRA-16746 Clarify in the documentation that "Cassandra must be stopped" applies to the source cluster for sstableloader

### DIFF
--- a/doc/source/tools/sstable/sstableloader.rst
+++ b/doc/source/tools/sstable/sstableloader.rst
@@ -25,7 +25,7 @@ To avoid having the sstable files to be loaded compacted while reading them, pla
 
 ref: https://issues.apache.org/jira/browse/CASSANDRA-1278
 
-Cassandra must be stopped before this tool is executed, or unexpected results will occur. Note: the script does not verify that Cassandra is stopped.
+If loading directly from a source cluster, Cassandra must be stopped on the source cluster before this tool is executed, or unexpected results will occur. Note: the script does not verify that Cassandra is stopped.
 
 Usage
 ^^^^^


### PR DESCRIPTION
patch by Ben Slater; reviewed by Stefan Miklosovic for CASSANDRA-16746