### PR TITLE
Update cqlsh.rst

### DIFF
--- a/doc/source/tools/cqlsh.rst
+++ b/doc/source/tools/cqlsh.rst
@@ -386,7 +386,7 @@ CSV data from stdin.
 
 See :ref:`shared-copy-options` for options that apply to both ``COPY TO`` and ``COPY FROM``.
 
-Options for ``COPY TO``
+Options for ``COPY FROM``
 ```````````````````````
 
 ``INGESTRATE``


### PR DESCRIPTION
The heading for `COPY FROM` options was wrong and is fixed.