### PR TITLE
CASSANDRA-16727 Fixes License text problem in website

### DIFF
--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -1,10 +1,10 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
+{% extends "layout.html" %}
+{# Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -12,9 +12,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
--->
-{% extends "layout.html" %}
+  limitations under the License. #}
 {%- block htmltitle -%}
 <title>{{ html_title }}</title>
 {%- endblock -%}

--- a/doc/source/_theme/cassandra_theme/defindex.html
+++ b/doc/source/_theme/cassandra_theme/defindex.html
@@ -1,4 +1,5 @@
-<!--
+---
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
@@ -12,9 +13,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitatins under the License.
--->
----
+  limitatins under the License. #}
 layout: doclandingpage
 title: "Documentation"
 is_homepage: false

--- a/doc/source/_theme/cassandra_theme/layout.html
+++ b/doc/source/_theme/cassandra_theme/layout.html
@@ -1,4 +1,5 @@
-<!--
+---
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
@@ -12,9 +13,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
--->
----
+  limitations under the License. #}
 layout: docpage
 {% block title %}
 title: "Documentation"

--- a/doc/source/_theme/cassandra_theme/search.html
+++ b/doc/source/_theme/cassandra_theme/search.html
@@ -1,5 +1,4 @@
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
+{# Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
@@ -12,8 +11,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License.
--->
+  limitations under the License. #}
 {%- extends "layout.html" %}
 {% block title %}
 title: "{{_('Search')}}"


### PR DESCRIPTION
Marked the license text as an RST comment and moved display of the license text in html to
cassandra website.  The comment placement affected Jekyll processing

Tested via desktop jekyll build