### PR TITLE
CASSANDRA-16768 Allow nodetool scrub to take a user defined list of SSTables 

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1646,6 +1646,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         return CompactionManager.instance.performGarbageCollection(this, tombstoneOption, jobs);
     }
 
+    public CompactionManager.AllSSTableOpStatus partialGarbageCollect(TombstoneOption tombstoneOption, int jobs, Collection<Descriptor> sstables) throws ExecutionException, InterruptedException
+    {
+        return CompactionManager.instance.performGarbageCollection(this, tombstoneOption, jobs, sstables);
+    }
+
     public void markObsolete(Collection<SSTableReader> sstables, OperationType compactionType)
     {
         assert !sstables.isEmpty();
@@ -2396,7 +2401,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
         return runWithCompactionsDisabled(callable, false, false);
     }
-
 
     @Override
     public String toString()

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1579,11 +1579,16 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
     public CompactionManager.AllSSTableOpStatus scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL, int jobs) throws ExecutionException, InterruptedException
     {
-        return scrub(disableSnapshot, skipCorrupted, reinsertOverflowedTTL, false, checkData, jobs);
+        return scrub(disableSnapshot, skipCorrupted, reinsertOverflowedTTL, false, checkData, jobs, null);
+    }
+
+    public CompactionManager.AllSSTableOpStatus partialScrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL, int jobs, Collection<Descriptor> sstables) throws ExecutionException, InterruptedException
+    {
+        return scrub(disableSnapshot, skipCorrupted, reinsertOverflowedTTL, false, checkData, jobs, sstables);
     }
 
     @VisibleForTesting
-    public CompactionManager.AllSSTableOpStatus scrub(boolean disableSnapshot, boolean skipCorrupted, boolean reinsertOverflowedTTL, boolean alwaysFail, boolean checkData, int jobs) throws ExecutionException, InterruptedException
+    public CompactionManager.AllSSTableOpStatus scrub(boolean disableSnapshot, boolean skipCorrupted, boolean reinsertOverflowedTTL, boolean alwaysFail, boolean checkData, int jobs, Collection<Descriptor> sstables) throws ExecutionException, InterruptedException
     {
         // skip snapshot creation during scrub, SEE JIRA 5891
         if(!disableSnapshot)
@@ -1591,8 +1596,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
 
         try
         {
-            return CompactionManager.instance.performScrub(ColumnFamilyStore.this, skipCorrupted, checkData, reinsertOverflowedTTL, jobs);
-        }
+            if (sstables == null)
+                return CompactionManager.instance.performScrub(ColumnFamilyStore.this, skipCorrupted, checkData, reinsertOverflowedTTL, jobs);
+            else
+                return CompactionManager.instance.performScrub(ColumnFamilyStore.this, skipCorrupted, checkData, reinsertOverflowedTTL, jobs, sstables);
+                    }
         catch(Throwable t)
         {
             if (!rebuildOnFailedScrub(t))

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -295,12 +295,16 @@ public class CompactionManager implements CompactionManagerMBean
         logger.info("Starting {} for {}.{}", operationType, cfs.keyspace.getName(), cfs.getTableName());
         List<LifecycleTransaction> transactions = new ArrayList<>();
         List<Future<?>> futures = new ArrayList<>();
+        int originalCount = 0;
+        int tableCount = 0;
         try (LifecycleTransaction compacting = cfs.markAllCompacting(operationType))
         {
             if (compacting == null)
                 return AllSSTableOpStatus.UNABLE_TO_CANCEL;
 
-            Iterable<SSTableReader> sstables = Lists.newArrayList(operation.filterSSTables(compacting));
+            List<SSTableReader> sstables = Lists.newArrayList(operation.filterSSTables(compacting));
+            originalCount = compacting.originals().size();
+            tableCount = sstables.size();
             if (Iterables.isEmpty(sstables))
             {
                 logger.info("No sstables to {} for {}.{}", operationType.name(), cfs.keyspace.getName(), cfs.name);
@@ -333,7 +337,7 @@ public class CompactionManager implements CompactionManagerMBean
                 }
             }
             FBUtilities.waitOnFutures(futures);
-            assert compacting.originals().isEmpty();
+            assert (compacting.originals().size() == originalCount - tableCount);
             logger.info("Finished {} for {}.{} successfully", operationType, cfs.keyspace.getName(), cfs.getTableName());
             return AllSSTableOpStatus.SUCCESSFUL;
         }
@@ -503,7 +507,19 @@ public class CompactionManager implements CompactionManagerMBean
         }, jobs, OperationType.CLEANUP);
     }
 
-    public AllSSTableOpStatus performGarbageCollection(final ColumnFamilyStore cfStore, TombstoneOption tombstoneOption, int jobs) throws InterruptedException, ExecutionException
+    public AllSSTableOpStatus performGarbageCollection(ColumnFamilyStore cfStore, TombstoneOption tombstoneOption, int jobs) throws InterruptedException, ExecutionException
+    {
+        return performGarbageCollection(cfStore, tombstoneOption, jobs, descriptor -> true);
+    }
+
+    public AllSSTableOpStatus performGarbageCollection(ColumnFamilyStore cfStore, TombstoneOption tombstoneOption, int jobs, Collection<Descriptor> dataFiles) throws InterruptedException, ExecutionException
+    {
+        Set<Descriptor> files = new HashSet<>(dataFiles);
+        return performGarbageCollection(cfStore, tombstoneOption, jobs, files::contains);
+    }
+
+    @VisibleForTesting
+    AllSSTableOpStatus performGarbageCollection(ColumnFamilyStore cfStore, TombstoneOption tombstoneOption, int jobs, Predicate<Descriptor> allowedFile) throws InterruptedException, ExecutionException
     {
         assert !cfStore.isIndex();
 
@@ -512,12 +528,15 @@ public class CompactionManager implements CompactionManagerMBean
             @Override
             public Iterable<SSTableReader> filterSSTables(LifecycleTransaction transaction)
             {
-                Iterable<SSTableReader> originals = transaction.originals();
-                if (cfStore.getCompactionStrategyManager().onlyPurgeRepairedTombstones())
-                    originals = Iterables.filter(originals, SSTableReader::isRepaired);
-                List<SSTableReader> sortedSSTables = Lists.newArrayList(originals);
-                Collections.sort(sortedSSTables, SSTableReader.maxTimestampAscending);
-                return sortedSSTables;
+                Predicate<SSTableReader> onlyRepaired = cfStore.getCompactionStrategyManager().onlyPurgeRepairedTombstones()
+                    ? SSTableReader::isRepaired
+                    : reader -> true;
+
+                return transaction.originals().stream()
+                    .filter(reader -> allowedFile.test(reader.descriptor))
+                    .filter(onlyRepaired)
+                    .sorted(SSTableReader.maxTimestampAscending)
+                    .collect(Collectors.toList());
             }
 
             @Override
@@ -865,22 +884,7 @@ public class CompactionManager implements CompactionManagerMBean
 
     public void forceUserDefinedCompaction(String dataFiles)
     {
-        String[] filenames = dataFiles.split(",");
-        Multimap<ColumnFamilyStore, Descriptor> descriptors = ArrayListMultimap.create();
-
-        for (String filename : filenames)
-        {
-            // extract keyspace and columnfamily name from filename
-            Descriptor desc = Descriptor.fromFilename(filename.trim());
-            if (Schema.instance.getCFMetaData(desc) == null)
-            {
-                logger.warn("Schema does not exist for file {}. Skipping.", filename);
-                continue;
-            }
-            // group by keyspace/columnfamily
-            ColumnFamilyStore cfs = Keyspace.open(desc.ksname).getColumnFamilyStore(desc.cfname);
-            descriptors.put(cfs, cfs.getDirectories().find(new File(filename.trim()).getName()));
-        }
+        Multimap<ColumnFamilyStore, Descriptor> descriptors =Descriptor.fromFilenamesGrouped(Arrays.asList(dataFiles.split(",")));
 
         List<Future<?>> futures = new ArrayList<>();
         int nowInSec = FBUtilities.nowInSeconds();

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -315,6 +315,12 @@ public interface StorageServiceMBean extends NotificationEmitter
     public int garbageCollect(String tombstoneOption, int jobs, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException;
 
     /**
+     * Rewrites all sstables from the given list of SSTable Data.db files.
+     * The tombstone option defines the granularity of the procedure: ROW removes deleted partitions and rows, CELL also removes overwritten or deleted cells.
+     */
+    public int userDefinedGarbageCollect(String tombstoneOption, int jobs, Collection<String> userDefinedTables) throws IOException, ExecutionException, InterruptedException;
+
+    /**
      * Flush all memtables for the given column families, or all columnfamilies for the given keyspace
      * if none are explicitly listed.
      * @param keyspaceName

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -293,6 +293,13 @@ public interface StorageServiceMBean extends NotificationEmitter
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL, int jobs, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
 
     /**
+     * Scrub (deserialize + reserialize at the latest version, skipping bad rows if any) for the given SSTable data files.
+     *
+     * Scrubbed CFs will be snapshotted first, if disableSnapshot is false
+     */
+    public int userDefinedScrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL, int jobs, Collection<String> userDefinedTables) throws IOException, ExecutionException, InterruptedException;
+
+    /**
      * Verify (checksums of) the given keyspace.
      * If tableNames array is empty, all CFs are verified.
      *

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -342,6 +342,22 @@ public class NodeProbe implements AutoCloseable
         }
     }
 
+    public void userDefinedScrub(PrintStream out, boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL, int jobs, List<String> userDefinedTables) throws IOException, ExecutionException, InterruptedException
+    {
+        checkJobs(out, jobs);
+        switch (ssProxy.userDefinedScrub(disableSnapshot, skipCorrupted, checkData, reinsertOverflowedTTL, jobs, userDefinedTables))
+        {
+            case 1:
+                failed = true;
+                out.println("Aborted scrubbing at least one table, check server logs for more information.");
+                break;
+            case 2:
+                failed = true;
+                out.println("Failed marking some sstables compacting, check server logs for more information");
+                break;
+        }
+    }
+
     public void verify(PrintStream out, boolean extendedVerify, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException
     {
         switch (verify(extendedVerify, keyspaceName, tableNames))

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -297,6 +297,11 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.garbageCollect(tombstoneOption, jobs, keyspaceName, tableNames);
     }
 
+    public int userDefinedGarbageCollect(String tombstoneOption, int jobs, List<String> userDefinedTables) throws IOException, ExecutionException, InterruptedException
+    {
+        return ssProxy.userDefinedGarbageCollect(tombstoneOption, jobs, userDefinedTables);
+    }
+
     private void checkJobs(PrintStream out, int jobs)
     {
         // TODO this should get the configured number of concurrent_compactors via JMX and not using DatabaseDescriptor
@@ -375,6 +380,15 @@ public class NodeProbe implements AutoCloseable
         {
             failed = true;
             out.println("Aborted garbage collection for at least one table in keyspace " + keyspaceName + ", check server logs for more information.");
+        }
+    }
+
+    public void userDefinedGarbageCollect(PrintStream out, String tombstoneOption, int jobs, List<String> userDefinedTables) throws IOException, ExecutionException, InterruptedException
+    {
+        if (userDefinedGarbageCollect(tombstoneOption, jobs, userDefinedTables) != 0)
+        {
+            failed = true;
+            out.println("Aborted garbage collection for at least one table, check server logs for more information.");
         }
     }
 


### PR DESCRIPTION
for CASSANDRA-16768

This is built on top of https://github.com/apache/cassandra/pull/1085 because they share some common changes.   Only the last commit is relevant to CASSANDRA-16768.   Review and merge https://github.com/apache/cassandra/pull/1085 first.