### PR TITLE
CASSANDRA-16621 using awaitility in spinAsserts

### DIFF
--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOError;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -82,11 +83,13 @@ import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.CounterId;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.FilterFactory;
+import org.awaitility.Awaitility;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class Util
@@ -596,17 +599,10 @@ public class Util
 
     public static <T> void spinAssertEquals(String message, T expected, Supplier<? extends T> actualSupplier, long timeout, TimeUnit timeUnit)
     {
-        long startNano = System.nanoTime();
-        long expireAtNano = startNano + timeUnit.toNanos(timeout);
-        T actual = null;
-        while (System.nanoTime() < expireAtNano)
-        {
-            actual = actualSupplier.get();
-            if (actual.equals(expected))
-                break;
-            Thread.yield();
-        }
-        assertEquals(message, expected, actual);
+        Awaitility.await()
+                  .with().pollInterval(Duration.ofMillis(1))
+                  .atMost(timeout, timeUnit)
+                  .untilAsserted(() -> assertThat(message, actualSupplier.get(), equalTo(expected)));
     }
 
     public static void joinThread(Thread thread) throws InterruptedException


### PR DESCRIPTION
#### What's in the PR
* changes to maintain uniformity in test cases by using awaitility in accordance with [16621](https://issues.apache.org/jira/browse/CASSANDRA-16621)