### PR TITLE
Fix two NPEs

### DIFF
--- a/src/java/org/apache/cassandra/auth/FunctionResource.java
+++ b/src/java/org/apache/cassandra/auth/FunctionResource.java
@@ -157,6 +157,7 @@ public class FunctionResource implements IResource
                                               "explictly qualified by a keyspace");
         List<AbstractType<?>> abstractTypes = new ArrayList<>(argTypes.size());
         for (CQL3Type.Raw cqlType : argTypes)
+            if (cqlType == null) continue;
             abstractTypes.add(cqlType.prepare(keyspace).getType());
 
         return new FunctionResource(keyspace, name, abstractTypes);

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java
@@ -61,7 +61,9 @@ public class ResultHandler implements Closeable
     {
         for (int i = 0; i < targetHosts.size(); i++)
         {
-            if (results.get(i).wasFailed())
+            ComparableResultSet result = results.get(i);
+            if (result == null) continue;
+            if (result.wasFailed())
                 logger.error("Query {} against {} failure: {}", query, targetHosts.get(i), results.get(i).getFailureException().getMessage());
         }
 


### PR DESCRIPTION
Hello,
Our static analyzer found two NPEs. We have checked the feasibility of this execution trace and provided patches in the pr. Please check and confirm them. It is necessary to defend this vulnerability to improve the code quality.
Here are the bug traces.

## NPE in ResultHandler.java

1. Function add executes and resultSets contains null
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Compare.java#L95

2. Program reaches the return point, modifying the value new(64).!0.!0 to null, where new(64) is the return value
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Compare.java#L97

3. The return value of function resultSets is passed as the second parameter of function handleResults.
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Compare.java#L73

4. results is passed as the this pointer to function get (results contains null)
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java#L64

5. The return value of function get is passed as the this pointer to function wasFailed (the return value of function get can be null), which will leak to null pointer dereference
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/tools/fqltool/src/org/apache/cassandra/fqltool/ResultHandler.java#L64

## NPE in FunctionResource.java

Because some code in the bug trace is in the file Cql_Parser.java, which is generated in the build phase. We provide the generated code as an attachment([Cql_Parser.zip](https://github.com/apache/cassandra/files/6747157/Cql_Parser.zip)). It is generated in the directory `cassandra/src/gen-java/org/apache/cassandra/cql3`

1. Return null to caller: Cql_Parser.java#L16076

2. Function collection_type executes and returns: Cql_Parser.java#L15653

3. Select the true branch at this point (backtracking!=0 is false): Cql_Parser.java#L15656

4. Return t to caller, which can be null (The return value can be null): Cql_Parser.java#L15723

5. Function comparatorType executes and returns: Cql_Parser.java#L9171

6. The return value of comparatorType is passed as the 3rd parameter of function functionFromCql: Cql_Parser.java#L9210

7. The return value of function iterator is passed as the this pointer to function next (the return value of function iterator can be null)
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/src/java/org/apache/cassandra/auth/FunctionResource.java#L159

8. cqlType is passed as the this pointer to function prepare (cqlType can be null), which will leak to null pointer dereference
https://github.com/apache/cassandra/blob/3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0/src/java/org/apache/cassandra/auth/FunctionResource.java#L160


Commit: 3af9b0a796d0f87e3596103e4b90d8c5d0c5fad0



ContainerAnalyzer