### PR TITLE
CASSANDRA-16786: Incorrect Java doc description on org.apache.cassandra.schema fix

### DIFF
--- a/src/java/org/apache/cassandra/schema/Difference.java
+++ b/src/java/org/apache/cassandra/schema/Difference.java
@@ -29,7 +29,7 @@ public enum Difference
 
     /**
      *
-     * Two schema objects are considered to differ DEEP-ly if their direct structure is altered.
+     * Two schema objects are considered to differ SHALLOW-ly if their direct structure is altered.
      *
      * For example, if a table T is altered to add a new column, a different compaction strategy, or a new description,
      * then it will differ SHALLOW-ly from the original.


### PR DESCRIPTION
patch for CASSANDRA-16786