### PR TITLE
CASSANDRA-12922. Bloom filter miss counts are not measured correctly.

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -139,6 +139,13 @@ public class BigTableReader extends SSTableReader
                                         boolean permitMatchPastLast,
                                         SSTableReadsListener listener)
     {
+        // Having no index file is impossible in a normal operation. The only way it might happen is running
+        // Scrubber that does not really rely onto this method.
+        if (ifile == null)
+        {
+            return null;
+        }
+
         if (op == Operator.EQ)
         {
             assert key instanceof DecoratedKey; // EQ only make sense if the key is a valid row key
@@ -158,6 +165,8 @@ public class BigTableReader extends SSTableReader
             RowIndexEntry cachedPosition = getCachedPosition(decoratedKey, updateCacheAndStats);
             if (cachedPosition != null)
             {
+                // we do not need to track "true positive" for Bloom Filter here because it has been already tracked
+                // inside getCachedPosition method
                 listener.onSSTableSelected(this, cachedPosition, SelectionReason.KEY_CACHE_HIT);
                 Tracing.trace("Key cache hit for sstable {}", descriptor.generation);
                 return cachedPosition;
@@ -198,9 +207,6 @@ public class BigTableReader extends SSTableReader
 
         int effectiveInterval = indexSummary.getEffectiveIndexIntervalAfterIndex(sampledIndex);
 
-        if (ifile == null)
-            return null;
-
         // scan the on-disk index, starting at the nearest sampled position.
         // The check against IndexInterval is to be exit the loop in the EQ case when the key looked for is not present
         // (bloom filter false positive). But note that for non-EQ cases, we might need to check the first key of the
@@ -235,6 +241,8 @@ public class BigTableReader extends SSTableReader
                     exactMatch = (comparison == 0);
                     if (v < 0)
                     {
+                        if (op == SSTableReader.Operator.EQ && updateCacheAndStats)
+                            bloomFilterTracker.addFalsePositive();
                         listener.onSSTableSkipped(this, SkippingReason.PARTITION_INDEX_LOOKUP);
                         Tracing.trace("Partition index lookup allows skipping sstable {}", descriptor.generation);
                         return null;


### PR DESCRIPTION
Summary of changes:
**source code**:
- moved index file presence check to the beginning of `getPosition` method
- added a comment for Key Cache lookup that there is no need to track BF stats
- started tracking false positive BF lookup for index interval check

**test**:
- removed BF stats checks from `testGetPositionsKeyCacheStats` test
- added `testGetPositionsBloomFilterStats` test with BF stats checks for all use cases (exit paths)
- replaced string by the existing constants (`"Standard2" -> CF_STANDARD2`)
- renamed a few constants for better readability