### PR TITLE
CASSANDRA-8132: Save or stream hints to a safe place in node replacement

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4530,6 +4530,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         onFinish.run();
     }
 
+    public void streamHintsBlocking() throws ExecutionException, InterruptedException
+    {
+        streamHints().get();
+        logger.debug("Hint transfer complete.");
+    }
+
     private Future streamHints()
     {
         return HintsService.instance.transferHints(this::getPreferredHintsStreamTarget);

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -715,6 +715,9 @@ public interface StorageServiceMBean extends NotificationEmitter
     Map<String, Boolean> getAutoCompactionStatus(String ks, String... tables) throws IOException;
 
     public void deliverHints(String host) throws UnknownHostException;
+    
+    /** Waits for hints on node to finish streaming to other target */
+    public void streamHintsBlocking() throws ExecutionException, InterruptedException;
 
     /** Returns the name of the cluster */
     public String getClusterName();

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -1052,6 +1053,11 @@ public class NodeProbe implements AutoCloseable
     public void truncateHints()
     {
         hsProxy.deleteAllHints();
+    }
+
+    public void transferHints() throws ExecutionException, InterruptedException
+    {
+        ssProxy.streamHintsBlocking();
     }
 
     public void refreshSizeEstimates()

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -196,6 +196,7 @@ public class NodeTool
                 SetCacheKeysToSave.class,
                 DisableHandoff.class,
                 Drain.class,
+                TransferHints.class,
                 TruncateHints.class,
                 TpStats.class,
                 TopPartitions.class,

--- a/src/java/org/apache/cassandra/tools/nodetool/TransferHints.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TransferHints.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+
+@Command(name = "transferhints", description = "transfer hints to closest neighbor according to snitch, blocking until completed")
+public class TransferHints extends NodeToolCmd
+{
+    @Option(title = "disable_handoff", name = {"-d", "--disable-handoff"}, description = "Disable hinted handoff from the start to prevent any further hints from being stored locally prior to transfer")
+    private boolean disableHandoff = false;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        boolean handOffInitiallyEnabled = probe.isHandoffEnabled();
+        if (handOffInitiallyEnabled && disableHandoff)
+            probe.disableHintedHandoff();
+
+        try
+        {
+            probe.transferHints();
+        }
+        catch (Exception e)
+        {
+            if (handOffInitiallyEnabled && disableHandoff)
+                probe.enableHintedHandoff();
+            throw new RuntimeException("Error occurred during hint transfer: ", e);
+        }
+    }
+}


### PR DESCRIPTION
The [JIRA](https://issues.apache.org/jira/browse/CASSANDRA-8132).

This seems to behave as expected. We are injecting writes to all nodes in the cluster when we kill one node:
```
INFO  [GossipStage:1] 2021-07-30 00:49:25,579 Gossiper.java:1290 - InetAddress /<DOWNED NODE IP> is now DOWN
```

We see hints are getting stored on other nodes, and when we run `nodetool transferhints -d`:
- the command blocks for a bit during the transfer
- no more hints on disk at the end
- hinted handoff is disabled at the end
```
$ ls /mnt/cass_data_disks/data1/hints/
a7c7f39d-bcaf-4b51-811a-5b00e708b7f5-1627606160115-2.crc32  a7c7f39d-bcaf-4b51-811a-5b00e708b7f5-1627606160115-2.hints  a7c7f39d-bcaf-4b51-811a-5b00e708b7f5-1627606170111-2.hints
$
$ nodetool statushandoff
Hinted handoff is running
$
$ date -u; nodetool transferhints -d; date -u
Fri Jul 30 00:59:10 UTC 2021
Fri Jul 30 00:59:18 UTC 2021
$
$ nodetool statushandoff
Hinted handoff is not running
```

The above timestamps for the hint transfer window are confirmed both in the system logs:
```
INFO  [HintsDispatcher:19] 2021-07-30 00:59:12,396 HintsDispatchExecutor.java:158 - Transferring all hints to <RECEIVING NODE IP>:7000: 15737a33-a0a6-4331-97bf-32f8af2534c1

INFO  [HintsDispatcher:19] 2021-07-30 00:59:12,532 HintsDispatchExecutor.java:282 - Finished hinted handoff of file a7c7f39d-bcaf-4b51-811a-5b00e708b7f5-1627606160115-2.hints to endpoint <RECEIVING NODE IP>:7000: 15737a33-a0a6-4331-97bf-32f8af2534c1
INFO  [HintsDispatcher:19] 2021-07-30 00:59:18,371 HintsDispatchExecutor.java:282 - Finished hinted handoff of file a7c7f39d-bcaf-4b51-811a-5b00e708b7f5-1627606170111-2.hints to endpoint <RECEIVING NODE IP>:7000: 15737a33-a0a6-4331-97bf-32f8af2534c1

DEBUG [RMI TCP Connection(10)-<SENDING NODE IP>] 2021-07-30 00:59:18,372 StorageService.java:4536 - Hint transfer complete
```
and the metric for total hints flat-lining:
![nodetool-transferhints](https://user-images.githubusercontent.com/11130580/127586500-c909f2c1-e26b-4cdd-9782-7c68e37b779d.png)
