### PR TITLE
fix formatting of zero latency value

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsKeyspace.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsKeyspace.java
@@ -66,13 +66,13 @@ public class StatsKeyspace
     {
         return readCount > 0
                ? totalReadTime / readCount / 1000
-               : Double.NaN;
+               : 0;
     }
 
     public double writeLatency()
     {
         return writeCount > 0
                ? totalWriteTime / writeCount / 1000
-               : Double.NaN;
+               : 0;
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2869953/132908280-dd959661-b926-41a6-b905-be0573b26cd0.png)


Non zero read/write values was resulting in an incorrect display of latency value in the output of `nodetool tablestats` command.

See the sample screenshot uploaded.

This patch will display latency value as `0` in case there is no read/write.