### PR TITLE
CASSANDRA-16983: Separating CQLSH credentials from the cqlshrc file

### DIFF
--- a/conf/cqlshrc.sample
+++ b/conf/cqlshrc.sample
@@ -19,8 +19,8 @@
 
 [authentication]
 ;; If Cassandra has auth enabled, fill out these options
-; username = fred
-; password = !!bang!!$
+;; Path to the credentials file, an initial ~ or ~user is expanded to that user's home directory
+; credentials = ~/.cassandra/credentials
 ; keyspace = ks1
 
 

--- a/conf/credentials.sample
+++ b/conf/credentials.sample
@@ -1,0 +1,25 @@
+; Licensed to the Apache Software Foundation (ASF) under one
+; or more contributor license agreements.  See the NOTICE file
+; distributed with this work for additional information
+; regarding copyright ownership.  The ASF licenses this file
+; to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance
+; with the License.  You may obtain a copy of the License at
+;
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing,
+; software distributed under the License is distributed on an
+; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+; KIND, either express or implied.  See the License for the
+; specific language governing permissions and limitations
+; under the License.
+;
+; Sample ~/.cassandra/credentials file.
+;
+; Please ensure this file is owned by the user and is not readable by group and other users
+
+[plain_text_auth]
+; username = fred
+; password = !!bang!!$
+

--- a/doc/source/tools/cqlsh.rst
+++ b/doc/source/tools/cqlsh.rst
@@ -47,6 +47,16 @@ The ``cqlshrc`` file holds configuration options for cqlsh.  By default this is 
 Example config values and documentation can be found in the ``conf/cqlshrc.sample`` file of a tarball installation.  You
 can also view the latest version of `cqlshrc online <https://github.com/apache/cassandra/blob/trunk/conf/cqlshrc.sample>`__.
 
+credentials
+^^^^^^^^^^^
+
+The ``credentials`` file holds authentication credentials for cqlsh.  By default this is in the user's home directory at
+``~/.cassandra/credentials``, but a custom location can be specified with the ``--credentials`` option.
+This file must be owned by the same user running the ``cqlsh``, and it must not be readable by group and other.
+
+Example config values and documentation can be found in the ``conf/credentials.sample`` file of a tarball installation.  You
+can also view the latest version of `credentials online <https://github.com/apache/cassandra/blob/trunk/conf/credentials.sample>`__.
+
 
 Command Line Options
 ^^^^^^^^^^^^^^^^^^^^
@@ -77,6 +87,7 @@ Options:
 ``-p`` ``--password``
   Password to authenticate against Cassandra with, should
   be used in conjunction with ``--user``
+  Insecure. Use ``credentials`` file if you can.
 
 ``-k`` ``--keyspace``
   Keyspace to authenticate to, should be used in conjunction
@@ -93,6 +104,9 @@ Options:
 
 ``--cqlshrc``
   Specify a non-default location for the ``cqlshrc`` file
+
+``--credentials``
+  Specify a non-default location for the ``credentials`` file
 
 ``-e`` ``--execute``
   Execute the given statement, then exit


### PR DESCRIPTION
This PR is for [CASSANDRA-16983](https://issues.apache.org/jira/browse/CASSANDRA-16983).

Changes made:
* Warn the user if a password is giving in the command line, and recommend them to use a credential file instead
* Warn the user if password is present in the cqlshrc file and the cqlshrc file is not secure (e.g.: world readable or owned by a different user). The username and password from the cqlshrc file is still accepted.
* Deprecate username and password in the cqlshrc file, and recommend the user to move them to a separate credential file. The username and password from the cqlshrc file is still accepted.
* Reject the credentials file if it's not secure, and tell the user how to secure it.
* Updated the documents
* Updated the sample cqlshrc file, and added a sample credentials file
* Removed redundant `+` operators between string literals, and fixed a bug when `~/.cqlshrc` and `~/.cassandra/cqlshrc` both exist, the warning text is shown incorrectly (this is not a part of [CASSANDRA-16983](https://issues.apache.org/jira/browse/CASSANDRA-16983), but I discovered and fixed the bug while I was working on it)

The credentials file intentionally choose to use the section name `plain_text_auth` instead of the old generic `authentication` in the cqlshrc file. This allows future expansion for supporting other authentication methods.