### PR TITLE
Use com.google.common.collect.Lists instead of com.google.monitoring.…

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/RowUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/RowUtil.java
@@ -25,10 +25,11 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
-import com.google.monitoring.runtime.instrumentation.common.collect.Lists;
+
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.distributed.api.QueryResults;


### PR DESCRIPTION
…runtime.instrumentation.common.collect.Lists in RowUtil.

Patch by Alex Petrov; reviewed by TBD for CASSANDRA-17022/