### PR TITLE
[CASSANDRA-17030] Allow GRANT/REVOKE multiple permissions in a single statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 2
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -130,10 +130,10 @@ jobs:
   repeated_jvm_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -305,10 +305,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -400,10 +400,10 @@ jobs:
   j11_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -510,10 +510,10 @@ jobs:
   repeated_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -632,10 +632,10 @@ jobs:
   j8_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -727,10 +727,10 @@ jobs:
   j11_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -823,10 +823,10 @@ jobs:
   j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -919,10 +919,10 @@ jobs:
   j11_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1015,10 +1015,10 @@ jobs:
   j8_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1110,10 +1110,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1205,10 +1205,10 @@ jobs:
   j11_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1350,10 +1350,10 @@ jobs:
   j8_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1472,10 +1472,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1568,10 +1568,10 @@ jobs:
   j11_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1667,10 +1667,10 @@ jobs:
   j8_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1743,10 +1743,10 @@ jobs:
   j8_upgradetests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1819,7 +1819,7 @@ jobs:
   utests_stress:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -1882,10 +1882,10 @@ jobs:
   j8_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1991,10 +1991,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 2
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2200,10 +2200,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2351,10 +2351,10 @@ jobs:
   j11_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2527,10 +2527,10 @@ jobs:
   j8_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2603,10 +2603,10 @@ jobs:
   j11_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2699,10 +2699,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 5
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2906,10 +2906,10 @@ jobs:
   j8_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3001,10 +3001,10 @@ jobs:
   j8_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3096,7 +3096,7 @@ jobs:
   utests_long:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3159,10 +3159,10 @@ jobs:
   utests_system_keyspace_directory:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3322,7 +3322,7 @@ jobs:
   utests_fqltool:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3385,10 +3385,10 @@ jobs:
   j11_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3484,10 +3484,10 @@ jobs:
   utests_compression:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3593,10 +3593,10 @@ jobs:
   j8_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -38,6 +38,9 @@ using the provided 'sstableupgrade' tool.
 
 New features
 ------------
+    - Support for multiple permission in a single GRANT/REVOKE/LIST statement has been added. It allows to
+      grant/revoke/list multiple permissions using a single statement by providing a list of comma-separated
+      permissions.
     - A new ALL TABLES IN KEYSPACE resource has been added. It allows to grant permissions for all tables and user types
       in a keyspace while preventing the user to use those permissions on the keyspace itself.
     - Added support for type casting in the WHERE clause components and in the values of INSERT and UPDATE statements.

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -1512,7 +1512,7 @@ syntax_rules += r'''
                | "EXECUTE"
                ;
 
-<permissionExpr> ::= ( <permission> "PERMISSION"? ( "," <permission> "PERMISSION"? )* )
+<permissionExpr> ::= ( [newpermission]=<permission> "PERMISSION"? ( "," [newpermission]=<permission> "PERMISSION"? )* )
                    | ( "ALL" "PERMISSIONS"? )
                    ;
 
@@ -1545,6 +1545,16 @@ syntax_rules += r'''
                 ;
 
 '''
+
+
+@completer_for('permissionExpr', 'newpermission')
+def permission_completer(ctxt, _):
+    new_permissions = set([permission.upper() for permission in ctxt.get_binding('newpermission')])
+    all_permissions = set([permission.arg for permission in ctxt.ruleset['permission'].arg])
+    suggestions = all_permissions - new_permissions
+    if len(suggestions) == 0:
+        return [Hint('No more permissions here.')]
+    return suggestions
 
 
 @completer_for('username', 'name')

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -1512,7 +1512,7 @@ syntax_rules += r'''
                | "EXECUTE"
                ;
 
-<permissionExpr> ::= ( <permission> "PERMISSION"? )
+<permissionExpr> ::= ( <permission> "PERMISSION"? ( "," <permission> "PERMISSION"? )* )
                    | ( "ALL" "PERMISSIONS"? )
                    ;
 

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -834,15 +834,23 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT'],
                             other_choices_ok=True)
         self.trycompletions("GRANT MODIFY ",
-                            choices=['ON', 'PERMISSION'])
+                            choices=[',', 'ON', 'PERMISSION'])
         self.trycompletions("GRANT MODIFY P",
-                            immediate='ERMISSION ON ')
-        self.trycompletions("GRANT MODIFY PERMISSION O",
+                            immediate='ERMISSION ')
+        self.trycompletions("GRANT MODIFY PERMISSION ",
+                            choices=[',', 'ON'])
+        self.trycompletions("GRANT MODIFY PERMISSION, ",
+                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT'])
+        self.trycompletions("GRANT MODIFY PERMISSION, D",
+                            choices=['DESCRIBE', 'DROP'])
+        self.trycompletions("GRANT MODIFY PERMISSION, DR",
+                            immediate='OP ')
+        self.trycompletions("GRANT MODIFY PERMISSION, DROP O",
                             immediate='N ')
-        self.trycompletions("GRANT MODIFY ON ",
+        self.trycompletions("GRANT MODIFY, DROP ON ",
                             choices=['ALL', 'KEYSPACE', 'MBEANS', 'ROLE', 'FUNCTION', 'MBEAN', 'TABLE'],
                             other_choices_ok=True)
-        self.trycompletions("GRANT MODIFY ON ALL ",
+        self.trycompletions("GRANT MODIFY, DROP ON ALL ",
                             choices=['KEYSPACES', 'TABLES'],
                             other_choices_ok=True)
         self.trycompletions("GRANT MODIFY PERMISSION ON KEY",
@@ -857,18 +865,28 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT'],
                             other_choices_ok=True)
         self.trycompletions("REVOKE MODIFY ",
-                            choices=['ON', 'PERMISSION'])
+                            choices=[',', 'ON', 'PERMISSION'])
         self.trycompletions("REVOKE MODIFY P",
-                            immediate='ERMISSION ON ')
-        self.trycompletions("REVOKE MODIFY PERMISSION O",
+                            immediate='ERMISSION ')
+        self.trycompletions("REVOKE MODIFY PERMISSION ",
+                            choices=[',', 'ON'])
+        self.trycompletions("REVOKE MODIFY PERMISSION, ",
+                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT'])
+        self.trycompletions("REVOKE MODIFY PERMISSION, D",
+                            choices=['DESCRIBE', 'DROP'])
+        self.trycompletions("REVOKE MODIFY PERMISSION, DR",
+                            immediate='OP ')
+        self.trycompletions("REVOKE MODIFY PERMISSION, DROP ",
+                            choices=[',', 'ON', 'PERMISSION'])
+        self.trycompletions("REVOKE MODIFY PERMISSION, DROP O",
                             immediate='N ')
-        self.trycompletions("REVOKE MODIFY PERMISSION ON ",
+        self.trycompletions("REVOKE MODIFY PERMISSION, DROP ON ",
                             choices=['ALL', 'KEYSPACE', 'MBEANS', 'ROLE', 'FUNCTION', 'MBEAN', 'TABLE'],
                             other_choices_ok=True)
-        self.trycompletions("REVOKE MODIFY ON ALL ",
+        self.trycompletions("REVOKE MODIFY, DROP ON ALL ",
                             choices=['KEYSPACES', 'TABLES'],
                             other_choices_ok=True)
-        self.trycompletions("REVOKE MODIFY PERMISSION ON KEY",
+        self.trycompletions("REVOKE MODIFY PERMISSION, DROP ON KEY",
                             immediate='SPACE ')
-        self.trycompletions("REVOKE MODIFY PERMISSION ON KEYSPACE system_tr",
+        self.trycompletions("REVOKE MODIFY PERMISSION, DROP ON KEYSPACE system_tr",
                             immediate='aces FROM ')

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1037,7 +1037,7 @@ truncateStatement returns [TruncateStatement stmt]
     ;
 
 /**
- * GRANT <permission> ON <resource> TO <rolename>
+ * GRANT <permission>[, <permission>]* | ALL ON <resource> TO <rolename>
  */
 grantPermissionsStatement returns [GrantPermissionsStatement stmt]
     : K_GRANT
@@ -1050,7 +1050,7 @@ grantPermissionsStatement returns [GrantPermissionsStatement stmt]
     ;
 
 /**
- * REVOKE <permission> ON <resource> FROM <rolename>
+ * REVOKE <permission>[, <permission>]* | ALL ON <resource> FROM <rolename>
  */
 revokePermissionsStatement returns [RevokePermissionsStatement stmt]
     : K_REVOKE
@@ -1105,7 +1105,7 @@ permission returns [Permission perm]
 
 permissionOrAll returns [Set<Permission> perms]
     : K_ALL ( K_PERMISSIONS )?       { $perms = Permission.ALL; }
-    | p=permission ( K_PERMISSION )? { $perms = EnumSet.of($p.perm); }
+    | p=permission ( K_PERMISSION )? { $perms = EnumSet.of($p.perm); } ( ',' p=permission ( K_PERMISSION )? { $perms.add($p.perm); } )*
     ;
 
 resource returns [IResource res]

--- a/test/unit/org/apache/cassandra/auth/GrantAndRevokeTest.java
+++ b/test/unit/org/apache/cassandra/auth/GrantAndRevokeTest.java
@@ -89,10 +89,7 @@ public class GrantAndRevokeTest extends CQLTester
 
         useSuperUser();
 
-        executeNet("GRANT ALTER ON KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
-        executeNet("GRANT DROP ON KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
-        executeNet("GRANT SELECT ON KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
-        executeNet("GRANT MODIFY ON KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
+        executeNet("GRANT ALTER, DROP, SELECT, MODIFY ON KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
 
         useUser(user, pass);
 
@@ -132,10 +129,7 @@ public class GrantAndRevokeTest extends CQLTester
 
         useSuperUser();
 
-        executeNet("REVOKE ALTER ON KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
-        executeNet("REVOKE DROP ON KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
-        executeNet("REVOKE SELECT ON KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
-        executeNet("REVOKE MODIFY ON KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
+        executeNet("REVOKE ALTER, DROP, MODIFY, SELECT ON KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
 
         table = KEYSPACE_PER_TEST + "." + createTable(KEYSPACE_PER_TEST, "CREATE TABLE %s (pk int, ck int, val int, val_2 text, PRIMARY KEY (pk, ck))");
         type = KEYSPACE_PER_TEST + "." + createType(KEYSPACE_PER_TEST, "CREATE TYPE %s (a int, b text)");
@@ -215,10 +209,7 @@ public class GrantAndRevokeTest extends CQLTester
 
         useSuperUser();
 
-        executeNet("GRANT ALTER ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
-        executeNet("GRANT DROP ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
-        executeNet("GRANT SELECT ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
-        executeNet("GRANT MODIFY ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
+        executeNet("GRANT ALTER, DROP, SELECT, MODIFY ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " TO " + user);
 
         useUser(user, pass);
 
@@ -261,10 +252,7 @@ public class GrantAndRevokeTest extends CQLTester
 
         useSuperUser();
 
-        executeNet("REVOKE ALTER ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
-        executeNet("REVOKE DROP ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
-        executeNet("REVOKE SELECT ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
-        executeNet("REVOKE MODIFY ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
+        executeNet("REVOKE ALTER, DROP, SELECT, MODIFY ON ALL TABLES IN KEYSPACE " + KEYSPACE_PER_TEST + " FROM " + user);
 
         table = KEYSPACE_PER_TEST + "." + createTable(KEYSPACE_PER_TEST, "CREATE TABLE %s (pk int, ck int, val int, val_2 text, PRIMARY KEY (pk, ck))");
         index = KEYSPACE_PER_TEST + '.' + createIndex(KEYSPACE_PER_TEST, "CREATE INDEX ON %s (val_2)");

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/RoleSyntaxTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/RoleSyntaxTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.cql3.validation.miscellaneous;
 
+import java.util.Arrays;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,6 +29,7 @@ public class RoleSyntaxTest extends CQLTester
 {
     private static final String NO_QUOTED_USERNAME = "Quoted strings are are not supported for user names " +
                                                      "and USER is deprecated, please use ROLE";
+
     @Test
     public void standardOptionsSyntaxTest() throws Throwable
     {
@@ -107,69 +110,63 @@ public class RoleSyntaxTest extends CQLTester
     @Test
     public void grantRevokePermissionsSyntaxTest() throws Throwable
     {
-        // grant/revoke on RoleResource
-        assertValidSyntax("GRANT ALTER ON ROLE r1 TO r2");
-        assertValidSyntax("GRANT ALTER ON ROLE 'r1' TO \"r2\"");
-        assertValidSyntax("GRANT ALTER ON ROLE \"r1\" TO 'r2'");
-        assertValidSyntax("GRANT ALTER ON ROLE $$r1$$ TO $$ r '2' $$");
-        assertValidSyntax("REVOKE ALTER ON ROLE r1 FROM r2");
-        assertValidSyntax("REVOKE ALTER ON ROLE 'r1' FROM \"r2\"");
-        assertValidSyntax("REVOKE ALTER ON ROLE \"r1\" FROM 'r2'");
-        assertValidSyntax("REVOKE ALTER ON ROLE $$r1$$ FROM $$ r '2' $$");
+        for (String r1 : Arrays.asList("r1", "'r1'", "\"r1\"", "$$r1$$"))
+        {
+            for (String r2 : Arrays.asList("r2", "\"r2\"", "'r2'", "$$ r '2' $$"))
+            {
+                // grant/revoke on RoleResource
+                assertValidSyntax(String.format("GRANT ALTER ON ROLE %s TO %s", r1, r2));
+                assertValidSyntax(String.format("GRANT ALTER PERMISSION ON ROLE %s TO %s", r1, r2));
+                assertValidSyntax(String.format("REVOKE ALTER ON ROLE %s FROM %s", r1, r2));
+                assertValidSyntax(String.format("REVOKE ALTER PERMISSION ON ROLE %s FROM %s", r1, r2));
 
-        // grant/revoke multiple permissions in a single statement
-        assertValidSyntax("GRANT CREATE, ALTER ON ROLE r1 TO r2");
-        assertValidSyntax("GRANT CREATE PERMISSION, ALTER PERMISSION ON ROLE r1 TO r2");
+                // grant/revoke multiple permissions in a single statement
+                assertValidSyntax(String.format("GRANT CREATE, ALTER ON ROLE %s TO %s", r1, r2));
+                assertValidSyntax(String.format("GRANT CREATE PERMISSION, ALTER PERMISSION ON ROLE %s TO %s", r1, r2));
+                assertValidSyntax(String.format("REVOKE CREATE, ALTER ON ROLE %s FROM %s", r1, r2));
+                assertValidSyntax(String.format("REVOKE CREATE PERMISSION, ALTER PERMISSION ON ROLE %s FROM %s", r1, r2));
+            }
+        }
 
-        // grant/revoke on DataResource
-        assertValidSyntax("GRANT SELECT ON KEYSPACE ks TO r1");
-        assertValidSyntax("GRANT SELECT ON KEYSPACE ks TO 'r1'");
-        assertValidSyntax("GRANT SELECT ON KEYSPACE ks TO \"r1\"");
-        assertValidSyntax("GRANT SELECT ON KEYSPACE ks TO $$ r '1' $$");
-        assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM r1");
-        assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM 'r1'");
-        assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM \"r1\"");
-        assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM $$ r '1' $$");
+        for (String r1 : Arrays.asList("r1", "'r1'", "\"r1\"", "$$r1$$", "$$ r '1' $$"))
+        {
+            // grant/revoke on DataResource
+            assertValidSyntax(String.format("GRANT SELECT ON KEYSPACE ks TO %s", r1));
+            assertValidSyntax(String.format("GRANT SELECT PERMISSION ON KEYSPACE ks TO %s", r1));
+            assertValidSyntax(String.format("REVOKE SELECT ON KEYSPACE ks FROM %s", r1));
+            assertValidSyntax(String.format("REVOKE SELECT PERMISSION ON KEYSPACE ks FROM %s", r1));
 
-        // grant/revoke multiple permissions in a single statement
-        assertValidSyntax("GRANT MODIFY, SELECT ON KEYSPACE ks TO r1");
-        assertValidSyntax("GRANT MODIFY PERMISSION, SELECT PERMISSION ON KEYSPACE ks TO r1");
-        assertValidSyntax("GRANT MODIFY, SELECT ON ALL KEYSPACES TO r1");
-        assertValidSyntax("GRANT MODIFY PERMISSION, SELECT PERMISSION ON ALL KEYSPACES TO r1");
-        assertValidSyntax("REVOKE MODIFY, SELECT ON KEYSPACE ks FROM r1");
-        assertValidSyntax("REVOKE MODIFY PERMISSION, SELECT PERMISSION ON KEYSPACE ks FROM r1");
-        assertValidSyntax("REVOKE MODIFY, SELECT ON ALL KEYSPACES FROM r1");
-        assertValidSyntax("REVOKE MODIFY PERMISSION, SELECT PERMISSION ON ALL KEYSPACES FROM r1");
+            // grant/revoke multiple permissions in a single statement
+            assertValidSyntax(String.format("GRANT MODIFY, SELECT ON KEYSPACE ks TO %s", r1));
+            assertValidSyntax(String.format("GRANT MODIFY PERMISSION, SELECT PERMISSION ON KEYSPACE ks TO %s", r1));
+            assertValidSyntax(String.format("GRANT MODIFY, SELECT ON ALL KEYSPACES TO %s", r1));
+            assertValidSyntax(String.format("GRANT MODIFY PERMISSION, SELECT PERMISSION ON ALL KEYSPACES TO %s", r1));
+            assertValidSyntax(String.format("REVOKE MODIFY, SELECT ON KEYSPACE ks FROM %s", r1));
+            assertValidSyntax(String.format("REVOKE MODIFY PERMISSION, SELECT PERMISSION ON KEYSPACE ks FROM %s", r1));
+            assertValidSyntax(String.format("REVOKE MODIFY, SELECT ON ALL KEYSPACES FROM %s", r1));
+            assertValidSyntax(String.format("REVOKE MODIFY PERMISSION, SELECT PERMISSION ON ALL KEYSPACES FROM %s", r1));
+        }
     }
 
     @Test
     public void listPermissionsSyntaxTest() throws Throwable
     {
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL ROLES OF r1");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL ROLES OF 'r1'");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL ROLES OF \"r1\"");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL ROLES OF $$ r '1' $$");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ROLE 'r1' OF r2");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ROLE \"r1\" OF r2");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ROLE $$ r '1' $$ OF r2");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ROLE 'r1' OF 'r2'");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ROLE \"r1\" OF \"r2\"");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ROLE $$r1$$ OF $$ r '2' $$");
+        for (String r1 : Arrays.asList("r1", "'r1'", "\"r1\"", "$$r1$$", "$$ r '1' $$"))
+        {
+            assertValidSyntax(String.format("LIST ALL PERMISSIONS ON ALL ROLES OF %s", r1));
+            assertValidSyntax(String.format("LIST ALL PERMISSIONS ON ALL KEYSPACES OF %s", r1));
+            assertValidSyntax(String.format("LIST ALL PERMISSIONS OF %s", r1));
+            assertValidSyntax(String.format("LIST MODIFY PERMISSION ON KEYSPACE ks OF %s", r1));
+            assertValidSyntax(String.format("LIST MODIFY, SELECT OF %s", r1));
+            assertValidSyntax(String.format("LIST MODIFY, SELECT PERMISSION ON KEYSPACE ks OF %s", r1));
 
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL KEYSPACES OF r1");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL KEYSPACES OF 'r1'");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL KEYSPACES OF \"r1\"");
-        assertValidSyntax("LIST ALL PERMISSIONS ON ALL KEYSPACES OF $$ r '1' $$");
-        assertValidSyntax("LIST ALL PERMISSIONS OF r1");
-        assertValidSyntax("LIST ALL PERMISSIONS OF 'r1'");
-        assertValidSyntax("LIST ALL PERMISSIONS OF \"r1\"");
-        assertValidSyntax("LIST ALL PERMISSIONS OF $$ r '1' $$");
-
-        assertValidSyntax("LIST ALTER PERMISSION ON ROLE r1 OF r2");
-        assertValidSyntax("LIST ALTER, DROP PERMISSION ON ROLE r1 OF r2");
-
-        assertValidSyntax("LIST MODIFY PERMISSION ON KEYSPACE ks OF r1");
-        assertValidSyntax("LIST MODIFY, SELECT PERMISSION ON KEYSPACE ks OF r1");
+            for (String r2 : Arrays.asList("r2", "\"r2\"", "'r2'", "$$ r '2' $$"))
+            {
+                assertValidSyntax(String.format("LIST ALL PERMISSIONS ON ROLE %s OF %s", r1, r2));
+                assertValidSyntax(String.format("LIST ALTER PERMISSION ON ROLE %s OF %s", r1, r2));
+                assertValidSyntax(String.format("LIST ALTER, DROP PERMISSION ON ROLE %s OF %s", r1, r2));
+            }
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/RoleSyntaxTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/RoleSyntaxTest.java
@@ -25,8 +25,8 @@ import org.apache.cassandra.cql3.CQLTester;
 
 public class RoleSyntaxTest extends CQLTester
 {
-    private final String NO_QUOTED_USERNAME = "Quoted strings are are not supported for user names " +
-                                              "and USER is deprecated, please use ROLE";
+    private static final String NO_QUOTED_USERNAME = "Quoted strings are are not supported for user names " +
+                                                     "and USER is deprecated, please use ROLE";
     @Test
     public void standardOptionsSyntaxTest() throws Throwable
     {
@@ -117,6 +117,10 @@ public class RoleSyntaxTest extends CQLTester
         assertValidSyntax("REVOKE ALTER ON ROLE \"r1\" FROM 'r2'");
         assertValidSyntax("REVOKE ALTER ON ROLE $$r1$$ FROM $$ r '2' $$");
 
+        // grant/revoke multiple permissions in a single statement
+        assertValidSyntax("GRANT CREATE, ALTER ON ROLE r1 TO r2");
+        assertValidSyntax("GRANT CREATE PERMISSION, ALTER PERMISSION ON ROLE r1 TO r2");
+
         // grant/revoke on DataResource
         assertValidSyntax("GRANT SELECT ON KEYSPACE ks TO r1");
         assertValidSyntax("GRANT SELECT ON KEYSPACE ks TO 'r1'");
@@ -126,6 +130,16 @@ public class RoleSyntaxTest extends CQLTester
         assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM 'r1'");
         assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM \"r1\"");
         assertValidSyntax("REVOKE SELECT ON KEYSPACE ks FROM $$ r '1' $$");
+
+        // grant/revoke multiple permissions in a single statement
+        assertValidSyntax("GRANT MODIFY, SELECT ON KEYSPACE ks TO r1");
+        assertValidSyntax("GRANT MODIFY PERMISSION, SELECT PERMISSION ON KEYSPACE ks TO r1");
+        assertValidSyntax("GRANT MODIFY, SELECT ON ALL KEYSPACES TO r1");
+        assertValidSyntax("GRANT MODIFY PERMISSION, SELECT PERMISSION ON ALL KEYSPACES TO r1");
+        assertValidSyntax("REVOKE MODIFY, SELECT ON KEYSPACE ks FROM r1");
+        assertValidSyntax("REVOKE MODIFY PERMISSION, SELECT PERMISSION ON KEYSPACE ks FROM r1");
+        assertValidSyntax("REVOKE MODIFY, SELECT ON ALL KEYSPACES FROM r1");
+        assertValidSyntax("REVOKE MODIFY PERMISSION, SELECT PERMISSION ON ALL KEYSPACES FROM r1");
     }
 
     @Test
@@ -150,6 +164,12 @@ public class RoleSyntaxTest extends CQLTester
         assertValidSyntax("LIST ALL PERMISSIONS OF 'r1'");
         assertValidSyntax("LIST ALL PERMISSIONS OF \"r1\"");
         assertValidSyntax("LIST ALL PERMISSIONS OF $$ r '1' $$");
+
+        assertValidSyntax("LIST ALTER PERMISSION ON ROLE r1 OF r2");
+        assertValidSyntax("LIST ALTER, DROP PERMISSION ON ROLE r1 OF r2");
+
+        assertValidSyntax("LIST MODIFY PERMISSION ON KEYSPACE ks OF r1");
+        assertValidSyntax("LIST MODIFY, SELECT PERMISSION ON KEYSPACE ks OF r1");
     }
 
     @Test


### PR DESCRIPTION
This commit allows GRANT/REVOKE statement to support multiple permissions with a single
statement. For example,

```cql
GRANT MODIFY, SELECT ON KEYSPACE field TO manager;
GRANT ALTER, DROP ON ROLE role1 TO role2;
```