### PR TITLE
First change for [CASSANDRA-15248] upgrade Guava dep from 18.0 to 19.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -323,7 +323,7 @@
           <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.1.7"/>
           <dependency groupId="net.jpountz.lz4" artifactId="lz4" version="1.3.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4"/>
-          <dependency groupId="com.google.guava" artifactId="guava" version="18.0">
+          <dependency groupId="com.google.guava" artifactId="guava" version="19.0">
             <exclusion groupId="com.google.code.findbugs" artifactId="jsr305" />
             <exclusion groupId="org.codehaus.mojo" artifactId="animal-sniffer-annotations" />
             <exclusion groupId="com.google.guava" artifactId="listenablefuture" />

--- a/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/Descriptor.java
@@ -270,7 +270,7 @@ public class Descriptor
         nexttok = tokenStack.pop();
         // generation OR format type
         SSTableFormat.Type fmt = SSTableFormat.Type.LEGACY;
-        if (!CharMatcher.DIGIT.matchesAllOf(nexttok))
+        if (!CharMatcher.digit().matchesAllOf(nexttok))
         {
             fmt = SSTableFormat.Type.validate(nexttok);
             nexttok = tokenStack.pop();

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -60,7 +60,7 @@ public interface SSTableFormat
         {
             //Since format comes right after generation
             //we disallow formats with numeric names
-            assert !CharMatcher.DIGIT.matchesAllOf(name);
+            assert !CharMatcher.digit().matchesAllOf(name);
 
             this.name = name;
             this.info = info;

--- a/src/java/org/apache/cassandra/repair/RepairJob.java
+++ b/src/java/org/apache/cassandra/repair/RepairJob.java
@@ -87,7 +87,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
             }
             // When all snapshot complete, send validation requests
             ListenableFuture<List<InetAddress>> allSnapshotTasks = Futures.allAsList(snapshotTasks);
-            validations = Futures.transform(allSnapshotTasks, new AsyncFunction<List<InetAddress>, List<TreeResponse>>()
+            validations = Futures.transformAsync(allSnapshotTasks, new AsyncFunction<List<InetAddress>, List<TreeResponse>>()
             {
                 public ListenableFuture<List<TreeResponse>> apply(List<InetAddress> endpoints)
                 {
@@ -105,7 +105,7 @@ public class RepairJob extends AbstractFuture<RepairResult> implements Runnable
         }
 
         // When all validations complete, submit sync tasks
-        ListenableFuture<List<SyncStat>> syncResults = Futures.transform(validations, new AsyncFunction<List<TreeResponse>, List<SyncStat>>()
+        ListenableFuture<List<SyncStat>> syncResults = Futures.transformAsync(validations, new AsyncFunction<List<TreeResponse>, List<SyncStat>>()
         {
             public ListenableFuture<List<SyncStat>> apply(List<TreeResponse> trees)
             {

--- a/src/java/org/apache/cassandra/repair/RepairRunnable.java
+++ b/src/java/org/apache/cassandra/repair/RepairRunnable.java
@@ -318,7 +318,7 @@ public class RepairRunnable extends WrappedRunnable implements ProgressEventNoti
         final Collection<Range<Token>> successfulRanges = new ArrayList<>();
         final AtomicBoolean hasFailure = new AtomicBoolean();
         final ListenableFuture<List<RepairSessionResult>> allSessions = Futures.successfulAsList(futures);
-        ListenableFuture anticompactionResult = Futures.transform(allSessions, new AsyncFunction<List<RepairSessionResult>, Object>()
+        ListenableFuture anticompactionResult = Futures.transformAsync(allSessions, new AsyncFunction<List<RepairSessionResult>, Object>()
         {
             @SuppressWarnings("unchecked")
             public ListenableFuture apply(List<RepairSessionResult> results)

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -183,7 +183,7 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
                 failureDetector.unregisterFailureDetectionEventListener(task);
                 gossiper.unregister(task);
             }
-        }, MoreExecutors.sameThreadExecutor());
+        }, MoreExecutors.directExecutor());
     }
 
     public synchronized void terminateSessions()

--- a/test/unit/org/apache/cassandra/repair/RepairJobTest.java
+++ b/test/unit/org/apache/cassandra/repair/RepairJobTest.java
@@ -237,7 +237,7 @@ public class RepairJobTest extends SchemaLoader
         // SyncTasks themselves should not contain significant memory
         assertTrue(ObjectSizes.measureDeep(syncTasks) < 0.8 * singleTreeSize);
 
-        ListenableFuture<List<SyncStat>> syncResults = Futures.transform(Futures.immediateFuture(mockTreeResponses), new AsyncFunction<List<TreeResponse>, List<SyncStat>>()
+        ListenableFuture<List<SyncStat>> syncResults = Futures.transformAsync(Futures.immediateFuture(mockTreeResponses), new AsyncFunction<List<TreeResponse>, List<SyncStat>>()
         {
             public ListenableFuture<List<SyncStat>> apply(List<TreeResponse> treeResponses)
             {


### PR DESCRIPTION
Aside from Guava dependency change (18.0 -> 19.0) two related code changes:

* `CharMatcher.DIGIT` (removed from Guava 26) replaced with `CharMatcher.digit()` (added in Guava 19)
* `Futures.transform()` (removed from Guava... 23?) replaced with `Futures.transformAsync()` (added in Guava 19)
* `MoreExecutors.sameThreadExecutor()` (removed from Guava 21) -> `MoreExecutors.directExecutor()` (has existed from earlier Guava versions) 

all of which are identical replacements (no functional differences).

Local test suite passes after changes.
First part of changes to fix:

https://issues.apache.org/jira/browse/CASSANDRA-15248
