### PR TITLE
CASSANDRA-17040: Upgrade Snappy version to support Apple M1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -46,6 +46,7 @@
  * GossiperTest.testHasVersion3Nodes didn't take into account trunk version changes, fixed to rely on latest version (CASSANDRA-16651)
 Merged from 4.0:
  * Push initial client connection messages to trace (CASSANDRA-17038)
+ * Update snappy-java to version 1.1.8.4 (CASSANDRA-17040)
  * Correct the internode message timestamp if sending node has wrapped (CASSANDRA-16997)
  * Avoid race causing us to return null in RangesAtEndpoint (CASSANDRA-16965)
  * Avoid rewriting all sstables during cleanup when transient replication is enabled (CASSANDRA-16966)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -60,6 +60,7 @@ Upgrading
       was created while the above property was set to be more than 30 otherwise they will not be able to log in.
     - Information about pending hints is now available through `nodetool listpendinghints` and `pending_hints` virtual
       table.
+    - Snappy-java was updated from 1.1.2.6 to 1.1.8.4 which supports Apple M1 devices.
 
 Deprecation
 -----------

--- a/build.xml
+++ b/build.xml
@@ -486,7 +486,7 @@
         <license name="The Apache Software License, Version 2.0" url="https://www.apache.org/licenses/LICENSE-2.0.txt"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>
         <dependencyManagement>
-          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.2.6"/>
+          <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.8.4"/>
           <dependency groupId="org.lz4" artifactId="lz4-java" version="1.8.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4" scope="provided"/>
           <dependency groupId="com.github.luben" artifactId="zstd-jni" version="1.5.0-4"/>


### PR DESCRIPTION
Snappy-java added M1 support since 1.1.8.2.(https://github.com/xerial/snappy-java/pull/268).

So let's upgrade snappy-java dependency to the latest release 1.1.8.4.

The PR is from: CASSANDRA-17019
