### PR TITLE
CASSANDRA-17041 : fix resource leak due to Files.list

### DIFF
--- a/src/java/org/apache/cassandra/hints/HintsCatalog.java
+++ b/src/java/org/apache/cassandra/hints/HintsCatalog.java
@@ -64,11 +64,10 @@ final class HintsCatalog
      */
     static HintsCatalog load(File hintsDirectory, ImmutableMap<String, Object> writerParams)
     {
-        try
+        try (Stream<Path> stream = Files.list(hintsDirectory.toPath()))
         {
             Map<UUID, List<HintsDescriptor>> stores =
-                Files.list(hintsDirectory.toPath())
-                     .filter(HintsDescriptor::isHintFileName)
+                stream.filter(HintsDescriptor::isHintFileName)
                      .map(HintsDescriptor::readFromFileQuietly)
                      .filter(Optional::isPresent)
                      .map(Optional::get)


### PR DESCRIPTION
Files.list will opend dir and we should close it.

 

see jdk:

the

{@code try}-with-resources construct should be used to ensure that the
stream's {@link Stream#close close} method is invoked after the stream
operations are completed.