### PR TITLE
CASSANDRA-17047 (3.0): Handle unexpected columns due to drop column schema races

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -313,7 +313,7 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -447,10 +447,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -575,7 +575,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -756,7 +756,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -934,7 +934,7 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -1011,10 +1011,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1236,10 +1236,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1361,10 +1361,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1441,7 +1441,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1622,7 +1622,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1730,10 +1730,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1807,10 +1807,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1887,7 +1887,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2068,7 +2068,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2243,10 +2243,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2622,10 +2622,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2750,7 +2750,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/test/distributed/org/apache/cassandra/distributed/test/SchemaTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SchemaTest.java
@@ -24,6 +24,8 @@ import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 
 import static org.junit.Assert.assertTrue;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 
 public class SchemaTest extends TestBaseImpl
 {
@@ -84,6 +86,116 @@ public class SchemaTest extends TestBaseImpl
                 cause = cause.getCause();
             }
             assertTrue(causeIsUnknownColumn);
+        }
+    }
+
+    @Test
+    public void dropColumnMixedMode() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(2).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (id int primary key, v1 int, v2 int, v3 int)"));
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 1, 10, 100, 1000);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 2, 20, 200, 2000);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 3, 30, 300, 3000);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 4, 40, 400, 4000);
+
+            cluster.forEach((instance) -> instance.flush(KEYSPACE));
+            cluster.get(1).schemaChangeInternal(withKeyspace("ALTER TABLE %s.tbl DROP v2"));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT id, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10),
+                       row(2, 20),
+                       row(4, 40),
+                       row(3, 30));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10, 1000),
+                       row(2, 20, 2000),
+                       row(4, 40, 4000),
+                       row(3, 30, 3000));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT id, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10),
+                       row(2, 20),
+                       row(4, 40),
+                       row(3, 30));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10, 100, 1000),
+                       row(2, 20, 200, 2000),
+                       row(4, 40, 400, 4000),
+                       row(3, 30, 300, 3000));
+        }
+    }
+
+    @Test
+    public void dropStaticColumnMixedMode() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(2).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int, c int, v1 int, v2 int, s1 int static, s2 int static, PRIMARY KEY(pk, c))"));
+
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, s1, s2) VALUES (?, ?, ?)") , ConsistencyLevel.ALL, 1, 10, 100);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, s1, s2) VALUES (?, ?, ?)") , ConsistencyLevel.ALL, 2, 20, 200);
+
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 1, 1, 10, 100);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 1, 2, 20, 200);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 1, 3, 30, 300);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 2, 1, 10, 100);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 2, 2, 20, 200);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 2, 3, 30, 300);
+
+            cluster.forEach((instance) -> instance.flush(KEYSPACE));
+            cluster.get(1).schemaChangeInternal(withKeyspace("ALTER TABLE %s.tbl DROP s2"));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT DISTINCT pk, s1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10),
+                       row(2, 20));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT pk, c, s1, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 10),
+                       row(1, 2, 10, 20),
+                       row(1, 3, 10, 30),
+                       row(2, 1, 20, 10),
+                       row(2, 2, 20, 20),
+                       row(2, 3, 20, 30));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT pk, c, s1 FROM %s.tbl WHERE pk IN (1, 2) AND c = 2"), ConsistencyLevel.ALL),
+                       row(1, 2, 10),
+                       row(2, 2, 20));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 10, 100),
+                       row(1, 2, 10, 20, 200),
+                       row(1, 3, 10, 30, 300),
+                       row(2, 1, 20, 10, 100),
+                       row(2, 2, 20, 20, 200),
+                       row(2, 3, 20, 30, 300));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT DISTINCT pk, s1, s2 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10, 100),
+                       row(2, 20, 200));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT pk, c, s1, s2, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 100, 10),
+                       row(1, 2, 10, 100, 20),
+                       row(1, 3, 10, 100, 30),
+                       row(2, 1, 20, 200, 10),
+                       row(2, 2, 20, 200, 20),
+                       row(2, 3, 20, 200, 30));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT pk, c, s1, s2 FROM %s.tbl WHERE pk IN (1, 2) AND c = 2"), ConsistencyLevel.ALL),
+                       row(1, 2, 10, 100),
+                       row(2, 2, 20, 200));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 100, 10, 100),
+                       row(1, 2, 10, 100, 20, 200),
+                       row(1, 3, 10, 100, 30, 300),
+                       row(2, 1, 20, 200, 10, 100),
+                       row(2, 2, 20, 200, 20, 200),
+                       row(2, 3, 20, 200, 30, 300));
         }
     }
 }


### PR DESCRIPTION
The patch ensure that even when a node is not aware of a DROP column it will answer correctly to the query by taking into account only the fetched columns requested by the coordinatoor.