### PR TITLE
CASSANDRA-17047(3.11): Handle unexpected columns due to drop column schema races

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -137,7 +137,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -319,7 +319,7 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -401,7 +401,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -642,10 +642,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -769,10 +769,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -899,7 +899,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1084,7 +1084,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1266,7 +1266,7 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -1345,10 +1345,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1574,10 +1574,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1701,10 +1701,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1780,10 +1780,10 @@ jobs:
   j8_jvm_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1968,7 +1968,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2145,10 +2145,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2249,7 +2249,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2359,10 +2359,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2438,10 +2438,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2520,7 +2520,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2705,7 +2705,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2882,10 +2882,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3012,7 +3012,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3194,10 +3194,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3454,10 +3454,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3584,7 +3584,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnFilter.java
@@ -82,10 +82,10 @@ public class ColumnFilter
                          PartitionColumns queried,
                          SortedSetMultimap<ColumnIdentifier, ColumnSubselection> subSelections)
     {
-        assert !isFetchAll || fetched != null;
+        assert fetched != null;
         assert isFetchAll || queried != null;
         this.isFetchAll = isFetchAll;
-        this.fetched = isFetchAll ? fetched : queried;
+        this.fetched = fetched;
         this.queried = queried;
         this.subSelections = subSelections;
     }
@@ -107,7 +107,7 @@ public class ColumnFilter
      */
     public static ColumnFilter selection(PartitionColumns columns)
     {
-        return new ColumnFilter(false, null, columns, null);
+        return new ColumnFilter(false, columns, columns, null);
     }
 
 	/**
@@ -381,7 +381,7 @@ public class ColumnFilter
                 queried = null;
             }
 
-            return new ColumnFilter(isFetchAll, isFetchAll ? metadata.partitionColumns() : null, queried, s);
+            return new ColumnFilter(isFetchAll, isFetchAll ? metadata.partitionColumns() : queried, queried, s);
         }
     }
 
@@ -495,6 +495,12 @@ public class ColumnFilter
             PartitionColumns fetched = null;
             PartitionColumns queried = null;
 
+            // Due to schema change propagation delays, it is possible that the replica receiving the query has more
+            // columns than the coordinator. Those columns need to be ignored when returning the results as it will
+            // otherwise trigger some errors on the coordinator side that is not aware of them.
+            boolean hasNoExtraStaticColumns = true;
+            boolean hasNoExtraRegularColumns = true;
+
             if (isFetchAll)
             {
                 if (version >= MessagingService.VERSION_3014)
@@ -502,6 +508,8 @@ public class ColumnFilter
                     Columns statics = Columns.serializer.deserialize(in, metadata);
                     Columns regulars = Columns.serializer.deserialize(in, metadata);
                     fetched = new PartitionColumns(statics, regulars);
+                    hasNoExtraStaticColumns = statics.containsAll(metadata.partitionColumns().statics);
+                    hasNoExtraRegularColumns = regulars.containsAll(metadata.partitionColumns().regulars);
                 }
                 else
                 {
@@ -539,7 +547,10 @@ public class ColumnFilter
                 queried = null;
             }
 
-            return new ColumnFilter(isFetchAll, fetched, queried, subSelections);
+            if (hasNoExtraStaticColumns && hasNoExtraRegularColumns)
+                return new ColumnFilter(isFetchAll, isFetchAll ? fetched : queried, queried, subSelections);
+
+            return new ColumnFilter(false, fetched, queried == null ? fetched : queried, subSelections);
         }
 
         public long serializedSize(ColumnFilter selection, int version)

--- a/test/distributed/org/apache/cassandra/distributed/test/SchemaTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SchemaTest.java
@@ -22,7 +22,10 @@ import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
+
 import static org.junit.Assert.assertTrue;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 
 public class SchemaTest extends TestBaseImpl
 {
@@ -83,6 +86,116 @@ public class SchemaTest extends TestBaseImpl
                 cause = cause.getCause();
             }
             assertTrue(causeIsUnknownColumn);
+        }
+    }
+
+    @Test
+    public void dropColumnMixedMode() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(2).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (id int primary key, v1 int, v2 int, v3 int)"));
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 1, 10, 100, 1000);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 2, 20, 200, 2000);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 3, 30, 300, 3000);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (id, v1, v2, v3) VALUES (?,?,?, ?)") , ConsistencyLevel.ALL, 4, 40, 400, 4000);
+
+            cluster.forEach((instance) -> instance.flush(KEYSPACE));
+            cluster.get(1).schemaChangeInternal(withKeyspace("ALTER TABLE %s.tbl DROP v2"));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT id, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10),
+                       row(2, 20),
+                       row(4, 40),
+                       row(3, 30));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10, 1000),
+                       row(2, 20, 2000),
+                       row(4, 40, 4000),
+                       row(3, 30, 3000));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT id, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10),
+                       row(2, 20),
+                       row(4, 40),
+                       row(3, 30));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10, 100, 1000),
+                       row(2, 20, 200, 2000),
+                       row(4, 40, 400, 4000),
+                       row(3, 30, 300, 3000));
+        }
+    }
+
+    @Test
+    public void dropStaticColumnMixedMode() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build(2).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int, c int, v1 int, v2 int, s1 int static, s2 int static, PRIMARY KEY(pk, c))"));
+
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, s1, s2) VALUES (?, ?, ?)") , ConsistencyLevel.ALL, 1, 10, 100);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, s1, s2) VALUES (?, ?, ?)") , ConsistencyLevel.ALL, 2, 20, 200);
+
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 1, 1, 10, 100);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 1, 2, 20, 200);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 1, 3, 30, 300);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 2, 1, 10, 100);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 2, 2, 20, 200);
+            cluster.coordinator(1).execute(withKeyspace("INSERT INTO %s.tbl (pk, c, v1, v2) VALUES (?, ?, ?, ?)") , ConsistencyLevel.ALL, 2, 3, 30, 300);
+
+            cluster.forEach((instance) -> instance.flush(KEYSPACE));
+            cluster.get(1).schemaChangeInternal(withKeyspace("ALTER TABLE %s.tbl DROP s2"));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT DISTINCT pk, s1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10),
+                       row(2, 20));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT pk, c, s1, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 10),
+                       row(1, 2, 10, 20),
+                       row(1, 3, 10, 30),
+                       row(2, 1, 20, 10),
+                       row(2, 2, 20, 20),
+                       row(2, 3, 20, 30));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT pk, c, s1 FROM %s.tbl WHERE pk IN (1, 2) AND c = 2"), ConsistencyLevel.ALL),
+                       row(1, 2, 10),
+                       row(2, 2, 20));
+
+            assertRows(cluster.coordinator(1).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 10, 100),
+                       row(1, 2, 10, 20, 200),
+                       row(1, 3, 10, 30, 300),
+                       row(2, 1, 20, 10, 100),
+                       row(2, 2, 20, 20, 200),
+                       row(2, 3, 20, 30, 300));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT DISTINCT pk, s1, s2 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 10, 100),
+                       row(2, 20, 200));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT pk, c, s1, s2, v1 FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 100, 10),
+                       row(1, 2, 10, 100, 20),
+                       row(1, 3, 10, 100, 30),
+                       row(2, 1, 20, 200, 10),
+                       row(2, 2, 20, 200, 20),
+                       row(2, 3, 20, 200, 30));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT pk, c, s1, s2 FROM %s.tbl WHERE pk IN (1, 2) AND c = 2"), ConsistencyLevel.ALL),
+                       row(1, 2, 10, 100),
+                       row(2, 2, 20, 200));
+
+            assertRows(cluster.coordinator(2).execute(withKeyspace("SELECT * FROM %s.tbl"), ConsistencyLevel.ALL),
+                       row(1, 1, 10, 100, 10, 100),
+                       row(1, 2, 10, 100, 20, 200),
+                       row(1, 3, 10, 100, 30, 300),
+                       row(2, 1, 20, 200, 10, 100),
+                       row(2, 2, 20, 200, 20, 200),
+                       row(2, 3, 20, 200, 30, 300));
         }
     }
 }


### PR DESCRIPTION
The patch ensure that even when a node is not aware of a DROP column it will answer correctly to the query by taking into account only the fetched columns requested by the coordinatoor.