### PR TITLE
Newer Java hides sun.rmi.registry.RegistryImpl and interface is fully implemented anyway

### DIFF
--- a/src/java/org/apache/cassandra/utils/JMXServerUtils.java
+++ b/src/java/org/apache/cassandra/utils/JMXServerUtils.java
@@ -325,7 +325,7 @@ public class JMXServerUtils
      * Better to use the internal API than re-invent the wheel.
      */
     @SuppressWarnings("restriction")
-    private static class JmxRegistry extends sun.rmi.registry.RegistryImpl {
+    private static class JmxRegistry implements java.rmi.registry.Registry {
         private final String lookupName;
         private Remote remoteServerStub;
 
@@ -333,7 +333,6 @@ public class JMXServerUtils
                     final RMIClientSocketFactory csf,
                     RMIServerSocketFactory ssf,
                     final String lookupName) throws RemoteException {
-            super(port, csf, ssf);
             this.lookupName = lookupName;
         }
 


### PR DESCRIPTION
Newer java versions appear to hide sun.rmi.registry.RegistryImpl, and thus cause compile error.  However, since the interface is fully implemented here (mostly stubs), I couldn't find a reason not to simply derive from the interface directly.