### PR TITLE
Paxos: in-progress-ballot needs to be set while accepting a proposal

### DIFF
--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -1214,9 +1214,10 @@ public final class SystemKeyspace
 
     public static void savePaxosProposal(Commit proposal)
     {
-        executeInternal(format("UPDATE system.%s USING TIMESTAMP ? AND TTL ? SET proposal_ballot = ?, proposal = ?, proposal_version = ? WHERE row_key = ? AND cf_id = ?", PAXOS),
+        executeInternal(format("UPDATE system.%s USING TIMESTAMP ? AND TTL ? SET in_progress_ballot = ?, proposal_ballot = ?, proposal = ?, proposal_version = ? WHERE row_key = ? AND cf_id = ?", PAXOS),
                         UUIDGen.microsTimestamp(proposal.ballot),
                         paxosTtlSec(proposal.update.metadata()),
+                        proposal.ballot,
                         proposal.ballot,
                         PartitionUpdate.toBytes(proposal.update, MessagingService.current_version),
                         MessagingService.current_version,


### PR DESCRIPTION
I was going through this blog post (thanks for @martinfowler for pointing me to this post)
, which talks about a bug in paxos implementation if in-progress ballot is not set while accepting a proposal.
https://brooker.co.za/blog/2021/11/16/paxos.html

I tried writing a failing test and possible fix. Will like to get comments.