### PR TITLE
CASSANDRA-17202 3.11 Avoid unnecessary String.format in QueryProcessor when getting stored prepared statement

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -486,7 +486,8 @@ public class QueryProcessor implements QueryHandler
                 return null;
 
             checkTrue(queryString.equals(existing.rawCQLStatement),
-                      String.format("MD5 hash collision: query with the same MD5 hash was already prepared. \n Existing: '%s'", existing.rawCQLStatement));
+                      "MD5 hash collision: query with the same MD5 hash was already prepared. \n Existing: '%s'",
+                      existing.rawCQLStatement);
             return ResultMessage.Prepared.forThrift(thriftStatementId, existing.boundNames);
         }
         else
@@ -497,7 +498,8 @@ public class QueryProcessor implements QueryHandler
                 return null;
 
             checkTrue(queryString.equals(existing.rawCQLStatement),
-                      String.format("MD5 hash collision: query with the same MD5 hash was already prepared. \n Existing: '%s'", existing.rawCQLStatement));
+                      "MD5 hash collision: query with the same MD5 hash was already prepared. \n Existing: '%s'",
+                      existing.rawCQLStatement);
             return new ResultMessage.Prepared(statementId, existing);
         }
     }


### PR DESCRIPTION
A copy of #1358 targeting `cassandra-3.11` branch.