### PR TITLE
CASSANDRA-17241: Improve audit logging documentation for production

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1469,7 +1469,7 @@ compaction_tombstone_warning_threshold: 100000
 # max_concurrent_automatic_sstable_upgrades: 1
 
 # Audit logging - Logs every incoming CQL command request, authentication to a node. See the docs
-# on audit_logging for full details about the various configuration options.
+# on audit_logging for full details about the various configuration options and production tips.
 audit_logging_options:
   enabled: false
   logger:
@@ -1485,10 +1485,12 @@ audit_logging_options:
   # block: true
   # max_queue_weight: 268435456 # 256 MiB
   # max_log_size: 17179869184 # 16 GiB
-  ## archive command is "/path/to/script.sh %path" where %path is replaced with the file being rolled:
+  #
+  ## If archive_command is empty or unset, Cassandra uses a built-in DeletingArchiver that deletes the oldest files if ``max_log_size`` is reached.
+  ## If archive_command is set, Cassandra do **not** use the DeletingArchiver, so it's the responsability of the script to make any required cleanup.
+  ## Example: "/path/to/script.sh %path" where %path is replaced with the file being rolled.
   # archive_command:
   # max_archive_retries: 10
-
 
 # default options for full query logging - these can be overridden from command line when executing
 # nodetool enablefullquerylog

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -44,8 +44,8 @@ num_tokens: 16
 allocate_tokens_for_local_replication_factor: 3
 
 # initial_token allows you to specify tokens manually.  While you can use it with
-# vnodes (num_tokens > 1, above) -- in which case you should provide a 
-# comma-separated list -- it's primarily used when adding nodes to legacy clusters 
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters
 # that do not have vnodes enabled.
 # initial_token:
 
@@ -264,7 +264,7 @@ credentials_validity: 2000ms
 partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 
 # Directories where Cassandra should store data on disk. If multiple
-# directories are specified, Cassandra will spread data evenly across 
+# directories are specified, Cassandra will spread data evenly across
 # them by partitioning the token ranges.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 # data_file_directories:
@@ -450,8 +450,8 @@ counter_cache_save_period: 7200s
 # while still having the cache during runtime.
 # cache_load_timeout: 30s
 
-# commitlog_sync may be either "periodic", "group", or "batch." 
-# 
+# commitlog_sync may be either "periodic", "group", or "batch."
+#
 # When in batch mode, Cassandra won't ack writes until the commit log
 # has been flushed to disk.  Each incoming write will trigger the flush task.
 # commitlog_sync_batch_window_in_ms is a deprecated value. Previously it had
@@ -871,7 +871,7 @@ incremental_backups: false
 snapshot_before_compaction: false
 
 # Whether or not a snapshot is taken of the data before keyspace truncation
-# or dropping of column families. The STRONGLY advised default of true 
+# or dropping of column families. The STRONGLY advised default of true
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
 auto_snapshot: true
@@ -923,7 +923,7 @@ column_index_cache_size: 2KiB
 #
 # concurrent_compactors defaults to the smaller of (number of disks,
 # number of cores), with a minimum of 2 and a maximum of 8.
-# 
+#
 # If your data directories are backed by SSD, you should increase this
 # to the number of cores.
 # concurrent_compactors: 1
@@ -951,7 +951,7 @@ compaction_throughput: 64MiB/s
 
 # When compacting, the replacement sstable(s) can be opened before they
 # are completely written, and used in place of the prior sstables for
-# any range that has been written. This helps to smoothly transfer reads 
+# any range that has been written. This helps to smoothly transfer reads
 # between the sstables, reducing page cache churn and keeping hot rows hot
 sstable_preemptive_open_interval: 50MiB
 
@@ -1084,10 +1084,10 @@ slow_query_log_timeout: 500ms
 # Enable operation timeout information exchange between nodes to accurately
 # measure request timeouts.  If disabled, replicas will assume that requests
 # were forwarded to them instantly by the coordinator, which means that
-# under overload conditions we will waste that much extra time processing 
+# under overload conditions we will waste that much extra time processing
 # already-timed-out requests.
 #
-# Warning: It is generally assumed that users have setup NTP on their clusters, and that clocks are modestly in sync, 
+# Warning: It is generally assumed that users have setup NTP on their clusters, and that clocks are modestly in sync,
 # since this is a requirement for general correctness of last write wins.
 # internode_timeout: true
 

--- a/doc/modules/cassandra/pages/new/auditlogging.adoc
+++ b/doc/modules/cassandra/pages/new/auditlogging.adoc
@@ -12,7 +12,7 @@ Some of the features of audit logging are:
 * Latency of database operations is not affected, so there is no performance impact.
 * Heap memory usage is bounded by a weighted queue, with configurable maximum weight sitting in front of logging thread.
 * Disk utilization is bounded by a configurable size, deleting old log segments once the limit is reached.
-* Can be enabled, disabled, or reset (to delete on-disk data) using the JMX tool, ``nodetool``.
+* Can be enabled or disabled at startup time using `cassandra.yaml` or at runtime using the JMX tool, ``nodetool``.
 * Can configure the settings in either the `cassandra.yaml` file or by using ``nodetool``.
 
 Audit logging includes all CQL requests, both successful and failed. 
@@ -88,10 +88,23 @@ Common audit log entry types are one of the following:
 | ERROR | REQUEST_FAILURE
 |===
 
+== Availability and durability
+
+NOTE: Unlike data, audit log entries are not replicated
+
+For a given query, the corresponding audit entry is only stored on the coordinator node.
+For example, an ``INSERT`` in a keyspace with replication factor of 3 will produce an audit entry on one node, the coordinator who handled the request, and not on the two other nodes.
+For this reason, and depending on compliance requirements you must meet, you have to make sure that audig logs are stored on a non-ephemeral storage.
+
+You can achieve custom needs with <<archive_command>> option.
+
 == Configuring audit logging in cassandra.yaml
 
 The `cassandra.yaml` file can be used to configure and enable audit logging.
 Configuration and enablement may be the same or different on each node, depending on the `cassandra.yaml` file settings.
+
+Audit logging can also be configured using ``nodetool`` when enabling the feature, and will override any values set in the `cassandra.yaml` file, as discussed in <<enabling_audit_with_nodetool, Enabling Audit Logging with nodetool>>.
+
 Audit logs are generated on each enabled node, so logs on each node will have that node's queries.
 All options for audit logging can be set in the `cassandra.yaml` file under the ``audit_logging_options:``.
 
@@ -123,16 +136,25 @@ audit_logging_options:
 
 === enabled
 
-Audit logging is enabled by setting the `enabled` option to `true` in
-the `audit_logging_options` setting. 
+Control wether audit logging is enabled or disabled (default).
+
+To enable audit logging set ``enabled: true``.
+
 If this option is enabled, audit logging will start when Cassandra is started.
-For example, ``enabled: true``.
+It can be disabled afterwards at runtime with <<enabling_audit_with_nodetool, nodetool>>.
+
+TIP: You can monitor if audit logging is enabled with ``AuditLogEnabled`` attribute of the JMX MBean ``org.apache.cassandra.db:type=StorageService``.
 
 === logger
 
 The type of audit logger is set with the `logger` option. 
-Supported values are: `BinAuditLogger` (default), `FileAuditLogger` and `NoOpAuditLogger`.
-`BinAuditLogger` logs events to a file in binary format. 
+Supported values are:
+
+- `BinAuditLogger` (default)
+- `FileAuditLogger`
+- `NoOpAuditLogger`.
+
+`BinAuditLogger` logs events to a file in binary format.
 `FileAuditLogger` uses the standard logging mechanism, `slf4j` to log events to the `audit/audit.log` file. It is a synchronous, file-based audit logger. The roll_cycle will be set in the `logback.xml` file.
 `NoOpAuditLogger` is a no-op implementation of the audit logger that shoudl be specified when audit logging is disabled.
 
@@ -144,6 +166,8 @@ logger:
   - class_name: FileAuditLogger
 ----
 
+TIP:  `BinAuditLogger` make use of open source https://github.com/OpenHFT/Chronicle-Queue[Chronicle Queue] under the hood. If you consider using audit logging for regulatory compliance purpose, it might be wise to be somewhat familiar with this library. See <<archive_command>> and <<roll_cycle>> for an example of the implications.
+
 === audit_logs_dir
 
 To write audit logs, an existing directory must be set in ``audit_logs_dir``.
@@ -151,7 +175,7 @@ To write audit logs, an existing directory must be set in ``audit_logs_dir``.
 The directory must have appropriate permissions set to allow reading, writing, and executing.
 Logging will recursively delete the directory contents as needed.
 Do not place links in this directory to other sections of the filesystem.
-For example, ``audit_logs_dir: /cassandra/audit/logs/hourly``.
+For example, ``audit_logs_dir: /non_ephemeral_storage/audit/logs/hourly``.
 
 The audit log directory can also be configured using the system property `cassandra.logdir.audit`, which by default is set to `cassandra.logdir + /audit/`.
 
@@ -173,7 +197,7 @@ excluded_keyspaces: system, system_schema, system_virtual_schema
 The categories of database operations to include are specified with the `included_categories` option as a comma-separated list. 
 The categories of database operations to exclude are specified with `excluded_categories` option as a comma-separated list. 
 The supported categories for audit log are: `AUTH`, `DCL`, `DDL`, `DML`, `ERROR`, `OTHER`, `PREPARE`, and `QUERY`.
-By default all supported categories are included, and no category is excluded. 
+By default, all supported categories are included, and no category is excluded.
 
 [source, yaml]
 ----
@@ -186,7 +210,7 @@ excluded_categories: DDL, DML, QUERY, PREPARE
 Users to audit log are set with the `included_users` and `excluded_users` options. 
 The `included_users` option specifies a comma-separated list of users to include explicitly.
 The `excluded_users` option specifies a comma-separated list of users to exclude explicitly.
-By default all users are included, and no users are excluded. 
+By default, all users are included, and no users are excluded.
 
 [source, yaml]
 ----
@@ -194,20 +218,55 @@ included_users:
 excluded_users: john, mary
 ----
 
+[[roll_cycle]]
 === roll_cycle
 
 The ``roll_cycle`` defines the frequency with which the audit log segments are rolled.
-Supported values are ``HOURLY`` (default), ``MINUTELY``, and ``DAILY``.
+Supported values are:
+
+- ``MINUTELY``
+- ``FIVE_MINUTELY``
+- ``TEN_MINUTELY``
+- ``TWENTY_MINUTELY``
+- ``HALF_HOURLY``
+- ``HOURLY`` (default)
+- ``TWO_HOURLY``
+- ``FOUR_HOURLY``
+- ``SIX_HOURLY``
+- ``DAILY``
+
 For example: ``roll_cycle: DAILY``
+
+WARNING: Read the following paragraph when changing ``roll_cycle`` on a production node.
+
+With the `BinLogger` implementation, any attempt to modify the roll cycle on a node where audit logging was previously enabled will fail silentely due to https://github.com/OpenHFT/Chronicle-Queue[Chronicle Queue] roll cycle inference mechanism (even if you delete the ``metadata.cq4t`` file).
+
+Here is an example of such an override visible in Cassandra logs:
+----
+INFO  [main] <DATE TIME> BinLog.java:420 - Attempting to configure bin log: Path: /path/to/audit Roll cycle: TWO_HOURLY [...]
+WARN  [main] <DATE TIME> SingleChronicleQueueBuilder.java:477 - Overriding roll cycle from TWO_HOURLY to FIVE_MINUTE
+----
+
+In order to change ``roll_cycle`` on a node, you have to:
+
+1. Stop Cassandra
+2. Move or offload all audit logs somewhere else (in a safe and durable location)
+3. Restart Cassandra.
+4. Check Cassandra logs
+5. Make sure that audit log filenames under ``audit_logs_dir`` correspond to the new roll cycle.
 
 === block
 
 The ``block`` option specifies whether audit logging should block writing or drop log records if the audit logging falls behind. Supported boolean values are ``true`` (default) or ``false``.
-For example: ``block: false`` to drop records
+
+For example: ``block: false`` to drop records (e.g. if audit is used for troobleshooting)
+
+For regulatory compliance purpose, it's a good practice to explicitely set ``block: true`` to prevent any regression in case of future default value change.
 
 === max_queue_weight
 
 The ``max_queue_weight`` option sets the maximum weight of in-memory queue for records waiting to be written to the file before blocking or dropping.  The option must be set to a positive value. The default value is 268435456, or 256 MiB.
+
 For example, to change the default: ``max_queue_weight: 134217728 # 128 MiB``
 
 === max_log_size
@@ -215,23 +274,37 @@ For example, to change the default: ``max_queue_weight: 134217728 # 128 MiB``
 The ``max_log_size`` option sets the maximum size of the rolled files to retain on disk before deleting the oldest file.  The option must be set to a positive value. The default is 17179869184, or 16 GiB.
 For example, to change the default: ``max_log_size: 34359738368 # 32 GiB``
 
+WARNING: ``max_log_size`` is ignored if ``archive_command`` option is set.
+
+[[archive_command]]
 === archive_command
 
+NOTE: If ``archive_command`` option is empty or unset (default), Cassandra uses a built-in DeletingArchiver that deletes the oldest files if ``max_log_size`` is reached.
+
 The ``archive_command`` option sets the user-defined archive script to execute on rolled log files.
-For example: ``archive_command: /usr/local/bin/archiveit.sh %path # %path is the file being rolled``
+For example: ``archive_command: "/usr/local/bin/archiveit.sh %path"``
+
+``%path`` is replaced with the absolute file path of the file being rolled.
+
+When using a user-defined script, Cassandra do **not** use the DeletingArchiver, so it's the responsability of the script to make any required cleanup.
+
+Cassandra will call the user-defined script as soon as the log file is rolled. It means that Chronicle Queue's QueueFileShrinkManager will not be able to shrink the sparse log file because it's done asynchronously. In other words, all log files will have at least the size of the default block size (80 MiB), even if there are only a few KB of real data. Consequently, some warnings will appear in Cassandra system.log:
+
+----
+WARN  [main/queue~file~shrink~daemon] <DATE TIME> QueueFileShrinkManager.java:63 - Failed to shrink file as it exists no longer, file=/path/to/xxx.cq4
+----
+
+TIP: Because Cassandra does not make use of Pretoucher, you can configure Chronicle Queue to shrink files synchronously -- i.e. as soon as the file is rolled -- with ``chronicle.queue.synchronousFileShrinking`` JVM properties. For instance, you can add the following line at the end of ``cassandra-env.sh``: ``JVM_OPTS="$JVM_OPTS -Dchronicle.queue.synchronousFileShrinking=true"``
 
 === max_archive_retries
 
 The ``max_archive_retries`` option sets the max number of retries of failed archive commands. The default is 10.
+
 For example: ``max_archive_retries: 10``
 
+Interval between each retry is hard coded to 5 minutes.
 
-An audit log file could get rolled for other reasons as well such as a
-log file reaches the configured size threshold.
-
-Audit logging can also be configured using ``nodetool` when enabling the feature, and will override any values set in the `cassandra.yaml` file, as discussed in the next section.
-
-
+[[enabling_audit_with_nodetool]]
 == Enabling Audit Logging with ``nodetool``
  
 Audit logging is enabled on a per-node basis using the ``nodetool enableauditlog`` command. The logging directory must be defined with ``audit_logs_dir`` in the `cassandra.yaml` file or uses the default value ``cassandra.logdir.audit``.


### PR DESCRIPTION
After using audit logging in production, it turns out that documentation is lacking some important information.

Namely:
- roll_cycle can be overriden by Chronicle Queue
- max_log_size is ignored if archive_command option is set
- archive_command prevents Chronicle Queue Shrink Manager from working