### PR TITLE
[CASSANDRA-17126] Removing usages of java.io.File and others from tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2223,6 +2223,7 @@
           <formatter type="plain"/>
           <formatter type="xml" tofile="${checkstyle.report.file}"/>
           <fileset dir="${build.src.java}" includes="**/*.java"/>
+          <!--<fileset dir="${test.dir}" includes="**/*.java"/>-->
       </checkstyle>
   </target>
 

--- a/test/distributed/org/apache/cassandra/distributed/test/MultipleDataDirectoryTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MultipleDataDirectoryTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.distributed.test;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Iterator;
@@ -38,6 +37,7 @@ import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.File;
 
 public class MultipleDataDirectoryTest extends TestBaseImpl
 {

--- a/test/long/org/apache/cassandra/cql3/CorruptionTest.java
+++ b/test/long/org/apache/cassandra/cql3/CorruptionTest.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.cql3;
 
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -37,6 +36,7 @@ import com.datastax.driver.core.policies.Policies;
 import com.datastax.driver.core.utils.Bytes;
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.util.FileWriter;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.service.EmbeddedCassandraService;
@@ -145,10 +145,12 @@ public class CorruptionTest extends SchemaLoader
                     String basename = "bad-data-tid" + Thread.currentThread().getId();
                     File put = new File(basename+"-put");
                     File get = new File(basename+"-get");
-                    try(FileWriter pw = new FileWriter(put.toJavaIOFile())) {
+                    try (FileWriter pw = put.newWriter(File.WriteMode.OVERWRITE))
+                    {
                         pw.write(new String(putdata));
                     }
-                    try(FileWriter pw = new FileWriter(get.toJavaIOFile())) {
+                    try (FileWriter pw = get.newWriter(File.WriteMode.OVERWRITE))
+                    {
                         pw.write(new String(getdata));
                     }
                 }

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -21,7 +21,7 @@ package org.apache.cassandra.db.commitlog;
  *
  */
 
-import java.io.*;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.*;

--- a/test/simulator/main/org/apache/cassandra/simulator/debug/Reconcile.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/debug/Reconcile.java
@@ -20,17 +20,13 @@ package org.apache.cassandra.simulator.debug;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -40,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.simulator.ClusterSimulation;
 import org.apache.cassandra.simulator.RandomSource;
 import org.apache.cassandra.utils.Closeable;
@@ -358,8 +355,8 @@ public class Reconcile
         File eventFile = new File(new File(loadFromDir), Long.toHexString(seed) + ".gz");
         File rngFile = new File(new File(loadFromDir), Long.toHexString(seed) + ".rng.gz");
 
-        try (BufferedReader eventIn = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(eventFile))));
-             DataInputPlus.DataInputStreamPlus rngIn = new DataInputPlus.DataInputStreamPlus(rngFile.exists() ? new GZIPInputStream(new FileInputStream(rngFile)) : new ByteArrayInputStream(new byte[0])))
+        try (BufferedReader eventIn = new BufferedReader(new InputStreamReader(new GZIPInputStream(eventFile.newInputStream())));
+             DataInputPlus.DataInputStreamPlus rngIn = new DataInputPlus.DataInputStreamPlus(rngFile.exists() ? new GZIPInputStream(rngFile.newInputStream()) : new ByteArrayInputStream(new byte[0])))
         {
             boolean inputHasWaitSites, inputHasWakeSites, inputHasRngCallSites;
             {
@@ -397,7 +394,7 @@ public class Reconcile
 
             class Line { int line = 1; } Line line = new Line(); // box for heap dump analysis
             try (ClusterSimulation<?> cluster = builder.create(seed);
-                 CloseableIterator<?> iter = cluster.simulation.iterator();)
+                 CloseableIterator<?> iter = cluster.simulation.iterator())
             {
                 try
                 {

--- a/test/simulator/main/org/apache/cassandra/simulator/debug/Record.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/debug/Record.java
@@ -19,8 +19,6 @@
 package org.apache.cassandra.simulator.debug;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.channels.Channels;
@@ -40,12 +38,14 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.io.util.BufferedDataOutputStreamPlus;
 import org.apache.cassandra.io.util.DataOutputStreamPlus;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.simulator.ClusterSimulation;
 import org.apache.cassandra.simulator.RandomSource;
 import org.apache.cassandra.utils.Closeable;
 import org.apache.cassandra.utils.CloseableIterator;
 import org.apache.cassandra.utils.concurrent.Threads;
 
+import static org.apache.cassandra.io.util.File.WriteMode.OVERWRITE;
 import static org.apache.cassandra.simulator.SimulatorUtils.failWithOOM;
 
 public class Record
@@ -72,8 +72,8 @@ public class Record
             logger.error("Seed 0x{} ({}) (With: {})", Long.toHexString(seed), eventFile, modifiers);
         }
 
-        try (PrintWriter eventOut = new PrintWriter(new GZIPOutputStream(new FileOutputStream(eventFile), 1 << 16));
-             DataOutputStreamPlus rngOut = new BufferedDataOutputStreamPlus(Channels.newChannel(withRng ? new GZIPOutputStream(new FileOutputStream(rngFile), 1 << 16) : new ByteArrayOutputStream(0))))
+        try (PrintWriter eventOut = new PrintWriter(new GZIPOutputStream(eventFile.newOutputStream(OVERWRITE), 1 << 16));
+             DataOutputStreamPlus rngOut = new BufferedDataOutputStreamPlus(Channels.newChannel(withRng ? new GZIPOutputStream(rngFile.newOutputStream(OVERWRITE), 1 << 16) : new ByteArrayOutputStream(0))))
         {
             eventOut.println("modifiers:"
                              + (withRng ? "rng," : "") + (withRngCallSites ? "rngCallSites," : "")

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -22,8 +22,11 @@ package org.apache.cassandra;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOError;
+import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.NoSuchFileException;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -849,5 +852,28 @@ public class Util
             throw new RuntimeException(e);
         }
         Gossiper.instance.expireUpgradeFromVersion();
+    }
+
+    /**
+     * Sets the length of the file to given size. File will be created if not exist.
+     *
+     * @param file file for which length needs to be set
+     * @param size new szie
+     * @throws IOException on any I/O error.
+     */
+    public static void setFileLength(File file, long size) throws IOException
+    {
+        try (FileChannel fileChannel = file.newReadWriteChannel())
+        {
+            if (file.length() >= size)
+            {
+                fileChannel.truncate(size);
+            }
+            else
+            {
+                fileChannel.position(size - 1);
+                fileChannel.write(ByteBuffer.wrap(new byte[1]));
+            }
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
+++ b/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.config;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
@@ -27,6 +26,8 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+
+import org.apache.cassandra.io.util.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -120,7 +121,7 @@ public class YamlConfigurationLoaderTest
         {
             try
             {
-                url = new File(path).toURI().toURL();
+                url = new File(path).toPath().toUri().toURL();
             }
             catch (MalformedURLException e)
             {

--- a/test/unit/org/apache/cassandra/db/ImportTest.java
+++ b/test/unit/org/apache/cassandra/db/ImportTest.java
@@ -19,7 +19,7 @@
 package org.apache.cassandra.db;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -46,6 +46,7 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertEquals;
@@ -314,10 +315,10 @@ public class ImportTest extends CQLTester
         getCurrentColumnFamilyStore().clearUnsafe();
 
         String filenameToCorrupt = sstableToCorrupt.descriptor.filenameFor(Component.STATS);
-        try (RandomAccessFile file = new RandomAccessFile(filenameToCorrupt, "rw"))
+        try (FileChannel fileChannel = new File(filenameToCorrupt).newReadWriteChannel())
         {
-            file.seek(0);
-            file.writeBytes(StringUtils.repeat('z', 2));
+            fileChannel.position(0);
+            fileChannel.write(ByteBufferUtil.bytes(StringUtils.repeat('z', 2)));
         }
 
         File backupdir = moveToBackupDir(sstables);
@@ -574,10 +575,10 @@ public class ImportTest extends CQLTester
         // corrupt the sstable which is still in the data directory
         SSTableReader sstableToCorrupt = sstables.iterator().next();
         String filenameToCorrupt = sstableToCorrupt.descriptor.filenameFor(Component.STATS);
-        try (RandomAccessFile file = new RandomAccessFile(filenameToCorrupt, "rw"))
+        try (FileChannel fileChannel = new File(filenameToCorrupt).newReadWriteChannel())
         {
-            file.seek(0);
-            file.writeBytes(StringUtils.repeat('z', 2));
+            fileChannel.position(0);
+            fileChannel.write(ByteBufferUtil.bytes(StringUtils.repeat('z', 2)));
         }
 
         for (int i = 10; i < 20; i++)

--- a/test/unit/org/apache/cassandra/db/MmapFileTest.java
+++ b/test/unit/org/apache/cassandra/db/MmapFileTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.db;
 
-import java.io.RandomAccessFile;
 import java.lang.management.ManagementFactory;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -25,6 +24,7 @@ import java.nio.file.StandardOpenOption;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.apache.cassandra.Util;
 import org.apache.cassandra.io.util.File;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,20 +56,9 @@ public class MmapFileTest
         {
             int size = 1024 * 1024;
 
-            try (RandomAccessFile raf = new RandomAccessFile(f1.toJavaIOFile(), "rw"))
-            {
-                raf.setLength(size);
-            }
-
-            try (RandomAccessFile raf = new RandomAccessFile(f2.toJavaIOFile(), "rw"))
-            {
-                raf.setLength(size);
-            }
-
-            try (RandomAccessFile raf = new RandomAccessFile(f3.toJavaIOFile(), "rw"))
-            {
-                raf.setLength(size);
-            }
+            Util.setFileLength(f1, size);
+            Util.setFileLength(f2, size);
+            Util.setFileLength(f3,size);
 
             try (FileChannel channel = FileChannel.open(f1.toPath(), StandardOpenOption.WRITE, StandardOpenOption.READ))
             {

--- a/test/unit/org/apache/cassandra/db/ScrubTest.java
+++ b/test/unit/org/apache/cassandra/db/ScrubTest.java
@@ -20,8 +20,8 @@ package org.apache.cassandra.db;
 
 import java.io.IOError;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -443,10 +443,10 @@ public class ScrubTest
 
     private static void overrideWithGarbage(SSTableReader sstable, long startPosition, long endPosition) throws IOException
     {
-        try (RandomAccessFile file = new RandomAccessFile(sstable.getFilename(), "rw"))
+        try (FileChannel fileChannel = new File(sstable.getFilename()).newReadWriteChannel())
         {
-            file.seek(startPosition);
-            file.writeBytes(StringUtils.repeat('z', (int) (endPosition - startPosition)));
+            fileChannel.position(startPosition);
+            fileChannel.write(ByteBufferUtil.bytes(StringUtils.repeat('z', (int) (endPosition - startPosition))));
         }
         if (ChunkCache.instance != null)
             ChunkCache.instance.invalidateFile(sstable.getFilename());

--- a/test/unit/org/apache/cassandra/db/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/db/SnapshotTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.db;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 
@@ -27,6 +26,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.util.File;
 
 public class SnapshotTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogSegmentManagerCDCTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogSegmentManagerCDCTest.java
@@ -18,7 +18,8 @@
 
 package org.apache.cassandra.db.commitlog;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -18,8 +18,13 @@
 */
 package org.apache.cassandra.db.commitlog;
 
-import java.io.*;
 import org.apache.cassandra.io.util.File;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.*;

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogUpgradeTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogUpgradeTest.java
@@ -21,7 +21,7 @@ package org.apache.cassandra.db.commitlog;
  *
  */
 
-import java.io.*;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Properties;
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogUpgradeTestMaker.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogUpgradeTestMaker.java
@@ -21,7 +21,7 @@ package org.apache.cassandra.db.commitlog;
  *
  */
 
-import java.io.*;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;

--- a/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/LogTransactionTest.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.db.lifecycle;
 
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -29,6 +28,8 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+
+import org.apache.cassandra.Util;
 import org.apache.cassandra.io.util.File;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1226,10 +1227,7 @@ public class LogTransactionTest extends AbstractTransactionalTest
             if (!file.exists())
                 assertTrue(file.createFileIfNotExists());
 
-            try (RandomAccessFile raf = new RandomAccessFile(file.toJavaIOFile(), "rw"))
-            {
-                raf.setLength(size);
-            }
+            Util.setFileLength(file, size);
         }
 
         FileHandle dFile = new FileHandle.Builder(descriptor.filenameFor(Component.DATA)).complete();

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -17,14 +17,15 @@
  */
 package org.apache.cassandra.index.sasi;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Writer;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -95,9 +96,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.*;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -2045,9 +2043,9 @@ public class SASIIndexTest
         Path path = FileSystems.getDefault().getPath(ssTable.getFilename().replace("-Data", "-SI_" + CLUSTERING_CF_NAME_1 + "_age"));
 
         // Overwrite index file with garbage
-        try (Writer writer = new FileWriter(path.toFile(), false))
+        try(FileChannel fc = FileChannel.open(path, StandardOpenOption.WRITE))
         {
-            writer.write("garbage");
+            fc.truncate(8).write(ByteBuffer.wrap("grabage".getBytes(StandardCharsets.UTF_8)));
         }
 
         long size1 = Files.readAttributes(path, BasicFileAttributes.class).size();

--- a/test/unit/org/apache/cassandra/io/compress/CompressedRandomAccessReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressedRandomAccessReaderTest.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.io.compress;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.io.RandomAccessFile; //checkstyle: permit this import
 import java.util.Arrays;
 import java.util.Random;
 

--- a/test/unit/org/apache/cassandra/io/util/ChecksummedRandomAccessReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/util/ChecksummedRandomAccessReaderTest.java
@@ -19,7 +19,8 @@
 package org.apache.cassandra.io.util;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -118,10 +119,10 @@ public class ChecksummedRandomAccessReaderTest
         assert data.exists();
 
         // simulate corruption of file
-        try (RandomAccessFile dataFile = new RandomAccessFile(data.toJavaIOFile(), "rw"))
+        try (FileChannel dataFile = data.newReadWriteChannel())
         {
-            dataFile.seek(1024);
-            dataFile.write((byte) 5);
+            dataFile.position(1024);
+            dataFile.write(ByteBuffer.wrap(new byte[] {5}));
         }
 
         try (RandomAccessReader reader = ChecksummedRandomAccessReader.open(data, crc))

--- a/test/unit/org/apache/cassandra/io/util/DataOutputTest.java
+++ b/test/unit/org/apache/cassandra/io/util/DataOutputTest.java
@@ -25,7 +25,6 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -363,8 +362,7 @@ public class DataOutputTest
         try
         {
             @SuppressWarnings("resource")
-            final RandomAccessFile raf = new RandomAccessFile(file.toJavaIOFile(), "rw");
-            DataOutputStreamPlus write = new BufferedDataOutputStreamPlus(raf.getChannel());
+            DataOutputStreamPlus write = new BufferedDataOutputStreamPlus(file.newReadWriteChannel());
             DataInput canon = testWrite(write);
             write.close();
             DataInputStream test = new DataInputStream(new FileInputStreamPlus(file));

--- a/test/unit/org/apache/cassandra/io/util/FileTest.java
+++ b/test/unit/org/apache/cassandra/io/util/FileTest.java
@@ -44,32 +44,33 @@ public class FileTest
     private static final java.io.File dir;
     static
     {
-        java.io.File parent = new java.io.File(JAVA_IO_TMPDIR.getString());
+        java.io.File parent = new java.io.File(JAVA_IO_TMPDIR.getString()); //checkstyle: permit this instantiation
         String dirName = Long.toHexString(ThreadLocalRandom.current().nextLong());
-        while (new java.io.File(parent, dirName).exists())
+        while (new java.io.File(parent, dirName).exists()) //checkstyle: permit this instantiation
             dirName = Long.toHexString(ThreadLocalRandom.current().nextLong());
-        dir = new java.io.File(parent, dirName);
+        dir = new java.io.File(parent, dirName); //checkstyle: permit this instantiation
         dir.mkdirs();
         new File(dir).deleteRecursiveOnExit();
     }
 
+
     @Test
     public void testEquivalence() throws IOException
     {
-        java.io.File notExists = new java.io.File(dir, "notExists");
-        java.io.File regular = new java.io.File(dir, "regular");
+        java.io.File notExists = new java.io.File(dir, "notExists"); //checkstyle: permit this instantiation
+        java.io.File regular = new java.io.File(dir, "regular"); //checkstyle: permit this instantiation
         regular.createNewFile();
-        java.io.File regularLink = new java.io.File(dir, "regularLink");
+        java.io.File regularLink = new java.io.File(dir, "regularLink"); //checkstyle: permit this instantiation
         Files.createSymbolicLink(regularLink.toPath(), regular.toPath());
-        java.io.File emptySubdir = new java.io.File(dir, "empty");
-        java.io.File emptySubdirLink = new java.io.File(dir, "emptyLink");
+        java.io.File emptySubdir = new java.io.File(dir, "empty"); //checkstyle: permit this instantiation
+        java.io.File emptySubdirLink = new java.io.File(dir, "emptyLink"); //checkstyle: permit this instantiation
         emptySubdir.mkdir();
         Files.createSymbolicLink(emptySubdirLink.toPath(), emptySubdir.toPath());
-        java.io.File nonEmptySubdir = new java.io.File(dir, "nonEmpty");
-        java.io.File nonEmptySubdirLink = new java.io.File(dir, "nonEmptyLink");
+        java.io.File nonEmptySubdir = new java.io.File(dir, "nonEmpty"); //checkstyle: permit this instantiation
+        java.io.File nonEmptySubdirLink = new java.io.File(dir, "nonEmptyLink"); //checkstyle: permit this instantiation
         nonEmptySubdir.mkdir();
         Files.createSymbolicLink(nonEmptySubdirLink.toPath(), nonEmptySubdir.toPath());
-        new java.io.File(nonEmptySubdir, "something").createNewFile();
+        new java.io.File(nonEmptySubdir, "something").createNewFile(); //checkstyle: permit this instantiation
 
         testEquivalence("");
 
@@ -112,7 +113,7 @@ public class FileTest
 
     private void    testEquivalence(String path) throws IOException
     {
-        java.io.File file = new java.io.File(path);
+        java.io.File file = new java.io.File(path); //checkstyle: permit this instantiation
         if (file.exists()) testExists(path);
         else testNotExists(path);
     }
@@ -136,7 +137,7 @@ public class FileTest
         testEquivalence(path, java.io.File::toPath, File::toPath);
         testEquivalence(path, java.io.File::list, File::tryListNames);
         testEquivalence(path, java.io.File::listFiles, File::tryList);
-        java.io.File file = new java.io.File(path);
+        java.io.File file = new java.io.File(path); //checkstyle: permit this instantiation
         if (file.getParentFile() != null) testBasic(file.getParent());
         if (!file.equals(file.getAbsoluteFile())) testBasic(file.getAbsolutePath());
         if (!file.equals(file.getCanonicalFile())) testBasic(file.getCanonicalPath());
@@ -151,7 +152,7 @@ public class FileTest
         );
         for (Triple<BiFunction<java.io.File, Boolean, Boolean>, BiFunction<File, Boolean, Boolean>, Function<java.io.File, Boolean>> test : tests)
         {
-            java.io.File file = new java.io.File(path);
+            java.io.File file = new java.io.File(path); //checkstyle: permit this instantiation
             boolean cur = test.v3.apply(file);
             boolean canRead = file.canRead();
             boolean canWrite = file.canWrite();
@@ -210,7 +211,7 @@ public class FileTest
 
     private <T> void testEquivalence(String path, IOFn<java.io.File, T> canonical, IOFn<File, T> test, IOBiConsumer<java.io.File, Boolean> afterEach)
     {
-        java.io.File file = new java.io.File(path);
+        java.io.File file = new java.io.File(path); //checkstyle: permit this instantiation
         Object expect;
         try
         {
@@ -246,7 +247,7 @@ public class FileTest
     }
     private void testTryVsConfirm(String path, Predicate<java.io.File> canonical, IOConsumer<File> test, IOBiConsumer<java.io.File, Boolean> afterEach)
     {
-        java.io.File file = new java.io.File(path);
+        java.io.File file = new java.io.File(path); //checkstyle: permit this instantiation
         boolean expect = canonical.test(file);
         try { afterEach.accept(file, expect); } catch (IOException e) { throw new AssertionError(e); }
         boolean actual;

--- a/test/unit/org/apache/cassandra/io/util/FileUtilsTest.java
+++ b/test/unit/org/apache/cassandra/io/util/FileUtilsTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.io.util;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,6 +28,7 @@ import java.util.Arrays;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.assertj.core.api.Assertions;
 
@@ -228,9 +228,9 @@ public class FileUtilsTest
 
     private File createFile(File file, long size)
     {
-        try (RandomAccessFile f = new RandomAccessFile(file.toJavaIOFile(), "rw"))
+        try
         {
-            f.setLength(size);
+            Util.setFileLength(file, size);
         }
         catch (Exception e)
         {

--- a/test/unit/org/apache/cassandra/io/util/NIODataInputStreamTest.java
+++ b/test/unit/org/apache/cassandra/io/util/NIODataInputStreamTest.java
@@ -26,8 +26,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -223,11 +223,11 @@ public class NIODataInputStreamTest
         assertEquals(8190 - 10 - 4096, is.available());
 
         File f = FileUtils.createTempFile("foo", "bar");
-        RandomAccessFile fos = new RandomAccessFile(f.toJavaIOFile(), "rw");
-        fos.write(new byte[10]);
-        fos.seek(0);
+        FileChannel fos = f.newReadWriteChannel();
+        fos.write(ByteBuffer.wrap(new byte[10]));
+        fos.position(0);
 
-        is = new NIODataInputStream(fos.getChannel(), 9);
+        is = new NIODataInputStream(fos, 9);
 
         int remaining = 10;
         assertEquals(10, is.available());

--- a/test/unit/org/apache/cassandra/net/AsyncStreamingOutputPlusTest.java
+++ b/test/unit/org/apache/cassandra/net/AsyncStreamingOutputPlusTest.java
@@ -19,7 +19,6 @@
 package org.apache.cassandra.net;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -157,8 +156,7 @@ public class AsyncStreamingOutputPlusTest
         StreamManager.StreamRateLimiter limiter = zeroCopy ? StreamManager.getEntireSSTableRateLimiter(FBUtilities.getBroadcastAddressAndPort())
                                                            : StreamManager.getRateLimiter(FBUtilities.getBroadcastAddressAndPort());
 
-        try (RandomAccessFile raf = new RandomAccessFile(file.path(), "r");
-             FileChannel fileChannel = raf.getChannel();
+        try (FileChannel fileChannel = file.newReadChannel();
              AsyncStreamingOutputPlus out = new AsyncStreamingOutputPlus(channel))
         {
             assertTrue(fileChannel.isOpen());

--- a/test/unit/org/apache/cassandra/schema/MockSchema.java
+++ b/test/unit/org/apache/cassandra/schema/MockSchema.java
@@ -18,9 +18,9 @@
 */
 package org.apache.cassandra.schema;
 
+import org.apache.cassandra.Util;
 import org.apache.cassandra.io.util.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -128,10 +128,7 @@ public class MockSchema
                 try
                 {
                     File file = new File(descriptor.filenameFor(Component.DATA));
-                    try (RandomAccessFile raf = new RandomAccessFile(file.toJavaIOFile(), "rw"))
-                    {
-                        raf.setLength(size);
-                    }
+                    Util.setFileLength(file, size);
                 }
                 catch (IOException e)
                 {

--- a/test/unit/org/apache/cassandra/security/EncryptionUtilsTest.java
+++ b/test/unit/org/apache/cassandra/security/EncryptionUtilsTest.java
@@ -18,7 +18,6 @@
 package org.apache.cassandra.security;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.HashMap;
@@ -82,7 +81,7 @@ public class EncryptionUtilsTest
 
         File f = FileUtils.createTempFile("commitlog-enc-utils-", ".tmp");
         f.deleteOnExit();
-        FileChannel channel = new RandomAccessFile(f.toJavaIOFile(), "rw").getChannel();
+        FileChannel channel = f.newReadWriteChannel();
         EncryptionUtils.encryptAndWrite(ByteBuffer.wrap(buf), channel, true, encryptor);
         channel.close();
 
@@ -111,7 +110,7 @@ public class EncryptionUtilsTest
         Cipher encryptor = cipherFactory.getEncryptor(tdeOptions.cipher, tdeOptions.key_alias);
         File f = FileUtils.createTempFile("commitlog-enc-utils-", ".tmp");
         f.deleteOnExit();
-        FileChannel channel = new RandomAccessFile(f.toJavaIOFile(), "rw").getChannel();
+        FileChannel channel = f.newReadWriteChannel();
         EncryptionUtils.encryptAndWrite(compressedBuffer, channel, true, encryptor);
 
         // decrypt

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerM3PTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerM3PTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.service;
 
-import java.io.File;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,6 +27,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.PropertyFileSnitch;
 

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -20,7 +20,6 @@
 package org.apache.cassandra.service;
 
 import org.apache.cassandra.io.util.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetAddress;
@@ -54,6 +53,7 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.PropertyFileSnitch;
 import org.apache.cassandra.locator.TokenMetadata;
 import org.apache.cassandra.schema.*;
+import org.apache.cassandra.io.util.FileWriter;
 import org.apache.cassandra.utils.FBUtilities;
 import org.assertj.core.api.Assertions;
 
@@ -138,7 +138,7 @@ public class StorageServiceServerTest
 
         // Check to make sure we don't delete non-temp, non-datafile locations
         WindowsFailedSnapshotTracker.resetForTests();
-        PrintWriter tempPrinter = new PrintWriter(new FileWriter(WindowsFailedSnapshotTracker.TODELETEFILE, true));
+        PrintWriter tempPrinter = new PrintWriter(new FileWriter(new File(WindowsFailedSnapshotTracker.TODELETEFILE), File.WriteMode.APPEND));
         tempPrinter.println(".safeDir");
         tempPrinter.close();
 

--- a/test/unit/org/apache/cassandra/service/snapshot/SnapshotManifestTest.java
+++ b/test/unit/org/apache/cassandra/service/snapshot/SnapshotManifestTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.service.snapshot;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Instant;

--- a/test/unit/org/apache/cassandra/service/snapshot/TableSnapshotTest.java
+++ b/test/unit/org/apache/cassandra/service/snapshot/TableSnapshotTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.service.snapshot;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;

--- a/test/unit/org/apache/cassandra/streaming/compression/CompressedInputStreamTest.java
+++ b/test/unit/org/apache/cassandra/streaming/compression/CompressedInputStreamTest.java
@@ -17,7 +17,10 @@
  */
 package org.apache.cassandra.streaming.compression;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
 import java.util.*;
 
 import org.apache.cassandra.io.util.File;
@@ -33,6 +36,7 @@ import org.apache.cassandra.io.compress.CompressedSequentialWriter;
 import org.apache.cassandra.io.compress.CompressionMetadata;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.DataInputPlus.DataInputStreamPlus;
+import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.io.util.SequentialWriterOption;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.io.sstable.Component;
@@ -154,7 +158,7 @@ public class CompressedInputStreamTest
             size += (c.length + 4); // 4bytes CRC
         byte[] toRead = new byte[size];
 
-        try (RandomAccessFile f = new RandomAccessFile(tmp.toJavaIOFile(), "r"))
+        try (RandomAccessReader f = RandomAccessReader.open(tmp))
         {
             int pos = 0;
             for (CompressionMetadata.Chunk c : chunks)

--- a/test/unit/org/apache/cassandra/utils/KeyGenerator.java
+++ b/test/unit/org/apache/cassandra/utils/KeyGenerator.java
@@ -21,11 +21,11 @@ package org.apache.cassandra.utils;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
+import java.nio.file.NoSuchFileException;
 import java.util.Random;
 
 public class KeyGenerator
@@ -160,9 +160,9 @@ public class KeyGenerator
         {
             try 
             {
-                reader = new BufferedReader(new InputStreamReader(new FileInputStream("/usr/share/dict/words")));
+                reader = new BufferedReader(new InputStreamReader(new FileInputStreamPlus("/usr/share/dict/words")));
             } 
-            catch (FileNotFoundException e)
+            catch (NoSuchFileException e)
             {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Replaced the usages of java.io.File, java.io.FileInputStream, java.io.FileOutputStream, java.io.FileWriter and java.io.RandomAccessFile from tests.

Could not find alternative to RandomAccessFile.setLength(), so added checkstyle exceptions.