### PR TITLE
CASSANDRA-17133: Fix broken test_timeuuid - upgrade_tests.cql_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 2
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -130,10 +130,10 @@ jobs:
   repeated_jvm_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -305,10 +305,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -400,10 +400,10 @@ jobs:
   j11_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -510,10 +510,10 @@ jobs:
   repeated_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -632,10 +632,10 @@ jobs:
   j8_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -727,10 +727,10 @@ jobs:
   j11_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -823,10 +823,10 @@ jobs:
   j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -919,10 +919,10 @@ jobs:
   j11_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1015,10 +1015,10 @@ jobs:
   j8_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1110,10 +1110,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1205,10 +1205,10 @@ jobs:
   j11_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1350,10 +1350,10 @@ jobs:
   j8_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1472,10 +1472,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1568,10 +1568,10 @@ jobs:
   j11_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1667,10 +1667,10 @@ jobs:
   j8_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1743,10 +1743,10 @@ jobs:
   j8_upgradetests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1819,7 +1819,7 @@ jobs:
   utests_stress:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -1882,10 +1882,10 @@ jobs:
   j8_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1991,10 +1991,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 5
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2200,10 +2200,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2351,10 +2351,10 @@ jobs:
   j11_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2527,10 +2527,10 @@ jobs:
   j8_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2603,10 +2603,10 @@ jobs:
   j11_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2699,10 +2699,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 5
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2906,10 +2906,10 @@ jobs:
   j8_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3001,10 +3001,10 @@ jobs:
   j8_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3096,7 +3096,7 @@ jobs:
   utests_long:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3159,10 +3159,10 @@ jobs:
   utests_system_keyspace_directory:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3322,7 +3322,7 @@ jobs:
   utests_fqltool:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3385,10 +3385,10 @@ jobs:
   j11_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3484,10 +3484,10 @@ jobs:
   utests_compression:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3593,10 +3593,10 @@ jobs:
   j8_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/src/java/org/apache/cassandra/cql3/functions/TimeFcts.java
+++ b/src/java/org/apache/cassandra/cql3/functions/TimeFcts.java
@@ -42,18 +42,14 @@ public abstract class TimeFcts
                                 now("currentdate", SimpleDateType.instance),
                                 now("currenttime", TimeType.instance),
                                 minTimeuuidFct,
-                                minTimeuuidFct(LongType.instance),
                                 maxTimeuuidFct,
-                                maxTimeuuidFct(LongType.instance),
                                 dateOfFct,
                                 unixTimestampOfFct,
                                 toDate(TimeUUIDType.instance),
                                 toTimestamp(TimeUUIDType.instance),
-                                toTimestamp(LongType.instance),
                                 toUnixTimestamp(TimeUUIDType.instance),
                                 toUnixTimestamp(TimestampType.instance),
                                 toDate(TimestampType.instance),
-                                toDate(LongType.instance),
                                 toUnixTimestamp(SimpleDateType.instance),
                                 toTimestamp(SimpleDateType.instance));
     }
@@ -68,7 +64,7 @@ public abstract class TimeFcts
                 return type.now();
             }
         };
-    }
+    };
 
     public static final Function minTimeuuidFct = new NativeScalarFunction("mintimeuuid", TimeUUIDType.instance, TimestampType.instance)
     {
@@ -82,21 +78,6 @@ public abstract class TimeFcts
         }
     };
 
-    public static final NativeScalarFunction minTimeuuidFct(final LongType type)
-    {
-        return new NativeScalarFunction("mintimeuuid", TimeUUIDType.instance, type)
-        {
-            public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> parameters)
-            {
-                ByteBuffer bb = parameters.get(0);
-                if (bb == null)
-                    return null;
-
-                return UUIDGen.toByteBuffer(UUIDGen.minTimeUUID(LongType.instance.toLong(bb)));
-            }
-        };
-    }
-
     public static final Function maxTimeuuidFct = new NativeScalarFunction("maxtimeuuid", TimeUUIDType.instance, TimestampType.instance)
     {
         public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> parameters)
@@ -108,21 +89,6 @@ public abstract class TimeFcts
             return UUIDGen.toByteBuffer(UUIDGen.maxTimeUUID(TimestampType.instance.compose(bb).getTime()));
         }
     };
-
-    public static NativeScalarFunction maxTimeuuidFct(final LongType type)
-    {
-        return new NativeScalarFunction("maxtimeuuid", TimeUUIDType.instance, type)
-        {
-            public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> parameters)
-            {
-                ByteBuffer bb = parameters.get(0);
-                if (bb == null)
-                    return null;
-
-                return UUIDGen.toByteBuffer(UUIDGen.maxTimeUUID(LongType.instance.toLong(bb)));
-            }
-        };
-    }
 
     /**
      * Function that convert a value of <code>TIMEUUID</code> into a value of type <code>TIMESTAMP</code>.
@@ -196,28 +162,6 @@ public abstract class TimeFcts
        };
    }
 
-    /**
-     * Creates a function that convert a value of CQL(bigint) into a <code>DATE</code>.
-     * @param type the temporal type
-     * @return a function that convert CQL(bigint) into a <code>DATE</code>.
-     */
-    public static NativeScalarFunction toDate(final LongType type)
-    {
-        return new NativeScalarFunction("todate", SimpleDateType.instance, type)
-        {
-            public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> parameters)
-            {
-                ByteBuffer bb = parameters.get(0);
-                if (bb == null || !bb.hasRemaining())
-                    return null;
-
-                long millis = LongType.instance.toLong(bb);
-                return SimpleDateType.instance.fromTimeInMillis(millis);
-            }
-        };
-    }
-
-
    /**
     * Creates a function that convert a value of the specified type into a <code>TIMESTAMP</code>.
     * @param type the temporal type
@@ -238,27 +182,6 @@ public abstract class TimeFcts
            }
        };
    }
-
-    /**
-     * Creates a function that convert a value of the specified type into a <code>TIMESTAMP</code>.
-     * @param type the temporal type
-     * @return a function that convert a value of the specified type into a <code>TIMESTAMP</code>.
-     */
-    public static NativeScalarFunction toTimestamp(final LongType type)
-    {
-        return new NativeScalarFunction("totimestamp", TimestampType.instance, type)
-        {
-            public ByteBuffer execute(ProtocolVersion protocolVersion, List<ByteBuffer> parameters)
-            {
-                ByteBuffer bb = parameters.get(0);
-                if (bb == null || !bb.hasRemaining())
-                    return null;
-
-                long millis = LongType.instance.toLong(bb);
-                return TimestampType.instance.fromTimeInMillis(millis);
-            }
-        };
-    }
 
     /**
      * Creates a function that convert a value of the specified type into an UNIX timestamp.

--- a/src/java/org/apache/cassandra/db/marshal/LongType.java
+++ b/src/java/org/apache/cassandra/db/marshal/LongType.java
@@ -139,7 +139,7 @@ public class LongType extends NumberType<Long>
     }
 
     @Override
-    public long toLong(ByteBuffer value)
+    protected long toLong(ByteBuffer value)
     {
         return ByteBufferUtil.toLong(value);
     }

--- a/test/unit/org/apache/cassandra/cql3/functions/TimeFctsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/TimeFctsTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import org.apache.cassandra.db.marshal.IntegerType;
 import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.SimpleDateType;
 import org.apache.cassandra.db.marshal.TimeUUIDType;
@@ -61,29 +60,11 @@ public class TimeFctsTest
     }
 
     @Test
-    public void testMinTimeUuidFromBigInt()
-    {
-        long timeInMillis = DATE_TIME.toInstant().toEpochMilli();
-        ByteBuffer input = LongType.instance.decompose(timeInMillis);
-        ByteBuffer output = executeFunction(TimeFcts.minTimeuuidFct(LongType.instance), input);
-        assertEquals(UUIDGen.minTimeUUID(timeInMillis), TimeUUIDType.instance.compose(output));
-    }
-
-    @Test
     public void testMaxTimeUuid()
     {
         long timeInMillis = DATE_TIME.toInstant().toEpochMilli();
         ByteBuffer input = TimestampType.instance.fromString(DATE_TIME_STRING + "+00");
         ByteBuffer output = executeFunction(TimeFcts.maxTimeuuidFct, input);
-        assertEquals(UUIDGen.maxTimeUUID(timeInMillis), TimeUUIDType.instance.compose(output));
-    }
-
-    @Test
-    public void testMaxTimeUuidFromBigInt()
-    {
-        long timeInMillis = DATE_TIME.toInstant().toEpochMilli();
-        ByteBuffer input = LongType.instance.decompose(timeInMillis);
-        ByteBuffer output = executeFunction(TimeFcts.maxTimeuuidFct(LongType.instance), input);
         assertEquals(UUIDGen.maxTimeUUID(timeInMillis), TimeUUIDType.instance.compose(output));
     }
 
@@ -161,16 +142,6 @@ public class TimeFctsTest
     }
 
     @Test
-    public void testBigIntegerToDate()
-    {
-        long millis = DATE.toInstant().toEpochMilli();
-
-        ByteBuffer input = LongType.instance.decompose(millis);
-        ByteBuffer output = executeFunction(toDate(LongType.instance), input);
-        assertEquals(DATE.toInstant().toEpochMilli(), SimpleDateType.instance.toTimeInMillis(output));
-    }
-
-    @Test
     public void testTimestampToDateWithEmptyInput()
     {
         ByteBuffer output = executeFunction(toDate(TimestampType.instance), ByteBufferUtil.EMPTY_BYTE_BUFFER);
@@ -182,16 +153,6 @@ public class TimeFctsTest
     {
         ByteBuffer input = TimestampType.instance.decompose(Date.from(DATE_TIME.toInstant()));
         ByteBuffer output = executeFunction(toUnixTimestamp(TimestampType.instance), input);
-        assertEquals(DATE_TIME.toInstant().toEpochMilli(), LongType.instance.compose(output).longValue());
-    }
-
-    @Test
-    public void testBigIntegerToTimestamp()
-    {
-        long millis = DATE_TIME.toInstant().toEpochMilli();
-
-        ByteBuffer input = LongType.instance.decompose(millis);
-        ByteBuffer output = executeFunction(toTimestamp(LongType.instance), input);
         assertEquals(DATE_TIME.toInstant().toEpochMilli(), LongType.instance.compose(output).longValue());
     }
 

--- a/test/unit/org/apache/cassandra/cql3/functions/TimeFctsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/TimeFctsTest.java
@@ -60,10 +60,28 @@ public class TimeFctsTest
     }
 
     @Test
+    public void testMinTimeUuidFromBigInt()
+    {
+        long timeInMillis = DATE_TIME.toInstant().toEpochMilli();
+        ByteBuffer input = LongType.instance.decompose(timeInMillis);
+        ByteBuffer output = executeFunction(TimeFcts.minTimeuuidFct, input);
+        assertEquals(UUIDGen.minTimeUUID(timeInMillis), TimeUUIDType.instance.compose(output));
+    }
+
+    @Test
     public void testMaxTimeUuid()
     {
         long timeInMillis = DATE_TIME.toInstant().toEpochMilli();
         ByteBuffer input = TimestampType.instance.fromString(DATE_TIME_STRING + "+00");
+        ByteBuffer output = executeFunction(TimeFcts.maxTimeuuidFct, input);
+        assertEquals(UUIDGen.maxTimeUUID(timeInMillis), TimeUUIDType.instance.compose(output));
+    }
+
+    @Test
+    public void testMaxTimeUuidFromBigInt()
+    {
+        long timeInMillis = DATE_TIME.toInstant().toEpochMilli();
+        ByteBuffer input = LongType.instance.decompose(timeInMillis);
         ByteBuffer output = executeFunction(TimeFcts.maxTimeuuidFct, input);
         assertEquals(UUIDGen.maxTimeUUID(timeInMillis), TimeUUIDType.instance.compose(output));
     }
@@ -142,6 +160,16 @@ public class TimeFctsTest
     }
 
     @Test
+    public void testBigIntegerToDate()
+    {
+        long millis = DATE.toInstant().toEpochMilli();
+
+        ByteBuffer input = LongType.instance.decompose(millis);
+        ByteBuffer output = executeFunction(toDate(TimestampType.instance), input);
+        assertEquals(DATE.toInstant().toEpochMilli(), SimpleDateType.instance.toTimeInMillis(output));
+    }
+
+    @Test
     public void testTimestampToDateWithEmptyInput()
     {
         ByteBuffer output = executeFunction(toDate(TimestampType.instance), ByteBufferUtil.EMPTY_BYTE_BUFFER);
@@ -153,6 +181,16 @@ public class TimeFctsTest
     {
         ByteBuffer input = TimestampType.instance.decompose(Date.from(DATE_TIME.toInstant()));
         ByteBuffer output = executeFunction(toUnixTimestamp(TimestampType.instance), input);
+        assertEquals(DATE_TIME.toInstant().toEpochMilli(), LongType.instance.compose(output).longValue());
+    }
+
+    @Test
+    public void testBigIntegerToTimestamp()
+    {
+        long millis = DATE_TIME.toInstant().toEpochMilli();
+
+        ByteBuffer input = LongType.instance.decompose(millis);
+        ByteBuffer output = executeFunction(toTimestamp(TimestampType.instance), input);
         assertEquals(DATE_TIME.toInstant().toEpochMilli(), LongType.instance.compose(output).longValue());
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/TimeuuidTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/TimeuuidTest.java
@@ -64,7 +64,7 @@ public class TimeuuidTest extends CQLTester
                        row(new Date(timestamp), timestamp));
         }
 
-        assertEmpty(execute("SELECT t FROM %s WHERE k = 0 AND t > maxTimeuuid(1564830182000) AND t < minTimeuuid('2012-11-07 18:18:22-0800')"));
+        assertEmpty(execute("SELECT t FROM %s WHERE k = 0 AND t > maxTimeuuid(1234567) AND t < minTimeuuid('2012-11-07 18:18:22-0800')"));
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/TimeuuidTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/TimeuuidTest.java
@@ -65,6 +65,7 @@ public class TimeuuidTest extends CQLTester
         }
 
         assertEmpty(execute("SELECT t FROM %s WHERE k = 0 AND t > maxTimeuuid(1234567) AND t < minTimeuuid('2012-11-07 18:18:22-0800')"));
+        assertEmpty(execute("SELECT t FROM %s WHERE k = 0 AND t > maxTimeuuid(1564830182000) AND t < minTimeuuid('2012-11-07 18:18:22-0800')"));
     }
 
     /**


### PR DESCRIPTION
There are two commits to this PR:
1. Reverts commit 8ddcd43 
2. Preserve tests from 8ddcd43 that use biting numbers