### PR TITLE
CASSANDRA-17224: Virtual table for exposing CQL metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 2
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -130,10 +130,10 @@ jobs:
   repeated_jvm_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -305,10 +305,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -400,10 +400,10 @@ jobs:
   j11_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -510,10 +510,10 @@ jobs:
   repeated_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -632,10 +632,10 @@ jobs:
   j8_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -727,10 +727,10 @@ jobs:
   j11_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -823,10 +823,10 @@ jobs:
   j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -919,10 +919,10 @@ jobs:
   j11_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1015,10 +1015,10 @@ jobs:
   j8_cqlsh-dtests-py3-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1110,10 +1110,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1205,10 +1205,10 @@ jobs:
   j11_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1350,10 +1350,10 @@ jobs:
   j8_repeated_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1472,10 +1472,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1568,10 +1568,10 @@ jobs:
   j11_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1667,10 +1667,10 @@ jobs:
   j8_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1743,10 +1743,10 @@ jobs:
   j8_upgradetests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1819,7 +1819,7 @@ jobs:
   utests_stress:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -1882,10 +1882,10 @@ jobs:
   j8_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1991,10 +1991,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 5
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2200,10 +2200,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2351,10 +2351,10 @@ jobs:
   j11_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2527,10 +2527,10 @@ jobs:
   j8_dtests-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2603,10 +2603,10 @@ jobs:
   j11_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2699,10 +2699,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 5
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2906,10 +2906,10 @@ jobs:
   j8_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3001,10 +3001,10 @@ jobs:
   j8_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3096,7 +3096,7 @@ jobs:
   utests_long:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3159,10 +3159,10 @@ jobs:
   utests_system_keyspace_directory:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3322,7 +3322,7 @@ jobs:
   utests_fqltool:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1
@@ -3385,10 +3385,10 @@ jobs:
   j11_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3484,10 +3484,10 @@ jobs:
   utests_compression:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3593,10 +3593,10 @@ jobs:
   j8_repeated_utest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra

--- a/doc/modules/cassandra/pages/new/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/new/virtualtables.adoc
@@ -99,6 +99,9 @@ recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and s
 |thread_pools |Lists metrics for each thread pool.
 
 |tombstones_per_read |Records counts, keyspace_name, tablek_name, max, and median for tombstones.
+
+|cql_metrcs |Lists metrics for CQL prepared statements.
+
 |===
 
 We shall discuss some of the virtual tables in more detail next.
@@ -288,6 +291,22 @@ tasks, use the following query:
 ....
 SELECT total - progress AS remaining
 FROM system_views.sstable_tasks;
+....
+
+=== CQL metrics Virtual Table
+
+Lists CQL prepared statements metrics. A query on CQL metrics virtual table lists below metrics.
+
+....
+cqlsh> select * from system_views.cql_metrics ;
+
+ name                         | value
+------------------------------+-------
+    prepared_statements_count |     0
+  prepared_statements_evicted |     0
+ prepared_statements_executed |     0
+    prepared_statements_ratio |     0
+  regular_statements_executed |    17
 ....
 
 === Other Virtual Tables

--- a/doc/modules/cassandra/pages/new/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/new/virtualtables.adoc
@@ -74,6 +74,8 @@ recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and s
 
 |coordinator_write_latency |Records counts, keyspace_name, table_name, max, median, and per_second for coordinator writes.
 
+|cql_metrcs |Lists metrics for CQL prepared statements.
+
 |disk_usage |Records disk usage including disk_space, keyspace_name, and table_name, sorted by system keyspaces.
 
 |internode_inbound |Lists information about the inbound internode messaging.
@@ -99,8 +101,6 @@ recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and s
 |thread_pools |Lists metrics for each thread pool.
 
 |tombstones_per_read |Records counts, keyspace_name, tablek_name, max, and median for tombstones.
-
-|cql_metrcs |Lists metrics for CQL prepared statements.
 
 |===
 
@@ -171,6 +171,22 @@ counters |       26214400 |           0 |         0 |       NaN |               
     rows |              0 |           0 |         0 |       NaN |                          0 |                              0 |             0 |          0
 
 (4 rows)
+....
+
+=== CQL metrics Virtual Table
+
+Lists CQL prepared statements metrics. A query on CQL metrics virtual table lists below metrics.
+
+....
+cqlsh> select * from system_views.cql_metrics ;
+
+ name                         | value
+------------------------------+-------
+    prepared_statements_count |     0
+  prepared_statements_evicted |     0
+ prepared_statements_executed |     0
+    prepared_statements_ratio |     0
+  regular_statements_executed |    17
 ....
 
 === Settings Virtual Table
@@ -291,22 +307,6 @@ tasks, use the following query:
 ....
 SELECT total - progress AS remaining
 FROM system_views.sstable_tasks;
-....
-
-=== CQL metrics Virtual Table
-
-Lists CQL prepared statements metrics. A query on CQL metrics virtual table lists below metrics.
-
-....
-cqlsh> select * from system_views.cql_metrics ;
-
- name                         | value
-------------------------------+-------
-    prepared_statements_count |     0
-  prepared_statements_evicted |     0
- prepared_statements_executed |     0
-    prepared_statements_ratio |     0
-  regular_statements_executed |    17
 ....
 
 === Other Virtual Tables

--- a/doc/modules/cassandra/pages/new/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/new/virtualtables.adoc
@@ -74,7 +74,7 @@ recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and s
 
 |coordinator_write_latency |Records counts, keyspace_name, table_name, max, median, and per_second for coordinator writes.
 
-|cql_metrcs |Lists metrics for CQL prepared statements.
+|cql_metrcs |Metrics specific to CQL prepared statement caching.
 
 |disk_usage |Records disk usage including disk_space, keyspace_name, and table_name, sorted by system keyspaces.
 
@@ -174,8 +174,7 @@ counters |       26214400 |           0 |         0 |       NaN |               
 ....
 
 === CQL metrics Virtual Table
-
-Lists CQL prepared statements metrics. A query on CQL metrics virtual table lists below metrics.
+The `cql_metrics` virtual table lists metrics specific to CQL prepared statement caching. A query on `cql_metrics` virtual table lists below metrics.
 
 ....
 cqlsh> select * from system_views.cql_metrics ;

--- a/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.dht.LocalPartitioner;
+import org.apache.cassandra.metrics.CQLMetrics;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.cql3.QueryProcessor;
+
+// Virtual table for CQL metrics
+public class CQLMetricsTable extends AbstractVirtualTable
+{
+    public static final String TABLE_NAME = "cql_metrics";
+    public static final String PREPARED_STATEMENTS_COUNT_COL = "prepared_statements_count";
+    public static final String PREPARED_STATEMENTS_EVICTED_COL = "prepared_statements_evicted";
+    public static final String PREPARED_STATEMENTS_EXECUTED_COL = "prepared_statements_executed";
+    public static final String PREPARED_STATEMENTS_RATIO_COL = "prepared_statements_ratio";
+    public static final String REGULAR_STATEMENTS_EXECUTED_COL = "regular_statements_executed";
+    public static final String NAME_COL = "name";
+    public static final String VALUE_ROW = "value";
+
+    private final CQLMetrics cqlMetrics;
+
+    // Default constructor references query processor metrics
+    CQLMetricsTable(String keyspace)
+    {
+        this(keyspace, QueryProcessor.metrics);
+    }
+
+    // For dependency injection
+    @VisibleForTesting
+    CQLMetricsTable(String keyspace, CQLMetrics cqlMetrics)
+    {
+        // create virtual table with this name
+        super(TableMetadata.builder(keyspace, TABLE_NAME)
+                           .kind(TableMetadata.Kind.VIRTUAL)
+                           .partitioner(new LocalPartitioner(UTF8Type.instance))
+                           .addPartitionKeyColumn(NAME_COL, UTF8Type.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_COUNT_COL, DoubleType.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_EVICTED_COL, DoubleType.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_EXECUTED_COL, DoubleType.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_RATIO_COL, DoubleType.instance)
+                           .addRegularColumn(REGULAR_STATEMENTS_EXECUTED_COL, DoubleType.instance)
+                           .build());
+        this.cqlMetrics = cqlMetrics;
+    }
+
+    @Override
+    public DataSet data()
+    {
+        // populate metrics in the virtual table
+        SimpleDataSet result = new SimpleDataSet(metadata());
+        addRow(result, VALUE_ROW, cqlMetrics);
+
+        return result;
+    }
+
+    private void addRow(SimpleDataSet dataSet, String name, CQLMetrics cqlMetrics)
+    {
+        dataSet.row(name)
+               .column(PREPARED_STATEMENTS_COUNT_COL, Double.valueOf(cqlMetrics.preparedStatementsCount.getValue()))
+               .column(PREPARED_STATEMENTS_EVICTED_COL, Double.valueOf(cqlMetrics.preparedStatementsEvicted.getCount()))
+               .column(PREPARED_STATEMENTS_EXECUTED_COL, Double.valueOf(cqlMetrics.preparedStatementsExecuted.getCount()))
+               .column(PREPARED_STATEMENTS_RATIO_COL, cqlMetrics.preparedStatementsRatio.getValue())
+               .column(REGULAR_STATEMENTS_EXECUTED_COL, Double.valueOf(cqlMetrics.regularStatementsExecuted.getCount()));
+    }
+}

--- a/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
@@ -21,14 +21,16 @@ package org.apache.cassandra.db.virtual;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.LocalPartitioner;
 import org.apache.cassandra.metrics.CQLMetrics;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.cql3.QueryProcessor;
 
-// Virtual table for CQL metrics
-public class CQLMetricsTable extends AbstractVirtualTable
+
+final class CQLMetricsTable extends AbstractVirtualTable
 {
     public static final String TABLE_NAME = "cql_metrics";
     public static final String PREPARED_STATEMENTS_COUNT_COL = "prepared_statements_count";
@@ -41,7 +43,6 @@ public class CQLMetricsTable extends AbstractVirtualTable
 
     private final CQLMetrics cqlMetrics;
 
-    // Default constructor references query processor metrics
     CQLMetricsTable(String keyspace)
     {
         this(keyspace, QueryProcessor.metrics);
@@ -51,16 +52,15 @@ public class CQLMetricsTable extends AbstractVirtualTable
     @VisibleForTesting
     CQLMetricsTable(String keyspace, CQLMetrics cqlMetrics)
     {
-        // create virtual table with this name
         super(TableMetadata.builder(keyspace, TABLE_NAME)
                            .kind(TableMetadata.Kind.VIRTUAL)
                            .partitioner(new LocalPartitioner(UTF8Type.instance))
                            .addPartitionKeyColumn(NAME_COL, UTF8Type.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_COUNT_COL, DoubleType.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_EVICTED_COL, DoubleType.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_EXECUTED_COL, DoubleType.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_COUNT_COL, Int32Type.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_EVICTED_COL, LongType.instance)
+                           .addRegularColumn(PREPARED_STATEMENTS_EXECUTED_COL, LongType.instance)
                            .addRegularColumn(PREPARED_STATEMENTS_RATIO_COL, DoubleType.instance)
-                           .addRegularColumn(REGULAR_STATEMENTS_EXECUTED_COL, DoubleType.instance)
+                           .addRegularColumn(REGULAR_STATEMENTS_EXECUTED_COL, LongType.instance)
                            .build());
         this.cqlMetrics = cqlMetrics;
     }
@@ -68,7 +68,6 @@ public class CQLMetricsTable extends AbstractVirtualTable
     @Override
     public DataSet data()
     {
-        // populate metrics in the virtual table
         SimpleDataSet result = new SimpleDataSet(metadata());
         addRow(result, VALUE_ROW, cqlMetrics);
 
@@ -78,10 +77,10 @@ public class CQLMetricsTable extends AbstractVirtualTable
     private void addRow(SimpleDataSet dataSet, String name, CQLMetrics cqlMetrics)
     {
         dataSet.row(name)
-               .column(PREPARED_STATEMENTS_COUNT_COL, Double.valueOf(cqlMetrics.preparedStatementsCount.getValue()))
-               .column(PREPARED_STATEMENTS_EVICTED_COL, Double.valueOf(cqlMetrics.preparedStatementsEvicted.getCount()))
-               .column(PREPARED_STATEMENTS_EXECUTED_COL, Double.valueOf(cqlMetrics.preparedStatementsExecuted.getCount()))
+               .column(PREPARED_STATEMENTS_COUNT_COL, cqlMetrics.preparedStatementsCount.getValue())
+               .column(PREPARED_STATEMENTS_EVICTED_COL, cqlMetrics.preparedStatementsEvicted.getCount())
+               .column(PREPARED_STATEMENTS_EXECUTED_COL, cqlMetrics.preparedStatementsExecuted.getCount())
                .column(PREPARED_STATEMENTS_RATIO_COL, cqlMetrics.preparedStatementsRatio.getValue())
-               .column(REGULAR_STATEMENTS_EXECUTED_COL, Double.valueOf(cqlMetrics.regularStatementsExecuted.getCount()));
+               .column(REGULAR_STATEMENTS_EXECUTED_COL, cqlMetrics.regularStatementsExecuted.getCount());
     }
 }

--- a/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
@@ -51,6 +51,7 @@ final class CQLMetricsTable extends AbstractVirtualTable
     CQLMetricsTable(String keyspace, CQLMetrics cqlMetrics)
     {
         super(TableMetadata.builder(keyspace, TABLE_NAME)
+                           .comment("Metrics specific to CQL prepared statement caching")
                            .kind(TableMetadata.Kind.VIRTUAL)
                            .partitioner(new LocalPartitioner(UTF8Type.instance))
                            .addPartitionKeyColumn(NAME_COL, UTF8Type.instance)

--- a/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CQLMetricsTable.java
@@ -21,8 +21,6 @@ package org.apache.cassandra.db.virtual;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.db.marshal.DoubleType;
-import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.db.marshal.LongType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.LocalPartitioner;
 import org.apache.cassandra.metrics.CQLMetrics;
@@ -33,13 +31,13 @@ import org.apache.cassandra.cql3.QueryProcessor;
 final class CQLMetricsTable extends AbstractVirtualTable
 {
     public static final String TABLE_NAME = "cql_metrics";
-    public static final String PREPARED_STATEMENTS_COUNT_COL = "prepared_statements_count";
-    public static final String PREPARED_STATEMENTS_EVICTED_COL = "prepared_statements_evicted";
-    public static final String PREPARED_STATEMENTS_EXECUTED_COL = "prepared_statements_executed";
-    public static final String PREPARED_STATEMENTS_RATIO_COL = "prepared_statements_ratio";
-    public static final String REGULAR_STATEMENTS_EXECUTED_COL = "regular_statements_executed";
+    public static final String PREPARED_STATEMENTS_COUNT = "prepared_statements_count";
+    public static final String PREPARED_STATEMENTS_EVICTED = "prepared_statements_evicted";
+    public static final String PREPARED_STATEMENTS_EXECUTED = "prepared_statements_executed";
+    public static final String PREPARED_STATEMENTS_RATIO = "prepared_statements_ratio";
+    public static final String REGULAR_STATEMENTS_EXECUTED = "regular_statements_executed";
     public static final String NAME_COL = "name";
-    public static final String VALUE_ROW = "value";
+    public static final String VALUE_COL = "value";
 
     private final CQLMetrics cqlMetrics;
 
@@ -56,11 +54,7 @@ final class CQLMetricsTable extends AbstractVirtualTable
                            .kind(TableMetadata.Kind.VIRTUAL)
                            .partitioner(new LocalPartitioner(UTF8Type.instance))
                            .addPartitionKeyColumn(NAME_COL, UTF8Type.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_COUNT_COL, Int32Type.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_EVICTED_COL, LongType.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_EXECUTED_COL, LongType.instance)
-                           .addRegularColumn(PREPARED_STATEMENTS_RATIO_COL, DoubleType.instance)
-                           .addRegularColumn(REGULAR_STATEMENTS_EXECUTED_COL, LongType.instance)
+                           .addRegularColumn(VALUE_COL, DoubleType.instance)
                            .build());
         this.cqlMetrics = cqlMetrics;
     }
@@ -69,18 +63,18 @@ final class CQLMetricsTable extends AbstractVirtualTable
     public DataSet data()
     {
         SimpleDataSet result = new SimpleDataSet(metadata());
-        addRow(result, VALUE_ROW, cqlMetrics);
+        addRow(result, PREPARED_STATEMENTS_COUNT, cqlMetrics.preparedStatementsCount.getValue());
+        addRow(result, PREPARED_STATEMENTS_EVICTED, cqlMetrics.preparedStatementsEvicted.getCount());
+        addRow(result, PREPARED_STATEMENTS_EXECUTED, cqlMetrics.preparedStatementsExecuted.getCount());
+        addRow(result, PREPARED_STATEMENTS_RATIO, cqlMetrics.preparedStatementsRatio.getValue());
+        addRow(result, REGULAR_STATEMENTS_EXECUTED, cqlMetrics.regularStatementsExecuted.getCount());
 
         return result;
     }
 
-    private void addRow(SimpleDataSet dataSet, String name, CQLMetrics cqlMetrics)
+    private void addRow(SimpleDataSet dataSet, String name, double value)
     {
         dataSet.row(name)
-               .column(PREPARED_STATEMENTS_COUNT_COL, cqlMetrics.preparedStatementsCount.getValue())
-               .column(PREPARED_STATEMENTS_EVICTED_COL, cqlMetrics.preparedStatementsEvicted.getCount())
-               .column(PREPARED_STATEMENTS_EXECUTED_COL, cqlMetrics.preparedStatementsExecuted.getCount())
-               .column(PREPARED_STATEMENTS_RATIO_COL, cqlMetrics.preparedStatementsRatio.getValue())
-               .column(REGULAR_STATEMENTS_EXECUTED_COL, cqlMetrics.regularStatementsExecuted.getCount());
+               .column(VALUE_COL, value);
     }
 }

--- a/src/java/org/apache/cassandra/db/virtual/SystemViewsKeyspace.java
+++ b/src/java/org/apache/cassandra/db/virtual/SystemViewsKeyspace.java
@@ -43,6 +43,7 @@ public final class SystemViewsKeyspace extends VirtualKeyspace
                     .add(new NetworkPermissionsCacheKeysTable(VIRTUAL_VIEWS))
                     .add(new PermissionsCacheKeysTable(VIRTUAL_VIEWS))
                     .add(new RolesCacheKeysTable(VIRTUAL_VIEWS))
+                    .add(new CQLMetricsTable(VIRTUAL_VIEWS))
                     .build());
     }
 }

--- a/test/unit/org/apache/cassandra/db/virtual/CQLMetricsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/CQLMetricsTableTest.java
@@ -50,19 +50,33 @@ public class CQLMetricsTableTest extends CQLTester
         String getMetricsQuery = "SELECT * FROM " + KS_NAME + "." + CQLMetricsTable.TABLE_NAME;
         ResultSet vtsRows = executeNet(getMetricsQuery);
 
-        assertEquals(6, vtsRows.getColumnDefinitions().size());
+        assertEquals(2, vtsRows.getColumnDefinitions().size());
 
         AtomicInteger rowCount = new AtomicInteger(0);
         vtsRows.forEach(r -> {
-            assertEquals(expectedMetrics.preparedStatementsCount.getValue(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_COUNT_COL), 0);
-            assertEquals(expectedMetrics.preparedStatementsEvicted.getCount(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_EVICTED_COL), 0);
-            assertEquals(expectedMetrics.preparedStatementsExecuted.getCount(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_EXECUTED_COL), 0);
-            assertEquals(expectedMetrics.preparedStatementsRatio.getValue(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_RATIO_COL), 0.01);
-            assertEquals(expectedMetrics.regularStatementsExecuted.getCount(), r.getDouble(CQLMetricsTable.REGULAR_STATEMENTS_EXECUTED_COL), 0);
+            final double metricValue = r.getDouble(CQLMetricsTable.VALUE_COL);
+            switch (r.getString(CQLMetricsTable.NAME_COL))
+            {
+                case CQLMetricsTable.PREPARED_STATEMENTS_COUNT:
+                    assertEquals(expectedMetrics.preparedStatementsCount.getValue(), metricValue, 0);
+                    break;
+                case CQLMetricsTable.PREPARED_STATEMENTS_EVICTED:
+                    assertEquals(expectedMetrics.preparedStatementsEvicted.getCount(), metricValue, 0);
+                    break;
+                case CQLMetricsTable.PREPARED_STATEMENTS_EXECUTED:
+                    assertEquals(expectedMetrics.preparedStatementsExecuted.getCount(), metricValue, 0);
+                    break;
+                case CQLMetricsTable.PREPARED_STATEMENTS_RATIO:
+                    assertEquals(expectedMetrics.preparedStatementsRatio.getValue(), metricValue, 0.01);
+                    break;
+                case CQLMetricsTable.REGULAR_STATEMENTS_EXECUTED:
+                    assertEquals(expectedMetrics.regularStatementsExecuted.getCount(), metricValue, 0);
+                    break;
+            }
             rowCount.getAndIncrement();
         });
 
-        assertEquals(1, rowCount.get());
+        assertEquals(5, rowCount.get());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/virtual/CQLMetricsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/CQLMetricsTableTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.collect.ImmutableList;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.metrics.CQLMetrics;
+
+public class CQLMetricsTableTest extends CQLTester
+{
+    private static final String KS_NAME = "vts";
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CQLTester.setUpClass();
+    }
+
+    private void queryAndValidateMetrics(CQLMetrics expectedMetrics) throws Throwable
+    {
+        String getMetricsQuery = "SELECT * FROM " + KS_NAME + "." + CQLMetricsTable.TABLE_NAME;
+        ResultSet vtsRows = executeNet(getMetricsQuery);
+
+        // validate - number of columns
+        assertEquals(6, vtsRows.getColumnDefinitions().size());
+
+        AtomicInteger rowCount = new AtomicInteger(0);
+        vtsRows.forEach(r -> {
+            assertEquals(expectedMetrics.preparedStatementsCount.getValue(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_COUNT_COL), 0);
+            assertEquals(expectedMetrics.preparedStatementsEvicted.getCount(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_EVICTED_COL), 0);
+            assertEquals(expectedMetrics.preparedStatementsExecuted.getCount(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_EXECUTED_COL), 0);
+            assertEquals(expectedMetrics.preparedStatementsRatio.getValue(), r.getDouble(CQLMetricsTable.PREPARED_STATEMENTS_RATIO_COL), 0.01);
+            assertEquals(expectedMetrics.regularStatementsExecuted.getCount(), r.getDouble(CQLMetricsTable.REGULAR_STATEMENTS_EXECUTED_COL), 0);
+            rowCount.getAndIncrement();
+        });
+
+        // validate - number of rows
+        assertEquals(1, rowCount.get());
+    }
+
+    @Test
+    public void testUsingPrepareStmts() throws Throwable
+    {
+        CQLMetricsTable table = new CQLMetricsTable(KS_NAME);
+        VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(KS_NAME, ImmutableList.of(table)));
+
+        String ks = createKeyspace("CREATE KEYSPACE %s WITH replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
+        String tbl = createTable(ks, "CREATE TABLE %s (id int PRIMARY KEY, cid int, val text)");
+        Session session = sessionNet();
+
+        // prepare statements
+        String insertCQL = "INSERT INTO " + ks + "." + tbl + " (id, cid, val) VALUES (?, ?, ?)";
+        PreparedStatement preparedInsert = session.prepare(insertCQL);
+
+        String selectCQL = "Select * from " + ks + "." + tbl + " where id = ?";
+        PreparedStatement preparedSelect = session.prepare(selectCQL);
+
+        for (int i = 0; i < 10; i++)
+        {
+            // execute prepared statements
+            session.execute(preparedInsert.bind(i, i, "value" + i));
+            session.execute(preparedSelect.bind(i));
+        }
+
+        queryAndValidateMetrics(QueryProcessor.metrics);
+    }
+
+    @Test
+    public void testUsingInjectedValues() throws Throwable
+    {
+        CQLMetrics cqlMetrics = new CQLMetrics();
+        CQLMetricsTable table = new CQLMetricsTable(KS_NAME, cqlMetrics);
+        VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(KS_NAME, ImmutableList.of(table)));
+
+        // With initial injected values
+        cqlMetrics.preparedStatementsExecuted.inc(50);
+        cqlMetrics.regularStatementsExecuted.inc(100);
+        cqlMetrics.preparedStatementsEvicted.inc(25);
+        queryAndValidateMetrics(cqlMetrics);
+
+        // Test again with updated values
+        cqlMetrics.preparedStatementsExecuted.inc(150);
+        cqlMetrics.regularStatementsExecuted.inc(200);
+        cqlMetrics.preparedStatementsEvicted.inc(50);
+        queryAndValidateMetrics(cqlMetrics);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/virtual/CQLMetricsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/CQLMetricsTableTest.java
@@ -50,7 +50,6 @@ public class CQLMetricsTableTest extends CQLTester
         String getMetricsQuery = "SELECT * FROM " + KS_NAME + "." + CQLMetricsTable.TABLE_NAME;
         ResultSet vtsRows = executeNet(getMetricsQuery);
 
-        // validate - number of columns
         assertEquals(6, vtsRows.getColumnDefinitions().size());
 
         AtomicInteger rowCount = new AtomicInteger(0);
@@ -63,7 +62,6 @@ public class CQLMetricsTableTest extends CQLTester
             rowCount.getAndIncrement();
         });
 
-        // validate - number of rows
         assertEquals(1, rowCount.get());
     }
 
@@ -77,7 +75,6 @@ public class CQLMetricsTableTest extends CQLTester
         String tbl = createTable(ks, "CREATE TABLE %s (id int PRIMARY KEY, cid int, val text)");
         Session session = sessionNet();
 
-        // prepare statements
         String insertCQL = "INSERT INTO " + ks + "." + tbl + " (id, cid, val) VALUES (?, ?, ?)";
         PreparedStatement preparedInsert = session.prepare(insertCQL);
 
@@ -86,7 +83,6 @@ public class CQLMetricsTableTest extends CQLTester
 
         for (int i = 0; i < 10; i++)
         {
-            // execute prepared statements
             session.execute(preparedInsert.bind(i, i, "value" + i));
             session.execute(preparedSelect.bind(i));
         }


### PR DESCRIPTION
Exposing CQL metrics to a virtual table. 

Below are CQL metrics from https://cassandra.apache.org/doc/latest/cassandra/operating/metrics.html#:~:text=org.apache.cassandra.metrics%3Atype%3DCQL,that%20are%20prepared%20vs%20unprepared.

Name | Type | Description
-- | -- | --
PreparedStatementsCount | Gauge<Integer> | Number of cached prepared statements.
PreparedStatementsEvicted | Counter | Number of prepared statements evicted from the prepared statement cache
PreparedStatementsExecuted | Counter | Number of prepared statements executed.
RegularStatementsExecuted | Counter | Number of non prepared statements executed.
PreparedStatementsRatio | Gauge<Double> | Percentage of statements that are prepared vs unprepared.


Here is the virtual table created with this diff, output from cqlsh:

```
cqlsh> select * from system_views.cql_metrics ;

 name                         | value
------------------------------+-------
    prepared_statements_count |     0
  prepared_statements_evicted |     0
 prepared_statements_executed |     0
    prepared_statements_ratio |     0
  regular_statements_executed |    17

(5 rows)
```
