### PR TITLE
CASSANDRA-17442 Fixes table misalignment in hints.adoc

### DIFF
--- a/doc/modules/cassandra/pages/operating/hints.adoc
+++ b/doc/modules/cassandra/pages/operating/hints.adoc
@@ -124,7 +124,6 @@ hinted_handoff_disabled_datacenters:
   - DC1
   - DC2
 ----
-
 |`unset`
 
 |`max_hint_window_in_ms` |Defines the maximum amount of time (ms) a node


### PR DESCRIPTION
I noticed in [official documentation](https://cassandra.apache.org/doc/latest/cassandra/operating/hints.html) site that the table was incorrect, and fixed it.


See:

![image](https://user-images.githubusercontent.com/715810/150949851-10bd0264-9db5-44a8-bcb8-276a94801b5b.png)
