### PR TITLE
Remove obsolete enum34 package

### DIFF
--- a/pylib/requirements.txt
+++ b/pylib/requirements.txt
@@ -9,7 +9,6 @@ six>=1.12.0
 coverage
 decorator
 docopt
-enum34
 flaky
 mock
 nose


### PR DESCRIPTION
Remove enum34 from requirements.txt which was only necessary for backwards compatibility with versions prior to 3.4 which introduced Enum (PEP 435).

See https://pypi.org/project/enum34/ which details its support for earlier python versions 2.4 ... 3.3