### PR TITLE
CASSANDRA-17346 : Hints page has a misaligned settings table

### DIFF
--- a/doc/modules/cassandra/pages/operating/hints.adoc
+++ b/doc/modules/cassandra/pages/operating/hints.adoc
@@ -118,7 +118,6 @@ Table 1. Settings for Hints
 A list of data centers that do not perform hinted handoffs even when
 handoff is otherwise enabled. Example:
 
-a|
 [source,yaml]
 ----
 hinted_handoff_disabled_datacenters:


### PR DESCRIPTION
Fixing the misalignment within the documentation table of the hint settings.

patch by Andrew Hogg; for CASSANDRA-17346