### PR TITLE
add: shorter version of version find (-v)

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -228,6 +228,7 @@ parser.add_option("--request-timeout", default=DEFAULT_REQUEST_TIMEOUT_SECONDS, 
                   help='Specify the default request timeout in seconds (default: %default seconds).')
 parser.add_option("-t", "--tty", action='store_true', dest='tty',
                   help='Force tty mode (command prompt).')
+parser.add_option('-v', action="version", help='Print current version of cqlsh.')
 
 # This is a hidden option to suppress the warning when the -p/--password command line option is used.
 # Power users may use this option if they know no other people has access to the system where cqlsh is run or don't care about security.


### PR DESCRIPTION
Added shorter version to print the version of `cqlsh` binary using
`-v` flag.

```sh
❯ ./bin/cqlsh -v
cqlsh 6.0.0
```

Ref: https://issues.apache.org/jira/browse/CASSANDRA-17236