### PR TITLE
CASSANDRA-17444 Update document properties heading.

### DIFF
--- a/doc/modules/cassandra/pages/configuration/cass_cl_archive_file.adoc
+++ b/doc/modules/cassandra/pages/configuration/cass_cl_archive_file.adoc
@@ -1,5 +1,5 @@
 [[cassandra-cl-archive]]
-== commitlog-archiving.properties file
+= commitlog-archiving.properties file
 
 The `commitlog-archiving.properties` configuration file can optionally
 set commands that are executed when archiving or restoring a commitlog

--- a/doc/modules/cassandra/pages/configuration/cass_topo_file.adoc
+++ b/doc/modules/cassandra/pages/configuration/cass_topo_file.adoc
@@ -1,5 +1,5 @@
 [[cassandra-topology]]
-cassandra-topologies.properties file ================================
+= cassandra-topologies.properties file
 
 The `PropertyFileSnitch` `snitch` option uses the
 `cassandra-topologies.properties` configuration file to determine which


### PR DESCRIPTION
Update document properties heading.
The headline was different from the rest of the page in the formato, so it has been corrected.

This page.
<img width="758" alt="2022-02-24 19 13 29" src="https://user-images.githubusercontent.com/16697482/155504556-f1502f00-c98f-4b39-a68f-e1b4f648e589.png">
https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_topo_file.html
https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_cl_archive_file.html

Other page.
https://cassandra.apache.org/doc/latest/cassandra/configuration/cass_yaml_file.html