### PR TITLE
cleanup cqlshlib unit test failures and warnings

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -337,7 +337,7 @@ pipeline {
           sh "rm -fR cassandra-builds"
           sh "git clone --depth 1 --single-branch https://gitbox.apache.org/repos/asf/cassandra-builds.git"
           sh "./cassandra-builds/build-scripts/cassandra-test-report.sh"
-          junit testResults: '**/build/test/**/TEST*.xml,**/cqlshlib.xml,**/nosetests.xml', testDataPublishers: [[$class: 'StabilityTestDataPublisher']]
+          junit testResults: '**/build/test/**/TEST*.xml,**/cqlshlib.xml', testDataPublishers: [[$class: 'StabilityTestDataPublisher']]
 
           // the following should fail on any installation other than ci-cassandra.apache.org
           //  TODO: keep jenkins infrastructure related settings in `cassandra_job_dsl_seed.groovy`

--- a/pylib/cqlshlib/sslhandling.py
+++ b/pylib/cqlshlib/sslhandling.py
@@ -18,7 +18,7 @@ import os
 import sys
 import ssl
 
-from six.moves import configparser
+import configparser
 
 
 def ssl_settings(host, config_file, env=os.environ):
@@ -39,7 +39,7 @@ def ssl_settings(host, config_file, env=os.environ):
     either in the config file or as an environment variable.
     Environment variables override any options set in cqlsh config file.
     """
-    configs = configparser.SafeConfigParser()
+    configs = configparser.ConfigParser()
     configs.read(config_file)
 
     def get_option(section, option):

--- a/pylib/cqlshlib/test/cassconnect.py
+++ b/pylib/cqlshlib/test/cassconnect.py
@@ -22,7 +22,6 @@ import random
 import string
 
 from cassandra.cluster import Cluster
-from cassandra.policies import RoundRobinPolicy
 from cassandra.metadata import maybe_escape_name as quote_name
 from cassandra.auth import PlainTextAuthProvider
 from cqlshlib.cql3handling import CqlRuleSet
@@ -36,7 +35,7 @@ test_keyspace_init = os.path.join(test_dir, 'test_keyspace_init.cql')
 def get_cassandra_connection(cql_version=None):
 
     auth_provider = PlainTextAuthProvider(username=TEST_USER, password=TEST_PWD)
-    conn = Cluster((TEST_HOST,), TEST_PORT, auth_provider=auth_provider, cql_version=cql_version, load_balancing_policy=RoundRobinPolicy())
+    conn = Cluster((TEST_HOST,), TEST_PORT, auth_provider=auth_provider, cql_version=cql_version)
 
     # until the cql lib does this for us
     conn.cql_version = cql_version

--- a/pylib/cqlshlib/test/test_copyutil.py
+++ b/pylib/cqlshlib/test/test_copyutil.py
@@ -79,6 +79,7 @@ class TestExportTask(CopyTaskTest):
             overridden_opts[k] = v
         export_task = ExportTask(shell, self.ks, self.table, self.columns, self.fname, overridden_opts, self.protocol_version, self.config_file)
         assert export_task.get_ranges() == expected_ranges
+        export_task.close()
 
     def test_get_ranges_murmur3(self):
         """


### PR DESCRIPTION
test_copyutil.py resolve with too many open files when ulimit is 256 with close
cassconnect.py: resolve DeprecationWarning: Legacy execution parameters
sslhandling.py: resolve DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser
remove unused reference to nosetests.xml in Jenkinsfile