### PR TITLE
CASSANDRA-17002: Virtual table for gossip info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,1923 +14,125 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-version: 2
 jobs:
-  j8_jvm_upgrade_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" "$HOME/cassandra/test/simulator/test/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  repeated_jvm_upgrade_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run repeated JUnit test
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_JVM_UPGRADE_DTEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_JVM_UPGRADE_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_JVM_UPGRADE_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_JVM_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running test-jvm-dtest-some ${REPEATED_JVM_UPGRADE_DTEST_CLASS} ${REPEATED_JVM_UPGRADE_DTEST_METHODS} ${REPEATED_JVM_UPGRADE_DTEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=test-jvm-dtest-some
-              class_path=${REPEATED_JVM_UPGRADE_DTEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_JVM_UPGRADE_DTEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_JVM_UPGRADE_DTEST_METHODS}"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/test-jvm-dtest-some-${REPEATED_JVM_UPGRADE_DTEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results/repeated_utest/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_unit_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  repeated_upgrade_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UPGRADE_DTEST_NAME}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UPGRADE_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UPGRADE_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UPGRADE_DTEST_NAME} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              stop_on_failure_arg=""
-              if ${REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if true; then
-                upgrade_arg="--execute-upgrade-tests"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_UPGRADE_DTEST_NAME} | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py38-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh-dtests-py3-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlsh-dtests-py3-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlsh-dtests-py38-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh-dtests-py3-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_repeated_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTEST_NAME}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTEST_NAME} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              stop_on_failure_arg=""
-              if ${REPEATED_DTEST_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if ${REPEATED_DTEST_VNODES}; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_repeated_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTEST_NAME}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTEST_NAME} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              stop_on_failure_arg=""
-              if ${REPEATED_DTEST_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if ${REPEATED_DTEST_VNODES}; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_upgradetests-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_upgradetests_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection all --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_upgradetests_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection all --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_upgradetests_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_upgradetests_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_stress:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (stress-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant stress-test
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_unit_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_jvm_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" "$HOME/cassandra/test/simulator/test/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
   j11_build:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
     parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
     steps:
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: 'git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          ~/cassandra
+
+          '
         name: Clone Cassandra Repository (via git)
-        command: |
-          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
     - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\n# Loop to prevent\
+          \ failure due to maven-ant-tasks not downloading a jar..\nfor x in $(seq\
+          \ 1 3); do\n    ${ANT_HOME}/bin/ant clean realclean jar\n    RETURN=\"$?\"\
+          \n    if [ \"${RETURN}\" -eq \"0\" ]; then\n        break\n    fi\ndone\n\
+          # Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"0\" ];\
+          \ then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit ${RETURN}\n\
+          fi\n"
         name: Build Cassandra
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant clean realclean jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
         no_output_timeout: 15m
     - run:
-        name: Run eclipse-warnings
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
           cd ~/cassandra
+
           ant eclipse-warnings
+
+          '
+        name: Run eclipse-warnings
     - persist_to_workspace:
-        root: /home/cassandra
         paths:
         - cassandra
         - .m2
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlshlib_tests:
+        root: /home/cassandra
+    working_directory: ~/
+  j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run cqlshlib Unit Tests
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra/pylib
-          ./cassandra-cqlsh-tests.sh ..
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/pylib
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -1966,224 +168,90 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j11_repeated_utest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run repeated JUnit test
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UTEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
 
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS} ${REPEATED_UTEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=${REPEATED_UTEST_TARGET}
-              class_path=${REPEATED_UTEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_UTEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_UTEST_METHODS}"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results/repeated_utest/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
+          '
         name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
           source ~/env3.6/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
           pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
           pip3 uninstall -y cqlsh
+
           pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
     - run:
-        name: Determine Tests to Run (j8_with_vnodes)
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
         no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
     - run:
-        name: Run dtests (j8_with_vnodes)
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail\
+          \ && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_without_vnodes)
         no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
+        destination: dtest_j11_without_vnodes
         path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
     - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
         path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
+    working_directory: ~/
+  j11_cqlsh-dtests-py3-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2216,69 +284,93 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
   j11_cqlsh-dtests-py38-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2314,274 +406,90 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j8_jvm_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
 
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" "$HOME/cassandra/test/simulator/test/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra Repository (via git)
-        command: |
-          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
-    - run:
-        name: Build Cassandra
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant clean realclean jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-        no_output_timeout: 15m
-    - run:
-        name: Run eclipse-warnings
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          ant eclipse-warnings
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - cassandra
-        - .m2
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py3-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
+          '
         name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
           pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
           pip3 uninstall -y cqlsh
+
           pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
     - run:
-        name: Determine Tests to Run (j8_without_vnodes)
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
         no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
     - run:
-        name: Run dtests (j8_without_vnodes)
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail\
+          \ && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_without_vnodes)
         no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
+        destination: dtest_j11_without_vnodes
         path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
     - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
         path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
+    working_directory: ~/
+  j11_cqlsh-dtests-py38-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2614,69 +522,93 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py38-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
         name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
           source ~/env3.8/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
           pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
           pip3 uninstall -y cqlsh
+
           pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
     - run:
-        name: Determine Tests to Run (j8_with_vnodes)
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
         no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
     - run:
-        name: Run dtests (j8_with_vnodes)
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_with_vnodes)
         no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
+        destination: dtest_j11_with_vnodes
         path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
     - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
         path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
+    working_directory: ~/
+  j11_cqlshlib_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2709,361 +641,33 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_long:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
     parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (long-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant long-test
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_system_keyspace_directory:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
 
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-system-keyspace-directory)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
           time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-system-keyspace-directory -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlshlib_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run cqlshlib Unit Tests
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
+
           cd /tmp/cassandra/pylib
+
           ./cassandra-cqlsh-tests.sh ..
+
+          '
+        name: Run cqlshlib Unit Tests
         no_output_timeout: 15m
     - store_test_results:
         path: /tmp/cassandra/pylib
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_fqltool:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
     working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (fqltool-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant fqltool-test
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
   j11_dtests-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:20210304
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -3099,81 +703,431 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  utests_compression:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 25
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail\
+          \ && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_jvm_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 32
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
           # which we do via the `circleci` cli tool.
 
+
           rm -fr ~/cassandra-dtest/upgrade_tests
+
           echo "***java tests***"
 
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
 
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          "$HOME/cassandra/test/simulator/test/**/*.java" > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
           echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
         no_output_timeout: 15m
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
-        name: Run Unit Tests (testclasslist-compression)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-compression -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
         no_output_timeout: 15m
     - store_test_results:
         path: /tmp/cassandra/build/test/output/
     - store_artifacts:
-        path: /tmp/cassandra/build/test/output
         destination: junitxml
+        path: /tmp/cassandra/build/test/output
     - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
         destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_repeated_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -3206,149 +1160,274 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_repeated_utest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTEST_NAME}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_DTEST_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTEST_NAME} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    stop_on_failure_arg=\"\"\
+          \n    if ${REPEATED_DTEST_STOP_ON_FAILURE}; then\n      stop_on_failure_arg=\"\
+          -x\"\n    fi\n\n    vnodes_args=\"\"\n    if ${REPEATED_DTEST_VNODES}; then\n\
+          \      vnodes_args=\"--use-vnodes --num-tokens=16\"\n    fi\n\n    upgrade_arg=\"\
+          \"\n    if false; then\n      upgrade_arg=\"--execute-upgrade-tests\"\n\
+          \    fi\n\n    # we need the \"set -o pipefail\" here so that the exit code\
+          \ that circleci will actually use is from pytest and not the exit code from\
+          \ tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt\n \
+          \ fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_repeated_utest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "if [ \"${REPEATED_UTEST_CLASS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated utest class name hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated utest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated\
+          \ utest count is lesser or equals than zero, exiting without running any\
+          \ test\"\nelse\n\n  # Calculate the number of test iterations to be run\
+          \ by the current parallel runner.\n  # Since we are running the same test\
+          \ multiple times there is no need to use `circleci tests split`.\n  count=$((${REPEATED_UTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS}\
+          \ ${REPEATED_UTEST_COUNT} times\"\n\n    set -x\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \    time mv ~/cassandra /tmp\n    cd /tmp/cassandra\n    if [ -d ~/dtest_jars\
+          \ ]; then\n      cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n    fi\n\n\
+          \    target=${REPEATED_UTEST_TARGET}\n    class_path=${REPEATED_UTEST_CLASS}\n\
+          \    class_name=\"${class_path##*.}\"\n\n    # Prepare the -Dtest.name argument.\n\
+          \    # It can be the fully qualified class name or the short class name,\
+          \ depending on the target.\n    if [[ $target == \"test\" || \\\n      \
+          \    $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" ]]; then\n\
+          \      name=\"-Dtest.name=$class_name\"\n    else\n      name=\"-Dtest.name=$class_path\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [ \"${REPEATED_UTEST_METHODS}\" == \"<nil>\" ]; then\n      methods=\"\
+          \"\n    else\n      methods=\"-Dtest.methods=${REPEATED_UTEST_METHODS}\"\
+          \n    fi\n\n    # Run the test target as many times as requested collecting\
+          \ the exit code,\n    # stopping the iteration only if stop_on_failure is\
+          \ set.\n    exit_code=\"$?\"\n    for i in $(seq -w 1 $count); do\n\n  \
+          \    echo \"Running test iteration $i of $count\"\n\n      # run the test\n\
+          \      status=\"passes\"\n      if !( set -o pipefail && ant $target $name\
+          \ $methods -Dno-build-test=true | tee stdout.txt ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n \
+          \     mkdir -p $dest\n      mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\n\
+          \    (exit ${exit_code})\n  fi\nfi\n"
         name: Run repeated JUnit test
         no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UTEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS} ${REPEATED_UTEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=${REPEATED_UTEST_TARGET}
-              class_path=${REPEATED_UTEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_UTEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_UTEST_METHODS}"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
     - store_test_results:
         path: /tmp/results/repeated_utest/output
     - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
         destination: stdout
+        path: /tmp/results/repeated_utest/stdout
     - store_artifacts:
-        path: /tmp/results/repeated_utest/output
         destination: junitxml
+        path: /tmp/results/repeated_utest/output
     - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
         destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  j11_unit_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:20210304
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -3381,69 +1460,116 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtest_jars_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
-    resource_class: medium
-    working_directory: ~/
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 40
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Build Cassandra DTest jars
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          mkdir ~/dtest_jars
-          git remote add apache https://github.com/apache/cassandra.git
-          for branch in cassandra-2.2 cassandra-3.0 cassandra-3.11 cassandra-4.0 trunk; do
-            # check out the correct cassandra version:
-            git remote set-branches --add apache '$branch'
-            git fetch --depth 1 apache $branch
-            git checkout $branch
-            git clean -fd
-            # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-            for x in $(seq 1 3); do
-                ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar
-                RETURN="$?"
-                if [ "${RETURN}" -eq "0" ]; then
-                    cp build/dtest*.jar ~/dtest_jars
-                    break
-                fi
-            done
-            # Exit, if we didn't build successfully
-            if [ "${RETURN}" -ne "0" ]; then
-                echo "Build failed with exit code: ${RETURN}"
-                exit ${RETURN}
-            fi
-          done
-          # and build the dtest-jar for the branch under test
-          ${ANT_HOME}/bin/ant realclean
-          git checkout origin/$CIRCLE_BRANCH
-          git clean -fd
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  cp build/dtest*.jar ~/dtest_jars
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-          ls -l ~/dtest_jars
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
         no_output_timeout: 15m
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - dtest_jars
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_build:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -3478,432 +1604,2528 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
     - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          ~/cassandra
+
+          '
+        name: Clone Cassandra Repository (via git)
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\n# Loop to prevent\
+          \ failure due to maven-ant-tasks not downloading a jar..\nfor x in $(seq\
+          \ 1 3); do\n    ${ANT_HOME}/bin/ant clean realclean jar\n    RETURN=\"$?\"\
+          \n    if [ \"${RETURN}\" -eq \"0\" ]; then\n        break\n    fi\ndone\n\
+          # Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"0\" ];\
+          \ then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit ${RETURN}\n\
+          fi\n"
+        name: Build Cassandra
+        no_output_timeout: 15m
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          cd ~/cassandra
+
+          ant eclipse-warnings
+
+          '
+        name: Run eclipse-warnings
+    - persist_to_workspace:
+        paths:
+        - cassandra
+        - .m2
+        root: /home/cassandra
+    working_directory: ~/
+  j8_cqlsh-dtests-py3-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py3-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py38-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py38-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlshlib_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          time mv ~/cassandra /tmp
+
+          cd /tmp/cassandra/pylib
+
+          ./cassandra-cqlsh-tests.sh ..
+
+          '
+        name: Run cqlshlib Unit Tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/pylib
+    working_directory: ~/
+  j8_dtest_jars_build:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\nmkdir ~/dtest_jars\n\
+          git remote add apache https://github.com/apache/cassandra.git\nfor branch\
+          \ in cassandra-2.2 cassandra-3.0 cassandra-3.11 cassandra-4.0 trunk; do\n\
+          \  # check out the correct cassandra version:\n  git remote set-branches\
+          \ --add apache '$branch'\n  git fetch --depth 1 apache $branch\n  git checkout\
+          \ $branch\n  git clean -fd\n  # Loop to prevent failure due to maven-ant-tasks\
+          \ not downloading a jar..\n  for x in $(seq 1 3); do\n      ${ANT_HOME}/bin/ant\
+          \ realclean; ${ANT_HOME}/bin/ant jar dtest-jar\n      RETURN=\"$?\"\n  \
+          \    if [ \"${RETURN}\" -eq \"0\" ]; then\n          cp build/dtest*.jar\
+          \ ~/dtest_jars\n          break\n      fi\n  done\n  # Exit, if we didn't\
+          \ build successfully\n  if [ \"${RETURN}\" -ne \"0\" ]; then\n      echo\
+          \ \"Build failed with exit code: ${RETURN}\"\n      exit ${RETURN}\n  fi\n\
+          done\n# and build the dtest-jar for the branch under test\n${ANT_HOME}/bin/ant\
+          \ realclean\ngit checkout origin/$CIRCLE_BRANCH\ngit clean -fd\nfor x in\
+          \ $(seq 1 3); do\n    ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant\
+          \ jar dtest-jar\n    RETURN=\"$?\"\n    if [ \"${RETURN}\" -eq \"0\" ];\
+          \ then\n        cp build/dtest*.jar ~/dtest_jars\n        break\n    fi\n\
+          done\n# Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"\
+          0\" ]; then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit\
+          \ ${RETURN}\nfi\nls -l ~/dtest_jars\n"
+        name: Build Cassandra DTest jars
+        no_output_timeout: 15m
+    - persist_to_workspace:
+        paths:
+        - dtest_jars
+        root: /home/cassandra
+    working_directory: ~/
+  j8_dtests-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_jvm_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 32
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          "$HOME/cassandra/test/simulator/test/**/*.java" > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_jvm_upgrade_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 12
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          "$HOME/cassandra/test/simulator/test/**/*.java" > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_repeated_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTEST_NAME}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_DTEST_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTEST_NAME} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    stop_on_failure_arg=\"\"\
+          \n    if ${REPEATED_DTEST_STOP_ON_FAILURE}; then\n      stop_on_failure_arg=\"\
+          -x\"\n    fi\n\n    vnodes_args=\"\"\n    if ${REPEATED_DTEST_VNODES}; then\n\
+          \      vnodes_args=\"--use-vnodes --num-tokens=16\"\n    fi\n\n    upgrade_arg=\"\
+          \"\n    if false; then\n      upgrade_arg=\"--execute-upgrade-tests\"\n\
+          \    fi\n\n    # we need the \"set -o pipefail\" here so that the exit code\
+          \ that circleci will actually use is from pytest and not the exit code from\
+          \ tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt\n \
+          \ fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_repeated_utest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "if [ \"${REPEATED_UTEST_CLASS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated utest class name hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated utest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated\
+          \ utest count is lesser or equals than zero, exiting without running any\
+          \ test\"\nelse\n\n  # Calculate the number of test iterations to be run\
+          \ by the current parallel runner.\n  # Since we are running the same test\
+          \ multiple times there is no need to use `circleci tests split`.\n  count=$((${REPEATED_UTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS}\
+          \ ${REPEATED_UTEST_COUNT} times\"\n\n    set -x\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \    time mv ~/cassandra /tmp\n    cd /tmp/cassandra\n    if [ -d ~/dtest_jars\
+          \ ]; then\n      cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n    fi\n\n\
+          \    target=${REPEATED_UTEST_TARGET}\n    class_path=${REPEATED_UTEST_CLASS}\n\
+          \    class_name=\"${class_path##*.}\"\n\n    # Prepare the -Dtest.name argument.\n\
+          \    # It can be the fully qualified class name or the short class name,\
+          \ depending on the target.\n    if [[ $target == \"test\" || \\\n      \
+          \    $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" ]]; then\n\
+          \      name=\"-Dtest.name=$class_name\"\n    else\n      name=\"-Dtest.name=$class_path\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [ \"${REPEATED_UTEST_METHODS}\" == \"<nil>\" ]; then\n      methods=\"\
+          \"\n    else\n      methods=\"-Dtest.methods=${REPEATED_UTEST_METHODS}\"\
+          \n    fi\n\n    # Run the test target as many times as requested collecting\
+          \ the exit code,\n    # stopping the iteration only if stop_on_failure is\
+          \ set.\n    exit_code=\"$?\"\n    for i in $(seq -w 1 $count); do\n\n  \
+          \    echo \"Running test iteration $i of $count\"\n\n      # run the test\n\
+          \      status=\"passes\"\n      if !( set -o pipefail && ant $target $name\
+          \ $methods -Dno-build-test=true | tee stdout.txt ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n \
+          \     mkdir -p $dest\n      mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\n\
+          \    (exit ${exit_code})\n  fi\nfi\n"
+        name: Run repeated JUnit test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utest/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  j8_unit_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 40
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_upgradetests-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 100
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_upgradetests_without_vnodes)***\"\nset -eo\
+          \ pipefail && ./run_dtests.py --execute-upgrade-tests-only --upgrade-target-version-only\
+          \ --upgrade-version-selection all --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\nelse\n  grep -e ''\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\
+          \ || { echo \"Filter did not match any tests! Exiting build.\"; exit 0;\
+          \ }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt\n\
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\\n'\
+          \ ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\n\
+          source ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n\
+          \ '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir\
+          \ -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p\
+          \ /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`\n\
+          set -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests-only\
+          \ --upgrade-target-version-only --upgrade-version-selection all --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_upgradetests_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_upgradetests_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_upgradetests_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  repeated_jvm_upgrade_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "if [ \"${REPEATED_JVM_UPGRADE_DTEST_CLASS}\" == \"<nil>\" ]; then\n\
+          \  echo \"Repeated utest class name hasn't been defined, exiting without\
+          \ running any test\"\nelif [ \"${REPEATED_JVM_UPGRADE_DTEST_COUNT}\" ==\
+          \ \"<nil>\" ]; then\n  echo \"Repeated utest count hasn't been defined,\
+          \ exiting without running any test\"\nelif [ \"${REPEATED_JVM_UPGRADE_DTEST_COUNT}\"\
+          \ -le 0 ]; then\n  echo \"Repeated utest count is lesser or equals than\
+          \ zero, exiting without running any test\"\nelse\n\n  # Calculate the number\
+          \ of test iterations to be run by the current parallel runner.\n  # Since\
+          \ we are running the same test multiple times there is no need to use `circleci\
+          \ tests split`.\n  count=$((${REPEATED_JVM_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))\n\
+          \  if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL)));\
+          \ then\n    count=$((count+1))\n  fi\n\n  if (($count <= 0)); then\n   \
+          \ echo \"No tests to run in this runner\"\n  else\n    echo \"Running test-jvm-dtest-some\
+          \ ${REPEATED_JVM_UPGRADE_DTEST_CLASS} ${REPEATED_JVM_UPGRADE_DTEST_METHODS}\
+          \ ${REPEATED_JVM_UPGRADE_DTEST_COUNT} times\"\n\n    set -x\n    export\
+          \ PATH=$JAVA_HOME/bin:$PATH\n    time mv ~/cassandra /tmp\n    cd /tmp/cassandra\n\
+          \    if [ -d ~/dtest_jars ]; then\n      cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          \    fi\n\n    target=test-jvm-dtest-some\n    class_path=${REPEATED_JVM_UPGRADE_DTEST_CLASS}\n\
+          \    class_name=\"${class_path##*.}\"\n\n    # Prepare the -Dtest.name argument.\n\
+          \    # It can be the fully qualified class name or the short class name,\
+          \ depending on the target.\n    if [[ $target == \"test\" || \\\n      \
+          \    $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" ]]; then\n\
+          \      name=\"-Dtest.name=$class_name\"\n    else\n      name=\"-Dtest.name=$class_path\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [ \"${REPEATED_JVM_UPGRADE_DTEST_METHODS}\" == \"<nil>\" ]; then\n\
+          \      methods=\"\"\n    else\n      methods=\"-Dtest.methods=${REPEATED_JVM_UPGRADE_DTEST_METHODS}\"\
+          \n    fi\n\n    # Run the test target as many times as requested collecting\
+          \ the exit code,\n    # stopping the iteration only if stop_on_failure is\
+          \ set.\n    exit_code=\"$?\"\n    for i in $(seq -w 1 $count); do\n\n  \
+          \    echo \"Running test iteration $i of $count\"\n\n      # run the test\n\
+          \      status=\"passes\"\n      if !( set -o pipefail && ant $target $name\
+          \ $methods -Dno-build-test=true | tee stdout.txt ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n \
+          \     mkdir -p $dest\n      mv stdout.txt $dest/test-jvm-dtest-some-${REPEATED_JVM_UPGRADE_DTEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE}\
+          \ = true ]] && (( $exit_code > 0 )); then\n        break\n      fi\n   \
+          \ done\n\n    (exit ${exit_code})\n  fi\nfi\n"
+        name: Run repeated JUnit test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utest/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  repeated_upgrade_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_UPGRADE_DTEST_NAME}\" == \"<nil>\" ]; then\n \
+          \ echo \"Repeated dtest name hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_UPGRADE_DTEST_COUNT}\" == \"<nil>\" ];\
+          \ then\n  echo \"Repeated dtest count hasn't been defined, exiting without\
+          \ running any test\"\nelif [ \"${REPEATED_UPGRADE_DTEST_COUNT}\" -le 0 ];\
+          \ then\n  echo \"Repeated dtest count is lesser or equals than zero, exiting\
+          \ without running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))\n  if\
+          \ (($CIRCLE_NODE_INDEX < (${REPEATED_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL)));\
+          \ then\n    count=$((count+1))\n  fi\n\n  if (($count <= 0)); then\n   \
+          \ echo \"No tests to run in this runner\"\n  else\n    echo \"Running ${REPEATED_UPGRADE_DTEST_NAME}\
+          \ $count times\"\n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    stop_on_failure_arg=\"\"\n    if ${REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if true; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests\"\n    fi\n\n    # we need the \"set -o pipefail\"\
+          \ here so that the exit code that circleci will actually use is from pytest\
+          \ and not the exit code from tee\n    set -o pipefail && cd ~/cassandra-dtest\
+          \ && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_UPGRADE_DTEST_NAME}\
+          \ | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  utests_compression:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-compression -Dtest.timeout=\"\
+          $test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit\n"
+        name: Run Unit Tests (testclasslist-compression)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_fqltool:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant fqltool-test\n"
+        name: Run Unit Tests (fqltool-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_long:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant long-test\n"
+        name: Run Unit Tests (long-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_stress:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant stress-test\n"
+        name: Run Unit Tests (stress-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_system_keyspace_directory:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210929
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-system-keyspace-directory\
+          \ -Dtest.timeout=\"$test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit\n"
+        name: Run Unit Tests (testclasslist-system-keyspace-directory)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+version: 2
 workflows:
+  java11_tests:
+    jobs:
+    - j11_build: {}
+    - j11_unit_tests:
+        requires:
+        - j11_build
+    - j11_jvm_dtests:
+        requires:
+        - j11_build
+    - j11_cqlshlib_tests:
+        requires:
+        - j11_build
+    - j11_dtests-with-vnodes:
+        requires:
+        - j11_build
+    - j11_dtests-no-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py3-with-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py38-with-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py3-no-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py38-no-vnodes:
+        requires:
+        - j11_build
+  java8_tests:
+    jobs:
+    - j8_build: {}
+    - j8_unit_tests:
+        requires:
+        - j8_build
+    - j8_jvm_dtests:
+        requires:
+        - j8_build
+    - j8_cqlshlib_tests:
+        requires:
+        - j8_build
+    - start_utests_long:
+        type: approval
+    - utests_long:
+        requires:
+        - start_utests_long
+        - j8_build
+    - start_utests_compression:
+        type: approval
+    - utests_compression:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - start_utests_stress:
+        type: approval
+    - utests_stress:
+        requires:
+        - start_utests_stress
+        - j8_build
+    - utests_fqltool:
+        requires:
+        - j8_build
+    - start_utests_system_keyspace_directory:
+        type: approval
+    - utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j8_build
+    - j8_dtest_jars_build:
+        requires:
+        - j8_build
+    - j8_jvm_upgrade_dtests:
+        requires:
+        - j8_dtest_jars_build
+    - j8_dtests-with-vnodes:
+        requires:
+        - j8_build
+    - j8_dtests-no-vnodes:
+        requires:
+        - j8_build
+    - j8_upgradetests-no-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py3-with-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py38-with-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py3-no-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py38-no-vnodes:
+        requires:
+        - j8_build
   version: 2
-  java8_separate_tests:
-    jobs:
-    - start_j8_build:
-        type: approval
-    - j8_build:
-        requires:
-        - start_j8_build
-    - start_j8_unit_tests:
-        type: approval
-    - j8_unit_tests:
-        requires:
-        - start_j8_unit_tests
-        - j8_build
-    - start_j8_jvm_dtests:
-        type: approval
-    - j8_jvm_dtests:
-        requires:
-        - start_j8_jvm_dtests
-        - j8_build
-    - start_j8_cqlshlib_tests:
-        type: approval
-    - j8_cqlshlib_tests:
-        requires:
-        - start_j8_cqlshlib_tests
-        - j8_build
-    - start_j11_unit_tests:
-        type: approval
-    - j11_unit_tests:
-        requires:
-        - start_j11_unit_tests
-        - j8_build
-    - start_utests_long:
-        type: approval
-    - utests_long:
-        requires:
-        - start_utests_long
-        - j8_build
-    - start_utests_compression:
-        type: approval
-    - utests_compression:
-        requires:
-        - start_utests_compression
-        - j8_build
-    - start_utests_stress:
-        type: approval
-    - utests_stress:
-        requires:
-        - start_utests_stress
-        - j8_build
-    - start_utests_fqltool:
-        type: approval
-    - utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j8_build
-    - start_utests_system_keyspace_directory:
-        type: approval
-    - utests_system_keyspace_directory:
-        requires:
-        - start_utests_system_keyspace_directory
-        - j8_build
-    - start_j8_dtest_jars_build:
-        type: approval
-    - j8_dtest_jars_build:
-        requires:
-        - j8_build
-        - start_j8_dtest_jars_build
-    - start_jvm_upgrade_dtest:
-        type: approval
-    - j8_jvm_upgrade_dtests:
-        requires:
-        - start_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-    - start_j8_dtests:
-        type: approval
-    - j8_dtests-with-vnodes:
-        requires:
-        - start_j8_dtests
-        - j8_build
-    - j8_dtests-no-vnodes:
-        requires:
-        - start_j8_dtests
-        - j8_build
-    - start_j11_dtests:
-        type: approval
-    - j11_dtests-with-vnodes:
-        requires:
-        - start_j11_dtests
-        - j8_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - start_j11_dtests
-        - j8_build
-    - start_upgrade_tests:
-        type: approval
-    - j8_upgradetests-no-vnodes:
-        requires:
-        - start_upgrade_tests
-        - j8_build
-    - start_j8_cqlsh_tests:
-        type: approval
-    - j8_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - j8_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - j8_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - j8_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - start_j11_cqlsh_tests:
-        type: approval
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - start_j8_repeated_utest:
-        type: approval
-    - j8_repeated_utest:
-        requires:
-        - start_j8_repeated_utest
-        - j8_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j8_build
-    - start_j8_repeated_dtest:
-        type: approval
-    - j8_repeated_dtest:
-        requires:
-        - start_j8_repeated_dtest
-        - j8_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j8_build
-    - start_repeated_upgrade_dtest:
-        type: approval
-    - repeated_upgrade_dtest:
-        requires:
-        - start_repeated_upgrade_dtest
-        - j8_build
-    - start_repeated_jvm_upgrade_dtest:
-        type: approval
-    - repeated_jvm_upgrade_dtest:
-        requires:
-        - start_repeated_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-  java8_pre-commit_tests:
-    jobs:
-    - start_pre-commit_tests:
-        type: approval
-    - j8_build:
-        requires:
-        - start_pre-commit_tests
-    - j8_unit_tests:
-        requires:
-        - j8_build
-    - j8_jvm_dtests:
-        requires:
-        - j8_build
-    - j8_cqlshlib_tests:
-        requires:
-        - j8_build
-    - j11_unit_tests:
-        requires:
-        - j8_build
-    - start_utests_long:
-        type: approval
-    - utests_long:
-        requires:
-        - start_utests_long
-        - j8_build
-    - start_utests_compression:
-        type: approval
-    - utests_compression:
-        requires:
-        - start_utests_compression
-        - j8_build
-    - start_utests_stress:
-        type: approval
-    - utests_stress:
-        requires:
-        - start_utests_stress
-        - j8_build
-    - start_utests_fqltool:
-        type: approval
-    - utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j8_build
-    - start_utests_system_keyspace_directory:
-        type: approval
-    - utests_system_keyspace_directory:
-        requires:
-        - start_utests_system_keyspace_directory
-        - j8_build
-    - start_j8_dtest_jars_build:
-        type: approval
-    - j8_dtest_jars_build:
-        requires:
-        - j8_build
-        - start_j8_dtest_jars_build
-    - start_jvm_upgrade_dtest:
-        type: approval
-    - j8_jvm_upgrade_dtests:
-        requires:
-        - start_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-    - j8_dtests-with-vnodes:
-        requires:
-        - j8_build
-    - j8_dtests-no-vnodes:
-        requires:
-        - j8_build
-    - j11_dtests-with-vnodes:
-        requires:
-        - j8_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - j8_build
-    - start_upgrade_tests:
-        type: approval
-    - j8_upgradetests-no-vnodes:
-        requires:
-        - j8_build
-        - start_upgrade_tests
-    - j8_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - j8_build
-    - start_j8_repeated_utest:
-        type: approval
-    - j8_repeated_utest:
-        requires:
-        - start_j8_repeated_utest
-        - j8_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j8_build
-    - start_j8_repeated_dtest:
-        type: approval
-    - j8_repeated_dtest:
-        requires:
-        - start_j8_repeated_dtest
-        - j8_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j8_build
-    - start_repeated_upgrade_dtest:
-        type: approval
-    - repeated_upgrade_dtest:
-        requires:
-        - start_repeated_upgrade_dtest
-        - j8_build
-    - start_repeated_jvm_upgrade_dtest:
-        type: approval
-    - repeated_jvm_upgrade_dtest:
-        requires:
-        - start_repeated_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-  java11_separate_tests:
-    jobs:
-    - start_j11_build:
-        type: approval
-    - j11_build:
-        requires:
-        - start_j11_build
-    - start_j11_unit_tests:
-        type: approval
-    - j11_unit_tests:
-        requires:
-        - start_j11_unit_tests
-        - j11_build
-    - start_j11_jvm_dtests:
-        type: approval
-    - j11_jvm_dtests:
-        requires:
-        - start_j11_jvm_dtests
-        - j11_build
-    - start_j11_cqlshlib_tests:
-        type: approval
-    - j11_cqlshlib_tests:
-        requires:
-        - start_j11_cqlshlib_tests
-        - j11_build
-    - start_j11_dtests:
-        type: approval
-    - j11_dtests-with-vnodes:
-        requires:
-        - start_j11_dtests
-        - j11_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - start_j11_dtests
-        - j11_build
-    - start_j11_cqlsh_tests:
-        type: approval
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j11_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j11_build
-  java11_pre-commit_tests:
-    jobs:
-    - start_pre-commit_tests:
-        type: approval
-    - j11_build:
-        requires:
-        - start_pre-commit_tests
-    - j11_unit_tests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests:
-        requires:
-        - j11_build
-    - j11_cqlshlib_tests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests:
-        requires:
-        - j11_build
-    - j11_cqlshlib_tests:
-        requires:
-        - j11_build
-    - j11_dtests-with-vnodes:
-        requires:
-        - j11_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - j11_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j11_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j11_build

--- a/doc/modules/cassandra/pages/new/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/new/virtualtables.adoc
@@ -74,9 +74,11 @@ recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and s
 
 |coordinator_write_latency |Records counts, keyspace_name, table_name, max, median, and per_second for coordinator writes.
 
-|cql_metrcs |Metrics specific to CQL prepared statement caching.
+|cql_metrics |Metrics specific to CQL prepared statement caching.
 
 |disk_usage |Records disk usage including disk_space, keyspace_name, and table_name, sorted by system keyspaces.
+
+|gossip_info |Lists the gossip information for the cluster.
 
 |internode_inbound |Lists information about the inbound internode messaging.
 
@@ -375,6 +377,24 @@ tasks, use the following query:
 ....
 SELECT total - progress AS remaining
 FROM system_views.sstable_tasks;
+....
+
+=== Gossip Information Virtual Table
+
+The `gossip_info` virtual table lists the Gossip information for the cluster. An example query is as follows:
+
+....
+cqlsh> select address, port, generation, heartbeat, load, dc, rack, release_version from system_views.gossip_info;
+
+ address   | port | generation | heartbeat | load    | dc          | rack  | release_version
+-----------+------+------------+-----------+---------+-------------+-------+-----------------
+ 127.0.0.1 | 7000 | 1645575140 |       312 | 70542.0 | datacenter1 | rack1 |    4.1-SNAPSHOT
+ 127.0.0.2 | 7000 | 1645575135 |       318 | 70499.0 | datacenter1 | rack1 |    4.1-SNAPSHOT
+ 127.0.0.3 | 7000 | 1645575140 |       312 | 70504.0 | datacenter1 | rack1 |    4.1-SNAPSHOT
+ 127.0.0.4 | 7000 | 1645575141 |       311 | 70502.0 | datacenter1 | rack1 |    4.1-SNAPSHOT
+ 127.0.0.5 | 7000 | 1645575136 |       315 | 70500.0 | datacenter1 | rack1 |    4.1-SNAPSHOT
+
+(5 rows)
 ....
 
 === Other Virtual Tables

--- a/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
@@ -85,13 +85,13 @@ final class GossipInfoTable extends AbstractVirtualTable
                                           .column(HEARTBEAT, getHeartBeat(localState));
 
             APPLICATION_STATE_SET.forEach(applicationState -> {
-                String state = applicationState.name().toLowerCase();
-                if (!"tokens".equals(state))
+                String lowercaseName = applicationState.name().toLowerCase();
+                if (!"tokens".equals(lowercaseName))
                 {
                     // do not a column for the ApplicationState.TOKENS value
-                    dataSet.column(state, getValue(localState, applicationState));
+                    dataSet.column(lowercaseName, getValue(localState, applicationState));
                 }
-                dataSet.column(state + "_version", getVersion(localState, applicationState));
+                dataSet.column(lowercaseName + "_version", getVersion(localState, applicationState));
             });
         }
         return result;
@@ -168,13 +168,13 @@ final class GossipInfoTable extends AbstractVirtualTable
         APPLICATION_STATE_SET.stream()
                              .map(Enum::name)
                              .map(String::toLowerCase)
-                             .forEach(state -> {
-                                 if (!"tokens".equals(state))
+                             .forEach(lowercaseName -> {
+                                 if (!"tokens".equals(lowercaseName))
                                  {
                                      // do not a column for the ApplicationState.TOKENS value
-                                     builder.addRegularColumn(state, UTF8Type.instance);
+                                     builder.addRegularColumn(lowercaseName, UTF8Type.instance);
                                  }
-                                 builder.addRegularColumn(state + "_version", Int32Type.instance);
+                                 builder.addRegularColumn(lowercaseName + "_version", Int32Type.instance);
                              });
 
         return builder.build();

--- a/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
@@ -88,7 +88,7 @@ final class GossipInfoTable extends AbstractVirtualTable
                 String lowercaseName = applicationState.name().toLowerCase();
                 if (!"tokens".equals(lowercaseName))
                 {
-                    // do not a column for the ApplicationState.TOKENS value
+                    // do not add a column for the ApplicationState.TOKENS value
                     dataSet.column(lowercaseName, getValue(localState, applicationState));
                 }
                 dataSet.column(lowercaseName + "_version", getVersion(localState, applicationState));
@@ -171,7 +171,7 @@ final class GossipInfoTable extends AbstractVirtualTable
                              .forEach(lowercaseName -> {
                                  if (!"tokens".equals(lowercaseName))
                                  {
-                                     // do not a column for the ApplicationState.TOKENS value
+                                     // do not add a column for the ApplicationState.TOKENS value
                                      builder.addRegularColumn(lowercaseName, UTF8Type.instance);
                                  }
                                  builder.addRegularColumn(lowercaseName + "_version", Int32Type.instance);

--- a/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import java.util.Map;
+
+import org.apache.cassandra.db.marshal.InetAddressType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.dht.LocalPartitioner;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.TableMetadata;
+
+/**
+ * A {@link VirtualTable} that return the Gossip information in tabular format.
+ */
+final class GossipInfoTable extends AbstractVirtualTable
+{
+    static final String TABLE_NAME = "gossip_info";
+    static final String TABLE_COMMENT = "lists the gossip information for the cluster";
+
+    static final String ADDRESS = "address";
+    static final String PORT = "port";
+    static final String HOSTNAME = "hostname";
+    static final String GENERATION = "generation";
+    static final String HEARTBEAT = "heartbeat";
+
+    // "value" fields coming from @org.apache.cassandra.gms.ApplicationState
+    static final String STATUS = "status";
+    static final String LOAD = "load";
+    static final String SCHEMA = "schema";
+    static final String DC = "dc";
+    static final String RACK = "rack";
+    static final String RELEASE_VERSION = "release_version";
+    static final String REMOVAL_COORDINATOR = "removal_coordinator";
+    static final String INTERNAL_IP = "internal_ip";
+    static final String RPC_ADDRESS = "rpc_address";
+    static final String SEVERITY = "severity";
+    static final String NET_VERSION = "net_version";
+    static final String HOST_ID = "host_id";
+    static final String RPC_READY = "rpc_ready";
+    static final String INTERNAL_ADDRESS_AND_PORT = "internal_address_and_port";
+    static final String NATIVE_ADDRESS_AND_PORT = "native_address_and_port";
+    static final String STATUS_WITH_PORT = "status_with_port";
+    static final String SSTABLE_VERSIONS = "sstable_versions";
+
+    // "version" fields coming from @org.apache.cassandra.gms.ApplicationState
+    static final String STATUS_VERSION = "status_version";
+    static final String LOAD_VERSION = "load_version";
+    static final String SCHEMA_VERSION = "schema_version";
+    static final String DC_VERSION = "dc_version";
+    static final String RACK_VERSION = "rack_version";
+    static final String RELEASE_VERSION_VERSION = "release_version_version";
+    static final String REMOVAL_COORDINATOR_VERSION = "removal_coordinator_version";
+    static final String INTERNAL_IP_VERSION = "internal_ip_version";
+    static final String RPC_ADDRESS_VERSION = "rpc_address_version";
+    static final String SEVERITY_VERSION = "severity_version";
+    static final String NET_VERSION_VERSION = "net_version_version";
+    static final String HOST_ID_VERSION = "host_id_version";
+    static final String TOKENS_VERSION = "tokens_version";
+    static final String RPC_READY_VERSION = "rpc_ready_version";
+    static final String INTERNAL_ADDRESS_AND_PORT_VERSION = "internal_address_and_port_version";
+    static final String NATIVE_ADDRESS_AND_PORT_VERSION = "native_address_and_port_version";
+    static final String STATUS_WITH_PORT_VERSION = "status_with_port_version";
+    static final String SSTABLE_VERSIONS_VERSION = "sstable_versions_version";
+
+    /**
+     * Construct a new {@link GossipInfoTable} for the given {@code keyspace}.
+     *
+     * @param keyspace the name of the keyspace
+     */
+    GossipInfoTable(String keyspace)
+    {
+        super(TableMetadata.builder(keyspace, TABLE_NAME)
+                           .comment(TABLE_COMMENT)
+                           .kind(TableMetadata.Kind.VIRTUAL)
+                           .partitioner(new LocalPartitioner(InetAddressType.instance))
+                           .addPartitionKeyColumn(ADDRESS, InetAddressType.instance)
+                           .addClusteringColumn(PORT, Int32Type.instance)
+                           .addRegularColumn(HOSTNAME, UTF8Type.instance)
+                           .addRegularColumn(GENERATION, Int32Type.instance)
+                           .addRegularColumn(HEARTBEAT, Int32Type.instance)
+                           .addRegularColumn(STATUS, UTF8Type.instance)
+                           .addRegularColumn(LOAD, UTF8Type.instance)
+                           .addRegularColumn(SCHEMA, UTF8Type.instance)
+                           .addRegularColumn(DC, UTF8Type.instance)
+                           .addRegularColumn(RACK, UTF8Type.instance)
+                           .addRegularColumn(RELEASE_VERSION, UTF8Type.instance)
+                           .addRegularColumn(REMOVAL_COORDINATOR, UTF8Type.instance)
+                           .addRegularColumn(INTERNAL_IP, UTF8Type.instance)
+                           .addRegularColumn(RPC_ADDRESS, UTF8Type.instance)
+                           .addRegularColumn(SEVERITY, UTF8Type.instance)
+                           .addRegularColumn(NET_VERSION, UTF8Type.instance)
+                           .addRegularColumn(HOST_ID, UTF8Type.instance)
+                           .addRegularColumn(RPC_READY, UTF8Type.instance)
+                           .addRegularColumn(INTERNAL_ADDRESS_AND_PORT, UTF8Type.instance)
+                           .addRegularColumn(NATIVE_ADDRESS_AND_PORT, UTF8Type.instance)
+                           .addRegularColumn(STATUS_WITH_PORT, UTF8Type.instance)
+                           .addRegularColumn(SSTABLE_VERSIONS, UTF8Type.instance)
+                           .addRegularColumn(STATUS_VERSION, Int32Type.instance)
+                           .addRegularColumn(LOAD_VERSION, Int32Type.instance)
+                           .addRegularColumn(SCHEMA_VERSION, Int32Type.instance)
+                           .addRegularColumn(DC_VERSION, Int32Type.instance)
+                           .addRegularColumn(RACK_VERSION, Int32Type.instance)
+                           .addRegularColumn(RELEASE_VERSION_VERSION, Int32Type.instance)
+                           .addRegularColumn(REMOVAL_COORDINATOR_VERSION, Int32Type.instance)
+                           .addRegularColumn(INTERNAL_IP_VERSION, Int32Type.instance)
+                           .addRegularColumn(RPC_ADDRESS_VERSION, Int32Type.instance)
+                           .addRegularColumn(SEVERITY_VERSION, Int32Type.instance)
+                           .addRegularColumn(NET_VERSION_VERSION, Int32Type.instance)
+                           .addRegularColumn(HOST_ID_VERSION, Int32Type.instance)
+                           .addRegularColumn(TOKENS_VERSION, Int32Type.instance)
+                           .addRegularColumn(RPC_READY_VERSION, Int32Type.instance)
+                           .addRegularColumn(INTERNAL_ADDRESS_AND_PORT_VERSION, Int32Type.instance)
+                           .addRegularColumn(NATIVE_ADDRESS_AND_PORT_VERSION, Int32Type.instance)
+                           .addRegularColumn(STATUS_WITH_PORT_VERSION, Int32Type.instance)
+                           .addRegularColumn(SSTABLE_VERSIONS_VERSION, Int32Type.instance)
+                           .build());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("deprecation")
+    @Override
+    public DataSet data()
+    {
+        SimpleDataSet result = new SimpleDataSet(metadata());
+        for (Map.Entry<InetAddressAndPort, EndpointState> entry : Gossiper.instance.endpointStateMap.entrySet())
+        {
+            InetAddressAndPort endpoint = entry.getKey();
+            EndpointState localState = entry.getValue();
+
+            result.row(endpoint.getAddress(), endpoint.getPort())
+                  .column(HOSTNAME, endpoint.getHostName())
+                  .column(GENERATION, getGeneration(localState))
+                  .column(HEARTBEAT, getHeartBeat(localState))
+                  .column(STATUS, getValue(localState, ApplicationState.STATUS))
+                  .column(LOAD, getValue(localState, ApplicationState.LOAD))
+                  .column(SCHEMA, getValue(localState, ApplicationState.SCHEMA))
+                  .column(DC, getValue(localState, ApplicationState.DC))
+                  .column(RACK, getValue(localState, ApplicationState.RACK))
+                  .column(RELEASE_VERSION, getValue(localState, ApplicationState.RELEASE_VERSION))
+                  .column(REMOVAL_COORDINATOR, getValue(localState, ApplicationState.REMOVAL_COORDINATOR))
+                  .column(INTERNAL_IP, getValue(localState, ApplicationState.INTERNAL_IP))
+                  .column(RPC_ADDRESS, getValue(localState, ApplicationState.RPC_ADDRESS))
+                  .column(SEVERITY, getValue(localState, ApplicationState.SEVERITY))
+                  .column(NET_VERSION, getValue(localState, ApplicationState.NET_VERSION))
+                  .column(HOST_ID, getValue(localState, ApplicationState.HOST_ID))
+                  .column(RPC_READY, getValue(localState, ApplicationState.RPC_READY))
+                  .column(INTERNAL_ADDRESS_AND_PORT, getValue(localState, ApplicationState.INTERNAL_ADDRESS_AND_PORT))
+                  .column(NATIVE_ADDRESS_AND_PORT, getValue(localState, ApplicationState.NATIVE_ADDRESS_AND_PORT))
+                  .column(STATUS_WITH_PORT, getValue(localState, ApplicationState.STATUS_WITH_PORT))
+                  .column(SSTABLE_VERSIONS, getValue(localState, ApplicationState.SSTABLE_VERSIONS))
+                  .column(STATUS_VERSION, getVersion(localState, ApplicationState.STATUS))
+                  .column(LOAD_VERSION, getVersion(localState, ApplicationState.LOAD))
+                  .column(SCHEMA_VERSION, getVersion(localState, ApplicationState.SCHEMA))
+                  .column(DC_VERSION, getVersion(localState, ApplicationState.DC))
+                  .column(RACK_VERSION, getVersion(localState, ApplicationState.RACK))
+                  .column(RELEASE_VERSION_VERSION, getVersion(localState, ApplicationState.RELEASE_VERSION))
+                  .column(REMOVAL_COORDINATOR_VERSION, getVersion(localState, ApplicationState.REMOVAL_COORDINATOR))
+                  .column(INTERNAL_IP_VERSION, getVersion(localState, ApplicationState.INTERNAL_IP))
+                  .column(RPC_ADDRESS_VERSION, getVersion(localState, ApplicationState.RPC_ADDRESS))
+                  .column(SEVERITY_VERSION, getVersion(localState, ApplicationState.SEVERITY))
+                  .column(NET_VERSION_VERSION, getVersion(localState, ApplicationState.NET_VERSION))
+                  .column(HOST_ID_VERSION, getVersion(localState, ApplicationState.HOST_ID))
+                  .column(TOKENS_VERSION, getVersion(localState, ApplicationState.TOKENS))
+                  .column(RPC_READY_VERSION, getVersion(localState, ApplicationState.RPC_READY))
+                  .column(INTERNAL_ADDRESS_AND_PORT_VERSION, getVersion(localState, ApplicationState.INTERNAL_ADDRESS_AND_PORT))
+                  .column(NATIVE_ADDRESS_AND_PORT_VERSION, getVersion(localState, ApplicationState.NATIVE_ADDRESS_AND_PORT))
+                  .column(STATUS_WITH_PORT_VERSION, getVersion(localState, ApplicationState.STATUS_WITH_PORT))
+                  .column(SSTABLE_VERSIONS_VERSION, getVersion(localState, ApplicationState.SSTABLE_VERSIONS));
+        }
+        return result;
+    }
+
+    /**
+     * Return the heartbeat generation of a given {@link EndpointState} or null if {@code localState} is null.
+     *
+     * @param localState a nullable endpoint state
+     * @return the heartbeat generation if available, null otherwise
+     */
+    private Integer getGeneration(EndpointState localState)
+    {
+        return localState == null ? null : localState.getHeartBeatState().getGeneration();
+    }
+
+    /**
+     * Return the heartbeat version of a given {@link EndpointState} or null if {@code localState} is null.
+     *
+     * @param localState a nullable endpoint state
+     * @return the heartbeat version if available, null otherwise
+     */
+    private Integer getHeartBeat(EndpointState localState)
+    {
+        return localState == null ? null : localState.getHeartBeatState().getHeartBeatVersion();
+    }
+
+    /**
+     * Returns the value from the {@link VersionedValue} of a given {@link ApplicationState key}, or null
+     * if {@code localState} is null or the {@link VersionedValue} does not exist in the {@link ApplicationState}.
+     *
+     * @param localState a nullable endpoint state
+     * @param key        the key to the application state
+     * @return the value, or null if not available
+     */
+    private String getValue(EndpointState localState, ApplicationState key)
+    {
+        VersionedValue value;
+        return localState == null || (value = localState.getApplicationState(key)) == null ? null : value.value;
+    }
+
+    /**
+     * Returns the version from the {@link VersionedValue} of a given {@link ApplicationState key}, or null
+     * if {@code localState} is null or the {@link VersionedValue} does not exist in the {@link ApplicationState}.
+     *
+     * @param localState a nullable endpoint state
+     * @param key        the key to the application state
+     * @return the version, or null if not available
+     */
+    private Integer getVersion(EndpointState localState, ApplicationState key)
+    {
+        VersionedValue value;
+        return localState == null || (value = localState.getApplicationState(key)) == null ? null : value.version;
+    }
+}

--- a/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
@@ -18,7 +18,9 @@
 
 package org.apache.cassandra.db.virtual;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.cassandra.db.marshal.InetAddressType;
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -45,44 +47,15 @@ final class GossipInfoTable extends AbstractVirtualTable
     static final String GENERATION = "generation";
     static final String HEARTBEAT = "heartbeat";
 
-    // "value" fields coming from @org.apache.cassandra.gms.ApplicationState
-    static final String STATUS = "status";
-    static final String LOAD = "load";
-    static final String SCHEMA = "schema";
-    static final String DC = "dc";
-    static final String RACK = "rack";
-    static final String RELEASE_VERSION = "release_version";
-    static final String REMOVAL_COORDINATOR = "removal_coordinator";
-    static final String INTERNAL_IP = "internal_ip";
-    static final String RPC_ADDRESS = "rpc_address";
-    static final String SEVERITY = "severity";
-    static final String NET_VERSION = "net_version";
-    static final String HOST_ID = "host_id";
-    static final String RPC_READY = "rpc_ready";
-    static final String INTERNAL_ADDRESS_AND_PORT = "internal_address_and_port";
-    static final String NATIVE_ADDRESS_AND_PORT = "native_address_and_port";
-    static final String STATUS_WITH_PORT = "status_with_port";
-    static final String SSTABLE_VERSIONS = "sstable_versions";
-
-    // "version" fields coming from @org.apache.cassandra.gms.ApplicationState
-    static final String STATUS_VERSION = "status_version";
-    static final String LOAD_VERSION = "load_version";
-    static final String SCHEMA_VERSION = "schema_version";
-    static final String DC_VERSION = "dc_version";
-    static final String RACK_VERSION = "rack_version";
-    static final String RELEASE_VERSION_VERSION = "release_version_version";
-    static final String REMOVAL_COORDINATOR_VERSION = "removal_coordinator_version";
-    static final String INTERNAL_IP_VERSION = "internal_ip_version";
-    static final String RPC_ADDRESS_VERSION = "rpc_address_version";
-    static final String SEVERITY_VERSION = "severity_version";
-    static final String NET_VERSION_VERSION = "net_version_version";
-    static final String HOST_ID_VERSION = "host_id_version";
-    static final String TOKENS_VERSION = "tokens_version";
-    static final String RPC_READY_VERSION = "rpc_ready_version";
-    static final String INTERNAL_ADDRESS_AND_PORT_VERSION = "internal_address_and_port_version";
-    static final String NATIVE_ADDRESS_AND_PORT_VERSION = "native_address_and_port_version";
-    static final String STATUS_WITH_PORT_VERSION = "status_with_port_version";
-    static final String SSTABLE_VERSIONS_VERSION = "sstable_versions_version";
+    @SuppressWarnings("deprecation")
+    static final Set<ApplicationState> APPLICATION_STATE_SET =
+    EnumSet.of(ApplicationState.STATUS, ApplicationState.LOAD, ApplicationState.SCHEMA, ApplicationState.DC,
+               ApplicationState.RACK, ApplicationState.RELEASE_VERSION, ApplicationState.REMOVAL_COORDINATOR,
+               ApplicationState.INTERNAL_IP, ApplicationState.RPC_ADDRESS, ApplicationState.SEVERITY,
+               ApplicationState.NET_VERSION, ApplicationState.HOST_ID, ApplicationState.TOKENS,
+               ApplicationState.RPC_READY, ApplicationState.INTERNAL_ADDRESS_AND_PORT,
+               ApplicationState.NATIVE_ADDRESS_AND_PORT, ApplicationState.STATUS_WITH_PORT,
+               ApplicationState.SSTABLE_VERSIONS);
 
     /**
      * Construct a new {@link GossipInfoTable} for the given {@code keyspace}.
@@ -91,57 +64,12 @@ final class GossipInfoTable extends AbstractVirtualTable
      */
     GossipInfoTable(String keyspace)
     {
-        super(TableMetadata.builder(keyspace, TABLE_NAME)
-                           .comment(TABLE_COMMENT)
-                           .kind(TableMetadata.Kind.VIRTUAL)
-                           .partitioner(new LocalPartitioner(InetAddressType.instance))
-                           .addPartitionKeyColumn(ADDRESS, InetAddressType.instance)
-                           .addClusteringColumn(PORT, Int32Type.instance)
-                           .addRegularColumn(HOSTNAME, UTF8Type.instance)
-                           .addRegularColumn(GENERATION, Int32Type.instance)
-                           .addRegularColumn(HEARTBEAT, Int32Type.instance)
-                           .addRegularColumn(STATUS, UTF8Type.instance)
-                           .addRegularColumn(LOAD, UTF8Type.instance)
-                           .addRegularColumn(SCHEMA, UTF8Type.instance)
-                           .addRegularColumn(DC, UTF8Type.instance)
-                           .addRegularColumn(RACK, UTF8Type.instance)
-                           .addRegularColumn(RELEASE_VERSION, UTF8Type.instance)
-                           .addRegularColumn(REMOVAL_COORDINATOR, UTF8Type.instance)
-                           .addRegularColumn(INTERNAL_IP, UTF8Type.instance)
-                           .addRegularColumn(RPC_ADDRESS, UTF8Type.instance)
-                           .addRegularColumn(SEVERITY, UTF8Type.instance)
-                           .addRegularColumn(NET_VERSION, UTF8Type.instance)
-                           .addRegularColumn(HOST_ID, UTF8Type.instance)
-                           .addRegularColumn(RPC_READY, UTF8Type.instance)
-                           .addRegularColumn(INTERNAL_ADDRESS_AND_PORT, UTF8Type.instance)
-                           .addRegularColumn(NATIVE_ADDRESS_AND_PORT, UTF8Type.instance)
-                           .addRegularColumn(STATUS_WITH_PORT, UTF8Type.instance)
-                           .addRegularColumn(SSTABLE_VERSIONS, UTF8Type.instance)
-                           .addRegularColumn(STATUS_VERSION, Int32Type.instance)
-                           .addRegularColumn(LOAD_VERSION, Int32Type.instance)
-                           .addRegularColumn(SCHEMA_VERSION, Int32Type.instance)
-                           .addRegularColumn(DC_VERSION, Int32Type.instance)
-                           .addRegularColumn(RACK_VERSION, Int32Type.instance)
-                           .addRegularColumn(RELEASE_VERSION_VERSION, Int32Type.instance)
-                           .addRegularColumn(REMOVAL_COORDINATOR_VERSION, Int32Type.instance)
-                           .addRegularColumn(INTERNAL_IP_VERSION, Int32Type.instance)
-                           .addRegularColumn(RPC_ADDRESS_VERSION, Int32Type.instance)
-                           .addRegularColumn(SEVERITY_VERSION, Int32Type.instance)
-                           .addRegularColumn(NET_VERSION_VERSION, Int32Type.instance)
-                           .addRegularColumn(HOST_ID_VERSION, Int32Type.instance)
-                           .addRegularColumn(TOKENS_VERSION, Int32Type.instance)
-                           .addRegularColumn(RPC_READY_VERSION, Int32Type.instance)
-                           .addRegularColumn(INTERNAL_ADDRESS_AND_PORT_VERSION, Int32Type.instance)
-                           .addRegularColumn(NATIVE_ADDRESS_AND_PORT_VERSION, Int32Type.instance)
-                           .addRegularColumn(STATUS_WITH_PORT_VERSION, Int32Type.instance)
-                           .addRegularColumn(SSTABLE_VERSIONS_VERSION, Int32Type.instance)
-                           .build());
+        super(buildTableMetadata(keyspace));
     }
 
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("deprecation")
     @Override
     public DataSet data()
     {
@@ -151,45 +79,20 @@ final class GossipInfoTable extends AbstractVirtualTable
             InetAddressAndPort endpoint = entry.getKey();
             EndpointState localState = entry.getValue();
 
-            result.row(endpoint.getAddress(), endpoint.getPort())
-                  .column(HOSTNAME, endpoint.getHostName())
-                  .column(GENERATION, getGeneration(localState))
-                  .column(HEARTBEAT, getHeartBeat(localState))
-                  .column(STATUS, getValue(localState, ApplicationState.STATUS))
-                  .column(LOAD, getValue(localState, ApplicationState.LOAD))
-                  .column(SCHEMA, getValue(localState, ApplicationState.SCHEMA))
-                  .column(DC, getValue(localState, ApplicationState.DC))
-                  .column(RACK, getValue(localState, ApplicationState.RACK))
-                  .column(RELEASE_VERSION, getValue(localState, ApplicationState.RELEASE_VERSION))
-                  .column(REMOVAL_COORDINATOR, getValue(localState, ApplicationState.REMOVAL_COORDINATOR))
-                  .column(INTERNAL_IP, getValue(localState, ApplicationState.INTERNAL_IP))
-                  .column(RPC_ADDRESS, getValue(localState, ApplicationState.RPC_ADDRESS))
-                  .column(SEVERITY, getValue(localState, ApplicationState.SEVERITY))
-                  .column(NET_VERSION, getValue(localState, ApplicationState.NET_VERSION))
-                  .column(HOST_ID, getValue(localState, ApplicationState.HOST_ID))
-                  .column(RPC_READY, getValue(localState, ApplicationState.RPC_READY))
-                  .column(INTERNAL_ADDRESS_AND_PORT, getValue(localState, ApplicationState.INTERNAL_ADDRESS_AND_PORT))
-                  .column(NATIVE_ADDRESS_AND_PORT, getValue(localState, ApplicationState.NATIVE_ADDRESS_AND_PORT))
-                  .column(STATUS_WITH_PORT, getValue(localState, ApplicationState.STATUS_WITH_PORT))
-                  .column(SSTABLE_VERSIONS, getValue(localState, ApplicationState.SSTABLE_VERSIONS))
-                  .column(STATUS_VERSION, getVersion(localState, ApplicationState.STATUS))
-                  .column(LOAD_VERSION, getVersion(localState, ApplicationState.LOAD))
-                  .column(SCHEMA_VERSION, getVersion(localState, ApplicationState.SCHEMA))
-                  .column(DC_VERSION, getVersion(localState, ApplicationState.DC))
-                  .column(RACK_VERSION, getVersion(localState, ApplicationState.RACK))
-                  .column(RELEASE_VERSION_VERSION, getVersion(localState, ApplicationState.RELEASE_VERSION))
-                  .column(REMOVAL_COORDINATOR_VERSION, getVersion(localState, ApplicationState.REMOVAL_COORDINATOR))
-                  .column(INTERNAL_IP_VERSION, getVersion(localState, ApplicationState.INTERNAL_IP))
-                  .column(RPC_ADDRESS_VERSION, getVersion(localState, ApplicationState.RPC_ADDRESS))
-                  .column(SEVERITY_VERSION, getVersion(localState, ApplicationState.SEVERITY))
-                  .column(NET_VERSION_VERSION, getVersion(localState, ApplicationState.NET_VERSION))
-                  .column(HOST_ID_VERSION, getVersion(localState, ApplicationState.HOST_ID))
-                  .column(TOKENS_VERSION, getVersion(localState, ApplicationState.TOKENS))
-                  .column(RPC_READY_VERSION, getVersion(localState, ApplicationState.RPC_READY))
-                  .column(INTERNAL_ADDRESS_AND_PORT_VERSION, getVersion(localState, ApplicationState.INTERNAL_ADDRESS_AND_PORT))
-                  .column(NATIVE_ADDRESS_AND_PORT_VERSION, getVersion(localState, ApplicationState.NATIVE_ADDRESS_AND_PORT))
-                  .column(STATUS_WITH_PORT_VERSION, getVersion(localState, ApplicationState.STATUS_WITH_PORT))
-                  .column(SSTABLE_VERSIONS_VERSION, getVersion(localState, ApplicationState.SSTABLE_VERSIONS));
+            SimpleDataSet dataSet = result.row(endpoint.getAddress(), endpoint.getPort())
+                                          .column(HOSTNAME, endpoint.getHostName())
+                                          .column(GENERATION, getGeneration(localState))
+                                          .column(HEARTBEAT, getHeartBeat(localState));
+
+            APPLICATION_STATE_SET.forEach(applicationState -> {
+                String state = applicationState.name().toLowerCase();
+                if (!"tokens".equals(state))
+                {
+                    // do not a column for the ApplicationState.TOKENS value
+                    dataSet.column(state, getValue(localState, applicationState));
+                }
+                dataSet.column(state + "_version", getVersion(localState, applicationState));
+            });
         }
         return result;
     }
@@ -242,5 +145,38 @@ final class GossipInfoTable extends AbstractVirtualTable
     {
         VersionedValue value;
         return localState == null || (value = localState.getApplicationState(key)) == null ? null : value.version;
+    }
+
+    /**
+     * Builds the {@link TableMetadata} to be provided to the superclass
+     *
+     * @param keyspace the name of the keyspace
+     * @return the TableMetadata class
+     */
+    private static TableMetadata buildTableMetadata(String keyspace)
+    {
+        TableMetadata.Builder builder = TableMetadata.builder(keyspace, TABLE_NAME)
+                                                     .comment(TABLE_COMMENT)
+                                                     .kind(TableMetadata.Kind.VIRTUAL)
+                                                     .partitioner(new LocalPartitioner(InetAddressType.instance))
+                                                     .addPartitionKeyColumn(ADDRESS, InetAddressType.instance)
+                                                     .addClusteringColumn(PORT, Int32Type.instance)
+                                                     .addRegularColumn(HOSTNAME, UTF8Type.instance)
+                                                     .addRegularColumn(GENERATION, Int32Type.instance)
+                                                     .addRegularColumn(HEARTBEAT, Int32Type.instance);
+
+        APPLICATION_STATE_SET.stream()
+                             .map(Enum::name)
+                             .map(String::toLowerCase)
+                             .forEach(state -> {
+                                 if (!"tokens".equals(state))
+                                 {
+                                     // do not a column for the ApplicationState.TOKENS value
+                                     builder.addRegularColumn(state, UTF8Type.instance);
+                                 }
+                                 builder.addRegularColumn(state + "_version", Int32Type.instance);
+                             });
+
+        return builder.build();
     }
 }

--- a/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/GossipInfoTable.java
@@ -49,7 +49,6 @@ final class GossipInfoTable extends AbstractVirtualTable
     static final String HEARTBEAT = "heartbeat";
 
     static final List<ApplicationState> APPLICATION_STATES = Arrays.stream(ApplicationState.values())
-                                                                   .filter(applicationState -> applicationState != ApplicationState.X_11_PADDING)
                                                                    .collect(Collectors.toList());
 
     /**

--- a/src/java/org/apache/cassandra/db/virtual/SystemViewsKeyspace.java
+++ b/src/java/org/apache/cassandra/db/virtual/SystemViewsKeyspace.java
@@ -46,6 +46,7 @@ public final class SystemViewsKeyspace extends VirtualKeyspace
                     .add(new CQLMetricsTable(VIRTUAL_VIEWS))
                     .add(new BatchMetricsTable(VIRTUAL_VIEWS))
                     .add(new StreamingVirtualTable(VIRTUAL_VIEWS))
+                    .add(new GossipInfoTable(VIRTUAL_VIEWS))
                     .build());
     }
 }

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -159,8 +159,9 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     @VisibleForTesting
     final Set<InetAddressAndPort> seeds = new ConcurrentSkipListSet<>();
 
-    /* map where key is the endpoint and value is the state associated with the endpoint */
-    final ConcurrentMap<InetAddressAndPort, EndpointState> endpointStateMap = new ConcurrentHashMap<>();
+    /* map where key is the endpoint and value is the state associated with the endpoint.
+     * This is made public to be consumed by the GossipInfoTable virtual table */
+    public final ConcurrentMap<InetAddressAndPort, EndpointState> endpointStateMap = new ConcurrentHashMap<>();
 
     /* map where key is endpoint and value is timestamp when this endpoint was removed from
      * gossip. We will ignore any gossip regarding these endpoints for QUARANTINE_DELAY time

--- a/src/java/org/apache/cassandra/gms/HeartBeatState.java
+++ b/src/java/org/apache/cassandra/gms/HeartBeatState.java
@@ -70,7 +70,7 @@ public class HeartBeatState
         return version == EMPTY_VERSION;
     }
 
-    int getGeneration()
+    public int getGeneration()
     {
         return generation;
     }
@@ -80,7 +80,7 @@ public class HeartBeatState
         version = VersionGenerator.getNextVersion();
     }
 
-    int getHeartBeatVersion()
+    public int getHeartBeatVersion()
     {
         return version;
     }

--- a/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.locator.InetAddressAndPort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GossipInfoTableTest extends CQLTester
+{
+    private static final String KS_NAME = "vts";
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private GossipInfoTable table;
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+        CQLTester.setUpClass();
+    }
+
+    @Before
+    public void config()
+    {
+        table = new GossipInfoTable(KS_NAME);
+        VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(KS_NAME, ImmutableList.of(table)));
+    }
+
+    @Test
+    public void testSelectAllWhenGossipInfoIsEmpty() throws Throwable
+    {
+        assertEmpty(execute("SELECT * FROM vts.gossip_info"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testSelectAllWithStateTransitions() throws Throwable
+    {
+        try
+        {
+            requireNetwork(); // triggers gossiper
+
+            UntypedResultSet resultSet = execute("SELECT * FROM vts.gossip_info");
+
+            assertThat(resultSet.size()).isEqualTo(1);
+            assertThat(Gossiper.instance.endpointStateMap.size()).isEqualTo(1);
+
+            Optional<Map.Entry<InetAddressAndPort, EndpointState>> entry = Gossiper.instance.endpointStateMap.entrySet()
+                                                                                                             .stream()
+                                                                                                             .findFirst();
+            assertThat(entry).isNotEmpty();
+
+            UntypedResultSet.Row row = resultSet.one();
+            assertThat(row.getColumns().size()).isEqualTo(40);
+
+            InetAddressAndPort endpoint = entry.get().getKey();
+            EndpointState localState = entry.get().getValue();
+
+            assertThat(endpoint).isNotNull();
+            assertThat(localState).isNotNull();
+            assertThat(row.getInetAddress("address")).isEqualTo(endpoint.getAddress());
+            assertThat(row.getInt("port")).isEqualTo(endpoint.getPort());
+            assertThat(row.getString("hostname")).isEqualTo(endpoint.getHostName());
+            assertThat(row.getInt("generation")).isEqualTo(localState.getHeartBeatState().getGeneration());
+
+            assertValue(row, "status", localState, ApplicationState.STATUS);
+            assertValue(row, "load", localState, ApplicationState.LOAD);
+            assertValue(row, "schema", localState, ApplicationState.SCHEMA);
+            assertValue(row, "dc", localState, ApplicationState.DC);
+            assertValue(row, "rack", localState, ApplicationState.RACK);
+            assertValue(row, "release_version", localState, ApplicationState.RELEASE_VERSION);
+            assertValue(row, "removal_coordinator", localState, ApplicationState.REMOVAL_COORDINATOR);
+            assertValue(row, "internal_ip", localState, ApplicationState.INTERNAL_IP);
+            assertValue(row, "rpc_address", localState, ApplicationState.RPC_ADDRESS);
+            assertValue(row, "severity", localState, ApplicationState.SEVERITY);
+            assertValue(row, "net_version", localState, ApplicationState.NET_VERSION);
+            assertValue(row, "host_id", localState, ApplicationState.HOST_ID);
+            assertValue(row, "rpc_ready", localState, ApplicationState.RPC_READY);
+            assertValue(row, "internal_address_and_port", localState, ApplicationState.INTERNAL_ADDRESS_AND_PORT);
+            assertValue(row, "native_address_and_port", localState, ApplicationState.NATIVE_ADDRESS_AND_PORT);
+            assertValue(row, "status_with_port", localState, ApplicationState.STATUS_WITH_PORT);
+            assertValue(row, "sstable_versions", localState, ApplicationState.SSTABLE_VERSIONS);
+
+            assertVersion(row, "status_version", localState, ApplicationState.STATUS);
+            assertVersion(row, "load_version", localState, ApplicationState.LOAD);
+            assertVersion(row, "schema_version", localState, ApplicationState.SCHEMA);
+            assertVersion(row, "dc_version", localState, ApplicationState.DC);
+            assertVersion(row, "rack_version", localState, ApplicationState.RACK);
+            assertVersion(row, "release_version_version", localState, ApplicationState.RELEASE_VERSION);
+            assertVersion(row, "removal_coordinator_version", localState, ApplicationState.REMOVAL_COORDINATOR);
+            assertVersion(row, "internal_ip_version", localState, ApplicationState.INTERNAL_IP);
+            assertVersion(row, "rpc_address_version", localState, ApplicationState.RPC_ADDRESS);
+            assertVersion(row, "severity_version", localState, ApplicationState.SEVERITY);
+            assertVersion(row, "net_version_version", localState, ApplicationState.NET_VERSION);
+            assertVersion(row, "host_id_version", localState, ApplicationState.HOST_ID);
+            assertVersion(row, "tokens_version", localState, ApplicationState.TOKENS);
+            assertVersion(row, "rpc_ready_version", localState, ApplicationState.RPC_READY);
+            assertVersion(row, "internal_address_and_port_version", localState, ApplicationState.INTERNAL_ADDRESS_AND_PORT);
+            assertVersion(row, "native_address_and_port_version", localState, ApplicationState.NATIVE_ADDRESS_AND_PORT);
+            assertVersion(row, "status_with_port_version", localState, ApplicationState.STATUS_WITH_PORT);
+            assertVersion(row, "sstable_versions_version", localState, ApplicationState.SSTABLE_VERSIONS);
+        }
+        finally
+        {
+            // clean up the gossip states
+            Gossiper.instance.clearUnsafe();
+        }
+    }
+
+    private void assertValue(UntypedResultSet.Row row, String column, EndpointState localState, ApplicationState key)
+    {
+        if (row.has(column))
+        {
+            assertThat(localState.getApplicationState(key)).as("'%s' is expected to be not-null", key)
+                                                           .isNotNull();
+            assertThat(row.getString(column)).as("'%s' is expected to match column '%s'", key, column)
+                                             .isEqualTo(localState.getApplicationState(key).value);
+        }
+        else
+        {
+            assertThat(localState.getApplicationState(key)).as("'%s' is expected to be null", key)
+                                                           .isNull();
+        }
+    }
+
+    private void assertVersion(UntypedResultSet.Row row, String column, EndpointState localState, ApplicationState key)
+    {
+        if (row.has(column))
+        {
+            assertThat(localState.getApplicationState(key)).as("'%s' is expected to be not-null", key)
+                                                           .isNotNull();
+            assertThat(row.getInt(column)).as("'%s' is expected to match column '%s'", key, column)
+                                          .isEqualTo(localState.getApplicationState(key).version);
+        }
+        else
+        {
+            assertThat(localState.getApplicationState(key)).as("'%s' is expected to be null", key)
+                                                           .isNull();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
@@ -80,7 +80,7 @@ public class GossipInfoTableTest extends CQLTester
             assertThat(entry).isNotEmpty();
 
             UntypedResultSet.Row row = resultSet.one();
-            assertThat(row.getColumns().size()).isEqualTo(40);
+            assertThat(row.getColumns().size()).isEqualTo(60);
 
             InetAddressAndPort endpoint = entry.get().getKey();
             EndpointState localState = entry.get().getValue();
@@ -109,6 +109,16 @@ public class GossipInfoTableTest extends CQLTester
             assertValue(row, "native_address_and_port", localState, ApplicationState.NATIVE_ADDRESS_AND_PORT);
             assertValue(row, "status_with_port", localState, ApplicationState.STATUS_WITH_PORT);
             assertValue(row, "sstable_versions", localState, ApplicationState.SSTABLE_VERSIONS);
+            assertValue(row, "x1", localState, ApplicationState.X1);
+            assertValue(row, "x2", localState, ApplicationState.X2);
+            assertValue(row, "x3", localState, ApplicationState.X3);
+            assertValue(row, "x4", localState, ApplicationState.X4);
+            assertValue(row, "x5", localState, ApplicationState.X5);
+            assertValue(row, "x6", localState, ApplicationState.X6);
+            assertValue(row, "x7", localState, ApplicationState.X7);
+            assertValue(row, "x8", localState, ApplicationState.X8);
+            assertValue(row, "x9", localState, ApplicationState.X9);
+            assertValue(row, "x10", localState, ApplicationState.X10);
 
             assertVersion(row, "status_version", localState, ApplicationState.STATUS);
             assertVersion(row, "load_version", localState, ApplicationState.LOAD);
@@ -128,6 +138,16 @@ public class GossipInfoTableTest extends CQLTester
             assertVersion(row, "native_address_and_port_version", localState, ApplicationState.NATIVE_ADDRESS_AND_PORT);
             assertVersion(row, "status_with_port_version", localState, ApplicationState.STATUS_WITH_PORT);
             assertVersion(row, "sstable_versions_version", localState, ApplicationState.SSTABLE_VERSIONS);
+            assertVersion(row, "x1", localState, ApplicationState.X1);
+            assertVersion(row, "x2", localState, ApplicationState.X2);
+            assertVersion(row, "x3", localState, ApplicationState.X3);
+            assertVersion(row, "x4", localState, ApplicationState.X4);
+            assertVersion(row, "x5", localState, ApplicationState.X5);
+            assertVersion(row, "x6", localState, ApplicationState.X6);
+            assertVersion(row, "x7", localState, ApplicationState.X7);
+            assertVersion(row, "x8", localState, ApplicationState.X8);
+            assertVersion(row, "x9", localState, ApplicationState.X9);
+            assertVersion(row, "x10", localState, ApplicationState.X10);
         }
         finally
         {

--- a/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/GossipInfoTableTest.java
@@ -80,7 +80,7 @@ public class GossipInfoTableTest extends CQLTester
             assertThat(entry).isNotEmpty();
 
             UntypedResultSet.Row row = resultSet.one();
-            assertThat(row.getColumns().size()).isEqualTo(60);
+            assertThat(row.getColumns().size()).isEqualTo(62);
 
             InetAddressAndPort endpoint = entry.get().getKey();
             EndpointState localState = entry.get().getValue();
@@ -109,6 +109,7 @@ public class GossipInfoTableTest extends CQLTester
             assertValue(row, "native_address_and_port", localState, ApplicationState.NATIVE_ADDRESS_AND_PORT);
             assertValue(row, "status_with_port", localState, ApplicationState.STATUS_WITH_PORT);
             assertValue(row, "sstable_versions", localState, ApplicationState.SSTABLE_VERSIONS);
+            assertValue(row, "x_11_padding", localState, ApplicationState.X_11_PADDING);
             assertValue(row, "x1", localState, ApplicationState.X1);
             assertValue(row, "x2", localState, ApplicationState.X2);
             assertValue(row, "x3", localState, ApplicationState.X3);
@@ -138,6 +139,7 @@ public class GossipInfoTableTest extends CQLTester
             assertVersion(row, "native_address_and_port_version", localState, ApplicationState.NATIVE_ADDRESS_AND_PORT);
             assertVersion(row, "status_with_port_version", localState, ApplicationState.STATUS_WITH_PORT);
             assertVersion(row, "sstable_versions_version", localState, ApplicationState.SSTABLE_VERSIONS);
+            assertVersion(row, "x_11_padding", localState, ApplicationState.X_11_PADDING);
             assertVersion(row, "x1", localState, ApplicationState.X1);
             assertVersion(row, "x2", localState, ApplicationState.X2);
             assertVersion(row, "x3", localState, ApplicationState.X3);


### PR DESCRIPTION
This commit adds a new virtual table that exposes the gossip information in tabular format.

The information is the same as the information presented through the `nodetool gossipinfo`
command, but the virtual table splits the version and value from `VersionedValue` into two
different columns. This is intended to help clients reading the vtable without the need of
parsing the version:value information (as it currently stands in gossipinfo).

The token value does not have a column. This is consistent with the gossipinfo output which
always renders ":<hidden>" for the Token value. Only the token_version column is available.