### PR TITLE
CASSNDRA-17512 Docs: Fix Dynamo paper links to have working urls

### DIFF
--- a/doc/modules/cassandra/pages/architecture/dynamo.adoc
+++ b/doc/modules/cassandra/pages/architecture/dynamo.adoc
@@ -1,7 +1,7 @@
 = Dynamo
 
 Apache Cassandra relies on a number of techniques from Amazon's
-http://courses.cse.tamu.edu/caverlee/csce438/readings/dynamo-paper.pdf[Dynamo]
+https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/dynamo.pdf[Dynamo]
 distributed storage key-value system. Each node in the Dynamo system has
 three main components:
 

--- a/doc/modules/cassandra/pages/architecture/overview.adoc
+++ b/doc/modules/cassandra/pages/architecture/overview.adoc
@@ -10,7 +10,7 @@ https://www.cs.cornell.edu/projects/ladis2009/papers/lakshman-ladis2009.pdf[Face
 using a staged event-driven architecture
 (http://www.sosp.org/2001/papers/welsh.pdf[SEDA]) to implement a
 combination of Amazon’s
-http://courses.cse.tamu.edu/caverlee/csce438/readings/dynamo-paper.pdf[Dynamo]
+https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/dynamo.pdf[Dynamo]
 distributed storage and replication techniques and Google's
 https://static.googleusercontent.com/media/research.google.com/en//archive/bigtable-osdi06.pdf[Bigtable]
 data and storage engine model. Dynamo and Bigtable were both developed


### PR DESCRIPTION
References to Dynamo paper at the Architecture [Overview](https://cassandra.apache.org/doc/latest/cassandra/architecture/overview.html) and [Dynamo](https://cassandra.apache.org/doc/latest/cassandra/architecture/dynamo.html) pages refer to an URL that gives 404 error. 

This pull request updates the URL to point to another copy of the same paper.

Before: http://courses.cse.tamu.edu/caverlee/csce438/readings/dynamo-paper.pdf
After: https://www.cs.cornell.edu/courses/cs5414/2017fa/papers/dynamo.pdf
