### PR TITLE
CASSANDRA-17564 - Add synchronization to wait for outstanding tasks in the compaction executor and nonPeriodicTasks during CassandraDaemon setup

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -139,6 +139,10 @@ public class CompactionManager implements CompactionManagerMBean
 
     private final RateLimiter compactionRateLimiter = RateLimiter.create(Double.MAX_VALUE);
 
+    public boolean isExecutorCompleted() {
+        return executor.getActiveTaskCount() !=0 || executor.getPendingTaskCount() != 0;
+    }
+
     public CompactionMetrics getMetrics()
     {
         return metrics;

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -60,6 +60,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SizeEstimatesRecorder;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.SystemKeyspaceMigrator41;
+import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.virtual.SystemViewsKeyspace;
 import org.apache.cassandra.db.virtual.VirtualKeyspaceRegistry;
@@ -326,6 +327,19 @@ public class CassandraDaemon
                     store.disableAutoCompaction();
                 }
             }
+        }
+
+        // wait for all tasks in compaction executor and nonPeriodicTasks
+        while (CompactionManager.instance.isExecutorCompleted()) {
+            try {
+                Thread.sleep(1000);
+            } catch (Exception ignored) { }
+        }
+        while (ScheduledExecutors.nonPeriodicTasks.getActiveTaskCount() != 0 ||
+                ScheduledExecutors.nonPeriodicTasks.getPendingTaskCount() != 0) {
+            try {
+                Thread.sleep(1000);
+            } catch (Exception ignored) { }
         }
 
         try


### PR DESCRIPTION
Propose a patch for [CASSANDRA-17564](https://issues.apache.org/jira/browse/CASSANDRA-17564)

Currently the patch is too straightforward and definitely needs more improvement. Probably we need to do the synchronization with a more elegant and robust approach. We are looking for more comments and suggestions, in terms of the issue and the patch.

Thanks.