### PR TITLE
CASSANDRA-17581 fix NodeProbe: Malformed IPv6 address at index

### DIFF
--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -102,7 +102,7 @@ import org.apache.cassandra.tools.nodetool.GetTimeout;
  */
 public class NodeProbe implements AutoCloseable
 {
-    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://[%s]:%d/jmxrmi";
+    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
     private static final String ssObjName = "org.apache.cassandra.db:type=StorageService";
     private static final int defaultPort = 7199;
 

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -184,6 +184,12 @@ public class NodeProbe implements AutoCloseable
      */
     private void connect() throws IOException
     {
+        String host = this.host;
+        if (host.contains(":"))
+        {
+            // Use square brackets to surround IPv6 addresses to fix CASSANDRA-7669 and CASSANDRA-17581
+            host = "[" + host + "]";
+        }
         JMXServiceURL jmxUrl = new JMXServiceURL(String.format(fmtUrl, host, port));
         Map<String,Object> env = new HashMap<String,Object>();
         if (username != null)


### PR DESCRIPTION
Fix error when `new NodeProbe("127.0.0.1", 7199)` with jdk 1.8.0_332:
```
java.io.IOException: Failed to retrieve RMIServer stub:
 javax.naming.InvalidNameException: Malformed IPv6 address at index 7: rmi://[127.0.0.1]:7199
 Root exception is java.lang.IllegalArgumentException: Malformed IPv6 address at index 7: rmi://[127.0.0.1]:7199
```