### PR TITLE
CASSANDRA-17577 add new CQLSH command SHOW REPLICAS

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -33,7 +33,6 @@ import traceback
 import warnings
 import webbrowser
 from contextlib import contextmanager
-from cassandra.metadata import Murmur3Token
 from glob import glob
 from io import StringIO
 from uuid import UUID
@@ -601,11 +600,12 @@ class Shell(cmd.Cmd):
     def show_session(self, sessionid, partial_session=False):
         print_trace_session(self, self.session, sessionid, partial_session)
 
-    def show_replicas(self, token, keyspace=None):
+    def show_replicas(self, token_value, keyspace=None):
         ks = self.current_keyspace if keyspace is None else keyspace
-        nodes = self.conn.metadata.token_map.get_replicas(self.current_keyspace, Murmur3Token(token))
+        token_map = self.conn.metadata.token_map
+        nodes = token_map.get_replicas(ks, token_map.token_class(token_value))
         addresses = [x.address for x in nodes]
-        print(f"Replicas for token {token} are {addresses}")
+        print(f"Replicas {addresses}")
 
     def get_connection_versions(self):
         result, = self.session.execute("select * from system.local where key = 'local'")

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -605,7 +605,7 @@ class Shell(cmd.Cmd):
         token_map = self.conn.metadata.token_map
         nodes = token_map.get_replicas(ks, token_map.token_class(token_value))
         addresses = [x.address for x in nodes]
-        print(f"Replicas {addresses}")
+        print(f"{addresses}")
 
     def get_connection_versions(self):
         result, = self.session.execute("select * from system.local where key = 'local'")

--- a/doc/modules/cassandra/pages/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/tools/cqlsh.adoc
@@ -167,7 +167,7 @@ Example:
 [source,none]
 ----
 cqlsh> SHOW VERSION
-[cqlsh 5.0.1 | Cassandra 3.8 | CQL spec 3.4.2 | Native protocol v4]
+[cqlsh 6.1.0 | Cassandra 4.0.1 | CQL spec 3.4.5 | Native protocol v5]
 ----
 
 === `SHOW HOST`
@@ -179,6 +179,21 @@ connected to in addition to the cluster name. Example:
 ----
 cqlsh> SHOW HOST
 Connected to Prod_Cluster at 192.0.0.1:9042.
+----
+
+=== `SHOW REPLICAS`
+
+Prints the IP address the Cassandra nodes which are replicas for the 
+listed given token and keyspace.
+
+`Usage`: `SHOW REPLICAS <token> (<keyspace>)`
+
+Example usage:
+
+[source,none]
+----
+cqlsh> SHOW REPLICAS 95
+Replicas for token 95 are ['192.0.0.1', '192.0.0.2']
 ----
 
 === `SHOW SESSION`

--- a/doc/modules/cassandra/pages/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/tools/cqlsh.adoc
@@ -193,7 +193,7 @@ Example usage:
 [source,none]
 ----
 cqlsh> SHOW REPLICAS 95
-Replicas for token 95 are ['192.0.0.1', '192.0.0.2']
+['192.0.0.1', '192.0.0.2']
 ----
 
 === `SHOW SESSION`

--- a/pylib/cqlshlib/cqlshhandling.py
+++ b/pylib/cqlshlib/cqlshhandling.py
@@ -131,7 +131,7 @@ cqlsh_serial_consistency_level_syntax_rules = r'''
 '''
 
 cqlsh_show_cmd_syntax_rules = r'''
-<showCommand> ::= "SHOW" what=( "VERSION" | "HOST" | "SESSION" sessionid=<uuid> )
+<showCommand> ::= "SHOW" what=( "VERSION" | "HOST" | "SESSION" sessionid=<uuid> | "REPLICAS" token=<wholenumber> (keyspace=<keyspaceName>)? )
                 ;
 '''
 


### PR DESCRIPTION
Note, for naming I used the Cassandra python driver convention of 'replicas'.  Replicas is a frequently used term. Nodetool uses 'endpoints', but this is otherwise not a commonly used term in Cassandra in my experience.  