### PR TITLE
CASSANDRA-17677: Fix BulkLoader to load entireSSTableThrottle and entireSSTableInterDcThrottle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,487 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-version: 2
 jobs:
-  j8_jvm_upgrade_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  repeated_jvm_upgrade_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run repeated JUnit test
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_JVM_UPGRADE_DTEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_JVM_UPGRADE_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_JVM_UPGRADE_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_JVM_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running test-jvm-dtest-some ${REPEATED_JVM_UPGRADE_DTEST_CLASS} ${REPEATED_JVM_UPGRADE_DTEST_METHODS} ${REPEATED_JVM_UPGRADE_DTEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=test-jvm-dtest-some
-              class_path=${REPEATED_JVM_UPGRADE_DTEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_JVM_UPGRADE_DTEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_JVM_UPGRADE_DTEST_METHODS}"
-              fi
-
-              # Prepare the JVM dtests vnodes argument, which is optional
-              vnodes_args=""
-              if false; then
-                vnodes_args="-Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods $vnodes_args -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/test-jvm-dtest-some-${REPEATED_JVM_UPGRADE_DTEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results/repeated_utest/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_jvm_dtests_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16' -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_unit_tests:
+  j11_build:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -531,383 +55,85 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  repeated_upgrade_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    parallelism: 1
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
-    - attach_workspace:
-        at: /home/cassandra
     - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UPGRADE_DTEST_NAME}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UPGRADE_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UPGRADE_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
+        command: 'echo ''*** id ***''
 
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
+          id
 
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UPGRADE_DTEST_NAME} $count times"
+          echo ''*** cat /proc/cpuinfo ***''
 
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
+          cat /proc/cpuinfo
 
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
+          echo ''*** free -m ***''
 
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
+          free -m
 
-              stop_on_failure_arg=""
-              if ${REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
+          echo ''*** df -m ***''
 
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
+          df -m
 
-              upgrade_arg=""
-              if true; then
-                upgrade_arg="--execute-upgrade-tests"
-              fi
+          echo ''*** ifconfig -a ***''
 
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_UPGRADE_DTEST_NAME} | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py38-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
+          ifconfig -a
 
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
 
           java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
 
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh-dtests-py3-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
+          '
+        name: Log Environment Information
     - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+        command: 'git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          ~/cassandra
+
+          '
+        name: Clone Cassandra Repository (via git)
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\n# Loop to prevent\
+          \ failure due to maven-ant-tasks not downloading a jar..\nfor x in $(seq\
+          \ 1 3); do\n    ${ANT_HOME}/bin/ant clean realclean jar\n    RETURN=\"$?\"\
+          \n    if [ \"${RETURN}\" -eq \"0\" ]; then\n        break\n    fi\ndone\n\
+          # Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"0\" ];\
+          \ then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit ${RETURN}\n\
+          fi\n"
+        name: Build Cassandra
         no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
 
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
+          cd ~/cassandra
 
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
+          ant eclipse-warnings
 
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
+          '
+        name: Run eclipse-warnings
+    - persist_to_workspace:
+        paths:
+        - cassandra
+        - .m2
+        root: /home/cassandra
+    working_directory: ~/
   j11_cqlsh-dtests-py3-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -944,67 +170,330 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail\
+          \ && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh-dtests-py3-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh-dtests-py38-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail\
+          \ && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
   j11_cqlsh-dtests-py38-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -1041,81 +530,613 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j11_jvm_dtests_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlshlib_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          time mv ~/cassandra /tmp
+
+          cd /tmp/cassandra/pylib
+
+          ./cassandra-cqlsh-tests.sh ..
+
+          '
+        name: Run cqlshlib Unit Tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/pylib
+    working_directory: ~/
+  j11_dtests-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail\
+          \ && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_jvm_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 36
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
           # which we do via the `circleci` cli tool.
 
+
           rm -fr ~/cassandra-dtest/upgrade_tests
+
           echo "***java tests***"
 
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
 
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
           echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
         no_output_timeout: 15m
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist   -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\n"
         name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16' -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
         no_output_timeout: 15m
     - store_test_results:
         path: /tmp/cassandra/build/test/output/
     - store_artifacts:
-        path: /tmp/cassandra/build/test/output
         destination: junitxml
+        path: /tmp/cassandra/build/test/output
     - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
         destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_jvm_dtests_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -1152,870 +1173,2344 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j8_simulator_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 36
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
           # which we do via the `circleci` cli tool.
 
+
           rm -fr ~/cassandra-dtest/upgrade_tests
+
           echo "***java tests***"
 
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
 
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
           echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
         no_output_timeout: 15m
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
-        name: Run Simulator Tests
-        command: |
-          set -x
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'\
+          \ -Dtest.timeout=\"$test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_repeated_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTEST_NAME}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_DTEST_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTEST_NAME} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    stop_on_failure_arg=\"\"\
+          \n    if ${REPEATED_DTEST_STOP_ON_FAILURE}; then\n      stop_on_failure_arg=\"\
+          -x\"\n    fi\n\n    vnodes_args=\"\"\n    if ${REPEATED_DTEST_VNODES}; then\n\
+          \      vnodes_args=\"--use-vnodes --num-tokens=16\"\n    fi\n\n    upgrade_arg=\"\
+          \"\n    if false; then\n      upgrade_arg=\"--execute-upgrade-tests\"\n\
+          \    fi\n\n    # we need the \"set -o pipefail\" here so that the exit code\
+          \ that circleci will actually use is from pytest and not the exit code from\
+          \ tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt\n \
+          \ fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_repeated_utest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "if [ \"${REPEATED_UTEST_CLASS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated utest class name hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated utest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated\
+          \ utest count is lesser or equals than zero, exiting without running any\
+          \ test\"\nelse\n\n  # Calculate the number of test iterations to be run\
+          \ by the current parallel runner.\n  # Since we are running the same test\
+          \ multiple times there is no need to use `circleci tests split`.\n  count=$((${REPEATED_UTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS}\
+          \ ${REPEATED_UTEST_COUNT} times\"\n\n    set -x\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \    time mv ~/cassandra /tmp\n    cd /tmp/cassandra\n    if [ -d ~/dtest_jars\
+          \ ]; then\n      cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n    fi\n\n\
+          \    target=${REPEATED_UTEST_TARGET}\n    class_path=${REPEATED_UTEST_CLASS}\n\
+          \    class_name=\"${class_path##*.}\"\n\n    # Prepare the -Dtest.name argument.\n\
+          \    # It can be the fully qualified class name or the short class name,\
+          \ depending on the target.\n    if [[ $target == \"test\" || \\\n      \
+          \    $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" ]]; then\n\
+          \      name=\"-Dtest.name=$class_name\"\n    else\n      name=\"-Dtest.name=$class_path\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [ \"${REPEATED_UTEST_METHODS}\" == \"<nil>\" ]; then\n      methods=\"\
+          \"\n    else\n      methods=\"-Dtest.methods=${REPEATED_UTEST_METHODS}\"\
+          \n    fi\n\n    # Prepare the JVM dtests vnodes argument, which is optional\n\
+          \    vnodes_args=\"\"\n    if ${REPEATED_UTEST_VNODES}; then\n      vnodes_args=\"\
+          -Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'\"\n    fi\n\n    # Run\
+          \ the test target as many times as requested collecting the exit code,\n\
+          \    # stopping the iteration only if stop_on_failure is set.\n    exit_code=\"\
+          $?\"\n    for i in $(seq -w 1 $count); do\n\n      echo \"Running test iteration\
+          \ $i of $count\"\n\n      # run the test\n      status=\"passes\"\n    \
+          \  if !( set -o pipefail && ant $target $name $methods $vnodes_args -Dno-build-test=true\
+          \ | tee stdout.txt ); then\n        status=\"fails\"\n        exit_code=1\n\
+          \      fi\n\n      # move the stdout output file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\n\
+          \    (exit ${exit_code})\n  fi\nfi\n"
+        name: Run repeated JUnit test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utest/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  j11_unit_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 41
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist   -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_build:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          ~/cassandra
+
+          '
+        name: Clone Cassandra Repository (via git)
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\n# Loop to prevent\
+          \ failure due to maven-ant-tasks not downloading a jar..\nfor x in $(seq\
+          \ 1 3); do\n    ${ANT_HOME}/bin/ant clean realclean jar\n    RETURN=\"$?\"\
+          \n    if [ \"${RETURN}\" -eq \"0\" ]; then\n        break\n    fi\ndone\n\
+          # Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"0\" ];\
+          \ then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit ${RETURN}\n\
+          fi\n"
+        name: Build Cassandra
+        no_output_timeout: 15m
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          cd ~/cassandra
+
+          ant eclipse-warnings
+
+          '
+        name: Run eclipse-warnings
+    - persist_to_workspace:
+        paths:
+        - cassandra
+        - .m2
+        root: /home/cassandra
+    working_directory: ~/
+  j8_cqlsh-dtests-py3-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py3-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py38-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py38-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlshlib_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
           time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant test-simulator-dtest
+
+          cd /tmp/cassandra/pylib
+
+          ./cassandra-cqlsh-tests.sh ..
+
+          '
+        name: Run cqlshlib Unit Tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/pylib
+    working_directory: ~/
+  j8_dtest_jars_build:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\nmkdir ~/dtest_jars\n\
+          git remote add apache https://github.com/apache/cassandra.git\nfor branch\
+          \ in cassandra-2.2 cassandra-3.0 cassandra-3.11 cassandra-4.0 cassandra-4.1\
+          \ trunk; do\n  # check out the correct cassandra version:\n  git remote\
+          \ set-branches --add apache '$branch'\n  git fetch --depth 1 apache $branch\n\
+          \  git checkout $branch\n  git clean -fd\n  # Loop to prevent failure due\
+          \ to maven-ant-tasks not downloading a jar..\n  for x in $(seq 1 3); do\n\
+          \      ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar\n\
+          \      RETURN=\"$?\"\n      if [ \"${RETURN}\" -eq \"0\" ]; then\n     \
+          \     cp build/dtest*.jar ~/dtest_jars\n          break\n      fi\n  done\n\
+          \  # Exit, if we didn't build successfully\n  if [ \"${RETURN}\" -ne \"\
+          0\" ]; then\n      echo \"Build failed with exit code: ${RETURN}\"\n   \
+          \   exit ${RETURN}\n  fi\ndone\n# and build the dtest-jar for the branch\
+          \ under test\n${ANT_HOME}/bin/ant realclean\ngit checkout origin/$CIRCLE_BRANCH\n\
+          git clean -fd\nfor x in $(seq 1 3); do\n    ${ANT_HOME}/bin/ant realclean;\
+          \ ${ANT_HOME}/bin/ant jar dtest-jar\n    RETURN=\"$?\"\n    if [ \"${RETURN}\"\
+          \ -eq \"0\" ]; then\n        cp build/dtest*.jar ~/dtest_jars\n        break\n\
+          \    fi\ndone\n# Exit, if we didn't build successfully\nif [ \"${RETURN}\"\
+          \ -ne \"0\" ]; then\n    echo \"Build failed with exit code: ${RETURN}\"\
+          \n    exit ${RETURN}\nfi\nls -l ~/dtest_jars\n"
+        name: Build Cassandra DTest jars
+        no_output_timeout: 15m
+    - persist_to_workspace:
+        paths:
+        - dtest_jars
+        root: /home/cassandra
+    working_directory: ~/
+  j8_dtests-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail &&\
+          \ cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s\
+          \ --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd\
+          \ ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_jvm_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 36
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist   -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_jvm_dtests_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 36
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'\
+          \ -Dtest.timeout=\"$test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_jvm_upgrade_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 14
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist   -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_repeated_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTEST_NAME}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_DTEST_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTEST_NAME} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    stop_on_failure_arg=\"\"\
+          \n    if ${REPEATED_DTEST_STOP_ON_FAILURE}; then\n      stop_on_failure_arg=\"\
+          -x\"\n    fi\n\n    vnodes_args=\"\"\n    if ${REPEATED_DTEST_VNODES}; then\n\
+          \      vnodes_args=\"--use-vnodes --num-tokens=16\"\n    fi\n\n    upgrade_arg=\"\
+          \"\n    if false; then\n      upgrade_arg=\"--execute-upgrade-tests\"\n\
+          \    fi\n\n    # we need the \"set -o pipefail\" here so that the exit code\
+          \ that circleci will actually use is from pytest and not the exit code from\
+          \ tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt\n \
+          \ fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_repeated_utest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "if [ \"${REPEATED_UTEST_CLASS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated utest class name hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated utest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UTEST_COUNT}\" -le 0 ]; then\n  echo \"Repeated\
+          \ utest count is lesser or equals than zero, exiting without running any\
+          \ test\"\nelse\n\n  # Calculate the number of test iterations to be run\
+          \ by the current parallel runner.\n  # Since we are running the same test\
+          \ multiple times there is no need to use `circleci tests split`.\n  count=$((${REPEATED_UTEST_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS}\
+          \ ${REPEATED_UTEST_COUNT} times\"\n\n    set -x\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \    time mv ~/cassandra /tmp\n    cd /tmp/cassandra\n    if [ -d ~/dtest_jars\
+          \ ]; then\n      cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n    fi\n\n\
+          \    target=${REPEATED_UTEST_TARGET}\n    class_path=${REPEATED_UTEST_CLASS}\n\
+          \    class_name=\"${class_path##*.}\"\n\n    # Prepare the -Dtest.name argument.\n\
+          \    # It can be the fully qualified class name or the short class name,\
+          \ depending on the target.\n    if [[ $target == \"test\" || \\\n      \
+          \    $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" ]]; then\n\
+          \      name=\"-Dtest.name=$class_name\"\n    else\n      name=\"-Dtest.name=$class_path\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [ \"${REPEATED_UTEST_METHODS}\" == \"<nil>\" ]; then\n      methods=\"\
+          \"\n    else\n      methods=\"-Dtest.methods=${REPEATED_UTEST_METHODS}\"\
+          \n    fi\n\n    # Prepare the JVM dtests vnodes argument, which is optional\n\
+          \    vnodes_args=\"\"\n    if ${REPEATED_UTEST_VNODES}; then\n      vnodes_args=\"\
+          -Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'\"\n    fi\n\n    # Run\
+          \ the test target as many times as requested collecting the exit code,\n\
+          \    # stopping the iteration only if stop_on_failure is set.\n    exit_code=\"\
+          $?\"\n    for i in $(seq -w 1 $count); do\n\n      echo \"Running test iteration\
+          \ $i of $count\"\n\n      # run the test\n      status=\"passes\"\n    \
+          \  if !( set -o pipefail && ant $target $name $methods $vnodes_args -Dno-build-test=true\
+          \ | tee stdout.txt ); then\n        status=\"fails\"\n        exit_code=1\n\
+          \      fi\n\n      # move the stdout output file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\n\
+          \    (exit ${exit_code})\n  fi\nfi\n"
+        name: Run repeated JUnit test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utest/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  j8_simulator_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\nant test-simulator-dtest\n"
+        name: Run Simulator Tests
         no_output_timeout: 30m
     - store_test_results:
         path: /tmp/cassandra/build/test/output/
     - store_artifacts:
-        path: /tmp/cassandra/build/test/output
         destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py3-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_repeated_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTEST_NAME}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTEST_NAME} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              stop_on_failure_arg=""
-              if ${REPEATED_DTEST_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if ${REPEATED_DTEST_VNODES}; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_repeated_dtest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTEST_NAME}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTEST_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTEST_NAME} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              stop_on_failure_arg=""
-              if ${REPEATED_DTEST_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if ${REPEATED_DTEST_VNODES}; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_DTEST_NAME} | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_upgradetests-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_upgradetests_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection all --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_upgradetests_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection all --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_upgradetests_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_upgradetests_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_stress:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (stress-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant stress-test
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
         path: /tmp/cassandra/build/test/output
-        destination: junitxml
     - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
         destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
   j8_unit_tests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2051,81 +3546,113 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
     - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_jvm_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 41
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
           # which we do via the `circleci` cli tool.
 
+
           rm -fr ~/cassandra-dtest/upgrade_tests
+
           echo "***java tests***"
 
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
 
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
           echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
         no_output_timeout: 15m
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist   -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\n"
         name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
         no_output_timeout: 15m
     - store_test_results:
         path: /tmp/cassandra/build/test/output/
     - store_artifacts:
-        path: /tmp/cassandra/build/test/output
         destination: junitxml
+        path: /tmp/cassandra/build/test/output
     - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
         destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_upgradetests-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2159,129 +3686,93 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 100
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra Repository (via git)
-        command: |
-          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
-    - run:
-        name: Build Cassandra
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant clean realclean jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-        no_output_timeout: 15m
-    - run:
-        name: Run eclipse-warnings
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          ant eclipse-warnings
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - cassandra
-        - .m2
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlshlib_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Run cqlshlib Unit Tests
-        command: |
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra/pylib
-          ./cassandra-cqlsh-tests.sh ..
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_upgradetests_without_vnodes)***\"\nset -eo\
+          \ pipefail && ./run_dtests.py --execute-upgrade-tests-only --upgrade-target-version-only\
+          \ --upgrade-version-selection all --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\nelse\n  grep -e ''\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\
+          \ || { echo \"Filter did not match any tests! Exiting build.\"; exit 0;\
+          \ }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt\n\
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\\n'\
+          \ ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\n\
+          source ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n\
+          \ '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir\
+          \ -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p\
+          \ /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`\n\
+          set -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests-only\
+          \ --upgrade-target-version-only --upgrade-version-selection all --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\n"
+        name: Run dtests (j8_upgradetests_without_vnodes)
         no_output_timeout: 15m
     - store_test_results:
-        path: /tmp/cassandra/pylib
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_upgradetests_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_upgradetests_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  repeated_jvm_upgrade_dtest:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2315,234 +3806,121 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
     - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_repeated_utest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: "if [ \"${REPEATED_JVM_UPGRADE_DTEST_CLASS}\" == \"<nil>\" ]; then\n\
+          \  echo \"Repeated utest class name hasn't been defined, exiting without\
+          \ running any test\"\nelif [ \"${REPEATED_JVM_UPGRADE_DTEST_COUNT}\" ==\
+          \ \"<nil>\" ]; then\n  echo \"Repeated utest count hasn't been defined,\
+          \ exiting without running any test\"\nelif [ \"${REPEATED_JVM_UPGRADE_DTEST_COUNT}\"\
+          \ -le 0 ]; then\n  echo \"Repeated utest count is lesser or equals than\
+          \ zero, exiting without running any test\"\nelse\n\n  # Calculate the number\
+          \ of test iterations to be run by the current parallel runner.\n  # Since\
+          \ we are running the same test multiple times there is no need to use `circleci\
+          \ tests split`.\n  count=$((${REPEATED_JVM_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))\n\
+          \  if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL)));\
+          \ then\n    count=$((count+1))\n  fi\n\n  if (($count <= 0)); then\n   \
+          \ echo \"No tests to run in this runner\"\n  else\n    echo \"Running test-jvm-dtest-some\
+          \ ${REPEATED_JVM_UPGRADE_DTEST_CLASS} ${REPEATED_JVM_UPGRADE_DTEST_METHODS}\
+          \ ${REPEATED_JVM_UPGRADE_DTEST_COUNT} times\"\n\n    set -x\n    export\
+          \ PATH=$JAVA_HOME/bin:$PATH\n    time mv ~/cassandra /tmp\n    cd /tmp/cassandra\n\
+          \    if [ -d ~/dtest_jars ]; then\n      cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          \    fi\n\n    target=test-jvm-dtest-some\n    class_path=${REPEATED_JVM_UPGRADE_DTEST_CLASS}\n\
+          \    class_name=\"${class_path##*.}\"\n\n    # Prepare the -Dtest.name argument.\n\
+          \    # It can be the fully qualified class name or the short class name,\
+          \ depending on the target.\n    if [[ $target == \"test\" || \\\n      \
+          \    $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" ]]; then\n\
+          \      name=\"-Dtest.name=$class_name\"\n    else\n      name=\"-Dtest.name=$class_path\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [ \"${REPEATED_JVM_UPGRADE_DTEST_METHODS}\" == \"<nil>\" ]; then\n\
+          \      methods=\"\"\n    else\n      methods=\"-Dtest.methods=${REPEATED_JVM_UPGRADE_DTEST_METHODS}\"\
+          \n    fi\n\n    # Prepare the JVM dtests vnodes argument, which is optional\n\
+          \    vnodes_args=\"\"\n    if false; then\n      vnodes_args=\"-Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'\"\
+          \n    fi\n\n    # Run the test target as many times as requested collecting\
+          \ the exit code,\n    # stopping the iteration only if stop_on_failure is\
+          \ set.\n    exit_code=\"$?\"\n    for i in $(seq -w 1 $count); do\n\n  \
+          \    echo \"Running test iteration $i of $count\"\n\n      # run the test\n\
+          \      status=\"passes\"\n      if !( set -o pipefail && ant $target $name\
+          \ $methods $vnodes_args -Dno-build-test=true | tee stdout.txt ); then\n\
+          \        status=\"fails\"\n        exit_code=1\n      fi\n\n      # move\
+          \ the stdout output file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/test-jvm-dtest-some-${REPEATED_JVM_UPGRADE_DTEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE}\
+          \ = true ]] && (( $exit_code > 0 )); then\n        break\n      fi\n   \
+          \ done\n\n    (exit ${exit_code})\n  fi\nfi\n"
         name: Run repeated JUnit test
         no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UTEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS} ${REPEATED_UTEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=${REPEATED_UTEST_TARGET}
-              class_path=${REPEATED_UTEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_UTEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_UTEST_METHODS}"
-              fi
-
-              # Prepare the JVM dtests vnodes argument, which is optional
-              vnodes_args=""
-              if ${REPEATED_UTEST_VNODES}; then
-                vnodes_args="-Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods $vnodes_args -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
     - store_test_results:
         path: /tmp/results/repeated_utest/output
     - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
         destination: stdout
+        path: /tmp/results/repeated_utest/stdout
     - store_artifacts:
+        destination: junitxml
         path: /tmp/results/repeated_utest/output
-        destination: junitxml
     - store_artifacts:
+        destination: logs
         path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests-with-vnodes:
+    working_directory: ~/
+  repeated_upgrade_dtest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -2578,972 +3956,228 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
     - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh-dtests-py38-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
         name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
 
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
 
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
 
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_jvm_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra Repository (via git)
-        command: |
-          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
-    - run:
-        name: Build Cassandra
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant clean realclean jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-        no_output_timeout: 15m
-    - run:
-        name: Run eclipse-warnings
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          ant eclipse-warnings
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - cassandra
-        - .m2
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py3-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
 
           source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
 
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py38-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
           export PATH=$JAVA_HOME/bin:$PATH
+
           pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
           pip3 uninstall -y cqlsh
+
           pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
 
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_long:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (long-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant long-test
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_system_keyspace_directory:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-system-keyspace-directory)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-system-keyspace-directory   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlshlib_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run cqlshlib Unit Tests
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra/pylib
-          ./cassandra-cqlsh-tests.sh ..
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/pylib
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  utests_fqltool:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (fqltool-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant fqltool-test
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
+          '
         name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
     - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
+        command: "if [ \"${REPEATED_UPGRADE_DTEST_NAME}\" == \"<nil>\" ]; then\n \
+          \ echo \"Repeated dtest name hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_UPGRADE_DTEST_COUNT}\" == \"<nil>\" ];\
+          \ then\n  echo \"Repeated dtest count hasn't been defined, exiting without\
+          \ running any test\"\nelif [ \"${REPEATED_UPGRADE_DTEST_COUNT}\" -le 0 ];\
+          \ then\n  echo \"Repeated dtest count is lesser or equals than zero, exiting\
+          \ without running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_UPGRADE_DTEST_COUNT} / CIRCLE_NODE_TOTAL))\n  if\
+          \ (($CIRCLE_NODE_INDEX < (${REPEATED_UPGRADE_DTEST_COUNT} % CIRCLE_NODE_TOTAL)));\
+          \ then\n    count=$((count+1))\n  fi\n\n  if (($count <= 0)); then\n   \
+          \ echo \"No tests to run in this runner\"\n  else\n    echo \"Running ${REPEATED_UPGRADE_DTEST_NAME}\
+          \ $count times\"\n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    stop_on_failure_arg=\"\"\n    if ${REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if true; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests\"\n    fi\n\n    # we need the \"set -o pipefail\"\
+          \ here so that the exit code that circleci will actually use is from pytest\
+          \ and not the exit code from tee\n    set -o pipefail && cd ~/cassandra-dtest\
+          \ && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir ${REPEATED_UPGRADE_DTEST_NAME}\
+          \ | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
         no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nset -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\n"
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
+        destination: dtest
         path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
     - store_artifacts:
+        destination: dtest_logs
         path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
+    working_directory: ~/
   utests_compression:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
           # which we do via the `circleci` cli tool.
 
+
           rm -fr ~/cassandra-dtest/upgrade_tests
+
           echo "***java tests***"
 
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
 
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
           echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
           cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
         no_output_timeout: 15m
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-compression   -Dtest.timeout=\"\
+          $test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit\n"
         name: Run Unit Tests (testclasslist-compression)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-compression   -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit
         no_output_timeout: 15m
     - store_test_results:
         path: /tmp/cassandra/build/test/output/
     - store_artifacts:
+        destination: junitxml
         path: /tmp/cassandra/build/test/output
-        destination: junitxml
     - store_artifacts:
+        destination: logs
         path: /tmp/cassandra/build/test/logs
-        destination: logs
+    working_directory: ~/
+  utests_fqltool:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -3579,249 +4213,30 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
     - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_repeated_utest:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run repeated JUnit test
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UTEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UTEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UTEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UTEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UTEST_TARGET} ${REPEATED_UTEST_CLASS} ${REPEATED_UTEST_METHODS} ${REPEATED_UTEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=${REPEATED_UTEST_TARGET}
-              class_path=${REPEATED_UTEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_UTEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_UTEST_METHODS}"
-              fi
-
-              # Prepare the JVM dtests vnodes argument, which is optional
-              vnodes_args=""
-              if ${REPEATED_UTEST_VNODES}; then
-                vnodes_args="-Dtest.jvm.args='-Dcassandra.dtest.num_tokens=16'"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods $vnodes_args -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${REPEATED_UTEST_TARGET}-${REPEATED_UTEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_UTEST_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results/repeated_utest/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_UTEST_TARGET: testsome
-    - REPEATED_UTEST_CLASS: null
-    - REPEATED_UTEST_METHODS: null
-    - REPEATED_UTEST_VNODES: false
-    - REPEATED_UTEST_COUNT: 100
-    - REPEATED_UTEST_STOP_ON_FAILURE: false
-    - REPEATED_DTEST_NAME: null
-    - REPEATED_DTEST_VNODES: false
-    - REPEATED_DTEST_COUNT: 100
-    - REPEATED_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_UPGRADE_DTEST_NAME: null
-    - REPEATED_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
-    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
-    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
-    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtest_jars_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
     parallelism: 1
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Build Cassandra DTest jars
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          mkdir ~/dtest_jars
-          git remote add apache https://github.com/apache/cassandra.git
-          for branch in cassandra-2.2 cassandra-3.0 cassandra-3.11 cassandra-4.0 cassandra-4.1 trunk; do
-            # check out the correct cassandra version:
-            git remote set-branches --add apache '$branch'
-            git fetch --depth 1 apache $branch
-            git checkout $branch
-            git clean -fd
-            # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-            for x in $(seq 1 3); do
-                ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar
-                RETURN="$?"
-                if [ "${RETURN}" -eq "0" ]; then
-                    cp build/dtest*.jar ~/dtest_jars
-                    break
-                fi
-            done
-            # Exit, if we didn't build successfully
-            if [ "${RETURN}" -ne "0" ]; then
-                echo "Build failed with exit code: ${RETURN}"
-                exit ${RETURN}
-            fi
-          done
-          # and build the dtest-jar for the branch under test
-          ${ANT_HOME}/bin/ant realclean
-          git checkout origin/$CIRCLE_BRANCH
-          git clean -fd
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  cp build/dtest*.jar ~/dtest_jars
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-          ls -l ~/dtest_jars
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant fqltool-test\n"
+        name: Run Unit Tests (fqltool-test)
         no_output_timeout: 15m
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - dtest_jars
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_long:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -3857,450 +4272,322 @@ jobs:
     - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
     - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant long-test\n"
+        name: Run Unit Tests (long-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_stress:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant stress-test\n"
+        name: Run Unit Tests (stress-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  utests_system_keyspace_directory:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_UTEST_TARGET: testsome
+    - REPEATED_UTEST_CLASS: null
+    - REPEATED_UTEST_METHODS: null
+    - REPEATED_UTEST_VNODES: false
+    - REPEATED_UTEST_COUNT: 100
+    - REPEATED_UTEST_STOP_ON_FAILURE: false
+    - REPEATED_DTEST_NAME: null
+    - REPEATED_DTEST_VNODES: false
+    - REPEATED_DTEST_COUNT: 100
+    - REPEATED_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_UPGRADE_DTEST_NAME: null
+    - REPEATED_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - REPEATED_JVM_UPGRADE_DTEST_CLASS: null
+    - REPEATED_JVM_UPGRADE_DTEST_METHODS: null
+    - REPEATED_JVM_UPGRADE_DTEST_COUNT: 100
+    - REPEATED_JVM_UPGRADE_DTEST_STOP_ON_FAILURE: false
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-system-keyspace-directory\
+          \   -Dtest.timeout=\"$test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit\n"
+        name: Run Unit Tests (testclasslist-system-keyspace-directory)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+version: 2
 workflows:
+  java11_tests:
+    jobs:
+    - j11_build: {}
+    - j11_unit_tests:
+        requires:
+        - j11_build
+    - j11_jvm_dtests:
+        requires:
+        - j11_build
+    - j11_jvm_dtests_vnode:
+        requires:
+        - j11_build
+    - j11_cqlshlib_tests:
+        requires:
+        - j11_build
+    - j11_dtests-with-vnodes:
+        requires:
+        - j11_build
+    - j11_dtests-no-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py3-with-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py38-with-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py3-no-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py38-no-vnodes:
+        requires:
+        - j11_build
+  java8_tests:
+    jobs:
+    - j8_build: {}
+    - j8_unit_tests:
+        requires:
+        - j8_build
+    - j8_jvm_dtests:
+        requires:
+        - j8_build
+    - j8_simulator_dtests:
+        requires:
+        - j8_build
+    - j8_jvm_dtests_vnode:
+        requires:
+        - j8_build
+    - j8_cqlshlib_tests:
+        requires:
+        - j8_build
+    - utests_long:
+        requires:
+        - j8_build
+    - utests_compression:
+        requires:
+        - j8_build
+    - utests_stress:
+        requires:
+        - j8_build
+    - utests_fqltool:
+        requires:
+        - j8_build
+    - utests_system_keyspace_directory:
+        requires:
+        - j8_build
+    - j8_dtest_jars_build:
+        requires:
+        - j8_build
+    - j8_jvm_upgrade_dtests:
+        requires:
+        - j8_dtest_jars_build
+    - j8_dtests-with-vnodes:
+        requires:
+        - j8_build
+    - j8_dtests-no-vnodes:
+        requires:
+        - j8_build
+    - j8_upgradetests-no-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py3-with-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py38-with-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py3-no-vnodes:
+        requires:
+        - j8_build
+    - j8_cqlsh-dtests-py38-no-vnodes:
+        requires:
+        - j8_build
   version: 2
-  java8_separate_tests:
-    jobs:
-    - start_j8_build:
-        type: approval
-    - j8_build:
-        requires:
-        - start_j8_build
-    - start_j8_unit_tests:
-        type: approval
-    - j8_unit_tests:
-        requires:
-        - start_j8_unit_tests
-        - j8_build
-    - start_j8_jvm_dtests:
-        type: approval
-    - j8_jvm_dtests:
-        requires:
-        - start_j8_jvm_dtests
-        - j8_build
-    - j8_simulator_dtests:
-        requires:
-        - start_j8_jvm_dtests
-        - j8_build
-    - j8_jvm_dtests_vnode:
-        requires:
-        - start_j8_jvm_dtests
-        - j8_build
-    - start_j8_cqlshlib_tests:
-        type: approval
-    - j8_cqlshlib_tests:
-        requires:
-        - start_j8_cqlshlib_tests
-        - j8_build
-    - start_j11_unit_tests:
-        type: approval
-    - j11_unit_tests:
-        requires:
-        - start_j11_unit_tests
-        - j8_build
-    - start_utests_long:
-        type: approval
-    - utests_long:
-        requires:
-        - start_utests_long
-        - j8_build
-    - start_utests_compression:
-        type: approval
-    - utests_compression:
-        requires:
-        - start_utests_compression
-        - j8_build
-    - start_utests_stress:
-        type: approval
-    - utests_stress:
-        requires:
-        - start_utests_stress
-        - j8_build
-    - start_utests_fqltool:
-        type: approval
-    - utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j8_build
-    - start_utests_system_keyspace_directory:
-        type: approval
-    - utests_system_keyspace_directory:
-        requires:
-        - start_utests_system_keyspace_directory
-        - j8_build
-    - start_j8_dtest_jars_build:
-        type: approval
-    - j8_dtest_jars_build:
-        requires:
-        - j8_build
-        - start_j8_dtest_jars_build
-    - start_jvm_upgrade_dtest:
-        type: approval
-    - j8_jvm_upgrade_dtests:
-        requires:
-        - start_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-    - start_j8_dtests:
-        type: approval
-    - j8_dtests-with-vnodes:
-        requires:
-        - start_j8_dtests
-        - j8_build
-    - j8_dtests-no-vnodes:
-        requires:
-        - start_j8_dtests
-        - j8_build
-    - start_j11_dtests:
-        type: approval
-    - j11_dtests-with-vnodes:
-        requires:
-        - start_j11_dtests
-        - j8_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - start_j11_dtests
-        - j8_build
-    - start_upgrade_tests:
-        type: approval
-    - j8_upgradetests-no-vnodes:
-        requires:
-        - start_upgrade_tests
-        - j8_build
-    - start_j8_cqlsh_tests:
-        type: approval
-    - j8_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - j8_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - j8_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - j8_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - start_j8_cqlsh_tests
-        - j8_build
-    - start_j11_cqlsh_tests:
-        type: approval
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - start_j8_repeated_utest:
-        type: approval
-    - j8_repeated_utest:
-        requires:
-        - start_j8_repeated_utest
-        - j8_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j8_build
-    - start_j8_repeated_dtest:
-        type: approval
-    - j8_repeated_dtest:
-        requires:
-        - start_j8_repeated_dtest
-        - j8_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j8_build
-    - start_repeated_upgrade_dtest:
-        type: approval
-    - repeated_upgrade_dtest:
-        requires:
-        - start_repeated_upgrade_dtest
-        - j8_build
-    - start_repeated_jvm_upgrade_dtest:
-        type: approval
-    - repeated_jvm_upgrade_dtest:
-        requires:
-        - start_repeated_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-  java8_pre-commit_tests:
-    jobs:
-    - start_pre-commit_tests:
-        type: approval
-    - j8_build:
-        requires:
-        - start_pre-commit_tests
-    - j8_unit_tests:
-        requires:
-        - j8_build
-    - j8_simulator_dtests:
-        requires:
-        - j8_build
-    - j8_jvm_dtests:
-        requires:
-        - j8_build
-    - j8_jvm_dtests_vnode:
-        requires:
-        - j8_build
-    - j8_cqlshlib_tests:
-        requires:
-        - j8_build
-    - j11_unit_tests:
-        requires:
-        - j8_build
-    - start_utests_long:
-        type: approval
-    - utests_long:
-        requires:
-        - start_utests_long
-        - j8_build
-    - start_utests_compression:
-        type: approval
-    - utests_compression:
-        requires:
-        - start_utests_compression
-        - j8_build
-    - start_utests_stress:
-        type: approval
-    - utests_stress:
-        requires:
-        - start_utests_stress
-        - j8_build
-    - start_utests_fqltool:
-        type: approval
-    - utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j8_build
-    - utests_system_keyspace_directory:
-        requires:
-        - j8_build
-    - start_j8_dtest_jars_build:
-        type: approval
-    - j8_dtest_jars_build:
-        requires:
-        - j8_build
-        - start_j8_dtest_jars_build
-    - start_jvm_upgrade_dtest:
-        type: approval
-    - j8_jvm_upgrade_dtests:
-        requires:
-        - start_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-    - j8_dtests-with-vnodes:
-        requires:
-        - j8_build
-    - j8_dtests-no-vnodes:
-        requires:
-        - j8_build
-    - j11_dtests-with-vnodes:
-        requires:
-        - j8_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - j8_build
-    - start_upgrade_tests:
-        type: approval
-    - j8_upgradetests-no-vnodes:
-        requires:
-        - j8_build
-        - start_upgrade_tests
-    - j8_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - j8_build
-    - start_j8_repeated_utest:
-        type: approval
-    - j8_repeated_utest:
-        requires:
-        - start_j8_repeated_utest
-        - j8_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j8_build
-    - start_j8_repeated_dtest:
-        type: approval
-    - j8_repeated_dtest:
-        requires:
-        - start_j8_repeated_dtest
-        - j8_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j8_build
-    - start_repeated_upgrade_dtest:
-        type: approval
-    - repeated_upgrade_dtest:
-        requires:
-        - start_repeated_upgrade_dtest
-        - j8_build
-    - start_repeated_jvm_upgrade_dtest:
-        type: approval
-    - repeated_jvm_upgrade_dtest:
-        requires:
-        - start_repeated_jvm_upgrade_dtest
-        - j8_dtest_jars_build
-  java11_separate_tests:
-    jobs:
-    - start_j11_build:
-        type: approval
-    - j11_build:
-        requires:
-        - start_j11_build
-    - start_j11_unit_tests:
-        type: approval
-    - j11_unit_tests:
-        requires:
-        - start_j11_unit_tests
-        - j11_build
-    - start_j11_jvm_dtests:
-        type: approval
-    - j11_jvm_dtests:
-        requires:
-        - start_j11_jvm_dtests
-        - j11_build
-    - j11_jvm_dtests_vnode:
-        requires:
-        - start_j11_jvm_dtests
-        - j11_build
-    - start_j11_cqlshlib_tests:
-        type: approval
-    - j11_cqlshlib_tests:
-        requires:
-        - start_j11_cqlshlib_tests
-        - j11_build
-    - start_j11_dtests:
-        type: approval
-    - j11_dtests-with-vnodes:
-        requires:
-        - start_j11_dtests
-        - j11_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - start_j11_dtests
-        - j11_build
-    - start_j11_cqlsh_tests:
-        type: approval
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j11_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j11_build
-  java11_pre-commit_tests:
-    jobs:
-    - start_pre-commit_tests:
-        type: approval
-    - j11_build:
-        requires:
-        - start_pre-commit_tests
-    - j11_unit_tests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests_vnode:
-        requires:
-        - j11_build
-    - j11_cqlshlib_tests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests:
-        requires:
-        - j11_build
-    - j11_cqlshlib_tests:
-        requires:
-        - j11_build
-    - j11_dtests-with-vnodes:
-        requires:
-        - j11_build
-    - j11_dtests-no-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py3-with-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py38-with-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py3-no-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py38-no-vnodes:
-        requires:
-        - j11_build
-    - start_j11_repeated_utest:
-        type: approval
-    - j11_repeated_utest:
-        requires:
-        - start_j11_repeated_utest
-        - j11_build
-    - start_j11_repeated_dtest:
-        type: approval
-    - j11_repeated_dtest:
-        requires:
-        - start_j11_repeated_dtest
-        - j11_build

--- a/doc/modules/cassandra/pages/operating/bulk_loading.adoc
+++ b/doc/modules/cassandra/pages/operating/bulk_loading.adoc
@@ -80,13 +80,23 @@ The following options are supported, with `-d,--nodes <initial hosts>` required:
 -d,--nodes <initial hosts>                                   Required.
                                                              Try to connect to these hosts (comma separated) initially for ring information
 
+-emib,--entire-sstable-throttle-mib <throttle-mib>           Entire SSTable throttle
+                                                             speed in MiB/s (default 0 for unlimited).
+
+-eidctmib,--entire-sstable-inter-dc-throttle-mib <inter-dc-throttle-mib>
+                                                             Entire SSTable inter-datacenter throttle
+                                                             speed in MiB/s (default 0 for unlimited).
+
 -f,--conf-path <path to config file>                         cassandra.yaml file path for streaming throughput and client/server SSL.
 
 -h,--help                                                    Display this help message
 
 -i,--ignore <NODES>                                          Don't stream to this (comma separated) list of nodes
 
--idct,--inter-dc-throttle <inter-dc-throttle>                Inter-datacenter throttle speed in Mbits (default unlimited)
+-idct,--inter-dc-throttle <inter-dc-throttle>                (deprecated) Inter-datacenter throttle speed in Mbits (default 0 for unlimited)
+                                                             Use -idctmib / --inter-dc-throttle-mib instead
+
+-idctmib,--inter-dc-throttle-mib <inter-dc-throttle-mib>     Inter-datacenter throttle speed in MiB/s (default 0 for unlimited)
 
 -k,--target-keyspace <target keyspace name>                  Target
                                                              keyspace name
@@ -111,8 +121,10 @@ The following options are supported, with `-d,--nodes <initial hosts>` required:
                                                              for TLS internode communication (default 7001)
 -st,--store-type <STORE-TYPE>                                Client SSL:
                                                              type of store
--t,--throttle <throttle>                                     Throttle
-                                                             speed in Mbits (default unlimited)
+-t,--throttle <throttle>                                     (deprecated) Throttle speed in Mbits (default 0 for unlimited)
+                                                             Use -tmib / --throttle-mib instead
+-tmib,--throttle-mib <throttle-mib>                          Throttle
+                                                             speed in MiB/s (default 0 for unlimited)
 -ts,--truststore <TRUSTSTORE>                                Client SSL:
                                                              full path to truststore
 -tspw,--truststore-password <TRUSTSTORE-PASSWORD>            Client SSL:

--- a/doc/modules/cassandra/pages/tools/sstable/sstableloader.adoc
+++ b/doc/modules/cassandra/pages/tools/sstable/sstableloader.adoc
@@ -45,10 +45,23 @@ internode communication (default 7001)
 
 |--no-progress |don't display progress
 
-|-t, --throttle <throttle> |throttle speed in Mbits (default unlimited)
+|-t, --throttle <throttle> |(deprecated) throttle speed in Mbits
+(default 0 for unlimited) Use -tmib / --throttle-mib instead
 
-|-idct, --inter-dc-throttle <inter-dc-throttle> |inter-datacenter
-throttle speed in Mbits (default unlimited)
+|-tmib, --throttle-mib <throttle-mib> |throttle speed in MiB/s
+(default 0 for unlimited)
+
+|-idct, --inter-dc-throttle <inter-dc-throttle> |(deprecated) inter-datacenter
+throttle speed in Mbits (default 0 for unlimited) Use -idctmib / --inter-dc-throttle-mib instead
+
+|-idctmib, --inter-dc-throttle-mib <inter-dc-throttle-mib> |inter-datacenter
+throttle speed in MiB/s (default 0 for unlimited)
+
+|-emib, --entire-sstable-throttle-mib <throttle-mib> |entire SSTable throttle
+speed in MiB/s (default 0 for unlimited)
+
+|-eidctmib, --entire-sstable-inter-dc-throttle-mib <inter-dc-throttle-mib> |entire
+SSTable inter-datacenter throttle speed in MiB/s (default 0 for unlimited)
 
 |-cph, --connections-per-host <connectionsPerHost> |number of concurrent
 connections-per-host

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2104,6 +2104,11 @@ public class DatabaseDescriptor
         conf.stream_throughput_outbound = new DataRateSpec.LongBytesPerSecondBound(value, MEBIBYTES_PER_SECOND);
     }
 
+    public static void setStreamThroughputOutboundBytesPerSec(long value)
+    {
+        conf.stream_throughput_outbound = new DataRateSpec.LongBytesPerSecondBound(value, BYTES_PER_SECOND);
+    }
+
     public static void setStreamThroughputOutboundMegabitsPerSec(int value)
     {
         conf.stream_throughput_outbound = DataRateSpec.LongBytesPerSecondBound.megabitsPerSecondInBytesPerSecond(value);
@@ -2162,6 +2167,11 @@ public class DatabaseDescriptor
                                                Integer.MAX_VALUE + " in megabits/s");
 
         conf.inter_dc_stream_throughput_outbound = new DataRateSpec.LongBytesPerSecondBound(value, MEBIBYTES_PER_SECOND);
+    }
+
+    public static void setInterDCStreamThroughputOutboundBytesPerSec(long value)
+    {
+        conf.inter_dc_stream_throughput_outbound = new DataRateSpec.LongBytesPerSecondBound(value, BYTES_PER_SECOND);
     }
 
     public static void setInterDCStreamThroughputOutboundMegabitsPerSec(int value)

--- a/src/java/org/apache/cassandra/tools/LoaderOptions.java
+++ b/src/java/org/apache/cassandra/tools/LoaderOptions.java
@@ -22,25 +22,37 @@ package org.apache.cassandra.tools;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.net.*;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.config.*;
+import com.datastax.driver.core.AuthProvider;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DataRateSpec;
+import org.apache.cassandra.config.EncryptionOptions;
+import org.apache.cassandra.config.YamlConfigurationLoader;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.tools.BulkLoader.CmdLineOptions;
 
-import com.datastax.driver.core.AuthProvider;
-import com.datastax.driver.core.PlainTextAuthProvider;
-import org.apache.commons.cli.*;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.cassandra.config.DataRateSpec.DataRateUnit.MEBIBYTES_PER_SECOND;
 
 public class LoaderOptions
 {
@@ -60,10 +72,25 @@ public class LoaderOptions
     public static final String IGNORE_NODES_OPTION = "ignore";
     public static final String CONNECTIONS_PER_HOST = "connections-per-host";
     public static final String CONFIG_PATH = "conf-path";
+
+    /**
+     * Throttle defined in megabits per second. CASSANDRA-10637 introduced a builder and is the preferred way to
+     * provide options instead of using these constant fields.
+     * @deprecated Use {@code throttle-mib} instead
+     */
+    @Deprecated
     public static final String THROTTLE_MBITS = "throttle";
+    public static final String THROTTLE_MEBIBYTES = "throttle-mib";
+    /**
+     * Inter-datacenter throttle defined in megabits per second. CASSANDRA-10637 introduced a builder and is the
+     * preferred way to provide options instead of using these constant fields.
+     * @deprecated Use {@code inter-dc-throttle-mib} instead
+     */
+    @Deprecated
     public static final String INTER_DC_THROTTLE_MBITS = "inter-dc-throttle";
-    public static final String ENTIRE_SSTABLE_THROTTLE_MBITS = "entire-sstable-throttle";
-    public static final String ENTIRE_SSTABLE_INTER_DC_THROTTLE_MBITS = "entire-sstable-inter-dc-throttle";
+    public static final String INTER_DC_THROTTLE_MEBIBYTES = "inter-dc-throttle-mib";
+    public static final String ENTIRE_SSTABLE_THROTTLE_MEBIBYTES = "entire-sstable-throttle-mib";
+    public static final String ENTIRE_SSTABLE_INTER_DC_THROTTLE_MEBIBYTES = "entire-sstable-inter-dc-throttle-mib";
     public static final String TOOL_NAME = "sstableloader";
     public static final String TARGET_KEYSPACE = "target-keyspace";
     public static final String TARGET_TABLE = "target-table";
@@ -86,10 +113,10 @@ public class LoaderOptions
     public final String user;
     public final String passwd;
     public final AuthProvider authProvider;
-    public final int throttle;
-    public final int interDcThrottle;
-    public final int entireSSTableThrottle;
-    public final int entireSSTableInterDcThrottle;
+    public final long throttleBytes;
+    public final long interDcThrottleBytes;
+    public final int entireSSTableThrottleMebibytes;
+    public final int entireSSTableInterDcThrottleMebibytes;
     public final int storagePort;
     public final int sslStoragePort;
     public final EncryptionOptions clientEncOptions;
@@ -110,10 +137,10 @@ public class LoaderOptions
         user = builder.user;
         passwd = builder.passwd;
         authProvider = builder.authProvider;
-        throttle = builder.throttle;
-        interDcThrottle = builder.interDcThrottle;
-        entireSSTableThrottle = builder.entireSSTableThrottle;
-        entireSSTableInterDcThrottle = builder.entireSSTableInterDcThrottle;
+        throttleBytes = builder.throttleBytes;
+        interDcThrottleBytes = builder.interDcThrottleBytes;
+        entireSSTableThrottleMebibytes = builder.entireSSTableThrottleMebibytes;
+        entireSSTableInterDcThrottleMebibytes = builder.entireSSTableInterDcThrottleMebibytes;
         storagePort = builder.storagePort;
         sslStoragePort = builder.sslStoragePort;
         clientEncOptions = builder.clientEncOptions;
@@ -136,10 +163,11 @@ public class LoaderOptions
         String passwd;
         String authProviderName;
         AuthProvider authProvider;
-        int throttle = 0;
-        int interDcThrottle = 0;
-        int entireSSTableThrottle = 0;
-        int entireSSTableInterDcThrottle = 0;
+        long throttleBytes = 0;
+        long interDcThrottleBytes = 0;
+        int entireSSTableThrottleMebibytes = 0;
+        int entireSSTableInterDcThrottleMebibytes = 0;
+
         int storagePort;
         int sslStoragePort;
         EncryptionOptions clientEncOptions = new EncryptionOptions();
@@ -228,27 +256,65 @@ public class LoaderOptions
             return this;
         }
 
+        public Builder throttleMebibytes(int throttleMebibytes)
+        {
+            this.throttleBytes = (long) MEBIBYTES_PER_SECOND.toBytesPerSecond(throttleMebibytes);
+            return this;
+        }
+
+        public Builder throttleMegabits(int throttleMegabits)
+        {
+            this.throttleBytes = (long) DataRateSpec.LongBytesPerSecondBound.megabitsPerSecondInBytesPerSecond(throttleMegabits).toBytesPerSecond();
+            return this;
+        }
+
+        @Deprecated
         public Builder throttle(int throttle)
         {
-            this.throttle = throttle;
+            return throttleMegabits(throttle);
+        }
+
+        public Builder interDcThrottleMebibytes(int interDcThrottleMebibytes)
+        {
+            this.interDcThrottleBytes = (long) MEBIBYTES_PER_SECOND.toBytesPerSecond(interDcThrottleMebibytes);
             return this;
         }
 
+        public Builder interDcThrottleMegabits(int interDcThrottleMegabits)
+        {
+            this.interDcThrottleBytes = (long) DataRateSpec.LongBytesPerSecondBound.megabitsPerSecondInBytesPerSecond(interDcThrottleMegabits).toBytesPerSecond();
+            return this;
+        }
+
+        @Deprecated
         public Builder interDcThrottle(int interDcThrottle)
         {
-            this.interDcThrottle = interDcThrottle;
+            return interDcThrottleMegabits(interDcThrottle);
+        }
+
+        public Builder entireSSTableThrottleMebibytes(int entireSSTableThrottleMebibytes)
+        {
+            this.entireSSTableThrottleMebibytes = entireSSTableThrottleMebibytes;
             return this;
         }
 
+        @Deprecated
         public Builder entireSSTableThrottle(int entireSSTableThrottle)
         {
-            this.entireSSTableThrottle = entireSSTableThrottle;
+            this.entireSSTableThrottleMebibytes = entireSSTableThrottle;
             return this;
         }
 
+        public Builder entireSSTableInterDcThrottleMebibytes(int entireSSTableInterDcThrottleMebibytes)
+        {
+            this.entireSSTableInterDcThrottleMebibytes = entireSSTableInterDcThrottleMebibytes;
+            return this;
+        }
+
+        @Deprecated
         public Builder entireSSTableInterDcThrottle(int entireSSTableInterDcThrottle)
         {
-            this.entireSSTableInterDcThrottle = entireSSTableInterDcThrottle;
+            this.entireSSTableInterDcThrottleMebibytes = entireSSTableInterDcThrottle;
             return this;
         }
 
@@ -475,7 +541,7 @@ public class LoaderOptions
                     connectionsPerHost = Integer.parseInt(cmd.getOptionValue(CONNECTIONS_PER_HOST));
                 }
 
-                throttle = config.stream_throughput_outbound.toMebibytesPerSecondAsInt();
+                throttleBytes = config.stream_throughput_outbound.toBytesPerSecondAsInt();
 
                 if (cmd.hasOption(SSL_STORAGE_PORT_OPTION))
                     logger.info("ssl storage port is deprecated and not used, all communication goes though storage port " +
@@ -520,28 +586,48 @@ public class LoaderOptions
                     System.exit(1);
                 }
 
+                if (cmd.hasOption(THROTTLE_MBITS) && cmd.hasOption(THROTTLE_MEBIBYTES))
+                {
+                    errorMsg(String.format("Both '%s' and '%s' were provided. Please only provide one of the two options", THROTTLE_MBITS, THROTTLE_MEBIBYTES), options);
+                }
+
+                if (cmd.hasOption(INTER_DC_THROTTLE_MBITS) && cmd.hasOption(INTER_DC_THROTTLE_MEBIBYTES))
+                {
+                    errorMsg(String.format("Both '%s' and '%s' were provided. Please only provide one of the two options", INTER_DC_THROTTLE_MBITS, INTER_DC_THROTTLE_MEBIBYTES), options);
+                }
+
                 if (cmd.hasOption(THROTTLE_MBITS))
                 {
-                    throttle = Integer.parseInt(cmd.getOptionValue(THROTTLE_MBITS));
+                    throttleMegabits(Integer.parseInt(cmd.getOptionValue(THROTTLE_MBITS)));
+                }
+
+                if (cmd.hasOption(THROTTLE_MEBIBYTES))
+                {
+                    throttleMebibytes(Integer.parseInt(cmd.getOptionValue(THROTTLE_MEBIBYTES)));
                 }
 
                 if (cmd.hasOption(INTER_DC_THROTTLE_MBITS))
                 {
-                    interDcThrottle = Integer.parseInt(cmd.getOptionValue(INTER_DC_THROTTLE_MBITS));
+                    interDcThrottleMegabits(Integer.parseInt(cmd.getOptionValue(INTER_DC_THROTTLE_MBITS)));
                 }
 
-                if (cmd.hasOption(ENTIRE_SSTABLE_THROTTLE_MBITS))
+                if (cmd.hasOption(INTER_DC_THROTTLE_MEBIBYTES))
                 {
-                    entireSSTableThrottle = Integer.parseInt(cmd.getOptionValue(ENTIRE_SSTABLE_THROTTLE_MBITS));
+                    interDcThrottleMebibytes(Integer.parseInt(cmd.getOptionValue(INTER_DC_THROTTLE_MEBIBYTES)));
                 }
 
-                if (cmd.hasOption(ENTIRE_SSTABLE_INTER_DC_THROTTLE_MBITS))
+                if (cmd.hasOption(ENTIRE_SSTABLE_THROTTLE_MEBIBYTES))
                 {
-                    entireSSTableInterDcThrottle = Integer.parseInt(cmd.getOptionValue(ENTIRE_SSTABLE_INTER_DC_THROTTLE_MBITS));
+                    entireSSTableThrottleMebibytes(Integer.parseInt(cmd.getOptionValue(ENTIRE_SSTABLE_THROTTLE_MEBIBYTES)));
+                }
+
+                if (cmd.hasOption(ENTIRE_SSTABLE_INTER_DC_THROTTLE_MEBIBYTES))
+                {
+                    entireSSTableInterDcThrottleMebibytes(Integer.parseInt(cmd.getOptionValue(ENTIRE_SSTABLE_INTER_DC_THROTTLE_MEBIBYTES)));
                 }
 
                 if (cmd.hasOption(SSL_TRUSTSTORE) || cmd.hasOption(SSL_TRUSTSTORE_PW) ||
-                            cmd.hasOption(SSL_KEYSTORE) || cmd.hasOption(SSL_KEYSTORE_PW))
+                    cmd.hasOption(SSL_KEYSTORE) || cmd.hasOption(SSL_KEYSTORE_PW))
                 {
                     clientEncOptions = clientEncOptions.withEnabled(true);
                 }
@@ -691,10 +777,12 @@ public class LoaderOptions
         options.addOption("p",  NATIVE_PORT_OPTION, "native transport port", "port used for native connection (default 9042)");
         options.addOption("sp",  STORAGE_PORT_OPTION, "storage port", "port used for internode communication (default 7000)");
         options.addOption("ssp",  SSL_STORAGE_PORT_OPTION, "ssl storage port", "port used for TLS internode communication (default 7001), this option is deprecated, all communication goes through storage port which handles encrypted communication as well");
-        options.addOption("t", THROTTLE_MBITS, "throttle", "throttle speed in Mbits (default unlimited)");
-        options.addOption("idct", INTER_DC_THROTTLE_MBITS, "inter-dc-throttle", "inter-datacenter throttle speed in Mbits (default unlimited)");
-        options.addOption("e", ENTIRE_SSTABLE_THROTTLE_MBITS, "entire-sstable-throttle", "entire SSTable throttle speed in Mbits (default unlimited)");
-        options.addOption("eidct", ENTIRE_SSTABLE_INTER_DC_THROTTLE_MBITS, "entire-sstable-inter-dc-throttle", "entire SSTable inter-datacenter throttle speed in Mbits (default unlimited)");
+        options.addOption("t", THROTTLE_MBITS, "throttle", "throttle speed in Mbps (default 0 for unlimited), this option is deprecated, use \"throttle-mib\" instead");
+        options.addOption("tmib", THROTTLE_MEBIBYTES, "throttle-mib", "throttle speed in MiB/s (default 0 for unlimited)");
+        options.addOption("idct", INTER_DC_THROTTLE_MBITS, "inter-dc-throttle", "inter-datacenter throttle speed in Mbps (default 0 for unlimited), this option is deprecated, use \"inter-dc-throttle-mib\" instead");
+        options.addOption("idctmib", INTER_DC_THROTTLE_MEBIBYTES, "inter-dc-throttle-mib", "inter-datacenter throttle speed in MiB/s (default 0 for unlimited), this option is deprecated, use \"inter-dc-throttle-mib\" instead");
+        options.addOption("emib", ENTIRE_SSTABLE_THROTTLE_MEBIBYTES, "entire-sstable-throttle-mib", "entire SSTable throttle speed in MiB/s (default 0 for unlimited)");
+        options.addOption("eidctmib", ENTIRE_SSTABLE_INTER_DC_THROTTLE_MEBIBYTES, "entire-sstable-inter-dc-throttle-mib", "entire SSTable inter-datacenter throttle speed in MiB/s (default 0 for unlimited)");
         options.addOption("u", USER_OPTION, "username", "username for cassandra authentication");
         options.addOption("pw", PASSWD_OPTION, "password", "password for cassandra authentication");
         options.addOption("ap", AUTH_PROVIDER_OPTION, "auth provider", "custom AuthProvider class name for cassandra authentication");

--- a/test/unit/org/apache/cassandra/tools/BulkLoaderTest.java
+++ b/test/unit/org/apache/cassandra/tools/BulkLoaderTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.tools;
 import org.junit.Test;
 
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 import org.hamcrest.CoreMatchers;
 
@@ -149,6 +150,52 @@ public class BulkLoaderTest extends OfflineToolUtils
                                                  "127.9.9.1:9041",
                                                  OfflineToolUtils.sstableDirName("legacy_sstables", "legacy_ma_simple"));
         assertEquals(-1, tool.getExitCode());
+        throw tool.getException().getCause().getCause().getCause();
+    }
+
+    @Test(expected = NoHostAvailableException.class)
+    public void testBulkLoader_WithArgs5() throws Throwable
+    {
+        ToolResult tool = ToolRunner.invokeClass(BulkLoader.class,
+                                                 "-d",
+                                                 "127.9.9.1:9041",
+                                                 "--throttle",
+                                                 "10",
+                                                 "--inter-dc-throttle",
+                                                 "15",
+                                                 "--entire-sstable-throttle-mib",
+                                                 "20",
+                                                 "--entire-sstable-inter-dc-throttle-mib",
+                                                 "25",
+                                                 OfflineToolUtils.sstableDirName("legacy_sstables", "legacy_ma_simple"));
+        assertEquals(-1, tool.getExitCode());
+        assertEquals(10 * 125_000, DatabaseDescriptor.getStreamThroughputOutboundBytesPerSec(), 0.0);
+        assertEquals(15 * 125_000, DatabaseDescriptor.getInterDCStreamThroughputOutboundBytesPerSec(), 0.0);
+        assertEquals(20, DatabaseDescriptor.getEntireSSTableStreamThroughputOutboundMebibytesPerSec(), 0.0);
+        assertEquals(25, DatabaseDescriptor.getEntireSSTableInterDCStreamThroughputOutboundMebibytesPerSec(), 0.0);
+        throw tool.getException().getCause().getCause().getCause();
+    }
+
+    @Test(expected = NoHostAvailableException.class)
+    public void testBulkLoader_WithArgs6() throws Throwable
+    {
+        ToolResult tool = ToolRunner.invokeClass(BulkLoader.class,
+                                                 "-d",
+                                                 "127.9.9.1:9041",
+                                                 "--throttle-mib",
+                                                 "3",
+                                                 "--inter-dc-throttle-mib",
+                                                 "4",
+                                                 "--entire-sstable-throttle-mib",
+                                                 "5",
+                                                 "--entire-sstable-inter-dc-throttle-mib",
+                                                 "6",
+                                                 OfflineToolUtils.sstableDirName("legacy_sstables", "legacy_ma_simple"));
+        assertEquals(-1, tool.getExitCode());
+        assertEquals(3 * 1024 * 1024, DatabaseDescriptor.getStreamThroughputOutboundBytesPerSec(), 0.0);
+        assertEquals(4 * 1024 * 1024, DatabaseDescriptor.getInterDCStreamThroughputOutboundBytesPerSec(), 0.0);
+        assertEquals(5, DatabaseDescriptor.getEntireSSTableStreamThroughputOutboundMebibytesPerSec(), 0.0);
+        assertEquals(6, DatabaseDescriptor.getEntireSSTableInterDCStreamThroughputOutboundMebibytesPerSec(), 0.0);
         throw tool.getException().getCause().getCause().getCause();
     }
 }

--- a/test/unit/org/apache/cassandra/tools/LoaderOptionsTest.java
+++ b/test/unit/org/apache/cassandra/tools/LoaderOptionsTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Paths;
+import java.security.Permission;
 
 import com.google.common.net.HostAndPort;
 import org.junit.Test;
@@ -30,24 +31,24 @@ import org.apache.cassandra.io.util.File;
 
 import static org.apache.cassandra.tools.OfflineToolUtils.sstableDirName;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 // LoaderOptionsTester for custom configuration
 public class LoaderOptionsTest
 {
     @Test
-    public void testNativePort() throws Exception {
+    public void testNativePort() throws Exception
+    {
         //Default Cassandra config
         File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
-        String[] args = { "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple")};
+        String[] args = { "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
         LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
         assertEquals(9042, options.nativePort);
 
 
         // SSL Enabled Cassandra config
         config = new File(Paths.get(".", "test", "conf", "unit-test-conf/test-native-port.yaml").normalize());
-        String[] args2 = { "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple")};
+        String[] args2 = { "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
         options = LoaderOptions.builder().parseArgs(args2).build();
         assertEquals(9142, options.nativePort);
 
@@ -58,7 +59,7 @@ public class LoaderOptionsTest
         // test native port set from command line
 
         config = new File(Paths.get(".", "test", "conf", "unit-test-conf/test-native-port.yaml").normalize().toFile());
-        String[] args3 = {"-d", "127.9.9.1", "-p", "9300", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple")};
+        String[] args3 = { "-d", "127.9.9.1", "-p", "9300", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
         options = LoaderOptions.builder().parseArgs(args3).build();
         assertEquals(9300, options.nativePort);
 
@@ -77,19 +78,111 @@ public class LoaderOptionsTest
     public void testEncryptionSettings() throws Exception
     {
         String[] args = { "-d", "127.9.9.1", "-ts", "test.jks", "-tspw", "truststorePass1", "-ks", "test.jks", "-kspw",
-                "testdata1", "--ssl-ciphers", "TLS_RSA_WITH_AES_256_CBC_SHA",
-                "--ssl-alg", "SunX509", "--store-type", "JKS", "--ssl-protocol", "TLS",
-                sstableDirName("legacy_sstables", "legacy_ma_simple") };
+                          "testdata1", "--ssl-ciphers", "TLS_RSA_WITH_AES_256_CBC_SHA",
+                          "--ssl-alg", "SunX509", "--store-type", "JKS", "--ssl-protocol", "TLS",
+                          sstableDirName("legacy_sstables", "legacy_ma_simple") };
         LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
         assertEquals("test.jks", options.clientEncOptions.keystore);
+    }
+
+    @Test
+    public void testThrottleDefaultSettings()
+    {
+        LoaderOptions options = LoaderOptions.builder().build();
+        assertEquals(0, options.throttleBytes, 0);
+        assertEquals(0, options.interDcThrottleBytes, 0);
+    }
+
+    @Test
+    public void testDeprecatedThrottleSettings() throws IOException
+    {
+        // Default Cassandra config
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "-t", "200", "-idct", "400", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+        LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
+        // converts from megabits to bytes
+        assertEquals(200 * 125_000, options.throttleBytes, 0);
+        assertEquals(400 * 125_000, options.interDcThrottleBytes, 0);
+    }
+
+    @Test
+    public void testDeprecatedThrottleSettingsWithLongSettingNames() throws IOException
+    {
+        // Default Cassandra config
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "--throttle", "200", "--inter-dc-throttle", "400", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+        LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
+        // converts from megabits to bytes
+        assertEquals(200 * 125_000, options.throttleBytes, 0);
+        assertEquals(400 * 125_000, options.interDcThrottleBytes, 0);
+    }
+
+    @Test
+    public void testThrottleSettings() throws IOException
+    {
+        // Default Cassandra config
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "-tmib", "24", "-idctmib", "48", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+        LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
+        // converts from mebibytes to bytes
+        assertEquals(24 * 1024 * 1024, options.throttleBytes, 0);
+        assertEquals(48 * 1024 * 1024, options.interDcThrottleBytes, 0);
+    }
+
+    @Test
+    public void testThrottleSettingsWithLongSettingNames() throws IOException
+    {
+        // Default Cassandra config
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "--throttle-mib", "24", "--inter-dc-throttle-mib", "48", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+        LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
+        // converts from mebibytes to bytes
+        assertEquals(24 * 1024 * 1024, options.throttleBytes, 0);
+        assertEquals(48 * 1024 * 1024, options.interDcThrottleBytes, 0);
+    }
+
+    @Test
+    public void failsWhenThrottleSettingAndDeprecatedAreProvided() throws IOException
+    {
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "-t", "200", "-tmib", "200", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+
+        failureHelper(args, 1);
+    }
+
+    @Test
+    public void failsWhenThrottleSettingAndDeprecatedAreProvidedWithLongSettingNames() throws IOException
+    {
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "--throttle", "200", "--throttle-mib", "200", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+
+        failureHelper(args, 1);
+    }
+
+    @Test
+    public void failsWhenInterDCThrottleSettingAndDeprecatedAreProvided() throws IOException
+    {
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "-idct", "200", "-idctmib", "200", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+
+        failureHelper(args, 1);
+    }
+
+    @Test
+    public void failsWhenInterDCThrottleSettingAndDeprecatedAreProvidedWithLongSettingNames() throws IOException
+    {
+        File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
+        String[] args = { "--inter-dc-throttle", "200", "--inter-dc-throttle-mib", "200", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+
+        failureHelper(args, 1);
     }
 
     @Test
     public void testEntireSSTableDefaultSettings()
     {
         LoaderOptions options = LoaderOptions.builder().build();
-        assertEquals(0, options.entireSSTableThrottle);
-        assertEquals(0, options.entireSSTableInterDcThrottle);
+        assertEquals(0, options.entireSSTableThrottleMebibytes);
+        assertEquals(0, options.entireSSTableInterDcThrottleMebibytes);
     }
 
     @Test
@@ -97,12 +190,10 @@ public class LoaderOptionsTest
     {
         // Default Cassandra config
         File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
-        String[] args = { "-e", "350", "-eidct", "600", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+        String[] args = { "-emib", "350", "-eidctmib", "600", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
         LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
-        assertNotNull(options.entireSSTableThrottle);
-        assertEquals(350, options.entireSSTableThrottle);
-        assertNotNull(options.entireSSTableInterDcThrottle);
-        assertEquals(600, options.entireSSTableInterDcThrottle);
+        assertEquals(350, options.entireSSTableThrottleMebibytes);
+        assertEquals(600, options.entireSSTableInterDcThrottleMebibytes);
     }
 
     @Test
@@ -110,12 +201,42 @@ public class LoaderOptionsTest
     {
         // Use long names for the args, i.e. entire-sstable-throttle
         File config = new File(Paths.get(".", "test", "conf", "cassandra.yaml").normalize());
-        String[] args = new String[]{ "--entire-sstable-throttle", "350", "--entire-sstable-inter-dc-throttle", "600", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
+        String[] args = new String[]{ "--entire-sstable-throttle-mib", "350", "--entire-sstable-inter-dc-throttle-mib", "600", "-d", "127.9.9.1", "-f", config.absolutePath(), sstableDirName("legacy_sstables", "legacy_ma_simple") };
         LoaderOptions options = LoaderOptions.builder().parseArgs(args).build();
-        assertNotNull(options.entireSSTableThrottle);
-        assertEquals(350, options.entireSSTableThrottle);
-        assertNotNull(options.entireSSTableInterDcThrottle);
-        assertEquals(600, options.entireSSTableInterDcThrottle);
+        assertEquals(350, options.entireSSTableThrottleMebibytes);
+        assertEquals(600, options.entireSSTableInterDcThrottleMebibytes);
+    }
+
+    private void failureHelper(String[] args, int expectedErrorCode)
+    {
+        // install security manager to get informed about the exit-code
+        System.setSecurityManager(new SecurityManager()
+        {
+            public void checkExit(int status)
+            {
+                throw new SystemExitException(status);
+            }
+
+            public void checkPermission(Permission perm)
+            {
+            }
+
+            public void checkPermission(Permission perm, Object context)
+            {
+            }
+        });
+        try
+        {
+            LoaderOptions.builder().parseArgs(args).build();
+        }
+        catch (SystemExitException e)
+        {
+            assertEquals(expectedErrorCode, e.status);
+        }
+        finally
+        {
+            System.setSecurityManager(null);
+        }
     }
 }
 


### PR DESCRIPTION
`entire_sstable_stream_throughput_outbound` and `entire_sstable_inter_dc_stream_throughput_outbound` were
introduced in CASSANDRA-17065. They were added to the LoaderOptions class but they are not being used in
the BulkLoader class. In this commit, we make use of the entire_sstable streaming options in BulkLoader.
In addittion, the `throttle` and `interDcThrottle` are being passed as MB/s but they should be MiB/s.
This commit fixes the verbiage as well as setting the correct value for those properties in BulkLoader.