### PR TITLE
Fix flaky test - org.apache.cassandra.distributed.test.MessageForwardingTest.mutationsForwardedToAllReplicasTest

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/MessageForwardingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MessageForwardingTest.java
@@ -24,13 +24,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.cassandra.concurrent.Stage;
+import org.apache.cassandra.concurrent.StageManager;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.impl.IsolatedExecutor;
@@ -65,6 +70,21 @@ public class MessageForwardingTest extends TestBaseImpl
             // about the result so
             //noinspection ResultOfMethodCallIgnored
             inserts.map(IsolatedExecutor::waitOn).count();
+
+            // Tracing is async with respect to queries, just because the query has completed it does not mean
+            // all tracing updates have completed. The tracing executor serializes work, so run a task through
+            // and everthing submitted before must have completed.
+            cluster.forEach(instance -> instance.runOnInstance(() -> {
+                Future<?> result = StageManager.getStage(Stage.TRACING).submit(() -> null);
+                try
+                {
+                    result.get(30, TimeUnit.SECONDS);
+                }
+                catch (ExecutionException | InterruptedException | TimeoutException ex)
+                {
+                    throw new RuntimeException(ex);
+                }
+            }));
 
             cluster.forEach(instance -> commitCounts.put(instance.broadcastAddress().getAddress(), 0));
             List<TracingUtil.TraceEntry> traces = TracingUtil.getTrace(cluster, sessionId, ConsistencyLevel.ALL);


### PR DESCRIPTION
…

Tracing excutor may not have completed when the trace is examined.  Wait for it.

patch by Jon Meredith; reviewed by ? for CASSANDRA-17583