### PR TITLE
CASSANDRA-17650: Add validation for batch_size_fail_threshold

### DIFF
--- a/src/java/org/apache/cassandra/config/DataStorageSpec.java
+++ b/src/java/org/apache/cassandra/config/DataStorageSpec.java
@@ -315,6 +315,14 @@ public abstract class DataStorageSpec
         {
             return Ints.saturatedCast(unit().toKibibytes(quantity()));
         }
+
+        /**
+         * @return the amount of data storage in bytes.
+         */
+        public long toBytesInLong()
+        {
+           return unit().toBytes(quantity());
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -559,7 +559,6 @@ public class DatabaseDescriptor
         checkValidForByteConversion(conf.column_index_size, "column_index_size");
         checkValidForByteConversion(conf.column_index_cache_size, "column_index_cache_size");
         checkValidForByteConversion(conf.batch_size_warn_threshold, "batch_size_warn_threshold");
-        checkValidForByteConversion(conf.batch_size_fail_threshold, "batch_size_fail_threshold");
 
         if (conf.native_transport_max_negotiable_protocol_version != null)
             logger.warn("The configuration option native_transport_max_negotiable_protocol_version has been deprecated " +

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1638,7 +1638,7 @@ public class DatabaseDescriptor
 
     public static long getBatchSizeFailThreshold()
     {
-        return conf.batch_size_fail_threshold.toBytes();
+        return conf.batch_size_fail_threshold.toBytesInLong();
     }
 
     public static int getBatchSizeFailThresholdInKiB()
@@ -1658,13 +1658,7 @@ public class DatabaseDescriptor
 
     public static void setBatchSizeFailThresholdInKiB(int threshold)
     {
-        conf.batch_size_fail_threshold = createIntKibibyteBoundAndEnsureItIsValidForByteConversion(threshold,"batch_size_fail_threshold");
-    }
-
-    private static DataStorageSpec.IntKibibytesBound createIntKibibyteBoundAndEnsureItIsValidForByteConversion(int byteValue, String configName){
-        DataStorageSpec.IntKibibytesBound intKibibytesBound = new DataStorageSpec.IntKibibytesBound(byteValue);
-        checkValidForByteConversion(intKibibytesBound, configName);
-        return intKibibytesBound;
+        conf.batch_size_fail_threshold = new DataStorageSpec.IntKibibytesBound(threshold);
     }
 
     public static Collection<String> getInitialTokens()
@@ -3708,12 +3702,19 @@ public class DatabaseDescriptor
         commitLogSegmentMgrProvider = provider;
     }
 
+    private static DataStorageSpec.IntKibibytesBound createIntKibibyteBoundAndEnsureItIsValidForByteConversion(int kibibytes, String propertyName)
+    {
+        DataStorageSpec.IntKibibytesBound intKibibytesBound = new DataStorageSpec.IntKibibytesBound(kibibytes);
+        checkValidForByteConversion(intKibibytesBound, propertyName);
+        return intKibibytesBound;
+    }
+
     /**
      * Ensures passed in configuration value is positive and will not overflow when converted to Bytes
      */
     private static void checkValidForByteConversion(final DataStorageSpec.IntKibibytesBound value, String name)
     {
-        long valueInBytes = value.toBytes();
+        long valueInBytes = value.toBytesInLong();
         if (valueInBytes < 0 || valueInBytes > Integer.MAX_VALUE - 1)
         {
             throw new ConfigurationException(String.format("%s must be positive value <= %dB, but was %dB",

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -559,6 +559,7 @@ public class DatabaseDescriptor
         checkValidForByteConversion(conf.column_index_size, "column_index_size");
         checkValidForByteConversion(conf.column_index_cache_size, "column_index_cache_size");
         checkValidForByteConversion(conf.batch_size_warn_threshold, "batch_size_warn_threshold");
+        checkValidForByteConversion(conf.batch_size_fail_threshold, "batch_size_fail_threshold");
 
         if (conf.native_transport_max_negotiable_protocol_version != null)
             logger.warn("The configuration option native_transport_max_negotiable_protocol_version has been deprecated " +
@@ -1607,9 +1608,7 @@ public class DatabaseDescriptor
 
     public static void setColumnIndexSize(int val)
     {
-        DataStorageSpec.IntKibibytesBound memory = new DataStorageSpec.IntKibibytesBound(val);
-        checkValidForByteConversion(memory, "column_index_size");
-        conf.column_index_size = new DataStorageSpec.IntKibibytesBound(val);
+        conf.column_index_size =  createIntKibibyteBoundAndEnsureItIsValidForByteConversion(val,"column_index_size");
     }
 
     public static int getColumnIndexCacheSize()
@@ -1624,9 +1623,7 @@ public class DatabaseDescriptor
 
     public static void setColumnIndexCacheSize(int val)
     {
-        DataStorageSpec.IntKibibytesBound memory = new DataStorageSpec.IntKibibytesBound(val);
-        checkValidForByteConversion(memory, "column_index_cache_size");
-        conf.column_index_cache_size = new DataStorageSpec.IntKibibytesBound(val);
+        conf.column_index_cache_size = createIntKibibyteBoundAndEnsureItIsValidForByteConversion(val,"column_index_cache_size");
     }
 
     public static int getBatchSizeWarnThreshold()
@@ -1656,14 +1653,18 @@ public class DatabaseDescriptor
 
     public static void setBatchSizeWarnThresholdInKiB(int threshold)
     {
-        DataStorageSpec.IntKibibytesBound storage = new DataStorageSpec.IntKibibytesBound(threshold);
-        checkValidForByteConversion(storage, "batch_size_warn_threshold");
-        conf.batch_size_warn_threshold = new DataStorageSpec.IntKibibytesBound(threshold);
+        conf.batch_size_warn_threshold = createIntKibibyteBoundAndEnsureItIsValidForByteConversion(threshold,"batch_size_warn_threshold");
     }
 
     public static void setBatchSizeFailThresholdInKiB(int threshold)
     {
-        conf.batch_size_fail_threshold = new DataStorageSpec.IntKibibytesBound(threshold);
+        conf.batch_size_fail_threshold = createIntKibibyteBoundAndEnsureItIsValidForByteConversion(threshold,"batch_size_fail_threshold");
+    }
+
+    private static DataStorageSpec.IntKibibytesBound createIntKibibyteBoundAndEnsureItIsValidForByteConversion(int byteValue, String configName){
+        DataStorageSpec.IntKibibytesBound intKibibytesBound = new DataStorageSpec.IntKibibytesBound(byteValue);
+        checkValidForByteConversion(intKibibytesBound, configName);
+        return intKibibytesBound;
     }
 
     public static Collection<String> getInitialTokens()

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -327,7 +327,13 @@ public class DatabaseDescriptorTest
         }
         catch (ConfigurationException ignored) { }
         Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
+    }
 
+    @Test
+    public void testWidenToLongInBytes() throws ConfigurationException
+    {
+        DatabaseDescriptor.setBatchSizeFailThresholdInKiB(2147483646);
+        Assert.assertEquals((2147483646L * 1024), DatabaseDescriptor.getBatchSizeFailThreshold());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -328,22 +328,6 @@ public class DatabaseDescriptorTest
         catch (ConfigurationException ignored) { }
         Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
 
-        try
-        {
-            DatabaseDescriptor.setBatchSizeFailThresholdInKiB(-1);
-            fail("Should have received a IllegalArgumentException batch_size_fail_threshold = -1");
-        }
-        catch (IllegalArgumentException ignored) { }
-        Assert.assertEquals(51200, DatabaseDescriptor.getBatchSizeFailThreshold());
-
-        try
-        {
-            DatabaseDescriptor.setBatchSizeWarnThresholdInKiB(2 * 1024 * 1024);
-            fail("Should have received a ConfigurationException batch_size_fail_threshold = 2GiB");
-        }
-        catch (ConfigurationException ignored) { }
-        Assert.assertEquals(51200, DatabaseDescriptor.getBatchSizeFailThreshold());
-
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -326,7 +326,24 @@ public class DatabaseDescriptorTest
             fail("Should have received a ConfigurationException batch_size_warn_threshold = 2GiB");
         }
         catch (ConfigurationException ignored) { }
-        Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize());
+        Assert.assertEquals(5120, DatabaseDescriptor.getBatchSizeWarnThreshold());
+
+        try
+        {
+            DatabaseDescriptor.setBatchSizeFailThresholdInKiB(-1);
+            fail("Should have received a IllegalArgumentException batch_size_fail_threshold = -1");
+        }
+        catch (IllegalArgumentException ignored) { }
+        Assert.assertEquals(51200, DatabaseDescriptor.getBatchSizeFailThreshold());
+
+        try
+        {
+            DatabaseDescriptor.setBatchSizeWarnThresholdInKiB(2 * 1024 * 1024);
+            fail("Should have received a ConfigurationException batch_size_fail_threshold = 2GiB");
+        }
+        catch (ConfigurationException ignored) { }
+        Assert.assertEquals(51200, DatabaseDescriptor.getBatchSizeFailThreshold());
+
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetColumnIndexSizeTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetColumnIndexSizeTest.java
@@ -72,7 +72,7 @@ public class SetGetColumnIndexSizeTest extends CQLTester
     @Test
     public void testInvalidValue()
     {
-        assertSetInvalidColumnIndexSize("2097152", "column_index_size must be positive value <= 2147483646B, but was 2147483647B", 2);
+        assertSetInvalidColumnIndexSize("2097152", "column_index_size must be positive value <= 2147483646B, but was 2147483648B", 2);
     }
 
     @Test


### PR DESCRIPTION
I also fixed the `batch_size_warn_threshold ` test. It was checking against `column_index_size` before.

[Task](https://issues.apache.org/jira/browse/CASSANDRA-17650)

