### PR TITLE
fix typos and clarify "architecture" docs

### DIFF
--- a/doc/modules/cassandra/pages/architecture/dynamo.adoc
+++ b/doc/modules/cassandra/pages/architecture/dynamo.adoc
@@ -42,7 +42,7 @@ uses a simpler last write wins model where every mutation is timestamped
 (including deletes) and then the latest version of data is the "winning"
 value. Formally speaking, Cassandra uses a Last-Write-Wins Element-Set
 conflict-free replicated data type for each CQL row, or 
-https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type LWW-Element-Set_(Last-Write-Wins-Element-Set)[LWW-Element-Set
+https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type#LWW-Element-Set_(Last-Write-Wins-Element-Set)[LWW-Element-Set
 CRDT], to resolve conflicting mutations on replica sets.
 
 === Consistent Hashing using a Token Ring
@@ -488,7 +488,7 @@ and every additional node brings linear improvements in compute and
 storage. In contrast, scaling-up implies adding more capacity to the
 existing database nodes. Cassandra is also capable of scale-up, and in
 certain environments it may be preferable depending on the deployment.
-Cassandra gives operators the flexibility to chose either scale-out or
+Cassandra gives operators the flexibility to choose either scale-out or
 scale-up.
 
 One key aspect of Dynamo that Cassandra follows is to attempt to run on

--- a/doc/modules/cassandra/pages/architecture/guarantees.adoc
+++ b/doc/modules/cassandra/pages/architecture/guarantees.adoc
@@ -1,13 +1,13 @@
 = Guarantees
 
 Apache Cassandra is a highly scalable and reliable database. Cassandra
-is used in web based applications that serve large number of clients and
+is used in web based applications that serve large numbers of clients and
 the quantity of data processed is web-scale (Petabyte) large. Cassandra
 makes some guarantees about its scalability, availability and
 reliability. To fully understand the inherent limitations of a storage
 system in an environment in which a certain level of network partition
 failure is to be expected and taken into account when designing the
-system it is important to first briefly introduce the CAP theorem.
+system, it is important to first briefly introduce the CAP theorem.
 
 == What is CAP?
 
@@ -47,12 +47,12 @@ Cassandra makes the following guarantees.
 * Batched writes across multiple tables are guaranteed to succeed
 completely or not at all
 * Secondary indexes are guaranteed to be consistent with their local
-replicas data
+replicas' data
 
 == High Scalability
 
 Cassandra is a highly scalable storage system in which nodes may be
-added/removed as needed. Using gossip-based protocol a unified and
+added/removed as needed. Using gossip-based protocol, a unified and
 consistent membership list is kept at each node.
 
 == High Availability
@@ -67,7 +67,7 @@ Cassandra guarantees data durability by using replicas. Replicas are
 multiple copies of a data stored on different nodes in a cluster. In a
 multi-datacenter environment the replicas may be stored on different
 datacenters. If one replica is lost due to unrecoverable node/datacenter
-failure the data is not completely lost as replicas are still available.
+failure, the data is not completely lost, as replicas are still available.
 
 == Eventual Consistency
 
@@ -75,8 +75,8 @@ Meeting the requirements of performance, reliability, scalability and
 high availability in production Cassandra is an eventually consistent
 storage system. Eventually consistent implies that all updates reach all
 replicas eventually. Divergent versions of the same data may exist
-temporarily but they are eventually reconciled to a consistent state.
-Eventual consistency is a tradeoff to achieve high availability and it
+temporarily, but they are eventually reconciled to a consistent state.
+Eventual consistency is a tradeoff to achieve high availability, and it
 involves some read and write latencies.
 
 == Lightweight transactions with linearizable consistency
@@ -85,8 +85,8 @@ Data must be read and written in a sequential order. Paxos consensus
 protocol is used to implement lightweight transactions. Paxos protocol
 implements lightweight transactions that are able to handle concurrent
 operations using linearizable consistency. Linearizable consistency is
-sequential consistency with real-time constraints and it ensures
-transaction isolation with compare and set (CAS) transaction. With CAS
+sequential consistency with real-time constraints, and it ensures
+transaction isolation with compare and set (CAS) transactions. With CAS
 replica data is compared and data that is found to be out of date is set
 to the most consistent value. Reads with linearizable consistency allow
 reading the current state of the data, which may possibly be
@@ -97,12 +97,12 @@ uncommitted, without making a new addition or update.
 The guarantee for batched writes across multiple tables is that they
 will eventually succeed, or none will. Batch data is first written to
 batchlog system data, and when the batch data has been successfully
-stored in the cluster the batchlog data is removed. The batch is
+stored in the cluster, the batchlog data is removed. The batch is
 replicated to another node to ensure the full batch completes in the
 event the coordinator node fails.
 
 == Secondary Indexes
 
 A secondary index is an index on a column and is used to query a table
-that is normally not queryable. Secondary indexes when built are
+that is normally not queryable. Secondary indexes, when built, are
 guaranteed to be consistent with their local replicas.

--- a/doc/modules/cassandra/pages/architecture/snitch.adoc
+++ b/doc/modules/cassandra/pages/architecture/snitch.adoc
@@ -2,9 +2,9 @@
 
 In cassandra, the snitch has two functions:
 
-* it teaches Cassandra enough about your network topology to route
+* It teaches Cassandra enough about your network topology to route
 requests efficiently.
-* it allows Cassandra to spread replicas around your cluster to avoid
+* It allows Cassandra to spread replicas around your cluster to avoid
 correlated failures. It does this by grouping machines into
 "datacenters" and "racks." Cassandra will do its best not to have more
 than one replica on the same "rack" (which may not actually be a
@@ -12,7 +12,7 @@ physical location).
 
 == Dynamic snitching
 
-The dynamic snitch monitor read latencies to avoid reading from hosts
+The dynamic snitch monitors read latencies to avoid reading from hosts
 that have slowed down. The dynamic snitch is configured with the
 following properties on `cassandra.yaml`:
 

--- a/doc/modules/cassandra/pages/architecture/storage_engine.adoc
+++ b/doc/modules/cassandra/pages/architecture/storage_engine.adoc
@@ -3,17 +3,17 @@
 [[commit-log]]
 == CommitLog
 
-Commitlogs are an append only log of all mutations local to a Cassandra
+Commitlogs are an append-only log of all mutations local to a Cassandra
 node. Any data written to Cassandra will first be written to a commit
 log before being written to a memtable. This provides durability in the
 case of unexpected shutdown. On startup, any mutations in the commit log
 will be applied to memtables.
 
-All mutations write optimized by storing in commitlog segments, reducing
-the number of seeks needed to write to disk. Commitlog Segments are
-limited by the `commitlog_segment_size` option, once the size is
+All mutations are write-optimized by storing in commitlog segments, reducing
+the number of seeks needed to write to disk. Commitlog segments are
+limited by the `commitlog_segment_size` option. Once the size is
 reached, a new commitlog segment is created. Commitlog segments can be
-archived, deleted, or recycled once all its data has been flushed to
+archived, deleted, or recycled once all their data has been flushed to
 SSTables. Commitlog segments are truncated when Cassandra has written
 data older than a certain point to the SSTables. Running "nodetool
 drain" before stopping Cassandra will write everything in the memtables
@@ -26,15 +26,13 @@ granularity of archiving; 8 or 16 MiB is reasonable. `commitlog_segment_size`
 also determines the default value of `max_mutation_size` in cassandra.yaml.
 By default, max_mutation_size is half the size of `commitlog_segment_size`.
 
-**NOTE: If `max_mutation_size` is set explicitly then
+[NOTE]
+.Note
+====
+If `max_mutation_size` is set explicitly then
 `commitlog_segment_size` must be set to at least twice the size of
-`max_mutation_size`**.
-
-Commitlogs are an append only log of all mutations local to a Cassandra
-node. Any data written to Cassandra will first be written to a commit
-log before being written to a memtable. This provides durability in the
-case of unexpected shutdown. On startup, any mutations in the commit log
-will be applied.
+`max_mutation_size`.
+====
 
 * `commitlog_sync`: may be either _periodic_ or _batch_.
 ** `batch`: In batch mode, Cassandra won’t ack writes until the commit
@@ -55,12 +53,16 @@ _Default Value:_ 10000ms
 
 _Default Value:_ batch
 
-** NOTE: In the event of an unexpected shutdown, Cassandra can lose up
+[NOTE]
+.Note
+====
+In the event of an unexpected shutdown, Cassandra can lose up
 to the sync period or more if the sync is delayed. If using "batch"
 mode, it is recommended to store commitlogs in a separate, dedicated
-device.*
+device.
+====
 
-* `commitlog_directory`: This option is commented out by default When
+* `commitlog_directory`: This option is commented out by default. When
 running on magnetic HDD, this should be a separate spindle than the data
 directories. If not set, the default directory is
 $CASSANDRA_HOME/data/commitlog.
@@ -71,7 +73,7 @@ _Default Value:_ /var/lib/cassandra/commitlog
 omitted, the commit log will be written uncompressed. LZ4, Snappy,
 Deflate and Zstd compressors are supported.
 
-(Default Value: (complex option):
+_Default Value:_ (complex option):
 
 [source, yaml]
 ----
@@ -221,5 +223,5 @@ match the "ib" SSTable version
 
 [source,bash]
 ----
-include:example$find_sstables.sh[]
+include::../../examples/BASH/find_sstables.sh[]
 ----


### PR DESCRIPTION
I'm reading the docs for the first time, and several typos stand
out. I've suggested mostly minor fixes here. I don't think any can
change the meaning of the content, but some of it was a bit ambiguous.