### PR TITLE
CASSANDRA-17422: fix for OutboundMessageQueueTest.testRemove

### DIFF
--- a/test/unit/org/apache/cassandra/net/OutboundMessageQueueTest.java
+++ b/test/unit/org/apache/cassandra/net/OutboundMessageQueueTest.java
@@ -65,7 +65,6 @@ public class OutboundMessageQueueTest
             try (OutboundMessageQueue.WithLock lock = queue.lockOrCallback(0, () -> {}))
             {
                 locked.countDown();
-                Uninterruptibles.awaitUninterruptibly(lockUntil);
             }
         }).start();
         Uninterruptibles.awaitUninterruptibly(locked);
@@ -85,6 +84,7 @@ public class OutboundMessageQueueTest
         Uninterruptibles.awaitUninterruptibly(start);
         lockUntil.countDown();
         Uninterruptibles.awaitUninterruptibly(finish);
+        Uninterruptibles.awaitUninterruptibly(lockUntil);
 
         try (OutboundMessageQueue.WithLock lock = queue.lockOrCallback(0, () -> {}))
         {


### PR DESCRIPTION
Fix for ticket CASSANDRA-17422: Test Failure: org.apache.cassandra.net.OutboundMessageQueueTest.testRemove-cdc