### PR TITLE
CASSANDRA-17753: Include GitSHA in nodetool version output

### DIFF
--- a/.build/build-git.xml
+++ b/.build/build-git.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project basedir="." name="apache-cassandra-git-tasks"
+         xmlns:if="ant:if">
+    <target name="get-git-sha">
+        <exec executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+            <arg value="describe"/>
+            <arg value="--match=''"/>
+            <arg value="--always"/>
+            <arg value="--abbrev=0"/>
+            <arg value="--dirty"/>
+            <redirector outputproperty="git.sha"/>
+        </exec>
+        <property name="git.sha" value="Unknown"/>
+        <echo level="info">git.sha=${git.sha}</echo>
+
+        <exec executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+            <arg value="diff"/>
+            <arg value="--stat"/>
+            <redirector outputproperty="git.diffstat"/>
+        </exec>
+        <condition property="is-dirty">
+            <contains string="${git.sha}" substring="-dirty"/>
+        </condition>
+        <echo level="warning" if:true="${is-dirty}">Repository state is dirty</echo>
+        <echo level="warning" if:true="${is-dirty}">${git.diffstat}</echo>
+    </target>
+</project>

--- a/.build/build-git.xml
+++ b/.build/build-git.xml
@@ -19,7 +19,17 @@
 <project basedir="." name="apache-cassandra-git-tasks"
          xmlns:if="ant:if">
     <target name="get-git-sha">
-        <exec executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+        <exec executable="git" osfamily="unix" dir="${basedir}" logError="false" failonerror="false" failifexecutionfails="false" resultproperty="git.is-available.exit-code">
+            <arg value="rev-parse"/>
+            <arg value="--is-inside-work-tree"/>
+            <redirector outputproperty="git.is-available.output"/>
+        </exec>
+        <condition property="git.is-available" else="false">
+            <equals arg1="${git.is-available.exit-code}" arg2="0"/>
+        </condition>
+        <echo message="git.is-available=${git.is-available}"/>
+
+        <exec if:true="${git.is-available}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
             <arg value="describe"/>
             <arg value="--match=''"/>
             <arg value="--always"/>
@@ -30,7 +40,7 @@
         <property name="git.sha" value="Unknown"/>
         <echo level="info">git.sha=${git.sha}</echo>
 
-        <exec executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+        <exec if:true="${git.is-available}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
             <arg value="diff"/>
             <arg value="--stat"/>
             <redirector outputproperty="git.diffstat"/>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * `nodetool version --verbose` now includes GitSHA; build depends on Git install locally (CASSANDRA-17753)
  * Introduce target directory to vtable output for sstable_tasks and for compactionstats (CASSANDRA-13010)
  * Read/Write/Truncate throw RequestFailure in a race condition with callback timeouts, should return Timeout instead (CASSANDRA-17828)
  * Add ability to log load profiles at fixed intervals (CASSANDRA-17821)

--- a/build.xml
+++ b/build.xml
@@ -882,11 +882,12 @@
     </target>
 
     <!-- create properties file with C version -->
-    <target name="createVersionPropFile">
+    <target name="createVersionPropFile" depends="get-git-sha">
       <taskdef name="propertyfile" classname="org.apache.tools.ant.taskdefs.optional.PropertyFile"/>
       <mkdir dir="${version.properties.dir}"/>
       <propertyfile file="${version.properties.dir}/version.properties">
         <entry key="CassandraVersion" value="${version}"/>
+        <entry key="GitSHA" value="${git.sha}"/>
       </propertyfile>
     </target>
 
@@ -929,7 +930,7 @@
         </javac>
     </target>
 
-    <target depends="init,gen-cql3-grammar,generate-cql-html,generate-jflex-java,rat-check"
+    <target depends="init,gen-cql3-grammar,generate-cql-html,generate-jflex-java,rat-check,get-git-sha"
             name="build-project">
         <echo message="${ant.project.name}: ${ant.file}"/>
         <!-- Order matters! -->
@@ -1126,6 +1127,7 @@
           <attribute name="Implementation-Title" value="Cassandra"/>
           <attribute name="Implementation-Version" value="${version}"/>
           <attribute name="Implementation-Vendor" value="Apache"/>
+          <attribute name="Implementation-Git-SHA" value="${git.sha}"/>
         <!-- </section> -->
         </manifest>
       </jar>
@@ -2369,4 +2371,5 @@
   <import file="${basedir}/.build/build-resolver.xml"/>
   <import file="${basedir}/.build/build-rat.xml"/>
   <import file="${basedir}/.build/build-owasp.xml"/>
+  <import file="${basedir}/.build/build-git.xml"/>
 </project>

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1876,3 +1876,4 @@ drop_compact_storage_enabled: false
 #    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
 #    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
 #    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
+

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3631,6 +3631,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return FBUtilities.getReleaseVersionString();
     }
 
+    @Override
+    public String getGitSHA()
+    {
+        return FBUtilities.getGitSHA();
+    }
+
     public String getSchemaVersion()
     {
         return Schema.instance.getVersion().toString();

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -103,6 +103,12 @@ public interface StorageServiceMBean extends NotificationEmitter
     public String getReleaseVersion();
 
     /**
+     * Fetch a string representation of the Cassandra git SHA.
+     * @return A string representation of the Cassandra git SHA.
+     */
+    public String getGitSHA();
+
+    /**
      * Fetch a string representation of the current Schema version.
      * @return A string representation of the Schema version.
      */

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -775,6 +775,11 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.getReleaseVersion();
     }
 
+    public String getGitSHA()
+    {
+        return ssProxy.getGitSHA();
+    }
+
     public int getCurrentGenerationNumber()
     {
         return ssProxy.getCurrentGenerationNumber();

--- a/src/java/org/apache/cassandra/tools/nodetool/Version.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Version.java
@@ -18,16 +18,23 @@
 package org.apache.cassandra.tools.nodetool;
 
 import io.airlift.airline.Command;
-
+import io.airlift.airline.Option;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
 @Command(name = "version", description = "Print cassandra version")
 public class Version extends NodeToolCmd
 {
+    @Option(title = "verbose",
+            name = {"-v", "--verbose"},
+            description = "Include additional information")
+    private boolean verbose = false;
+
     @Override
     public void execute(NodeProbe probe)
     {
         probe.output().out.println("ReleaseVersion: " + probe.getReleaseVersion());
+        if (verbose)
+            probe.output().out.println("GitSHA: " + probe.getGitSHA());
     }
 }

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -105,6 +105,7 @@ public class FBUtilities
 
     private static final Logger logger = LoggerFactory.getLogger(FBUtilities.class);
     public static final String UNKNOWN_RELEASE_VERSION = "Unknown";
+    public static final String UNKNOWN_GIT_SHA = "Unknown";
 
     public static final BigInteger TWO = new BigInteger("2");
     private static final String DEFAULT_TRIGGER_DIR = "triggers";
@@ -419,24 +420,40 @@ public class FBUtilities
         return previousReleaseVersionString;
     }
 
-    public static String getReleaseVersionString()
+    private static Properties getVersionProperties()
     {
         try (InputStream in = FBUtilities.class.getClassLoader().getResourceAsStream("org/apache/cassandra/config/version.properties"))
         {
             if (in == null)
             {
-                return System.getProperty("cassandra.releaseVersion", UNKNOWN_RELEASE_VERSION);
+                return null;
             }
             Properties props = new Properties();
             props.load(in);
-            return props.getProperty("CassandraVersion");
+            return props;
         }
         catch (Exception e)
         {
             JVMStabilityInspector.inspectThrowable(e);
             logger.warn("Unable to load version.properties", e);
-            return "debug version";
+            return null;
         }
+    }
+
+    public static String getReleaseVersionString()
+    {
+        Properties props = getVersionProperties();
+        if (props == null)
+            return System.getProperty("cassandra.releaseVersion", UNKNOWN_RELEASE_VERSION);
+        return props.getProperty("CassandraVersion");
+    }
+
+    public static String getGitSHA()
+    {
+        Properties props = getVersionProperties();
+        if (props == null)
+            return System.getProperty("cassandra.gitSHA", UNKNOWN_GIT_SHA);
+        return props.getProperty("GitSHA", UNKNOWN_GIT_SHA);
     }
 
     public static String getReleaseVersionMajor()

--- a/test/distributed/org/apache/cassandra/distributed/test/NodeToolTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NodeToolTest.java
@@ -116,4 +116,18 @@ public class NodeToolTest extends TestBaseImpl
             ringResult.asserts().stderrContains("is not permitted as this cache is disabled");
         }
     }
+
+    @Test
+    public void testVersionIncludesGitSHAWhenVerbose() throws Throwable
+    {
+        NODE.nodetoolResult("version")
+            .asserts()
+            .success()
+            .stdoutNotContains("GitSHA:");
+
+        NODE.nodetoolResult("version", "--verbose")
+            .asserts()
+            .success()
+            .stdoutContains("GitSHA:");
+    }
 }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/CASSANDRA-17753
CircleCI: https://app.circleci.com/pipelines/github/aratno/cassandra?branch=CASSANDRA-17753-nodetool-version-gitsha

```bash
# When Cassandra is built with a clean Git index
$ ./bin/nodetool version
ReleaseVersion: 4.1-alpha2-SNAPSHOT
GitSHA: 5fce07e2f1e2e0b9cf7d82adfd8c0b21993f8672

# When Cassandra is built with a dirty Git index
$ ./bin/nodetool version
ReleaseVersion: 4.1-alpha2-SNAPSHOT
GitSHA: 5fce07e2f1e2e0b9cf7d82adfd8c0b21993f8672-dirty
```