### PR TITLE
Fix for CASSANDRA-14218: Deprecate Throwables.propagate usage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * Deprecate Throwables.propagate usage (CASSANDRA-14218)
  * Add guardrail to disallow DROP KEYSPACE commands (CASSANDRA-17767)
  * Remove ephemeral snapshot marker file and introduce a flag to SnapshotManifest (CASSANDRA-16911)
  * Add a virtual table that exposes currently running queries (CASSANDRA-15241)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 4.2
- * Deprecate Throwables.propagate usage (CASSANDRA-14218)
+ * Deprecate Throwables.propagate usage (CASSANDRA-14218) 
  * Add guardrail to disallow DROP KEYSPACE commands (CASSANDRA-17767)
  * Remove ephemeral snapshot marker file and introduce a flag to SnapshotManifest (CASSANDRA-16911)
  * Add a virtual table that exposes currently running queries (CASSANDRA-15241)

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -238,8 +238,10 @@ public class ChunkCache
             }
             catch (Throwable t)
             {
-                Throwables.propagateIfInstanceOf(t.getCause(), CorruptSSTableException.class);
-                throw Throwables.propagate(t);
+                if (t.getCause() instanceof CorruptSSTableException)
+                    throw (CorruptSSTableException)t.getCause();
+                Throwables.throwIfUnchecked(t);
+                throw new RuntimeException(t);
             }
         }
 

--- a/src/java/org/apache/cassandra/db/SnapshotDetailsTabularData.java
+++ b/src/java/org/apache/cassandra/db/SnapshotDetailsTabularData.java
@@ -66,7 +66,8 @@ public class SnapshotDetailsTabularData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/CompactionHistoryTabularData.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionHistoryTabularData.java
@@ -59,7 +59,8 @@ public class CompactionHistoryTabularData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/Scrubber.java
+++ b/src/java/org/apache/cassandra/db/compaction/Scrubber.java
@@ -27,7 +27,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 
 import org.apache.cassandra.io.util.File;
@@ -317,7 +316,7 @@ public class Scrubber implements Closeable
         }
         catch (IOException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         finally
         {

--- a/src/java/org/apache/cassandra/db/compaction/Upgrader.java
+++ b/src/java/org/apache/cassandra/db/compaction/Upgrader.java
@@ -101,7 +101,8 @@ public class Upgrader
         }
         catch (Exception e)
         {
-            Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
         finally
         {

--- a/src/java/org/apache/cassandra/db/compaction/Verifier.java
+++ b/src/java/org/apache/cassandra/db/compaction/Verifier.java
@@ -340,7 +340,8 @@ public class Verifier implements Closeable
         }
         catch (Throwable t)
         {
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
         finally
         {

--- a/src/java/org/apache/cassandra/db/memtable/Flushing.java
+++ b/src/java/org/apache/cassandra/db/memtable/Flushing.java
@@ -82,7 +82,9 @@ public class Flushing
         }
         catch (Throwable e)
         {
-            throw Throwables.propagate(abortRunnables(runnables, e));
+            Throwable t = abortRunnables(runnables, e);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/src/java/org/apache/cassandra/hints/Hint.java
+++ b/src/java/org/apache/cassandra/hints/Hint.java
@@ -120,7 +120,8 @@ public final class Hint
         }
         catch (Exception e)
         {
-            throw Throwables.propagate(e.getCause());
+            Throwables.throwIfUnchecked(e.getCause());
+            throw new RuntimeException(e.getCause());
         }
     }
 

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -32,7 +32,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.primitives.Longs;
 
 import org.apache.cassandra.db.TypeSizes;
@@ -412,7 +411,7 @@ public class CompressionMetadata
             }
             catch (FileNotFoundException | NoSuchFileException fnfe)
             {
-                throw Throwables.propagate(fnfe);
+                throw new RuntimeException(fnfe);
             }
             catch (IOException e)
             {

--- a/src/java/org/apache/cassandra/io/sstable/ISSTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/ISSTableScanner.java
@@ -64,7 +64,8 @@ public interface ISSTableScanner extends UnfilteredPartitionIterator
 
         if (throwable != null)
         {
-            Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
 
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -182,8 +182,10 @@ class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
             if (diskWriter.exception instanceof IOException)
                 throw (IOException) diskWriter.exception;
             else
+            {
                 Throwables.throwIfUnchecked(diskWriter.exception);
                 throw new RuntimeException(diskWriter.exception);
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleUnsortedWriter.java
@@ -182,7 +182,8 @@ class SSTableSimpleUnsortedWriter extends AbstractSSTableSimpleWriter
             if (diskWriter.exception instanceof IOException)
                 throw (IOException) diskWriter.exception;
             else
-                throw Throwables.propagate(diskWriter.exception);
+                Throwables.throwIfUnchecked(diskWriter.exception);
+                throw new RuntimeException(diskWriter.exception);
         }
     }
 

--- a/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableSimpleWriter.java
@@ -85,7 +85,9 @@ class SSTableSimpleWriter extends AbstractSSTableSimpleWriter
         }
         catch (Throwable t)
         {
-            throw Throwables.propagate(writer == null ? t : writer.abort(t));
+            Throwable e = writer == null ? t : writer.abort(t);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -65,7 +65,6 @@ import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.SyncUtil;
 
-import static com.google.common.base.Throwables.propagate;
 import static org.apache.cassandra.config.CassandraRelevantProperties.JAVA_IO_TMPDIR;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 
@@ -479,7 +478,7 @@ public final class FileUtils
     public static void handleFSErrorAndPropagate(FSError e)
     {
         JVMStabilityInspector.inspectThrowable(e);
-        throw propagate(e);
+        throw e;
     }
 
     /**

--- a/src/java/org/apache/cassandra/repair/consistent/admin/CleanupSummary.java
+++ b/src/java/org/apache/cassandra/repair/consistent/admin/CleanupSummary.java
@@ -32,7 +32,6 @@ import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -57,7 +56,7 @@ public class CleanupSummary
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -126,7 +125,7 @@ public class CleanupSummary
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/repair/consistent/admin/PendingStat.java
+++ b/src/java/org/apache/cassandra/repair/consistent/admin/PendingStat.java
@@ -32,7 +32,6 @@ import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
@@ -55,7 +54,7 @@ public class PendingStat
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -94,7 +93,7 @@ public class PendingStat
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/repair/consistent/admin/PendingStats.java
+++ b/src/java/org/apache/cassandra/repair/consistent/admin/PendingStats.java
@@ -28,7 +28,6 @@ import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 
 public class PendingStats
 {
@@ -51,7 +50,7 @@ public class PendingStats
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -87,7 +86,7 @@ public class PendingStats
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/repair/consistent/admin/RepairStats.java
+++ b/src/java/org/apache/cassandra/repair/consistent/admin/RepairStats.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.management.openmbean.*;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 
 import org.apache.cassandra.repair.consistent.RepairedState;
 
@@ -47,7 +46,7 @@ public class RepairStats
             }
             catch (OpenDataException e)
             {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -75,7 +74,7 @@ public class RepairStats
             }
             catch (OpenDataException e)
             {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -112,7 +111,7 @@ public class RepairStats
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -165,7 +164,7 @@ public class RepairStats
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/java/org/apache/cassandra/streaming/StreamTransferTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamTransferTask.java
@@ -144,7 +144,8 @@ public class StreamTransferTask extends StreamTask
         }
         streams.clear();
         if (fail != null)
-            Throwables.propagate(fail);
+            Throwables.throwIfUnchecked(fail);
+            throw new RuntimeException(fail);
     }
 
     public synchronized int getTotalNumberOfFiles()

--- a/src/java/org/apache/cassandra/streaming/StreamTransferTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamTransferTask.java
@@ -143,9 +143,10 @@ public class StreamTransferTask extends StreamTask
             }
         }
         streams.clear();
-        if (fail != null)
+        if (fail != null) {
             Throwables.throwIfUnchecked(fail);
             throw new RuntimeException(fail);
+        }
     }
 
     public synchronized int getTotalNumberOfFiles()

--- a/src/java/org/apache/cassandra/streaming/management/ProgressInfoCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/ProgressInfoCompositeData.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.management.openmbean.*;
 
-import com.google.common.base.Throwables;
-
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.streaming.ProgressInfo;
 import org.apache.cassandra.utils.TimeUUID;
@@ -68,7 +66,7 @@ public class ProgressInfoCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);           
         }
     }
 
@@ -89,7 +87,7 @@ public class ProgressInfoCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -107,7 +105,7 @@ public class ProgressInfoCompositeData
         }
         catch (UnknownHostException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/java/org/apache/cassandra/streaming/management/SessionCompleteEventCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/SessionCompleteEventCompositeData.java
@@ -21,8 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.management.openmbean.*;
 
-import com.google.common.base.Throwables;
-
 import org.apache.cassandra.streaming.StreamEvent;
 
 public class SessionCompleteEventCompositeData
@@ -53,7 +51,7 @@ public class SessionCompleteEventCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -70,7 +68,7 @@ public class SessionCompleteEventCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/java/org/apache/cassandra/streaming/management/SessionInfoCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/SessionInfoCompositeData.java
@@ -22,7 +22,6 @@ import java.util.*;
 import javax.management.openmbean.*;
 
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -83,7 +82,7 @@ public class SessionInfoCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -121,7 +120,7 @@ public class SessionInfoCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -138,7 +137,7 @@ public class SessionInfoCompositeData
         }
         catch (UnknownHostException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         Function<CompositeData, StreamSummary> toStreamSummary = new Function<CompositeData, StreamSummary>()
         {

--- a/src/java/org/apache/cassandra/streaming/management/StreamStateCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/StreamStateCompositeData.java
@@ -66,7 +66,8 @@ public class StreamStateCompositeData
         }
         catch (OpenDataException e)
         {
-            throw new RuntimeException(e);        }
+            throw new RuntimeException(e);        
+        }
     }
 
     public static CompositeData toCompositeData(final StreamState streamState)
@@ -112,7 +113,8 @@ public class StreamStateCompositeData
         }
         catch (OpenDataException e)
         {
-            throw new RuntimeException(e);        }
+            throw new RuntimeException(e);
+        }
     }
 
     public static StreamState fromCompositeData(CompositeData cd)

--- a/src/java/org/apache/cassandra/streaming/management/StreamStateCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/StreamStateCompositeData.java
@@ -21,7 +21,6 @@ import java.util.*;
 import javax.management.openmbean.*;
 
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -67,8 +66,7 @@ public class StreamStateCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
-        }
+            throw new RuntimeException(e);        }
     }
 
     public static CompositeData toCompositeData(final StreamState streamState)
@@ -114,8 +112,7 @@ public class StreamStateCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
-        }
+            throw new RuntimeException(e);        }
     }
 
     public static StreamState fromCompositeData(CompositeData cd)

--- a/src/java/org/apache/cassandra/streaming/management/StreamSummaryCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/StreamSummaryCompositeData.java
@@ -51,7 +51,8 @@ public class StreamSummaryCompositeData
         }
         catch (OpenDataException e)
         {
-            throw new RuntimeException(e);        }
+            throw new RuntimeException(e);
+        }
     }
 
     public static CompositeData toCompositeData(StreamSummary streamSummary)
@@ -66,7 +67,8 @@ public class StreamSummaryCompositeData
         }
         catch (OpenDataException e)
         {
-            throw new RuntimeException(e);        }
+            throw new RuntimeException(e);
+        }
     }
 
     public static StreamSummary fromCompositeData(CompositeData cd)

--- a/src/java/org/apache/cassandra/streaming/management/StreamSummaryCompositeData.java
+++ b/src/java/org/apache/cassandra/streaming/management/StreamSummaryCompositeData.java
@@ -21,8 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.management.openmbean.*;
 
-import com.google.common.base.Throwables;
-
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.streaming.StreamSummary;
 
@@ -53,8 +51,7 @@ public class StreamSummaryCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
-        }
+            throw new RuntimeException(e);        }
     }
 
     public static CompositeData toCompositeData(StreamSummary streamSummary)
@@ -69,8 +66,7 @@ public class StreamSummaryCompositeData
         }
         catch (OpenDataException e)
         {
-            throw Throwables.propagate(e);
-        }
+            throw new RuntimeException(e);        }
     }
 
     public static StreamSummary fromCompositeData(CompositeData cd)

--- a/src/java/org/apache/cassandra/tools/LoaderOptions.java
+++ b/src/java/org/apache/cassandra/tools/LoaderOptions.java
@@ -26,7 +26,6 @@ import java.net.*;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
 
 import org.apache.cassandra.config.*;
@@ -174,9 +173,9 @@ public class LoaderOptions
             }
             catch (UnknownHostException e)
             {
-                Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
-
+            
             return new LoaderOptions(this);
         }
 

--- a/src/java/org/apache/cassandra/tools/SSTableOfflineRelevel.java
+++ b/src/java/org/apache/cassandra/tools/SSTableOfflineRelevel.java
@@ -122,8 +122,8 @@ public class SSTableOfflineRelevel
                 catch (Throwable t)
                 {
                     out.println("Couldn't open sstable: "+sstable.getKey().filenameFor(Component.DATA));
-                    Throwables.propagate(t);
-                }
+                    Throwables.throwIfUnchecked(t);
+                    throw new RuntimeException(t);                }
             }
         }
         if (sstableMultimap.isEmpty())

--- a/src/java/org/apache/cassandra/tools/SSTableOfflineRelevel.java
+++ b/src/java/org/apache/cassandra/tools/SSTableOfflineRelevel.java
@@ -123,7 +123,8 @@ public class SSTableOfflineRelevel
                 {
                     out.println("Couldn't open sstable: "+sstable.getKey().filenameFor(Component.DATA));
                     Throwables.throwIfUnchecked(t);
-                    throw new RuntimeException(t);                }
+                    throw new RuntimeException(t);
+                }
             }
         }
         if (sstableMultimap.isEmpty())

--- a/src/java/org/apache/cassandra/utils/WrappedRunnable.java
+++ b/src/java/org/apache/cassandra/utils/WrappedRunnable.java
@@ -17,8 +17,6 @@
  */
 package org.apache.cassandra.utils;
 
-import com.google.common.base.Throwables;
-
 public abstract class WrappedRunnable implements Runnable
 {
     public final void run()
@@ -27,9 +25,13 @@ public abstract class WrappedRunnable implements Runnable
         {
             runMayThrow();
         }
+        catch (RuntimeException e) 
+        {
+            throw e;
+        }
         catch (Exception e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/test/microbench/org/apache/cassandra/test/microbench/instance/ReadTest.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/instance/ReadTest.java
@@ -109,7 +109,8 @@ public abstract class ReadTest extends SimpleTableWriter
                                                    }
                                                    catch (Throwable throwable)
                                                    {
-                                                       throw Throwables.propagate(throwable);
+                                                       Throwables.throwIfUnchecked(throwable);
+                                                       throw new RuntimeException(throwable);
                                                    }
                                                }));
         }
@@ -142,7 +143,8 @@ public abstract class ReadTest extends SimpleTableWriter
                                                    }
                                                    catch (Throwable throwable)
                                                    {
-                                                       throw Throwables.propagate(throwable);
+                                                       Throwables.throwIfUnchecked(throwable);
+                                                       throw new RuntimeException(throwable);
                                                    }
                                                }));
         }

--- a/test/microbench/org/apache/cassandra/test/microbench/instance/SimpleTableWriter.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/instance/SimpleTableWriter.java
@@ -138,7 +138,8 @@ public abstract class SimpleTableWriter extends CQLTester
                                                    }
                                                    catch (Throwable throwable)
                                                    {
-                                                       throw Throwables.propagate(throwable);
+                                                       Throwables.throwIfUnchecked(throwable);
+                                                       throw new RuntimeException(throwable);
                                                    }
                                                }));
         }
@@ -169,7 +170,8 @@ public abstract class SimpleTableWriter extends CQLTester
                                                    }
                                                    catch (Throwable throwable)
                                                    {
-                                                       throw Throwables.propagate(throwable);
+                                                       Throwables.throwIfUnchecked(throwable);
+                                                       throw new RuntimeException(throwable);
                                                    }
                                                }));
         }

--- a/test/simulator/main/org/apache/cassandra/simulator/paxos/PaxosSimulation.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/paxos/PaxosSimulation.java
@@ -262,15 +262,9 @@ public abstract class PaxosSimulation implements Simulation, ClusterActionListen
         }
 
         log(causedByPrimaryKey);
-        if (causedByPrimaryKey != null) {
-            Throwables.throwIfUnchecked(causedByThrowable);
-            throw new RuntimeException(causedByThrowable);
-        }
-        else 
-        {
-            Throwables.throwIfUnchecked(simulated.failures.get().get(0));
-            throw new RuntimeException(simulated.failures.get().get(0));
-        }
+        Throwable t = (causedByPrimaryKey != null) ? causedByThrowable : simulated.failures.get().get(0);
+        Throwables.throwIfUnchecked(t);
+        throw new RuntimeException(t);
     }
 
     public void close()

--- a/test/simulator/main/org/apache/cassandra/simulator/paxos/PaxosSimulation.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/paxos/PaxosSimulation.java
@@ -262,8 +262,15 @@ public abstract class PaxosSimulation implements Simulation, ClusterActionListen
         }
 
         log(causedByPrimaryKey);
-        if (causedByPrimaryKey != null) throw Throwables.propagate(causedByThrowable);
-        else throw Throwables.propagate(simulated.failures.get().get(0));
+        if (causedByPrimaryKey != null) {
+            Throwables.throwIfUnchecked(causedByThrowable);
+            throw new RuntimeException(causedByThrowable);
+        }
+        else 
+        {
+            Throwables.throwIfUnchecked(simulated.failures.get().get(0));
+            throw new RuntimeException(simulated.failures.get().get(0));
+        }
     }
 
     public void close()

--- a/test/unit/org/apache/cassandra/cql3/MemtableSizeTest.java
+++ b/test/unit/org/apache/cassandra/cql3/MemtableSizeTest.java
@@ -150,7 +150,8 @@ public class MemtableSizeTest extends CQLTester
         }
         catch (Throwable throwable)
         {
-            Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/net/SocketUtils.java
+++ b/test/unit/org/apache/cassandra/net/SocketUtils.java
@@ -21,8 +21,6 @@ package org.apache.cassandra.net;
 import java.io.IOException;
 import java.net.ServerSocket;
 
-import com.google.common.base.Throwables;
-
 public class SocketUtils
 {
     public static synchronized int findAvailablePort() throws RuntimeException
@@ -37,7 +35,7 @@ public class SocketUtils
         }
         catch (IOException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         finally
         {
@@ -49,7 +47,7 @@ public class SocketUtils
                 }
                 catch (IOException e)
                 {
-                    Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         }

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceTestBase.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceTestBase.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 
-import com.google.common.base.Throwables;
-
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.BooleanType;
 import org.apache.cassandra.db.marshal.DecimalType;
@@ -434,7 +432,7 @@ public class ByteSourceTestBase
         }
         catch (UnknownHostException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Replaced all occurances of `Throwables.propagate()`