### PR TITLE
CASSANDRA-17668 handle leak of non-standard Java types as clients using JMX cannot handle them

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -95,7 +95,17 @@ Upgrading
 
 Deprecation
 -----------
-
+    - In the JMX MBean org.apache.cassandra.db:type=RepairService`:
+        - deprecate the getter/setter methods `getRepairSessionSpaceInMebibytes` and `setRepairSessionSpaceInMebibytes`
+          in favor of `getRepairSessionSpaceInMiB` and `setRepairSessionSpaceInMiB` respectively
+    - In the JMX MBean `org.apache.cassandra.db:type=StorageService`:
+        - deprecate the getter/setter methods `getRepairSessionMaxTreeDepth` and `setRepairSessionMaxTreeDepth`
+          in favor of `getRepairSessionMaximumTreeDepth` and `setRepairSessionMaximumTreeDepth`
+        - deprecate the setter method `setColumnIndexSize` in favor of `setColumnIndexSizeInKiB`
+        - deprecate the getter/setter methods `getColumnIndexCacheSize` and `setColumnIndexCacheSize` in favor of
+          `getColumnIndexCacheSizeInKiB` and `setColumnIndexCacheSizeInKiB` respectively
+        - deprecate the getter/setter methods `getBatchSizeWarnThreshold` and `setBatchSizeWarnThreshold` in favor of
+          `getBatchSizeWarnThresholdInKiB` and `setBatchSizeWarnThresholdInKiB` respectively
 
 4.1
 ===

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.concurrent.ExecutorPlus;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.EndpointsByRange;
 import org.apache.cassandra.locator.EndpointsForRange;
@@ -297,14 +298,40 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         return DatabaseDescriptor.getRepairSessionSpaceInMiB();
     }
 
+    @Deprecated
     @Override
     public void setRepairSessionSpaceInMebibytes(int sizeInMebibytes)
     {
         DatabaseDescriptor.setRepairSessionSpaceInMiB(sizeInMebibytes);
     }
 
+    @Deprecated
     @Override
     public int getRepairSessionSpaceInMebibytes()
+    {
+        return DatabaseDescriptor.getRepairSessionSpaceInMiB();
+    }
+
+    @Override
+    public void setRepairSessionSpaceInMiB(int sizeInMebibytes)
+    {
+        try
+        {
+            DatabaseDescriptor.setRepairSessionSpaceInMiB(sizeInMebibytes);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    /*
+     * In CASSANDRA-17668, JMX setters that did not throw standard exceptions were deprecated in favor of ones that do.
+     * For consistency purposes, the respective getter "getRepairSessionSpaceInMebibytes" was also deprecated and
+     * replaced by this method.
+     */
+    @Override
+    public int getRepairSessionSpaceInMiB()
     {
         return DatabaseDescriptor.getRepairSessionSpaceInMiB();
     }

--- a/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
@@ -34,8 +34,19 @@ public interface ActiveRepairServiceMBean
     @Deprecated
     public int getRepairSessionSpaceInMegabytes();
 
+    /**
+     * @deprecated use setRepairSessionSpaceInMiB instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setRepairSessionSpaceInMebibytes(int sizeInMebibytes);
+    /**
+     * @deprecated use getRepairSessionSpaceInMiB instead
+     */
+    @Deprecated
     public int getRepairSessionSpaceInMebibytes();
+
+    public void setRepairSessionSpaceInMiB(int sizeInMebibytes);
+    public int getRepairSessionSpaceInMiB();
 
     public boolean getUseOffheapMerkleTrees();
     public void setUseOffheapMerkleTrees(boolean value);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4554,12 +4554,40 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                ImmutableList.<String>builder().add(pair.left.name()).addAll(pair.right).build();
     }
 
+    @Deprecated
+    @Override
     public void setRepairSessionMaxTreeDepth(int depth)
     {
         DatabaseDescriptor.setRepairSessionMaxTreeDepth(depth);
     }
 
+    @Deprecated
+    @Override
     public int getRepairSessionMaxTreeDepth()
+    {
+        return DatabaseDescriptor.getRepairSessionMaxTreeDepth();
+    }
+
+    @Override
+    public void setRepairSessionMaximumTreeDepth(int depth)
+    {
+        try
+        {
+            DatabaseDescriptor.setRepairSessionMaxTreeDepth(depth);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    /*
+     * In CASSANDRA-17668, JMX setters that did not throw standard exceptions were deprecated in favor of ones that do.
+     * For consistency purposes, the respective getter "getRepairSessionMaxTreeDepth" was also deprecated and replaced
+     * by this method.
+     */
+    @Override
+    public int getRepairSessionMaximumTreeDepth()
     {
         return DatabaseDescriptor.getRepairSessionMaxTreeDepth();
     }
@@ -6219,11 +6247,29 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("updated replica_filtering_protection.cached_rows_fail_threshold to {}", threshold);
     }
 
+    @Override
     public int getColumnIndexSizeInKiB()
     {
         return DatabaseDescriptor.getColumnIndexSizeInKiB();
     }
 
+    @Override
+    public void setColumnIndexSizeInKiB(int columnIndexSizeInKiB)
+    {
+        int oldValueInKiB = DatabaseDescriptor.getColumnIndexSizeInKiB();
+        try
+        {
+            DatabaseDescriptor.setColumnIndexSize(columnIndexSizeInKiB);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        logger.info("Updated column_index_size to {} KiB (was {} KiB)", columnIndexSizeInKiB, oldValueInKiB);
+    }
+
+    @Deprecated
+    @Override
     public void setColumnIndexSize(int columnIndexSizeInKB)
     {
         int oldValueInKiB = DatabaseDescriptor.getColumnIndexSizeInKiB();
@@ -6231,15 +6277,44 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("Updated column_index_size to {} KiB (was {} KiB)", columnIndexSizeInKB, oldValueInKiB);
     }
 
+    @Deprecated
+    @Override
     public int getColumnIndexCacheSize()
     {
         return DatabaseDescriptor.getColumnIndexCacheSizeInKiB();
     }
 
+    @Deprecated
+    @Override
     public void setColumnIndexCacheSize(int cacheSizeInKB)
     {
         DatabaseDescriptor.setColumnIndexCacheSize(cacheSizeInKB);
         logger.info("Updated column_index_cache_size to {}", cacheSizeInKB);
+    }
+
+    /*
+     * In CASSANDRA-17668, JMX setters that did not throw standard exceptions were deprecated in favor of ones that do.
+     * For consistency purposes, the respective getter "getColumnIndexCacheSize" was also deprecated and replaced by
+     * this method.
+     */
+    @Override
+    public int getColumnIndexCacheSizeInKiB()
+    {
+        return DatabaseDescriptor.getColumnIndexCacheSizeInKiB();
+    }
+
+    @Override
+    public void setColumnIndexCacheSizeInKiB(int cacheSizeInKiB)
+    {
+        try
+        {
+            DatabaseDescriptor.setColumnIndexCacheSize(cacheSizeInKiB);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        logger.info("Updated column_index_cache_size to {}", cacheSizeInKiB);
     }
 
     public int getBatchSizeFailureThreshold()
@@ -6253,15 +6328,45 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("updated batch_size_fail_threshold to {}", threshold);
     }
 
+    @Deprecated
+    @Override
     public int getBatchSizeWarnThreshold()
     {
         return DatabaseDescriptor.getBatchSizeWarnThresholdInKiB();
     }
 
+    @Deprecated
+    @Override
     public void setBatchSizeWarnThreshold(int threshold)
     {
         DatabaseDescriptor.setBatchSizeWarnThresholdInKiB(threshold);
         logger.info("Updated batch_size_warn_threshold to {}", threshold);
+    }
+
+    /*
+     * In CASSANDRA-17668, JMX setters that did not throw standard exceptions were deprecated in favor of ones that do.
+     * For consistency purposes, the respective getter "getBatchSizeWarnThreshold" was also deprecated and replaced by
+     * this method.
+     */
+    @Override
+    public int getBatchSizeWarnThresholdInKiB()
+    {
+        return DatabaseDescriptor.getBatchSizeWarnThresholdInKiB();
+    }
+
+    @Override
+    public void setBatchSizeWarnThresholdInKiB(int thresholdInKiB)
+    {
+        try
+        {
+            DatabaseDescriptor.setBatchSizeWarnThresholdInKiB(thresholdInKiB);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+
+        logger.info("Updated batch_size_warn_threshold to {}", thresholdInKiB);
     }
 
     public int getInitialRangeTombstoneListAllocationSize()

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -417,9 +417,21 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     public void forceTerminateAllRepairSessions();
 
+    /**
+     * @deprecated use setRepairSessionMaximumTreeDepth instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setRepairSessionMaxTreeDepth(int depth);
 
+    /**
+     * @deprecated use getRepairSessionMaximumTreeDepth instead
+     */
+    @Deprecated
     public int getRepairSessionMaxTreeDepth();
+
+    public void setRepairSessionMaximumTreeDepth(int depth);
+
+    public int getRepairSessionMaximumTreeDepth();
 
     /**
      * Get the status of a given parent repair session.
@@ -865,23 +877,59 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     /** Returns the granularity of the collation index of rows within a partition **/
     public int getColumnIndexSizeInKiB();
+
     /** Sets the granularity of the collation index of rows within a partition **/
+    public void setColumnIndexSizeInKiB(int columnIndexSizeInKiB);
+
+    /**
+     * Sets the granularity of the collation index of rows within a partition
+     * @deprecated use setColumnIndexSizeInKiB instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setColumnIndexSize(int columnIndexSizeInKB);
 
-    /** Returns the threshold for skipping the column index when caching partition info **/
+    /**
+     * Returns the threshold for skipping the column index when caching partition info
+     * @deprecated use getColumnIndexCacheSizeInKiB
+     */
+    @Deprecated
     public int getColumnIndexCacheSize();
-    /** Sets the threshold for skipping the column index when caching partition info **/
+
+    /**
+     * Sets the threshold for skipping the column index when caching partition info
+     * @deprecated use setColumnIndexCacheSizeInKiB instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setColumnIndexCacheSize(int cacheSizeInKB);
+
+    /** Returns the threshold for skipping the column index when caching partition info **/
+    public int getColumnIndexCacheSizeInKiB();
+
+    /** Sets the threshold for skipping the column index when caching partition info **/
+    public void setColumnIndexCacheSizeInKiB(int cacheSizeInKiB);
 
     /** Returns the threshold for rejecting queries due to a large batch size */
     public int getBatchSizeFailureThreshold();
     /** Sets the threshold for rejecting queries due to a large batch size */
     public void setBatchSizeFailureThreshold(int batchSizeDebugThreshold);
 
-    /** Returns the threshold for warning queries due to a large batch size */
+    /**
+     * Returns the threshold for warning queries due to a large batch size
+     * @deprecated use getBatchSizeWarnThresholdInKiB instead
+     */
+    @Deprecated
     public int getBatchSizeWarnThreshold();
-    /** Sets the threshold for warning queries due to a large batch size */
+    /**
+     * Sets the threshold for warning queries due to a large batch size
+     * @deprecated use setBatchSizeWarnThresholdInKiB instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setBatchSizeWarnThreshold(int batchSizeDebugThreshold);
+
+    /** Returns the threshold for warning queries due to a large batch size */
+    public int getBatchSizeWarnThresholdInKiB();
+    /** Sets the threshold for warning queries due to a large batch size **/
+    public void setBatchSizeWarnThresholdInKiB(int batchSizeDebugThreshold);
 
     /** Sets the hinted handoff throttle in KiB per second, per delivery thread. */
     public void setHintedHandoffThrottleInKB(int throttleInKB);

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -415,7 +415,7 @@ public class DatabaseDescriptorTest
             try
             {
                 DatabaseDescriptor.setRepairSessionSpaceInMiB(0);
-                fail("Should have received a ConfigurationException for depth of 9");
+                fail("Should have received a ConfigurationException for depth of 0");
             }
             catch (ConfigurationException ignored) { }
 

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -198,4 +198,112 @@ public class StorageServiceTest
         // fast tasks are shut down as part of the Runtime shutdown hook.
         assertFalse(ScheduledExecutors.scheduledFastTasks.isTerminated());
     }
+
+    @Test
+    public void testRepairSessionMaximumTreeDepth()
+    {
+        StorageService storageService = StorageService.instance;
+        int previousDepth = storageService.getRepairSessionMaximumTreeDepth();
+        try
+        {
+            Assert.assertEquals(20, storageService.getRepairSessionMaximumTreeDepth());
+            storageService.setRepairSessionMaximumTreeDepth(10);
+            Assert.assertEquals(10, storageService.getRepairSessionMaximumTreeDepth());
+
+            try
+            {
+                storageService.setRepairSessionMaximumTreeDepth(9);
+                fail("Should have received a IllegalArgumentException for depth of 9");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(10, storageService.getRepairSessionMaximumTreeDepth());
+
+            try
+            {
+                storageService.setRepairSessionMaximumTreeDepth(-20);
+                fail("Should have received a IllegalArgumentException for depth of -20");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(10, storageService.getRepairSessionMaximumTreeDepth());
+
+            storageService.setRepairSessionMaximumTreeDepth(22);
+            Assert.assertEquals(22, storageService.getRepairSessionMaximumTreeDepth());
+        }
+        finally
+        {
+            storageService.setRepairSessionMaximumTreeDepth(previousDepth);
+        }
+    }
+
+    @Test
+    public void testColumnIndexSizeInKiB()
+    {
+        StorageService storageService = StorageService.instance;
+        int previousColumnIndexSize = storageService.getColumnIndexSizeInKiB();
+        try
+        {
+            storageService.setColumnIndexSizeInKiB(1024);
+            Assert.assertEquals(1024, storageService.getColumnIndexSizeInKiB());
+
+            try
+            {
+                storageService.setColumnIndexSizeInKiB(2 * 1024 * 1024);
+                fail("Should have received an IllegalArgumentException column_index_size = 2GiB");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(1024, storageService.getColumnIndexSizeInKiB());
+        }
+        finally
+        {
+            storageService.setColumnIndexSizeInKiB(previousColumnIndexSize);
+        }
+    }
+
+    @Test
+    public void testColumnIndexCacheSizeInKiB()
+    {
+        StorageService storageService = StorageService.instance;
+        int previousColumnIndexCacheSize = storageService.getColumnIndexCacheSizeInKiB();
+        try
+        {
+            storageService.setColumnIndexCacheSizeInKiB(1024);
+            Assert.assertEquals(1024, storageService.getColumnIndexCacheSizeInKiB());
+
+            try
+            {
+                storageService.setColumnIndexCacheSizeInKiB(2 * 1024 * 1024);
+                fail("Should have received an IllegalArgumentException column_index_cache_size= 2GiB");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(1024, storageService.getColumnIndexCacheSizeInKiB());
+        }
+        finally
+        {
+            storageService.setColumnIndexCacheSizeInKiB(previousColumnIndexCacheSize);
+        }
+    }
+
+    @Test
+    public void testBatchSizeWarnThresholdInKiB()
+    {
+        StorageService storageService = StorageService.instance;
+        int previousBatchSizeWarnThreshold = storageService.getBatchSizeWarnThresholdInKiB();
+        try
+        {
+            storageService.setBatchSizeWarnThresholdInKiB(1024);
+            Assert.assertEquals(1024, storageService.getBatchSizeWarnThresholdInKiB());
+
+            try
+            {
+                storageService.setBatchSizeWarnThresholdInKiB(2 * 1024 * 1024);
+                fail("Should have received an IllegalArgumentException batch_size_warn_threshold = 2GiB");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(1024, storageService.getBatchSizeWarnThresholdInKiB());
+        }
+        finally
+        {
+            storageService.setBatchSizeWarnThresholdInKiB(previousBatchSizeWarnThreshold);
+        }
+    }
 }


### PR DESCRIPTION
DatabaseDescriptor had changes where some methods threw non-standard exceptions.  This caused some of the JMX setter methods that called them to throw them as well which causes issues as the clients can't handle them.  This pull request addresses these issues by creating new APIs that catches and converts the non-standard exceptions to standard ones and deprecates the old setters.  For consistency, since the setters have been deprecated, new getters have been created as well.   