### PR TITLE
Fix typo from actie to active CASSANDRA-17845.

### DIFF
--- a/doc/modules/cassandra/pages/cql/ddl.adoc
+++ b/doc/modules/cassandra/pages/cql/ddl.adoc
@@ -6,7 +6,7 @@ data in the table. Tables are located in _keyspaces_.
 A keyspace defines options that apply to all the keyspace's tables. 
 The xref:cql/ddl.adoc#replication-strategy[replication strategy] is an important keyspace option, as is the replication factor. 
 A good general rule is one keyspace per application.
-It is common for a cluster to define only one keyspace for an actie application.
+It is common for a cluster to define only one keyspace for an active application.
 
 This section describes the statements used to create, modify, and remove
 those keyspace and tables.


### PR DESCRIPTION
My first attempt at submitting a patch so apologies if incorrect.  This fixes the issue raised in [CASSANDRA-17845](https://issues.apache.org/jira/browse/CASSANDRA-17845) which pointed out that `actie` should be `active`.