### PR TITLE
CASSANDRA-17668 handle leak of non-standard Java types as clients using JMX cannot handle them

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -82,6 +82,12 @@ Statement re-prepare storms
       loops caused by the driver. This new behaviour will be picked up only when the entire cluster has been updated
       to 3.0.26 or higher. In case of a mixed version cluster, different major versions will be taken as a minimum
       required version.
+      
+Deprecation
+-----------
+    - In the JMX MBean `org.apache.cassandra.db:type=StorageService`:
+        - deprecate the getter/setter methods `getRepairSessionMaxTreeDepth` and `setRepairSessionMaxTreeDepth`
+          in favor of `getRepairSessionMaximumTreeDepth` and `setRepairSessionMaximumTreeDepth`
 
 3.11.11
 =======

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3799,12 +3799,35 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         ActiveRepairService.instance.terminateSessions();
     }
 
+    @Deprecated
+    @Override
     public void setRepairSessionMaxTreeDepth(int depth)
     {
         DatabaseDescriptor.setRepairSessionMaxTreeDepth(depth);
     }
 
+    @Deprecated
+    @Override
     public int getRepairSessionMaxTreeDepth()
+    {
+        return DatabaseDescriptor.getRepairSessionMaxTreeDepth();
+    }
+
+    @Override
+    public void setRepairSessionMaximumTreeDepth(int depth)
+    {
+        try
+        {
+            DatabaseDescriptor.setRepairSessionMaxTreeDepth(depth);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    @Override
+    public int getRepairSessionMaximumTreeDepth()
     {
         return DatabaseDescriptor.getRepairSessionMaxTreeDepth();
     }

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -387,9 +387,21 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     public void forceTerminateAllRepairSessions();
 
+    /**
+     * @deprecated use setRepairSessionMaximumTreeDepth instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setRepairSessionMaxTreeDepth(int depth);
 
+    /**
+     * @deprecated use getRepairSessionMaximumTreeDepth instead
+     */
+    @Deprecated
     public int getRepairSessionMaxTreeDepth();
+
+    public void setRepairSessionMaximumTreeDepth(int depth);
+
+    public int getRepairSessionMaximumTreeDepth();
 
     /**
      * transfer this node's data to other machines and remove it from service.

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import static org.junit.Assert.fail;
+
+public class StorageServiceTest
+{
+    @Before
+    public void setup()
+    {
+        DatabaseDescriptor.daemonInitialization();
+    }
+
+    @Test
+    public void testRepairSessionMaximumTreeDepth()
+    {
+        StorageService storageService = StorageService.instance;
+        int previousDepth = storageService.getRepairSessionMaximumTreeDepth();
+        try
+        {
+            Assert.assertEquals(18, storageService.getRepairSessionMaximumTreeDepth());
+            storageService.setRepairSessionMaximumTreeDepth(10);
+            Assert.assertEquals(10, storageService.getRepairSessionMaximumTreeDepth());
+
+            try
+            {
+                storageService.setRepairSessionMaximumTreeDepth(9);
+                fail("Should have received a IllegalArgumentException for depth of 9");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(10, storageService.getRepairSessionMaximumTreeDepth());
+
+            try
+            {
+                storageService.setRepairSessionMaximumTreeDepth(-20);
+                fail("Should have received a IllegalArgumentException for depth of -20");
+            }
+            catch (IllegalArgumentException ignored) { }
+            Assert.assertEquals(10, storageService.getRepairSessionMaximumTreeDepth());
+
+            storageService.setRepairSessionMaximumTreeDepth(22);
+            Assert.assertEquals(22, storageService.getRepairSessionMaximumTreeDepth());
+        }
+        finally
+        {
+            storageService.setRepairSessionMaximumTreeDepth(previousDepth);
+        }
+    }
+}


### PR DESCRIPTION
DatabaseDescriptor had changes where some methods threw non-standard exceptions.  This caused some of the JMX setter methods that called them to throw them as well which causes issues as the clients can't handle them.  This pull request addresses these issues by creating new APIs that catches and converts the non-standard exceptions to standard ones and deprecates the old setters.  For consistency, since the setters have been deprecated, new getters have been created as well.   