### PR TITLE
CASSANDRA-17668 handle leak of non-standard Java types as clients using JMX cannot handle them

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -68,6 +68,16 @@ Deprecation
 ---------
     - JavaScript user-defined functions have been deprecated. They are planned for removal
       in the next major release. (CASSANDRA-17280)
+    - In the JMX MBean org.apache.cassandra.db:type=RepairService`:
+        - deprecate the getter/setter methods `getRepairSessionSpaceInMegabytes` and `setRepairSessionSpaceInMegabytes`
+          in favor of `getRepairSessionSpaceInMB` and `setRepairSessionSpaceInMB` respectively
+    - In the JMX MBean `org.apache.cassandra.db:type=StorageService`:
+        - deprecate the getter/setter methods `getRepairSessionMaxTreeDepth` and `setRepairSessionMaxTreeDepth`
+          in favor of `getRepairSessionMaximumTreeDepth` and `setRepairSessionMaximumTreeDepth`
+        - deprecate the getter/setter methods `getColumnIndexCacheSize` and `setColumnIndexCacheSize` in favor of
+          `getColumnIndexCacheSizeInKiB` and `setColumnIndexCacheSizeInKiB` respectively
+        - deprecate the getter/setter methods `getBatchSizeWarnThreshold` and `setBatchSizeWarnThreshold` in favor of
+          `getBatchSizeWarnThresholdInKiB` and `setBatchSizeWarnThresholdInKiB` respectively
 
 4.0.2
 =====

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import org.apache.cassandra.concurrent.DebuggableThreadPoolExecutor;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.EndpointsByRange;
 import org.apache.cassandra.locator.EndpointsForRange;
 import org.slf4j.Logger;
@@ -247,14 +248,36 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         consistent.local.cancelSession(sessionID, force);
     }
 
+    @Deprecated
     @Override
     public void setRepairSessionSpaceInMegabytes(int sizeInMegabytes)
     {
         DatabaseDescriptor.setRepairSessionSpaceInMegabytes(sizeInMegabytes);
     }
 
+    @Deprecated
     @Override
     public int getRepairSessionSpaceInMegabytes()
+    {
+        return DatabaseDescriptor.getRepairSessionSpaceInMegabytes();
+    }
+
+    @Override
+    public void setRepairSessionSpaceInMB(int sizeInMegabytes)
+    {
+        try
+        {
+            DatabaseDescriptor.setRepairSessionSpaceInMegabytes(sizeInMegabytes);
+        }
+        catch(ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+
+    }
+
+    @Override
+    public int getRepairSessionSpaceInMB()
     {
         return DatabaseDescriptor.getRepairSessionSpaceInMegabytes();
     }

--- a/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
@@ -35,10 +35,10 @@ public interface ActiveRepairServiceMBean
      */
     @Deprecated
     public void setRepairSessionSpaceInMegabytes(int sizeInMegabytes);
-    @Deprecated
     /**
      * use getRepairSessionSpaceInMB instead
      */
+    @Deprecated
     public int getRepairSessionSpaceInMegabytes();
 
     public void setRepairSessionSpaceInMB(int sizeInMegabytes);

--- a/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
@@ -29,8 +29,20 @@ public interface ActiveRepairServiceMBean
     public List<Map<String, String>> getSessions(boolean all, String rangesStr);
     public void failSession(String session, boolean force);
 
+    /**
+     * use setRepairSessionSpaceInMB instead as it will not throw non-standard exceptions
+     * @deprecated
+     */
+    @Deprecated
     public void setRepairSessionSpaceInMegabytes(int sizeInMegabytes);
+    @Deprecated
+    /**
+     * use getRepairSessionSpaceInMB instead
+     */
     public int getRepairSessionSpaceInMegabytes();
+
+    public void setRepairSessionSpaceInMB(int sizeInMegabytes);
+    public int getRepairSessionSpaceInMB();
 
     public boolean getUseOffheapMerkleTrees();
     public void setUseOffheapMerkleTrees(boolean value);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4187,12 +4187,35 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                ImmutableList.<String>builder().add(pair.left.name()).addAll(pair.right).build();
     }
 
+    @Deprecated
+    @Override
     public void setRepairSessionMaxTreeDepth(int depth)
     {
         DatabaseDescriptor.setRepairSessionMaxTreeDepth(depth);
     }
 
+    @Deprecated
+    @Override
     public int getRepairSessionMaxTreeDepth()
+    {
+        return DatabaseDescriptor.getRepairSessionMaxTreeDepth();
+    }
+
+    @Override
+    public void setRepairSessionMaximumTreeDepth(int depth)
+    {
+        try
+        {
+            DatabaseDescriptor.setRepairSessionMaxTreeDepth(depth);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    @Override
+    public int getRepairSessionMaximumTreeDepth()
     {
         return DatabaseDescriptor.getRepairSessionMaxTreeDepth();
     }
@@ -5763,15 +5786,39 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("updated replica_filtering_protection.cached_rows_fail_threshold to {}", threshold);
     }
 
+    @Deprecated
+    @Override
     public int getColumnIndexCacheSize()
     {
         return DatabaseDescriptor.getColumnIndexCacheSizeInKB();
     }
 
+    @Deprecated
+    @Override
     public void setColumnIndexCacheSize(int cacheSizeInKB)
     {
         DatabaseDescriptor.setColumnIndexCacheSize(cacheSizeInKB);
         logger.info("Updated column_index_cache_size_in_kb to {}", cacheSizeInKB);
+    }
+
+    @Override
+    public int getColumnIndexCacheSizeInKiB()
+    {
+        return DatabaseDescriptor.getColumnIndexCacheSizeInKB();
+    }
+
+    @Override
+    public void setColumnIndexCacheSizeInKiB(int cacheSizeInKiB)
+    {
+        try
+        {
+            DatabaseDescriptor.setColumnIndexCacheSize(cacheSizeInKiB);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        logger.info("Updated column_index_cache_size to {}", cacheSizeInKiB);
     }
 
     public int getBatchSizeFailureThreshold()
@@ -5785,15 +5832,40 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         logger.info("updated batch_size_fail_threshold_in_kb to {}", threshold);
     }
 
+    @Deprecated
+    @Override
     public int getBatchSizeWarnThreshold()
     {
         return DatabaseDescriptor.getBatchSizeWarnThresholdInKB();
     }
 
+    @Deprecated
+    @Override
     public void setBatchSizeWarnThreshold(int threshold)
     {
         DatabaseDescriptor.setBatchSizeWarnThresholdInKB(threshold);
         logger.info("Updated batch_size_warn_threshold_in_kb to {}", threshold);
+    }
+
+    @Override
+    public int getBatchSizeWarnThresholdInKiB()
+    {
+        return DatabaseDescriptor.getBatchSizeWarnThresholdInKB();
+    }
+
+    @Override
+    public void setBatchSizeWarnThresholdInKiB(int thresholdInKiB)
+    {
+        try
+        {
+            DatabaseDescriptor.setBatchSizeWarnThresholdInKB(thresholdInKiB);
+        }
+        catch (ConfigurationException e)
+        {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+
+        logger.info("Updated batch_size_warn_threshold to {}", thresholdInKiB);
     }
 
     public int getInitialRangeTombstoneListAllocationSize()

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -390,9 +390,21 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     public void forceTerminateAllRepairSessions();
 
+    /**
+     * @deprecated use setRepairSessionMaximumTreeDepth instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setRepairSessionMaxTreeDepth(int depth);
 
+    /**
+     * @deprecated use getRepairSessionMaximumTreeDepth instead
+     */
+    @Deprecated
     public int getRepairSessionMaxTreeDepth();
+
+    public void setRepairSessionMaximumTreeDepth(int depth);
+
+    public int getRepairSessionMaximumTreeDepth();
 
     /**
      * Get the status of a given parent repair session.
@@ -743,20 +755,48 @@ public interface StorageServiceMBean extends NotificationEmitter
     /** Sets the number of rows cached at the coordinator before filtering/index queries fail outright. */
     public void setCachedReplicaRowsFailThreshold(int threshold);
 
-    /** Returns the threshold for skipping the column index when caching partition info **/
+    /**
+     * Returns the threshold for skipping the column index when caching partition info
+     * @deprecated use getColumnIndexCacheSizeInKiB
+     */
+    @Deprecated
     public int getColumnIndexCacheSize();
-    /** Sets the threshold for skipping the column index when caching partition info **/
+
+    /**
+     * Sets the threshold for skipping the column index when caching partition info
+     * @deprecated use setColumnIndexCacheSizeInKiB instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setColumnIndexCacheSize(int cacheSizeInKB);
+
+    /** Returns the threshold for skipping the column index when caching partition info **/
+    public int getColumnIndexCacheSizeInKiB();
+
+    /** Sets the threshold for skipping the column index when caching partition info **/
+    public void setColumnIndexCacheSizeInKiB(int cacheSizeInKiB);
 
     /** Returns the threshold for rejecting queries due to a large batch size */
     public int getBatchSizeFailureThreshold();
     /** Sets the threshold for rejecting queries due to a large batch size */
     public void setBatchSizeFailureThreshold(int batchSizeDebugThreshold);
 
-    /** Returns the threshold for warning queries due to a large batch size */
+    /**
+     * Returns the threshold for warning queries due to a large batch size
+     * @deprecated use getBatchSizeWarnThresholdInKiB instead
+     */
+    @Deprecated
     public int getBatchSizeWarnThreshold();
-    /** Sets the threshold for warning queries due to a large batch size */
+    /**
+     * Sets the threshold for warning queries due to a large batch size
+     * @deprecated use setBatchSizeWarnThresholdInKiB instead as it will not throw non-standard exceptions
+     */
+    @Deprecated
     public void setBatchSizeWarnThreshold(int batchSizeDebugThreshold);
+
+    /** Returns the threshold for warning queries due to a large batch size */
+    public int getBatchSizeWarnThresholdInKiB();
+    /** Sets the threshold for warning queries due to a large batch size **/
+    public void setBatchSizeWarnThresholdInKiB(int batchSizeDebugThreshold);
 
     /** Sets the hinted handoff throttle in kb per second, per delivery thread. */
     public void setHintedHandoffThrottleInKB(int throttleInKB);

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -385,7 +385,7 @@ public class DatabaseDescriptorTest
             try
             {
                 DatabaseDescriptor.setRepairSessionSpaceInMegabytes(0);
-                fail("Should have received a ConfigurationException for depth of 9");
+                fail("Should have received a ConfigurationException for depth of 0");
             }
             catch (ConfigurationException ignored) { }
 


### PR DESCRIPTION
DatabaseDescriptor had changes where some methods threw non-standard exceptions.  This caused some of the JMX setter methods that called them to throw them as well which causes issues as the clients can't handle them.  This pull request addresses these issues by creating new APIs that catches and converts the non-standard exceptions to standard ones and deprecates the old setters.  For consistency, since the setters have been deprecated, new getters have been created as well.   