### PR TITLE
Fix typo

### DIFF
--- a/doc/modules/cassandra/pages/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/operating/metrics.adoc
@@ -60,7 +60,8 @@ Reported name format:
 There is a special table called '`all`' without a keyspace. This
 represents the aggregation of metrics across *all* tables and keyspaces
 on the node.
-====[cols=",,",options="header",]
+====
+[cols=",,",options="header",]
 |===
 |Name |Type |Description
 |MemtableOnHeapSize |Gauge<Long> |Total amount of data stored in the


### PR DESCRIPTION
Add a missing character return, without it, a bad HTML layout was generated : table is displayed incorporated in the note.