### PR TITLE
CASSANDRA-17945 Update StorageService.getNativeaddress to handle IPv6 addresses

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2158,10 +2158,31 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 throw new RuntimeException(e);
             }
         }
-        else if (Gossiper.instance.getEndpointStateForEndpoint(endpoint).getApplicationState(ApplicationState.RPC_ADDRESS) == null)
-            return endpoint.getAddress().getHostAddress() + ":" + DatabaseDescriptor.getNativeTransportPort();
         else
-            return Gossiper.instance.getEndpointStateForEndpoint(endpoint).getApplicationState(ApplicationState.RPC_ADDRESS).value + ":" + DatabaseDescriptor.getNativeTransportPort();
+        {
+            final String ipAddress;
+            // If RPC_ADDRESS present in gossip for this endpoint use it.  This is expected for 3.x nodes.
+            if (Gossiper.instance.getEndpointStateForEndpoint(endpoint).getApplicationState(ApplicationState.RPC_ADDRESS) != null)
+            {
+                ipAddress = Gossiper.instance.getEndpointStateForEndpoint(endpoint).getApplicationState(ApplicationState.RPC_ADDRESS).value;
+            }
+            else
+            {
+                // otherwise just use the IP of the endpoint itself.
+                ipAddress = endpoint.getHostAddress(false);
+            }
+
+            // include the configured native_transport_port.
+            try
+            {
+                InetAddressAndPort address = InetAddressAndPort.getByNameOverrideDefaults(ipAddress, DatabaseDescriptor.getNativeTransportPort());
+                return address.getHostAddress(withPort);
+            }
+            catch (UnknownHostException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     public Map<List<String>, List<String>> getRangeToRpcaddressMap(String keyspace)


### PR DESCRIPTION
[CASSANDRA-17945](https://issues.apache.org/jira/browse/CASSANDRA-17945)

StorageService.getNativeaddress does not currently correctly handle IPv6 addresses correctly when NATIVE_ADDRESS_AND_PORT are not present in that it simply concatenates the IP address with the default native port, e.g.:

0:0:0:0:0:0:5a:3:9042

This does not parse into an InetSocketAddress as the address and port can't be disambiguated.

Such a case would usually be present when there are 3.x nodes present in a cluster with 4.0 nodes.

Change updates RPC_ADDRESS and else case to create InetAddressAndPort instances with DatabaseDescriptor.getNativeTransportPort and returns the getHostAddress(withPort) which properly bracket encodes the address, e.g.:

[0:0:0:0:0:0:5a:3]:9042

which can be parsed as an InetSocketAddress.

