### PR TITLE
CASSANDRA-16357: Add Unavailables metric for CASWrite

### DIFF
--- a/doc/modules/cassandra/pages/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/operating/metrics.adoc
@@ -428,7 +428,7 @@ Metrics::
 
   |ContentionHistogram |Histogram |How many contended reads were
   encountered
-  |===gi
+  |===
 RequestType::
   CASWrite
 Description::

--- a/doc/modules/cassandra/pages/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/operating/metrics.adoc
@@ -428,7 +428,7 @@ Metrics::
 
   |ContentionHistogram |Histogram |How many contended reads were
   encountered
-  |===
+  |===gi
 RequestType::
   CASWrite
 Description::

--- a/doc/modules/cassandra/pages/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/operating/metrics.adoc
@@ -443,6 +443,8 @@ Metrics::
 
   |  |Latency |Transaction write latency.
 
+  |Unavailables |Counter |Number of unavailable exceptions encountered.
+
   |UnfinishedCommit |Counter |Number of transactions that were committed
   on write.
 


### PR DESCRIPTION
Update metrics documentation so that Unavailables is reflected in CASWrite. 
 * Currently, the document shows that Unavailables only exists for CASRead, Read, Write, RangeSlice and ViewWrite

```
patch by Natnael Adere; reviewed by <Reviewers> for CASSANDRA-16357

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)
