### PR TITLE
CASSANDRA-17934 4.1 Resolve IP option for Nodetool gossiping command

### DIFF
--- a/src/java/org/apache/cassandra/gms/FailureDetector.java
+++ b/src/java/org/apache/cassandra/gms/FailureDetector.java
@@ -107,20 +107,35 @@ public class FailureDetector implements IFailureDetector, FailureDetectorMBean
 
     public String getAllEndpointStates()
     {
-        return getAllEndpointStates(false);
+        return getAllEndpointStates(false, false);
+    }
+
+    public String getAllEndpointStatesWithResolveIp()
+    {
+        return getAllEndpointStates(false, true);
     }
 
     public String getAllEndpointStatesWithPort()
     {
-        return getAllEndpointStates(true);
+        return getAllEndpointStates(true, false);
+    }
+
+    public String getAllEndpointStatesWithPortAndResolveIp()
+    {
+        return getAllEndpointStates(true, true);
     }
 
     public String getAllEndpointStates(boolean withPort)
     {
+        return getAllEndpointStates(withPort, false);
+    }
+
+    public String getAllEndpointStates(boolean withPort, boolean resolveIp)
+    {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<InetAddressAndPort, EndpointState> entry : Gossiper.instance.endpointStateMap.entrySet())
         {
-            sb.append(entry.getKey().toString(withPort)).append("\n");
+            sb.append(resolveIp ? entry.getKey().getHostName(withPort) : entry.getKey().toString(withPort)).append("\n");
             appendEndpointState(sb, entry.getValue());
         }
         return sb.toString();

--- a/src/java/org/apache/cassandra/gms/FailureDetectorMBean.java
+++ b/src/java/org/apache/cassandra/gms/FailureDetectorMBean.java
@@ -32,7 +32,9 @@ public interface FailureDetectorMBean
     public double getPhiConvictThreshold();
 
     @Deprecated public String getAllEndpointStates();
+    @Deprecated public String getAllEndpointStatesWithResolveIp();
     public String getAllEndpointStatesWithPort();
+    public String getAllEndpointStatesWithPortAndResolveIp();
 
     public String getEndpointState(String address) throws UnknownHostException;
 

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -124,8 +124,7 @@ public final class InetAddressAndPort extends InetSocketAddress implements Compa
 
     public String getHostName(boolean withPort)
     {
-        StringBuilder sb = new StringBuilder(getHostName());
-        return withPort ? sb.append(":").append(getPort()).toString() : sb.toString();
+        return withPort ? String.format("%s:%s", getHostName(), getPort()) : getHostName();
     }
 
     public static String hostAddressAndPort(InetSocketAddress address)

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -122,6 +122,12 @@ public final class InetAddressAndPort extends InetSocketAddress implements Compa
         return hostAddress(this, withPort);
     }
 
+    public String getHostName(boolean withPort)
+    {
+        StringBuilder sb = new StringBuilder(getHostName());
+        return withPort ? sb.append(":").append(getPort()).toString() : sb.toString();
+    }
+
     public static String hostAddressAndPort(InetSocketAddress address)
     {
         return hostAddress(address, true);

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1426,7 +1426,19 @@ public class NodeProbe implements AutoCloseable
 
     public String getGossipInfo(boolean withPort)
     {
-        return withPort ? fdProxy.getAllEndpointStatesWithPort() : fdProxy.getAllEndpointStates();
+        return getGossipInfo(withPort, false);
+    }
+
+    public String getGossipInfo(boolean withPort, boolean resolveIp)
+    {
+        if (resolveIp)
+        {
+            return withPort ? fdProxy.getAllEndpointStatesWithPortAndResolveIp() : fdProxy.getAllEndpointStatesWithResolveIp();
+        }
+        else
+        {
+            return withPort ? fdProxy.getAllEndpointStatesWithPort() : fdProxy.getAllEndpointStates();
+        }
     }
 
     public void stop(String string)

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1432,13 +1432,9 @@ public class NodeProbe implements AutoCloseable
     public String getGossipInfo(boolean withPort, boolean resolveIp)
     {
         if (resolveIp)
-        {
             return withPort ? fdProxy.getAllEndpointStatesWithPortAndResolveIp() : fdProxy.getAllEndpointStatesWithResolveIp();
-        }
         else
-        {
             return withPort ? fdProxy.getAllEndpointStatesWithPort() : fdProxy.getAllEndpointStates();
-        }
     }
 
     public void stop(String string)

--- a/src/java/org/apache/cassandra/tools/nodetool/GossipInfo.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GossipInfo.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.tools.nodetool;
 
 import io.airlift.airline.Command;
+import io.airlift.airline.Option;
 
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
@@ -25,9 +26,12 @@ import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 @Command(name = "gossipinfo", description = "Shows the gossip information for the cluster")
 public class GossipInfo extends NodeToolCmd
 {
+    @Option(title = "resolve_ip", name = {"-r", "--resolve-ip"}, description = "Show node domain names instead of IPs")
+    private boolean resolveIp = false;
+
     @Override
     public void execute(NodeProbe probe)
     {
-        probe.output().out.println(probe.getGossipInfo(printPort));
+        probe.output().out.println(probe.getGossipInfo(printPort, resolveIp));
     }
 }

--- a/test/unit/org/apache/cassandra/locator/InetAddressAndPortTest.java
+++ b/test/unit/org/apache/cassandra/locator/InetAddressAndPortTest.java
@@ -165,6 +165,41 @@ public class InetAddressAndPortTest
         assertEquals(ipv6forJMX, InetAddressAndPort.getByName(ipv6).getHostAddressAndPortForJMX());
     }
 
+    @Test
+    public void getHostNameForIPv4WithoutPortTest() throws Exception
+    {
+        byte[] ipBytes = new byte[] { 127, 0, 0, 1};
+        InetAddressAndPort obj = InetAddressAndPort.getByAddress(InetAddress.getByAddress("resolved4", ipBytes));
+        assertEquals("resolved4", obj.getHostName());
+        assertEquals("resolved4", obj.getHostName(false));
+    }
+
+    @Test
+    public void getHostNameForIPv6WithoutPortTest() throws Exception
+    {
+        byte[] ipBytes = new byte[] { 0x20, 0x01, 0xd, (byte) 0xb8, 0, 0, 0, 0, 0, 0, (byte) 0xff, 0, 0x00, 0x42, (byte) 0x83, 0x29};
+        InetAddressAndPort obj = InetAddressAndPort.getByAddress(InetAddress.getByAddress("resolved6", ipBytes));
+        assertEquals("resolved6", obj.getHostName());
+        assertEquals("resolved6", obj.getHostName(false));
+    }
+
+    @Test
+    public void getHostNameForIPv4WitPortTest() throws Exception
+    {
+        InetAddress ipv4 = InetAddress.getByAddress("resolved4", new byte[] { 127, 0, 0, 1});
+        InetAddressAndPort obj = InetAddressAndPort.getByAddressOverrideDefaults(ipv4, 42);
+        assertEquals("resolved4:42", obj.getHostName(true));
+    }
+
+    @Test
+    public void getHostNameForIPv6WithPortTest() throws Exception
+    {
+        byte[] ipBytes = new byte[] { 0x20, 0x01, 0xd, (byte) 0xb8, 0, 0, 0, 0, 0, 0, (byte) 0xff, 0, 0x00, 0x42, (byte) 0x83, 0x29 };
+        InetAddress ipv6 = InetAddress.getByAddress("resolved6", ipBytes);
+        InetAddressAndPort obj = InetAddressAndPort.getByAddressOverrideDefaults(ipv6, 42);
+        assertEquals("resolved6:42", obj.getHostName(true));
+    }
+
     private void shouldThrow(ThrowingRunnable t, Class expectedClass)
     {
         try

--- a/test/unit/org/apache/cassandra/tools/nodetool/GossipInfoTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GossipInfoTest.java
@@ -62,6 +62,7 @@ public class GossipInfoTest extends CQLTester
                 "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
                 "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
                 "                [(-u <username> | --username <username>)] gossipinfo\n" +
+                "                [(-r | --resolve-ip)]\n" +
                 "\n" +
                 "OPTIONS\n" +
                 "        -h <host>, --host <host>\n" +
@@ -78,6 +79,9 @@ public class GossipInfoTest extends CQLTester
                 "\n" +
                 "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
                 "            Path to the JMX password file\n" +
+                "\n" +
+                "        -r, --resolve-ip\n" +
+                "            Show node domain names instead of IPs\n" +
                 "\n" +
                 "        -u <username>, --username <username>\n" +
                 "            Remote jmx agent username\n" +
@@ -117,5 +121,32 @@ public class GossipInfoTest extends CQLTester
         tool.assertOnCleanExit();
         String newHeartbeatCount = StringUtils.substringBetween(stdout, "heartbeat:", "\n");
         assertThat(Integer.parseInt(origHeartbeatCount)).isLessThanOrEqualTo(Integer.parseInt(newHeartbeatCount));
+    }
+
+    @Test
+    public void testGossipInfoWithPortPrint()
+    {
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("-pp", "gossipinfo");
+        tool.assertOnCleanExit();
+        String stdout = tool.getStdout();
+        Assertions.assertThat(stdout).containsPattern("/127.0.0.1\\:[0-9]+\\s+generation");
+    }
+
+    @Test
+    public void testGossipInfoWithResolveIp()
+    {
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("gossipinfo", "--resolve-ip");
+        tool.assertOnCleanExit();
+        String stdout = tool.getStdout();
+        Assertions.assertThat(stdout).containsPattern("^localhost\\s+generation");
+    }
+
+    @Test
+    public void testGossipInfoWithPortPrintAndResolveIp()
+    {
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("-pp", "gossipinfo", "--resolve-ip");
+        tool.assertOnCleanExit();
+        String stdout = tool.getStdout();
+        Assertions.assertThat(stdout).containsPattern("^localhost\\:[0-9]+\\s+generation");
     }
 }


### PR DESCRIPTION
Add --resolve-ip option on 'nodetool gossipinfo' ([CASSANDRA-17934](https://issues.apache.org/jira/browse/CASSANDRA-17934))

### Command help update
```
maxim@309034f0356a:~/cassandra-dev$ ./bin/nodetool help gossipinfo
NAME
        nodetool gossipinfo - Shows the gossip information for the cluster

SYNOPSIS
        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]

... removed irrelevant lines ....

                [(-u <username> | --username <username>)] gossipinfo
                [(-r | --resolve-ip)]

OPTIONS
        -h <host>, --host <host>
            Node hostname or ip address

... removed irrelevant lines ...

        -r, --resolve-ip
            Show node domain names instead of IPs

        -u <username>, --username <username>
            Remote jmx agent username
```

### Behavior without new option
```
maxim@309034f0356a:~/cassandra-dev$ ./bin/nodetool gossipinfo
localhost/127.0.0.1
  generation:1665667078

... removed irrelevant gossip info ...

maxim@309034f0356a:~/cassandra-dev$ ./bin/nodetool -pp gossipinfo
localhost/127.0.0.1:7000
  generation:1665667078

... removed irrelevant gossip info ...
```

### Behavior with the new option
```
maxim@309034f0356a:~/cassandra-dev$ ./bin/nodetool gossipinfo --resolve-ip
localhost
  generation:1665667078

... removed irrelevant gossip info ...

maxim@309034f0356a:~/cassandra-dev$ ./bin/nodetool -pp gossipinfo --resolve-ip
localhost:7000
  generation:1665667078

... removed irrelevant gossip info ...
```

### Assumptions taken during development
**(1)** Class `org.apache.cassandra.gms.FailureDetectorMBean`.
  The method `getAllEndpointStates` was marked as `@Deprecated`.
  I've preserved this for the new method `getAllEndpointStatesWithResolveIp` as it does the same logic with addition of resolve ip.

**(2)** Class `org.apache.cassandra.locator.InetAddressAndPort`.
  The method `public static String toString(InetAddress address, int port)` is commented specifically to return the following template:
  `hostname / IP:port` (port is optional).
  This is by design - to preserve `java.net.InetAddress`'s method `toString` template.
  I've opted out to keep this and not remove the `hostname` part to keep the `java.net.InetAddress`'s convention.

patch by [Maxim Chanturiay](https://www.linkedin.com/in/maxim-ch); reviewed by <Reviewers> for CASSANDRA-17934
```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

