### PR TITLE
CASSANDRA-16491 track and handle errors during nodetool bootstrap resume properly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * Nodetool bootstrap resume will now return an error if the operation fails (CASSANDRA-16491)
  * Disable resumable bootstrap by default (CASSANDRA-17679)
  * Include Git SHA in --verbose flag for nodetool version (CASSANDRA-17753)
  * Update Byteman to 4.0.20 and Jacoco to 0.8.8 (CASSANDRA-16413)

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2005,6 +2005,8 @@ public class NodeProbe implements AutoCloseable
             {
                 out.println("Resuming bootstrap");
                 monitor.awaitCompletion();
+                if (monitor.getError() != null)
+                    throw monitor.getError();
             }
             else
             {

--- a/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
@@ -131,6 +131,7 @@ public class BootstrapBinaryDisabledTest extends TestBaseImpl
             .failure()
             .errorContains("Cannot join the ring until bootstrap completes");
 
+        node.nodetoolResult("bootstrap", "resume").asserts().failure();
         RewriteEnabled.disable();
         node.nodetoolResult("bootstrap", "resume").asserts().success();
         if (isWriteSurvey)


### PR DESCRIPTION
There is some issue where the `nodetool bootstrap resume` command returns success successfully even when some error happens during the operation.  To address that, we now keep track of the errors when they occur in `BootstrapMonitor` and now throw them after signaling.  Also as part of this MR, I made a change so we don't send a `ProgressEventType.COMPLETE` event anymore when we see an error as that seems to be a bit misleading.

To reproduce a scenario, I killed one of the nodes involved in the bootstrap resume process and checked if errors were thrown in the terminal.