### PR TITLE
CASSANDRA-17999: Bug fix for WriteTimeoutException when using Paxos v2 in LWT performance test

### DIFF
--- a/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
@@ -260,7 +260,7 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
      */
     private void response(boolean success, InetAddressAndPort from)
     {
-        if (consistencyForCommit.isDatacenterLocal() && InOurDc.endpoints().test(from))
+        if (consistencyForCommit.isDatacenterLocal() && !InOurDc.endpoints().test(from))
             return;
 
         long responses = responsesUpdater.addAndGet(this, success ? 0x1L : 0x100000000L);


### PR DESCRIPTION
A bug fix for WriteTimeoutException when using Paxos v2 in an LWT performance test that only has a single datacenter due to Paxos still waiting for a response from another datacenter during the Commit/Acknowledge phase even though we are running with LOCAL_SERIAL.

patch by @marianne-manaog ; reviewed by @blambov for [CASSANDRA-17999](https://issues.apache.org/jira/browse/CASSANDRA-17999)

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-17999)

