### PR TITLE
Fix Splitter sometimes creating more splits than requested

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -135,7 +135,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -318,7 +318,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -501,7 +501,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -684,7 +684,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -864,10 +864,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1089,10 +1089,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1214,10 +1214,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1332,10 +1332,10 @@ jobs:
   j8_jvm_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1518,7 +1518,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1694,7 +1694,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1802,10 +1802,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1879,10 +1879,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1959,7 +1959,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2142,7 +2142,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2317,10 +2317,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2445,7 +2445,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2625,10 +2625,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2804,7 +2804,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3021,11 +3021,23 @@ workflows:
         requires:
         - start_j8_unit_tests
         - build
+    - start_j8_unit_tests_repeat:
+        type: approval
+    - j8_unit_tests_repeat:
+        requires:
+        - start_j8_unit_tests_repeat
+        - build
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
         requires:
         - start_j8_jvm_dtests
+        - build
+    - start_j8_jvm_dtests_repeat:
+        type: approval
+    - j8_jvm_dtests_repeat:
+        requires:
+        - start_j8_jvm_dtests_repeat
         - build
     - start_utests_long:
         type: approval
@@ -3033,11 +3045,23 @@ workflows:
         requires:
         - start_utests_long
         - build
+    - start_utests_long_repeat:
+        type: approval
+    - utests_long_repeat:
+        requires:
+        - start_utests_long_repeat
+        - build
     - start_utests_cdc:
         type: approval
     - utests_cdc:
         requires:
         - start_utests_cdc
+        - build
+    - start_utests_cdc_repeat:
+        type: approval
+    - utests_cdc_repeat:
+        requires:
+        - start_utests_cdc_repeat
         - build
     - start_utests_compression:
         type: approval
@@ -3045,11 +3069,23 @@ workflows:
         requires:
         - start_utests_compression
         - build
+    - start_utests_compression_repeat:
+        type: approval
+    - utests_compression_repeat:
+        requires:
+        - start_utests_compression_repeat
+        - build
     - start_utests_stress:
         type: approval
     - utests_stress:
         requires:
         - start_utests_stress
+        - build
+    - start_utests_stress_repeat:
+        type: approval
+    - utests_stress_repeat:
+        requires:
+        - start_utests_stress_repeat
         - build
     - start_j8_dtest_jars_build:
         type: approval
@@ -3063,11 +3099,23 @@ workflows:
         requires:
         - start_jvm_upgrade_dtests
         - j8_dtest_jars_build
+    - start_jvm_upgrade_dtests_repeat:
+        type: approval
+    - j8_jvm_upgrade_dtests_repeat:
+        requires:
+        - start_jvm_upgrade_dtests_repeat
+        - j8_dtest_jars_build
     - start_j8_dtests:
         type: approval
     - j8_dtests:
         requires:
         - start_j8_dtests
+        - build
+    - start_j8_dtests_repeat:
+        type: approval
+    - j8_dtests_repeat:
+        requires:
+        - start_j8_dtests_repeat
         - build
     - start_j8_dtests_vnode:
         type: approval
@@ -3075,11 +3123,29 @@ workflows:
         requires:
         - start_j8_dtests_vnode
         - build
+    - start_j8_dtests_vnode_repeat:
+        type: approval
+    - j8_dtests_vnode_repeat:
+        requires:
+        - start_j8_dtests_vnode_repeat
+        - build
     - start_upgrade_dtests:
         type: approval
     - j8_upgrade_dtests:
         requires:
         - start_upgrade_dtests
+        - build
+    - start_j8_upgrade_dtests_repeat:
+        type: approval
+    - j8_upgrade_dtests_repeat:
+        requires:
+        - start_j8_upgrade_dtests_repeat
+        - build
+    - start_j8_repeated_ant_test:
+        type: approval
+    - j8_repeated_ant_test:
+        requires:
+        - start_j8_repeated_ant_test
         - build
   pre-commit_tests:
     jobs:
@@ -3091,12 +3157,22 @@ workflows:
     - j8_unit_tests:
         requires:
         - build
+    - j8_unit_tests_repeat:
+        requires:
+        - build
     - j8_jvm_dtests:
+        requires:
+        - build
+    - j8_jvm_dtests_repeat:
         requires:
         - build
     - start_utests_long:
         type: approval
     - utests_long:
+        requires:
+        - start_utests_long
+        - build
+    - utests_long_repeat:
         requires:
         - start_utests_long
         - build
@@ -3106,15 +3182,27 @@ workflows:
         requires:
         - start_utests_cdc
         - build
+    - utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - build
     - start_utests_compression:
         type: approval
     - utests_compression:
         requires:
         - start_utests_compression
         - build
+    - utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - build
     - start_utests_stress:
         type: approval
     - utests_stress:
+        requires:
+        - start_utests_stress
+        - build
+    - utests_stress_repeat:
         requires:
         - start_utests_stress
         - build
@@ -3127,10 +3215,19 @@ workflows:
     - j8_jvm_upgrade_dtests:
         requires:
         - j8_dtest_jars_build
+    - j8_jvm_upgrade_dtests_repeat:
+        requires:
+        - j8_dtest_jars_build
     - j8_dtests:
         requires:
         - build
+    - j8_dtests_repeat:
+        requires:
+        - build
     - j8_dtests_vnode:
+        requires:
+        - build
+    - j8_dtests_vnode_repeat:
         requires:
         - build
     - start_upgrade_tests:
@@ -3138,4 +3235,11 @@ workflows:
     - j8_upgrade_dtests:
         requires:
         - start_upgrade_tests
+        - build
+    - j8_upgrade_dtests_repeat:
+        requires:
+        - start_upgrade_tests
+        - build
+    - j8_repeated_ant_test:
+        requires:
         - build

--- a/src/java/org/apache/cassandra/dht/Splitter.java
+++ b/src/java/org/apache/cassandra/dht/Splitter.java
@@ -60,6 +60,7 @@ public abstract class Splitter
 
         List<Token> boundaries = new ArrayList<>();
         BigInteger sum = BigInteger.ZERO;
+        BigInteger tokensLeft = totalTokens;
         for (Range<Token> r : localRanges)
         {
             Token right = token(r.right);
@@ -70,8 +71,14 @@ public abstract class Splitter
                 BigInteger withinRangeBoundary = perPart.subtract(sum);
                 left = left.add(withinRangeBoundary);
                 boundaries.add(tokenForValue(left));
+                tokensLeft = tokensLeft.subtract(perPart);
                 currentRangeWidth = currentRangeWidth.subtract(withinRangeBoundary);
                 sum = BigInteger.ZERO;
+                int partsLeft = parts - boundaries.size();
+                if (partsLeft == 0)
+                    break;
+                else if (partsLeft == 1)
+                    perPart = tokensLeft;
             }
             sum = sum.add(currentRangeWidth);
         }


### PR DESCRIPTION
Spliter.splitOwnedRanges for some inputs creates an extra split. For example, when we request 7 ranges from 0..31 range, it will return 8 ranges. There is an assertion in that method which verifies whether it returns the requested number of splits. Since those numbers differs, when Cassandra is be started with assertions enabled, it would fail.

patch by Jacek Lewandowski; reviewed by Marcus Eriksson for CASSANDRA-18013