### PR TITLE
CASSANDRA-17999: Fix bug in CASTest.java to avoid 'WriteTimeoutException' for local tests

### DIFF
--- a/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosCommit.java
@@ -260,7 +260,7 @@ public class PaxosCommit<OnDone extends Consumer<? super PaxosCommit.Status>> ex
      */
     private void response(boolean success, InetAddressAndPort from)
     {
-        if (consistencyForCommit.isDatacenterLocal() && InOurDc.endpoints().test(from))
+        if (consistencyForCommit.isDatacenterLocal() && !InOurDc.endpoints().test(from))
             return;
 
         long responses = responsesUpdater.addAndGet(this, success ? 0x1L : 0x100000000L);

--- a/test/distributed/org/apache/cassandra/distributed/test/CASTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CASTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ANY;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.ONE;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.LOCAL_QUORUM;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.QUORUM;
 import static org.apache.cassandra.distributed.api.ConsistencyLevel.SERIAL;
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
@@ -755,4 +756,28 @@ public class CASTest extends CASCommonTestCases
     {
         return THREE_NODES;
     }
+
+    /**
+     * Regression test for a bug (CASSANDRA-17999) where a WriteTimeoutException is encountered when using Paxos v2 in
+     * an LWT performance test that only has a single datacenter because Paxos was still waiting for a response from
+     * another datacenter during the Commit/Acknowledge phase even though we were running with LOCAL_SERIAL.
+     *
+     *
+     * <p>This specifically test for the inconsistency described/fixed by CASSANDRA-17999.
+     */
+    @Test
+    public void testWriteTimeoutExceptionUsingPaxosInLwtPerformaceTest() throws IOException
+    {
+
+        THREE_NODES.schemaChange(String.format("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}", KEYSPACE));
+
+        String tableName = tableName("t");
+        String table = KEYSPACE + "." + tableName;
+        THREE_NODES.schemaChange("CREATE TABLE " + table + " (k int PRIMARY KEY, v int)");
+
+        THREE_NODES.coordinator(1).execute("INSERT INTO " + table + " (k, v) VALUES (5, 5) IF NOT EXISTS", LOCAL_QUORUM);
+        THREE_NODES.coordinator(1).execute("UPDATE " + table + " SET v = 123 WHERE k = 5 IF EXISTS", LOCAL_QUORUM);
+
+    }
+
 }


### PR DESCRIPTION
A bug fix and a related in-jvm dtest for WriteTimeoutException when using Paxos v2 in an LWT performance test that only has a single datacenter due to Paxos still waiting for a response from another datacenter during the Commit/Acknowledge phase even though we are running with LOCAL_SERIAL.

patch by @marianne-manaog ; reviewed by @blambov for [CASSANDRA-17999](https://issues.apache.org/jira/browse/CASSANDRA-17999)

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-17999)