### PR TITLE
Fix Splitter sometimes creating more splits than requested

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -141,7 +141,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -228,10 +228,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -386,7 +386,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -575,7 +575,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -665,7 +665,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -751,10 +751,10 @@ jobs:
   j8_jvm_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -871,7 +871,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -960,7 +960,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1075,10 +1075,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1178,10 +1178,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1285,7 +1285,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1375,7 +1375,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1570,7 +1570,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1657,10 +1657,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1760,10 +1760,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1867,7 +1867,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2057,7 +2057,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2171,10 +2171,10 @@ jobs:
   j11_jvm_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2405,7 +2405,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2594,7 +2594,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2752,10 +2752,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2887,7 +2887,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2974,10 +2974,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3132,7 +3132,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3221,7 +3221,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3310,7 +3310,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3425,10 +3425,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3531,7 +3531,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3620,7 +3620,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3709,7 +3709,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3827,7 +3827,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3944,7 +3944,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4030,10 +4030,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4162,10 +4162,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4266,10 +4266,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4350,10 +4350,10 @@ jobs:
   j8_jvm_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4439,10 +4439,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4546,7 +4546,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4636,7 +4636,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4726,7 +4726,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4815,7 +4815,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4929,10 +4929,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5050,7 +5050,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5244,10 +5244,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5328,10 +5328,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5478,7 +5478,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5564,10 +5564,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5674,7 +5674,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5939,7 +5939,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6053,10 +6053,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6185,10 +6185,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6408,10 +6408,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6514,7 +6514,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6734,10 +6734,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6844,7 +6844,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6933,7 +6933,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7135,6 +7135,12 @@ workflows:
         requires:
         - start_j8_unit_tests
         - j8_build
+    - start_j8_unit_tests_repeat:
+        type: approval
+    - j8_unit_tests_repeat:
+        requires:
+        - start_j8_unit_tests_repeat
+        - j8_build
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
@@ -7147,11 +7153,29 @@ workflows:
         requires:
         - start_j8_jvm_dtests_vnode
         - j8_build
+    - start_j8_jvm_dtests_repeat:
+        type: approval
+    - j8_jvm_dtests_repeat:
+        requires:
+        - start_j8_jvm_dtests_repeat
+        - j8_build
+    - start_j8_jvm_dtests_vnode_repeat:
+        type: approval
+    - j8_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j8_jvm_dtests_vnode_repeat
+        - j8_build
     - start_j8_simulator_dtests:
         type: approval
     - j8_simulator_dtests:
         requires:
         - start_j8_simulator_dtests
+        - j8_build
+    - start_j8_simulator_dtests_repeat:
+        type: approval
+    - j8_simulator_dtests_repeat:
+        requires:
+        - start_j8_simulator_dtests_repeat
         - j8_build
     - start_j8_cqlshlib_tests:
         type: approval
@@ -7165,6 +7189,12 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j8_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j8_build
     - start_j8_utests_long:
         type: approval
     - j8_utests_long:
@@ -7176,6 +7206,18 @@ workflows:
     - j11_utests_long:
         requires:
         - start_j11_utests_long
+        - j8_build
+    - start_j8_utests_long_repeat:
+        type: approval
+    - j8_utests_long_repeat:
+        requires:
+        - start_j8_utests_long_repeat
+        - j8_build
+    - start_j11_utests_long_repeat:
+        type: approval
+    - j11_utests_long_repeat:
+        requires:
+        - start_j11_utests_long_repeat
         - j8_build
     - start_j8_utests_cdc:
         type: approval
@@ -7189,6 +7231,18 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j8_build
+    - start_j8_utests_cdc_repeat:
+        type: approval
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_j8_utests_cdc_repeat
+        - j8_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j8_build
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -7200,6 +7254,18 @@ workflows:
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
+        - j8_build
+    - start_j8_utests_compression_repeat:
+        type: approval
+    - j8_utests_compression_repeat:
+        requires:
+        - start_j8_utests_compression_repeat
+        - j8_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
         - j8_build
     - start_j8_utests_trie:
         type: approval
@@ -7213,6 +7279,18 @@ workflows:
         requires:
         - start_j11_utests_trie
         - j8_build
+    - start_j8_utests_trie_repeat:
+        type: approval
+    - j8_utests_trie_repeat:
+        requires:
+        - start_j8_utests_trie_repeat
+        - j8_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
+        - j8_build
     - start_j8_utests_stress:
         type: approval
     - j8_utests_stress:
@@ -7224,6 +7302,18 @@ workflows:
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
+        - j8_build
+    - start_j8_utests_stress_repeat:
+        type: approval
+    - j8_utests_stress_repeat:
+        requires:
+        - start_j8_utests_stress_repeat
+        - j8_build
+    - start_j11_utests_stress_repeat:
+        type: approval
+    - j11_utests_stress_repeat:
+        requires:
+        - start_j11_utests_stress_repeat
         - j8_build
     - start_j8_utests_fqltool:
         type: approval
@@ -7237,6 +7327,18 @@ workflows:
         requires:
         - start_j11_utests_fqltool
         - j8_build
+    - start_j8_utests_fqltool_repeat:
+        type: approval
+    - j8_utests_fqltool_repeat:
+        requires:
+        - start_j8_utests_fqltool_repeat
+        - j8_build
+    - start_j11_utests_fqltool_repeat:
+        type: approval
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_j11_utests_fqltool_repeat
+        - j8_build
     - start_j8_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
@@ -7249,6 +7351,18 @@ workflows:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j8_build
+    - start_j8_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j8_utests_system_keyspace_directory_repeat
+        - j8_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j8_build
     - start_j8_dtest_jars_build:
         type: approval
     - j8_dtest_jars_build:
@@ -7260,6 +7374,12 @@ workflows:
     - j8_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
+        - j8_dtest_jars_build
+    - start_jvm_upgrade_dtests_repeat:
+        type: approval
+    - j8_jvm_upgrade_dtests_repeat:
+        requires:
+        - start_jvm_upgrade_dtests_repeat
         - j8_dtest_jars_build
     - start_j8_dtests:
         type: approval
@@ -7327,6 +7447,48 @@ workflows:
         requires:
         - start_j11_cqlsh_tests
         - j8_build
+    - start_j8_repeated_ant_test:
+        type: approval
+    - j8_repeated_ant_test:
+        requires:
+        - start_j8_repeated_ant_test
+        - j8_build
+    - start_j11_repeated_ant_test:
+        type: approval
+    - j11_repeated_ant_test:
+        requires:
+        - start_j11_repeated_ant_test
+        - j8_build
+    - start_j8_dtests_repeat:
+        type: approval
+    - j8_dtests_repeat:
+        requires:
+        - start_j8_dtests_repeat
+        - j8_build
+    - start_j8_dtests_vnode_repeat:
+        type: approval
+    - j8_dtests_vnode_repeat:
+        requires:
+        - start_j8_dtests_vnode_repeat
+        - j8_build
+    - start_j11_dtests_repeat:
+        type: approval
+    - j11_dtests_repeat:
+        requires:
+        - start_j11_dtests_repeat
+        - j8_build
+    - start_j11_dtests_vnode_repeat:
+        type: approval
+    - j11_dtests_vnode_repeat:
+        requires:
+        - start_j11_dtests_vnode_repeat
+        - j8_build
+    - start_j8_upgrade_dtests_repeat:
+        type: approval
+    - j8_upgrade_dtests_repeat:
+        requires:
+        - start_j8_upgrade_dtests_repeat
+        - j8_build
   java8_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -7337,19 +7499,34 @@ workflows:
     - j8_unit_tests:
         requires:
         - j8_build
+    - j8_unit_tests_repeat:
+        requires:
+        - j8_build
     - j8_simulator_dtests:
+        requires:
+        - j8_build
+    - j8_simulator_dtests_repeat:
         requires:
         - j8_build
     - j8_jvm_dtests:
         requires:
         - j8_build
+    - j8_jvm_dtests_repeat:
+        requires:
+        - j8_build
     - j8_jvm_dtests_vnode:
+        requires:
+        - j8_build
+    - j8_jvm_dtests_vnode_repeat:
         requires:
         - j8_build
     - j8_cqlshlib_tests:
         requires:
         - j8_build
     - j11_unit_tests:
+        requires:
+        - j8_build
+    - j11_unit_tests_repeat:
         requires:
         - j8_build
     - start_utests_long:
@@ -7359,6 +7536,14 @@ workflows:
         - start_utests_long
         - j8_build
     - j11_utests_long:
+        requires:
+        - start_utests_long
+        - j8_build
+    - j8_utests_long_repeat:
+        requires:
+        - start_utests_long
+        - j8_build
+    - j11_utests_long_repeat:
         requires:
         - start_utests_long
         - j8_build
@@ -7372,6 +7557,14 @@ workflows:
         requires:
         - start_utests_cdc
         - j8_build
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -7379,6 +7572,14 @@ workflows:
         - start_utests_compression
         - j8_build
     - j11_utests_compression:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - j8_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - j11_utests_compression_repeat:
         requires:
         - start_utests_compression
         - j8_build
@@ -7392,6 +7593,14 @@ workflows:
         requires:
         - start_utests_trie
         - j8_build
+    - j8_utests_trie_repeat:
+        requires:
+        - start_utests_trie
+        - j8_build
+    - j11_utests_trie_repeat:
+        requires:
+        - start_utests_trie
+        - j8_build
     - start_utests_stress:
         type: approval
     - j8_utests_stress:
@@ -7399,6 +7608,14 @@ workflows:
         - start_utests_stress
         - j8_build
     - j11_utests_stress:
+        requires:
+        - start_utests_stress
+        - j8_build
+    - j8_utests_stress_repeat:
+        requires:
+        - start_utests_stress
+        - j8_build
+    - j11_utests_stress_repeat:
         requires:
         - start_utests_stress
         - j8_build
@@ -7412,12 +7629,27 @@ workflows:
         requires:
         - start_utests_fqltool
         - j8_build
+    - j8_utests_fqltool_repeat:
+        requires:
+        - start_utests_fqltool
+        - j8_build
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_utests_fqltool
+        - j8_build
     - start_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - j8_build
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j8_build
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - j8_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
@@ -7430,21 +7662,40 @@ workflows:
     - j8_jvm_upgrade_dtests:
         requires:
         - j8_dtest_jars_build
+    - j8_jvm_upgrade_dtests_repeat:
+        requires:
+        - j8_dtest_jars_build
     - j8_dtests:
+        requires:
+        - j8_build
+    - j8_dtests_repeat:
         requires:
         - j8_build
     - j8_dtests_vnode:
         requires:
         - j8_build
+    - j8_dtests_vnode_repeat:
+        requires:
+        - j8_build
     - j11_dtests:
+        requires:
+        - j8_build
+    - j11_dtests_repeat:
         requires:
         - j8_build
     - j11_dtests_vnode:
         requires:
         - j8_build
+    - j11_dtests_vnode_repeat:
+        requires:
+        - j8_build
     - start_upgrade_dtests:
         type: approval
     - j8_upgrade_dtests:
+        requires:
+        - j8_build
+        - start_upgrade_dtests
+    - j8_upgrade_dtests_repeat:
         requires:
         - j8_build
         - start_upgrade_dtests
@@ -7485,6 +7736,12 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j11_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
@@ -7496,6 +7753,18 @@ workflows:
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
+        - j11_build
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
+        - j11_build
+    - start_j11_jvm_dtests_vnode_repeat:
+        type: approval
+    - j11_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j11_jvm_dtests_vnode_repeat
         - j11_build
     - start_j11_cqlshlib_tests:
         type: approval
@@ -7539,11 +7808,23 @@ workflows:
         requires:
         - start_j11_utests_long
         - j11_build
+    - start_j11_utests_long_repeat:
+        type: approval
+    - j11_utests_long_repeat:
+        requires:
+        - start_j11_utests_long_repeat
+        - j11_build
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
+        - j11_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
         - j11_build
     - start_j11_utests_compression:
         type: approval
@@ -7551,11 +7832,23 @@ workflows:
         requires:
         - start_j11_utests_compression
         - j11_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
     - start_j11_utests_trie:
         type: approval
     - j11_utests_trie:
         requires:
         - start_j11_utests_trie
+        - j11_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
         - j11_build
     - start_j11_utests_stress:
         type: approval
@@ -7563,17 +7856,53 @@ workflows:
         requires:
         - start_j11_utests_stress
         - j11_build
+    - start_j11_utests_stress_repeat:
+        type: approval
+    - j11_utests_stress_repeat:
+        requires:
+        - start_j11_utests_stress_repeat
+        - j11_build
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+    - start_j11_utests_fqltool_repeat:
+        type: approval
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_j11_utests_fqltool_repeat
+        - j11_build
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
+        - j11_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+    - start_j11_repeated_ant_test:
+        type: approval
+    - j11_repeated_ant_test:
+        requires:
+        - start_j11_repeated_ant_test
+        - j11_build
+    - start_j11_dtests_repeat:
+        type: approval
+    - j11_dtests_repeat:
+        requires:
+        - start_j11_dtests_repeat
+        - j11_build
+    - start_j11_dtests_vnode_repeat:
+        type: approval
+    - j11_dtests_vnode_repeat:
+        requires:
+        - start_j11_dtests_vnode_repeat
         - j11_build
   java11_pre-commit_tests:
     jobs:
@@ -7585,10 +7914,19 @@ workflows:
     - j11_unit_tests:
         requires:
         - j11_build
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests:
         requires:
         - j11_build
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests_vnode:
+        requires:
+        - j11_build
+    - j11_jvm_dtests_vnode_repeat:
         requires:
         - j11_build
     - j11_cqlshlib_tests:
@@ -7600,7 +7938,13 @@ workflows:
     - j11_dtests:
         requires:
         - j11_build
+    - j11_dtests_repeat:
+        requires:
+        - j11_build
     - j11_dtests_vnode:
+        requires:
+        - j11_build
+    - j11_dtests_vnode_repeat:
         requires:
         - j11_build
     - j11_cqlsh_dtests_py3:
@@ -7621,9 +7965,17 @@ workflows:
         requires:
         - start_utests_long
         - j11_build
+    - j11_utests_long_repeat:
+        requires:
+        - start_utests_long
+        - j11_build
     - start_utests_cdc:
         type: approval
     - j11_utests_cdc:
+        requires:
+        - start_utests_cdc
+        - j11_build
+    - j11_utests_cdc_repeat:
         requires:
         - start_utests_cdc
         - j11_build
@@ -7633,9 +7985,17 @@ workflows:
         requires:
         - start_utests_compression
         - j11_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
     - start_utests_trie:
         type: approval
     - j11_utests_trie:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j11_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j11_build
@@ -7645,15 +8005,27 @@ workflows:
         requires:
         - start_utests_stress
         - j11_build
+    - j11_utests_stress_repeat:
+        requires:
+        - start_utests_stress
+        - j11_build
     - start_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_utests_fqltool
+        - j11_build
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build

--- a/src/java/org/apache/cassandra/dht/Splitter.java
+++ b/src/java/org/apache/cassandra/dht/Splitter.java
@@ -139,6 +139,7 @@ public abstract class Splitter
 
         List<Token> boundaries = new ArrayList<>();
         BigInteger sum = BigInteger.ZERO;
+        BigInteger tokensLeft = totalTokens;
         for (WeightedRange weightedRange : weightedRanges)
         {
             BigInteger currentRangeWidth = weightedRange.totalTokens(this);
@@ -148,8 +149,14 @@ public abstract class Splitter
                 BigInteger withinRangeBoundary = perPart.subtract(sum);
                 left = left.add(withinRangeBoundary);
                 boundaries.add(tokenForValue(left));
+                tokensLeft = tokensLeft.subtract(perPart);
                 currentRangeWidth = currentRangeWidth.subtract(withinRangeBoundary);
                 sum = BigInteger.ZERO;
+                int partsLeft = parts - boundaries.size();
+                if (partsLeft == 0)
+                    break;
+                else if (partsLeft == 1)
+                    perPart = tokensLeft;
             }
             sum = sum.add(currentRangeWidth);
         }

--- a/test/unit/org/apache/cassandra/dht/SplitterTest.java
+++ b/test/unit/org/apache/cassandra/dht/SplitterTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.dht;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -27,8 +28,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.utils.Pair;
+import org.assertj.core.api.Assertions;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
@@ -37,6 +41,7 @@ import static org.junit.Assert.fail;
 
 public class SplitterTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(SplitterTest.class);
 
     @Test
     public void randomSplitTestNoVNodesRandomPartitioner()
@@ -60,6 +65,23 @@ public class SplitterTest
     public void randomSplitTestVNodesMurmur3Partitioner()
     {
         randomSplitTestVNodes(new Murmur3Partitioner());
+    }
+
+    // CASSANDRA-18013
+    @Test
+    public void testSplitOwnedRanges() {
+        Splitter splitter = getSplitter(Murmur3Partitioner.instance);
+        long lt = 0;
+        long rt = 31;
+        Range<Token> range = new Range<>(getWrappedToken(Murmur3Partitioner.instance, BigInteger.valueOf(lt)),
+                                         getWrappedToken(Murmur3Partitioner.instance, BigInteger.valueOf(rt)));
+
+        for (int i = 1; i <= (rt - lt); i++)
+        {
+            List<Token> splits = splitter.splitOwnedRanges(i, Arrays.asList(new Splitter.WeightedRange(1.0d, range)), false);
+            logger.info("{} splits of {} are: {}", i, range, splits);
+            Assertions.assertThat(splits).hasSize(i);
+        }
     }
 
     @Test


### PR DESCRIPTION
Spliter.splitOwnedRanges for some inputs creates an extra split. For example, when we request 7 ranges from 0..31 range, it will return 8 ranges. There is an assertion in that method which verifies whether it returns the requested number of splits. Since those numbers differs, when Cassandra is be started with assertions enabled, it would fail.

patch by Jacek Lewandowski; reviewed by Marcus Eriksson for CASSANDRA-18013
