### PR TITLE
CASSANDRA-18025: cassandra-stress: not all contact point are passed down to driver

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/StressSettings.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/StressSettings.java
@@ -125,12 +125,11 @@ public class StressSettings implements Serializable
 
             try
             {
-                String currentNode = node.randomNode();
                 if (client != null)
                     return client;
 
                 EncryptionOptions encOptions = transport.getEncryptionOptions();
-                JavaDriverClient c = new JavaDriverClient(this, currentNode, port.nativePort, encOptions);
+                JavaDriverClient c = new JavaDriverClient(this, node.nodes, port.nativePort, encOptions);
                 c.connect(mode.compression());
                 if (keyspace != null)
                     c.execute("USE \"" + keyspace + "\";", org.apache.cassandra.db.ConsistencyLevel.ONE);

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.stress.util;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -47,7 +48,7 @@ public class JavaDriverClient
         InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
     }
 
-    public final String host;
+    public final List<String> hosts;
     public final int port;
     public final String username;
     public final String password;
@@ -63,15 +64,15 @@ public class JavaDriverClient
 
     private static final ConcurrentMap<String, PreparedStatement> stmts = new ConcurrentHashMap<>();
 
-    public JavaDriverClient(StressSettings settings, String host, int port)
+    public JavaDriverClient(StressSettings settings, List<String> hosts, int port)
     {
-        this(settings, host, port, new EncryptionOptions());
+        this(settings, hosts, port, new EncryptionOptions());
     }
 
-    public JavaDriverClient(StressSettings settings, String host, int port, EncryptionOptions encryptionOptions)
+    public JavaDriverClient(StressSettings settings, List<String> hosts, int port, EncryptionOptions encryptionOptions)
     {
         this.protocolVersion = settings.mode.protocolVersion;
-        this.host = host;
+        this.hosts = hosts;
         this.port = port;
         this.username = settings.mode.username;
         this.password = settings.mode.password;
@@ -133,10 +134,15 @@ public class JavaDriverClient
                                      .setMaxRequestsPerConnection(HostDistance.LOCAL, maxPendingPerConnection)
                                      .setNewConnectionThreshold(HostDistance.LOCAL, 100);
 
-        HostAndPort hap = HostAndPort.fromString(host).withDefaultPort(port);
-        InetSocketAddress contact = new InetSocketAddress(InetAddress.getByName(hap.getHost()), hap.getPort());
+        List<InetSocketAddress> contacts = new ArrayList<>();
+        for (String host : hosts)
+        {
+            HostAndPort hap = HostAndPort.fromString(host).withDefaultPort(port);
+            InetSocketAddress contact = new InetSocketAddress(InetAddress.getByName(hap.getHost()), hap.getPort());
+            contacts.add(contact);
+        }
         Cluster.Builder clusterBuilder = Cluster.builder()
-                                                .addContactPointsWithPorts(contact)
+                                                .addContactPointsWithPorts(contacts)
                                                 .withPoolingOptions(poolingOpts)
                                                 .withoutJMXReporting()
                                                 .withProtocolVersion(protocolVersion)


### PR DESCRIPTION
cassandra-stress: not all contact point are passed down to driver

Seem like c-s is randomly selecting a node from the nodes passed down to it in the command line, and use that node as contact point to the driver. When using c-s together with other management operations (for example expending/shrinking the cluster),

we can get into situation some of the nodes mentioned in the command line aren't reachable/available, and c-s instead of applying the best practices of having multiple contact points, pass down only one that can be unavailable and fail completely without trying any of the other nodes mentioned in the command line.

patch by Israel Fruchter(@fruch) for CASSANDRA-18025
