### PR TITLE
CASSANDRA-12525 When adding new nodes to a cluster which has authentication enabled, we end up losing cassandra user's current crendentials and they get reverted back to default cassandra/cassandra crendetials

### DIFF
--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -365,7 +365,7 @@ public class CassandraRoleManager implements IRoleManager
     @VisibleForTesting
     public static String createDefaultRoleQuery()
     {
-        return String.format("INSERT INTO %s.%s (role, is_superuser, can_login, salted_hash) VALUES ('%s', true, true, '%s')",
+        return String.format("INSERT INTO %s.%s (role, is_superuser, can_login, salted_hash) VALUES ('%s', true, true, '%s') USING TIMESTAMP 0",
                              SchemaConstants.AUTH_KEYSPACE_NAME,
                              AuthKeyspace.ROLES,
                              DEFAULT_SUPERUSER_NAME,

--- a/test/distributed/org/apache/cassandra/distributed/test/AuthTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/AuthTest.java
@@ -24,9 +24,21 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Test;
 
+import org.apache.cassandra.auth.CassandraRoleManager;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.IInstanceConfig;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.TokenSupplier;
+import org.apache.cassandra.distributed.shared.NetworkTopology;
 import org.apache.cassandra.service.StorageService;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.BOOTSTRAP_SCHEMA_DELAY_MS;
+import static org.apache.cassandra.distributed.action.GossipHelper.withProperty;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class AuthTest extends TestBaseImpl
@@ -52,4 +64,60 @@ public class AuthTest extends TestBaseImpl
             assertTrue(setupCalled);
         }
     }
+
+    /**
+     * Sows that in some circumstances CassandraRoleManager will create the cassandra role twice
+     */
+    @Test
+    public void authSetupIsCalledTwice() throws IOException
+    {
+        try (Cluster cluster = builder().withNodes(1)
+                                        .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(3))
+                                        .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(3, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK, GOSSIP).set("authenticator", "PasswordAuthenticator"))
+                                        .start())
+        {
+            boolean defaultRoleSetup = cluster.get(1).callOnInstance(() -> {
+                long maxWait = TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
+                long start = System.nanoTime();
+                while (!CassandraRoleManager.hasExistingRoles() && System.nanoTime() - start < maxWait)
+                    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+
+                return CassandraRoleManager.hasExistingRoles();
+            });
+            assertTrue(defaultRoleSetup);
+
+            //get the time from the the first role setup
+            Long time1 = (Long)cluster.coordinator(1).execute("SELECT WRITETIME (salted_hash) from system_auth.roles where role = 'cassandra'",
+                                           ConsistencyLevel.ONE)[0][0];
+
+
+
+            IInstanceConfig config = cluster.newInstanceConfig();
+            // set boostrap to false to simulate a seed node
+            config.set("auto_bootstrap", false);
+            IInvokableInstance newInstance = cluster.bootstrap(config);
+            withProperty(BOOTSTRAP_SCHEMA_DELAY_MS.getKey(), Integer.toString(90 * 1000),
+                         () -> withProperty("cassandra.join_ring", false, () -> newInstance.startup(cluster)));
+            newInstance.nodetoolResult("join").asserts().success();
+            defaultRoleSetup =  newInstance.callOnInstance(() -> {
+                long maxWait = TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
+                long start = System.nanoTime();
+                while (!CassandraRoleManager.hasExistingRoles() && System.nanoTime() - start < maxWait)
+                    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+
+                return CassandraRoleManager.hasExistingRoles() ;
+            });
+            assertTrue(defaultRoleSetup);
+
+            // get write titme frome second role setup
+            Long time2 = (Long)cluster.coordinator(1).execute("SELECT WRITETIME (salted_hash) from system_auth.roles where role = 'cassandra'",
+                                                               ConsistencyLevel.ONE)[0][0];
+            // we don't do this here but if the user changed the Cassandra user password it will be (read) reapired if the second node has a later
+            // write timsestamp - check that this is not the case
+            assertTrue(time1 >= time2);
+        }
+    }
+
+
 }


### PR DESCRIPTION
This changes the creation of the default role to use write time 0 - thus ensuring, if it runs twice in a cluster, repairs won't overwrite the password a user might have assigned on a different node to the cassandra role.

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

