### PR TITLE
CASSANDRA-18097: Fix for Clock.waitUntil formula

### DIFF
--- a/src/java/org/apache/cassandra/service/paxos/ContentionStrategy.java
+++ b/src/java/org/apache/cassandra/service/paxos/ContentionStrategy.java
@@ -372,7 +372,7 @@ public class ContentionStrategy
         }
     }
 
-    private long computeWaitUntilForContention(int attempts, TableMetadata table, DecoratedKey partitionKey, ConsistencyLevel consistency, Type type)
+    long computeWaitUntilForContention(int attempts, TableMetadata table, DecoratedKey partitionKey, ConsistencyLevel consistency, Type type)
     {
         if (attempts >= traceAfterAttempts && !Tracing.isTracing())
         {
@@ -411,7 +411,7 @@ public class ContentionStrategy
         return nanoTime() + MICROSECONDS.toNanos(wait);
     }
 
-    private boolean doWaitForContention(long deadline, int attempts, TableMetadata table, DecoratedKey partitionKey, ConsistencyLevel consistency, Type type)
+    boolean doWaitForContention(long deadline, int attempts, TableMetadata table, DecoratedKey partitionKey, ConsistencyLevel consistency, Type type)
     {
         long until = computeWaitUntilForContention(attempts, table, partitionKey, consistency, type);
         if (until >= deadline)

--- a/src/java/org/apache/cassandra/service/paxos/ContentionStrategy.java
+++ b/src/java/org/apache/cassandra/service/paxos/ContentionStrategy.java
@@ -164,7 +164,6 @@ public class ContentionStrategy
         default LatencySelector write(double percentile) { return (read, write) -> write.get(percentile); }
         default LatencySelector maxReadWrite(double percentile) { return (read, write) -> max(read.get(percentile), write.get(percentile)); }
     }
-
     static interface LatencyModifier
     {
         long modify(long latency, int attempts);
@@ -409,7 +408,7 @@ public class ContentionStrategy
         }
 
         long wait = waitRandomizer.wait(minWaitMicros, maxWaitMicros, attempts);
-        return nanoTime() + wait;
+        return nanoTime() + MICROSECONDS.toNanos(wait);
     }
 
     private boolean doWaitForContention(long deadline, int attempts, TableMetadata table, DecoratedKey partitionKey, ConsistencyLevel consistency, Type type)

--- a/src/java/org/apache/cassandra/utils/Clock.java
+++ b/src/java/org/apache/cassandra/utils/Clock.java
@@ -136,7 +136,7 @@ public interface Clock
     @Intercept
     public static void waitUntil(long deadlineNanos) throws InterruptedException
     {
-        long waitNanos = Clock.Global.nanoTime() - deadlineNanos;
+        long waitNanos = deadlineNanos - Clock.Global.nanoTime();
         if (waitNanos > 0)
             TimeUnit.NANOSECONDS.sleep(waitNanos);
     }


### PR DESCRIPTION
A bug fix for incorrect formula for waitNanos in Clock.java and added tests to verify behaviour of ContentionStrategy backoff methods.

patch by @belliottsmith;

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-18097)