### PR TITLE
[CASSANDRA-11537] Friendly error message when nodetool is used on uninitialized Cassandra node

### DIFF
--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -176,7 +176,7 @@ public class AuthorizationProxy implements InvocationHandler
         if (authorize(subject, methodName, args))
             return invoke(method, args);
 
-        throw new SecurityException("Access Denied");
+        throw new SecurityException(String.format("Access denied to method %s of object %s.", methodName, args[0]));
     }
 
     /**

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -176,7 +176,7 @@ public class AuthorizationProxy implements InvocationHandler
         if (authorize(subject, methodName, args))
             return invoke(method, args);
 
-        throw new SecurityException(String.format("Access denied to method %s of object %s.", methodName, args[0]));
+        throw new SecurityException("Access Denied");
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -378,10 +378,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         super(JMXBroadcastExecutor.executor);
 
         jmxObjectName = "org.apache.cassandra.db:type=StorageService";
-        MBeanWrapper.instance.registerMBean(this, jmxObjectName);
-        MBeanWrapper.instance.registerMBean(StreamManager.instance, StreamManager.OBJECT_NAME);
 
         sstablesTracker = new SSTablesGlobalTracker(SSTableFormat.Type.current());
+    }
+
+    private void registerMBeans()
+    {
+        MBeanWrapper.instance.registerMBean(this, jmxObjectName);
+        MBeanWrapper.instance.registerMBean(StreamManager.instance, StreamManager.OBJECT_NAME);
     }
 
     public void registerDaemon(CassandraDaemon daemon)
@@ -841,7 +845,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (!Boolean.parseBoolean(System.getProperty("cassandra.start_gossip", "true")))
         {
             logger.info("Not starting gossip as requested.");
-            initialized = true;
+            completeInitialization();
             return;
         }
 
@@ -879,6 +883,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             logger.info("Not joining ring as requested. Use JMX (StorageService->joinRing()) to initiate ring joining");
         }
 
+        completeInitialization();
+    }
+
+    private void completeInitialization()
+    {
+        if (!initialized)
+            registerMBeans();
         initialized = true;
     }
 

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -290,6 +290,9 @@ public class NodeProbe implements AutoCloseable
                 ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
         runtimeProxy = ManagementFactory.newPlatformMXBeanProxy(
                 mbeanServerConn, ManagementFactory.RUNTIME_MXBEAN_NAME, RuntimeMXBean.class);
+        if (!isInitialized()) {
+            throw new IllegalStateException("Node is not initialized yet.");
+        }
     }
 
     private RMIClientSocketFactory getRMIClientSocketFactory()

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -290,9 +290,6 @@ public class NodeProbe implements AutoCloseable
                 ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
         runtimeProxy = ManagementFactory.newPlatformMXBeanProxy(
                 mbeanServerConn, ManagementFactory.RUNTIME_MXBEAN_NAME, RuntimeMXBean.class);
-        if (!isInitialized()) {
-            throw new IllegalStateException("Node is not initialized yet.");
-        }
     }
 
     private RMIClientSocketFactory getRMIClientSocketFactory()

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -45,6 +45,8 @@ import java.util.Map.Entry;
 import java.util.Scanner;
 import java.util.SortedMap;
 
+import javax.management.InstanceNotFoundException;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 
@@ -307,6 +309,10 @@ public class NodeTool
 
     protected void err(Throwable e)
     {
+        // CASSANDRA-11537: friendly error message when server is not ready
+        if (e instanceof InstanceNotFoundException)
+            throw new IllegalArgumentException("Server is not initialized yet, cannot run nodetool.");
+
         output.err.println("error: " + e.getMessage());
         output.err.println("-- StackTrace --");
         output.err.println(getStackTraceAsString(e));

--- a/test/unit/org/apache/cassandra/tools/NodeProbeTest.java
+++ b/test/unit/org/apache/cassandra/tools/NodeProbeTest.java
@@ -37,6 +37,7 @@ public class NodeProbeTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
         probe = new NodeProbe(jmxHost, jmxPort);
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/ClearSnapshotTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ClearSnapshotTest.java
@@ -61,6 +61,7 @@ public class ClearSnapshotTest extends CQLTester
     public static void setup() throws Exception
     {
         startJMXServer();
+        requireNetwork();
         probe = new NodeProbe(jmxHost, jmxPort);
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactTest.java
@@ -35,6 +35,7 @@ public class CompactTest extends CQLTester
     @BeforeClass
     public static void setup() throws Throwable
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetAuditLogTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetAuditLogTest.java
@@ -32,6 +32,7 @@ public class GetAuditLogTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetAuthCacheConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetAuthCacheConfigTest.java
@@ -42,6 +42,7 @@ public class GetAuthCacheConfigTest extends CQLTester
     {
         CQLTester.setUpClass();
         CQLTester.requireAuthentication();
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetFullQueryLogTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetFullQueryLogTest.java
@@ -38,6 +38,7 @@ public class GetFullQueryLogTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
@@ -62,6 +62,7 @@ public class InvalidateCredentialsCacheTest extends CQLTester
                 .newAuthenticator((EndPoint) null, null)
                 .initialResponse());
 
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
@@ -65,6 +65,7 @@ public class InvalidateJmxPermissionsCacheTest extends CQLTester
 
         AuthCacheService.initializeAndRegisterCaches();
 
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
@@ -47,6 +47,7 @@ public class InvalidateNetworkPermissionsCacheTest extends CQLTester
         roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOptions());
         AuthCacheService.initializeAndRegisterCaches();
 
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
@@ -85,6 +85,7 @@ public class InvalidatePermissionsCacheTest extends CQLTester
             authorizer.grant(AuthenticatedUser.SYSTEM_USER, permissions, resource, ROLE_B);
         }
 
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
@@ -47,6 +47,7 @@ public class InvalidateRolesCacheTest extends CQLTester
         roleManager.createRole(AuthenticatedUser.SYSTEM_USER, ROLE_B, AuthTestUtils.getLoginRoleOptions());
         AuthCacheService.initializeAndRegisterCaches();
 
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAuthCacheConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAuthCacheConfigTest.java
@@ -42,6 +42,7 @@ public class SetAuthCacheConfigTest extends CQLTester
     {
         CQLTester.setUpClass();
         CQLTester.requireAuthentication();
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetColumnIndexSizeTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetColumnIndexSizeTest.java
@@ -36,6 +36,7 @@ public class SetGetColumnIndexSizeTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
@@ -38,6 +38,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableInterDCStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableInterDCStreamThroughputTest.java
@@ -39,6 +39,7 @@ public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableStreamThroughputTest.java
@@ -39,6 +39,7 @@ public class SetGetEntireSSTableStreamThroughputTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetInterDCStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetInterDCStreamThroughputTest.java
@@ -46,6 +46,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetStreamThroughputTest.java
@@ -47,6 +47,7 @@ public class SetGetStreamThroughputTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SnapshotTest.java
@@ -36,6 +36,7 @@ public class SnapshotTest extends CQLTester
     @BeforeClass
     public static void setup() throws Exception
     {
+        requireNetwork();
         startJMXServer();
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/UninitializedServerTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/UninitializedServerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.cql3.CQLTester.startJMXServer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UninitializedServerTest extends CQLTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        // Ensure StorageProxy is initialized on start-up; see CASSANDRA-3797.
+        Class.forName("org.apache.cassandra.service.StorageProxy");
+        startJMXServer();
+    }
+
+    public static void startCassandraNode() {
+        requireNetwork();
+    }
+
+    @Test
+    public void testUnintializedServer()
+    {
+        // fails, not finished initializing node
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("ring", "system_schema");
+        assertThat(tool.getStdout()).contains("nodetool: Node is not initialized yet.");
+
+        // succeeds, node is initialized
+        startCassandraNode();
+        tool = ToolRunner.invokeNodetool("ring", "system_schema");
+        tool.assertOnCleanExit();
+        assertThat(tool.getStdout()).contains("Datacenter: datacenter1");
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/UninitializedServerTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/UninitializedServerTest.java
@@ -34,11 +34,6 @@ public class UninitializedServerTest extends CQLTester
         startJMXServer();
     }
 
-    private void initializeCassandra()
-    {
-        requireNetwork();
-    }
-
     @Test
     public void testUnintializedServer()
     {


### PR DESCRIPTION
[CASSANDRA-11537](https://issues.apache.org/jira/browse/CASSANDRA-11537)
 
To reproduce this, you can run a loop on a nodetool command while a Cassandra node is initializing. I used ring.

patch by William Nguyen; reviewed by Paulo Motta for [CASSANDRA-11537](https://issues.apache.org/jira/browse/CASSANDRA-11537)

