### PR TITLE
[CASSANDRA-16418]: Unsafe to run nodetool cleanup during bootstrap or decommission

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -569,11 +569,7 @@ public class CompactionManager implements CompactionManagerMBean
     {
         assert !cfStore.isIndex();
         Keyspace keyspace = cfStore.keyspace;
-        if (!StorageService.instance.isJoined())
-        {
-            logger.info("Cleanup cannot run before a node has joined the ring");
-            return AllSSTableOpStatus.ABORTED;
-        }
+
         // if local ranges is empty, it means no data should remain
         final RangesAtEndpoint replicas = StorageService.instance.getLocalReplicas(keyspace.getName());
         final Set<Range<Token>> allRanges = replicas.ranges();

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3849,13 +3849,13 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (SchemaConstants.isLocalSystemKeyspace(keyspaceName))
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
 
-        if (!instance.isJoined())
-            throw new RuntimeException("Cleanup cannot run before a node has joined the ring.");
-
         InetAddressAndPort localAddress = FBUtilities.getBroadcastAddressAndPort();
+        Integer pendingRangesCount = tokenMetadata.getPendingRanges(keyspaceName, localAddress).size();
 
-        if (tokenMetadata.getPendingRanges(keyspaceName, localAddress).size() > 0)
-            throw new RuntimeException("Node is receiving data. Not safe to run cleanup.");
+        if (pendingRangesCount > 0)
+        {
+            throw new RuntimeException("Node is involved in cluster membership changes. Not safe to run cleanup.");
+        }
 
         CompactionManager.AllSSTableOpStatus status = CompactionManager.AllSSTableOpStatus.SUCCESSFUL;
         for (ColumnFamilyStore cfStore : getValidColumnFamilies(false, false, keyspaceName, tables))

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3850,9 +3850,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
 
         InetAddressAndPort localAddress = FBUtilities.getBroadcastAddressAndPort();
-        Integer pendingRangesCount = tokenMetadata.getPendingRanges(keyspaceName, localAddress).size();
-
-        if (pendingRangesCount > 0)
+        if (tokenMetadata.getPendingRanges(keyspaceName, localAddress).size() > 0)
         {
             throw new RuntimeException("Node is involved in cluster membership changes. Not safe to run cleanup.");
         }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3849,6 +3849,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (SchemaConstants.isLocalSystemKeyspace(keyspaceName))
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
 
+        if (!instance.isJoined())
+            throw new RuntimeException("Cleanup cannot run before a node has joined the ring.");
+
+        InetAddressAndPort localAddress = FBUtilities.getBroadcastAddressAndPort();
+
+        if (tokenMetadata.getPendingRanges(keyspaceName, localAddress).size() > 0)
+            throw new RuntimeException("Node is receiving data. Not safe to run cleanup.");
+
         CompactionManager.AllSSTableOpStatus status = CompactionManager.AllSSTableOpStatus.SUCCESSFUL;
         for (ColumnFamilyStore cfStore : getValidColumnFamilies(false, false, keyspaceName, tables))
         {

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -168,6 +168,7 @@ import static org.apache.cassandra.service.ActiveRepairService.*;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.apache.cassandra.utils.FBUtilities.now;
+import static org.apache.cassandra.utils.FBUtilities.getBroadcastAddressAndPort;
 
 /**
  * This abstraction contains the token/identifier of this node
@@ -3849,11 +3850,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (SchemaConstants.isLocalSystemKeyspace(keyspaceName))
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
 
-        InetAddressAndPort localAddress = FBUtilities.getBroadcastAddressAndPort();
-        if (tokenMetadata.getPendingRanges(keyspaceName, localAddress).size() > 0)
-        {
+        if (tokenMetadata.getPendingRanges(keyspaceName, getBroadcastAddressAndPort()).size() > 0)
             throw new RuntimeException("Node is involved in cluster membership changes. Not safe to run cleanup.");
-        }
 
         CompactionManager.AllSSTableOpStatus status = CompactionManager.AllSSTableOpStatus.SUCCESSFUL;
         for (ColumnFamilyStore cfStore : getValidColumnFamilies(false, false, keyspaceName, tables))

--- a/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
@@ -73,6 +73,18 @@ public class GossipHelper
         };
     }
 
+    public static InstanceAction statusToDecommission(IInvokableInstance newNode)
+    {
+        return (instance) ->
+        {
+            changeGossipState(instance,
+                              newNode,
+                              Arrays.asList(tokens(newNode),
+                                            statusLeaving(newNode),
+                                            statusWithPortLeaving(newNode)));
+        };
+    }
+
     public static InstanceAction statusToNormal(IInvokableInstance peer)
     {
         return (target) ->

--- a/test/distributed/org/apache/cassandra/distributed/test/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CleanupFailureTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.carrotsearch.hppc.LongArrayList;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.lifecycle.View;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.IInstanceConfig;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.test.ring.BootstrapTest;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.StorageService;
+import org.mortbay.util.IO;
+
+import static java.util.Arrays.asList;
+import static org.apache.cassandra.distributed.action.GossipHelper.bootstrap;
+import static org.apache.cassandra.distributed.action.GossipHelper.decommission;
+import static org.apache.cassandra.distributed.action.GossipHelper.pullSchemaFrom;
+import static org.apache.cassandra.distributed.action.GossipHelper.statusToBootstrap;
+import static org.apache.cassandra.distributed.action.GossipHelper.withProperty;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+public class CleanupFailureTest extends TestBaseImpl
+{
+    private static Cluster CLUSTER;
+
+    @BeforeClass
+    public static void before() throws IOException
+    {
+        CLUSTER = init(Cluster.build()
+                              .withNodes(3)
+                              .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL))
+                              .start());
+    }
+
+    @AfterClass
+    public static void after()
+    {
+        if (CLUSTER != null)
+            CLUSTER.close();
+    }
+
+    @Test
+    public void testCleanupFailsDuringOngoingDecommission()
+    {
+        // set up keyspace and table
+        CLUSTER.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+        CLUSTER.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        CLUSTER.schemaChange("ALTER KEYSPACE " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+        CLUSTER.schemaChange("ALTER KEYSPACE system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+
+        // disable autocompaction
+        CLUSTER.get(1).nodetoolResult("disableautocompaction", KEYSPACE).asserts().success();
+
+        // populate data and flush
+        for(int i=0; i < 20; i++){
+            CLUSTER.get(1).coordinator().execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)",
+                    ConsistencyLevel.ALL,
+                    1, i, i);
+            CLUSTER.get(1).flush(KEYSPACE);
+        }
+
+        // assert data has been populated
+        Object[][] beforeDecommResponse = CLUSTER.get(1).executeInternal("SELECT * FROM " + KEYSPACE + ".tbl ;");
+        Assert.assertEquals(20, beforeDecommResponse.length);
+
+        // assert 20 sstables
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("tbl");
+            View view = cfs.getTracker().getView();
+            Assert.assertEquals(20, view.liveSSTables().size());
+        });
+
+        CLUSTER.get(2).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("tbl");
+            View view = cfs.getTracker().getView();
+            Assert.assertEquals(0, view.liveSSTables().size());
+        });
+
+        // kick off decommission
+        Thread decommThread = new Thread(() -> CLUSTER.run(decommission(), 1));
+        decommThread.start();
+
+        // run cleanup while decomm is ongoing
+        while(decommThread.isAlive()){
+            Thread t = new Thread(() -> CLUSTER.get(2).nodetool("cleanup"));
+            t.start();
+            try
+            {
+                t.join();
+                Thread.sleep(1000);
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+
+        try
+        {
+            decommThread.join();
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        // check data still present
+        Object[][] afterDecommResponse = CLUSTER.get(2).executeInternal("SELECT * FROM " + KEYSPACE + ".tbl ;");
+        Assert.assertEquals(20, afterDecommResponse.length);
+
+        CLUSTER.get(2).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("tbl");
+            View view = cfs.getTracker().getView();
+            Assert.assertEquals(1, view.liveSSTables().size());
+        });
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
@@ -22,15 +22,16 @@ import java.io.IOException;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.TokenSupplier;
+import org.apache.cassandra.distributed.shared.NetworkTopology;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 
 import static org.apache.cassandra.distributed.action.GossipHelper.decommission;
+import static org.apache.cassandra.distributed.test.ring.BootstrapTest.populate;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
@@ -38,16 +39,6 @@ import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 public class CleanupFailureTest extends TestBaseImpl
 {
     private static Cluster CLUSTER;
-
-    @BeforeClass
-    public static void before() throws IOException
-    {
-        CLUSTER = init(Cluster.build()
-                              .withNodes(2)
-                              .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(2))
-                              .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL))
-                              .start());
-    }
 
     @AfterClass
     public static void after()
@@ -57,8 +48,15 @@ public class CleanupFailureTest extends TestBaseImpl
     }
 
     @Test
-    public void testCleanupFailsDuringOngoingDecommission()
+    public void testCleanupFailsDuringOngoingDecommission() throws IOException, InterruptedException
     {
+        // set up cluster
+        CLUSTER = init(Cluster.build()
+                      .withNodes(2)
+                      .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(2))
+                      .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL))
+                      .start());
+
         // set up keyspace and table
         CLUSTER.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
         CLUSTER.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
@@ -67,9 +65,7 @@ public class CleanupFailureTest extends TestBaseImpl
         CLUSTER.schemaChange("ALTER KEYSPACE system_traces WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
 
         // populate data
-        CLUSTER.get(1).coordinator().execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)",
-                ConsistencyLevel.ALL,
-                1, 1, 1);
+        populate(CLUSTER,0,1);
 
         Object[][] beforeDecommResponse = CLUSTER.coordinator(1).execute("SELECT * FROM " + KEYSPACE + ".tbl ;", ConsistencyLevel.ONE);
         Assert.assertEquals(1, beforeDecommResponse.length);
@@ -83,28 +79,63 @@ public class CleanupFailureTest extends TestBaseImpl
         {
             Thread t = new Thread(() -> CLUSTER.get(2).nodetool("cleanup"));
             t.start();
-            try
-            {
-                t.join();
-                Thread.sleep(1000);
-            }
-            catch (InterruptedException e)
-            {
-                throw new RuntimeException(e);
-            }
+            t.join();
+            Thread.sleep(1000);
         }
 
-        try
-        {
-            decommThread.join();
-        }
-        catch (InterruptedException e)
-        {
-            throw new RuntimeException(e);
-        }
+        decommThread.join();
 
         // check data still present on node2
         Object[][] afterDecommResponse = CLUSTER.get(2).executeInternal("SELECT * FROM " + KEYSPACE + ".tbl ;");
         Assert.assertEquals(1, afterDecommResponse.length);
+    }
+    @Test
+    public void testCleanupFailsDuringOngoingBootstrap() throws IOException, InterruptedException
+    {
+        // set up cluster
+        int originalNodeCount = 1;
+        int expandedNodeCount = originalNodeCount + 1;
+
+        CLUSTER = init(Cluster.build()
+                              .withNodes(originalNodeCount)
+                              .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(expandedNodeCount))
+                              .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(expandedNodeCount, "dc0", "rack0"))
+                              .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL))
+                              .start());
+
+        // set up keyspace and table
+        CLUSTER.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+        CLUSTER.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+        CLUSTER.schemaChange("ALTER KEYSPACE " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+        CLUSTER.schemaChange("ALTER KEYSPACE system_distributed WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+        CLUSTER.schemaChange("ALTER KEYSPACE system_traces WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};");
+
+        // populate data
+        populate(CLUSTER,0,10000);
+        CLUSTER.get(1).flush(KEYSPACE);
+
+        Object[][] beforeBootstrapResponse = CLUSTER.coordinator(1).execute("SELECT * FROM " + KEYSPACE + ".tbl ;", ConsistencyLevel.ONE);
+        Assert.assertEquals(10000, beforeBootstrapResponse.length);
+
+        // kick off bootstrap
+        Thread bootstrapThread = new Thread(() -> bootstrapAndJoinNode(CLUSTER));
+        bootstrapThread.start();
+
+        // run cleanup while bootstrap is ongoing
+        while(bootstrapThread.isAlive())
+        {
+            Thread t = new Thread(() -> CLUSTER.get(2).nodetool("cleanup"));
+            t.start();
+            t.join();
+            Thread.sleep(100);
+        }
+
+        bootstrapThread.join();
+
+        // assert data on new node
+        Assert.assertEquals(expandedNodeCount, CLUSTER.size());
+
+        Object[][] afterBootstrapResponse = CLUSTER.get(2).executeInternal("SELECT * FROM " + KEYSPACE + ".tbl ;");
+        Assert.assertEquals(5006, afterBootstrapResponse.length);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
@@ -137,5 +137,6 @@ public class CleanupFailureTest extends TestBaseImpl
 
         Object[][] afterBootstrapResponse = CLUSTER.get(2).executeInternal("SELECT * FROM " + KEYSPACE + ".tbl ;");
         Assert.assertEquals(5006, afterBootstrapResponse.length);
+
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupFailureTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.distributed.test.ring;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;

--- a/test/unit/org/apache/cassandra/db/CleanupTest.java
+++ b/test/unit/org/apache/cassandra/db/CleanupTest.java
@@ -117,9 +117,11 @@ public class CleanupTest
     }
 
     @Test
-    public void testCleanup() throws ExecutionException, InterruptedException
+    public void testCleanup() throws ExecutionException, InterruptedException, UnknownHostException
     {
-        StorageService.instance.getTokenMetadata().clearUnsafe();
+        TokenMetadata tmd = StorageService.instance.getTokenMetadata();
+        tmd.clearUnsafe();
+        tmd.updateNormalToken(token(new byte[]{ 50 }), InetAddressAndPort.getByName("127.0.0.1"));
 
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD1);


### PR DESCRIPTION
Changes:

- Added check during cleanup to ensure the node has no pending ranges before proceeding
- Bug from JIRA ticket did not exist for bootstrap due to existing safety check but the check was one level below other safeguard checks so moved it to same location

To reproduce, run cleanup on a node receiving data while another node is being decommissioned. I created 20 sstables of data.

patch by Lindsey Zurovchak; reviewed by Paulo Motta for [CASSANDRA-16418](https://issues.apache.org/jira/browse/CASSANDRA-16418)
