### PR TITLE
CASSANDRA-18153-Memtable being flushed without hostId in version "me"…

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java
+++ b/src/java/org/apache/cassandra/io/sstable/metadata/MetadataCollector.java
@@ -24,6 +24,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.Optional;
 
 import com.google.common.base.Preconditions;
 
@@ -123,7 +124,7 @@ public class MetadataCollector implements PartitionStatisticsCollector
 
     public MetadataCollector(ClusteringComparator comparator)
     {
-        this(comparator, StorageService.instance.getLocalHostUUID());
+        this(comparator, Optional.ofNullable(StorageService.instance.getLocalHostUUID()).orElseGet(SystemKeyspace::getLocalHostId));
     }
 
     public MetadataCollector(ClusteringComparator comparator, UUID originatingHostId)


### PR DESCRIPTION
… and newer during CommitLogReplay

This issue cause some WARN during startup - WARN Origin of N sstables is unknown or doesn't match the local node; commitLogIntervals for them were ignored RootCause: Storage service is not yet available during commitlog replay phase. Solution: We can get host uuid from systemkeyspace.

by ABonacin

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

