### PR TITLE
CASSANDRA-18187 - Add unit tests for per-row TTL and Timestamp usage in CQLSSTableWriter

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -58,7 +58,8 @@ import org.apache.cassandra.schema.*;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.Clock;
+
+import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 
 /**
  * Utility to write SSTables.
@@ -246,7 +247,7 @@ public class CQLSSTableWriter implements Closeable
         ClientState state = ClientState.forInternalCalls();
         List<ByteBuffer> keys = modificationStatement.buildPartitionKeyNames(options, state);
 
-        long now = Clock.Global.currentTimeMillis();
+        long now = currentTimeMillis();
         // Note that we asks indexes to not validate values (the last 'false' arg below) because that triggers a 'Keyspace.open'
         // and that forces a lot of initialization that we don't want.
         UpdateParameters params = new UpdateParameters(modificationStatement.metadata,

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -58,8 +58,7 @@ import org.apache.cassandra.schema.*;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
-
-import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
+import org.apache.cassandra.utils.Clock;
 
 /**
  * Utility to write SSTables.
@@ -247,7 +246,7 @@ public class CQLSSTableWriter implements Closeable
         ClientState state = ClientState.forInternalCalls();
         List<ByteBuffer> keys = modificationStatement.buildPartitionKeyNames(options, state);
 
-        long now = currentTimeMillis();
+        long now = Clock.Global.currentTimeMillis();
         // Note that we asks indexes to not validate values (the last 'false' arg below) because that triggers a 'Keyspace.open'
         // and that forces a lot of initialization that we don't want.
         UpdateParameters params = new UpdateParameters(modificationStatement.metadata,

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -1138,8 +1138,10 @@ public class CQLSSTableWriterTest
                                                          " (k, c1, c2, v) VALUES (?,?,?,?) using timestamp ?" )
                                                   .build();
 
-        writer.addRow( 1, 2, 3, "a", now); // This write should be the one found at the end because it has a higher timestamp
-        writer.addRow( 1, 4, 5, "b", then);
+        // Note that, all other things being equal, Cassandra will sort these rows lexicographically, so we use "higher" values in the
+        // row we expect to "win" so that we're sure that it isn't just accidentally picked due to the row sorting.
+        writer.addRow( 1, 4, 5, "b", now); // This write should be the one found at the end because it has a higher timestamp
+        writer.addRow( 1, 2, 3, "a", then);
         writer.close();
         loadSSTables(dataDir, keyspace);
 
@@ -1149,9 +1151,9 @@ public class CQLSSTableWriterTest
         Iterator<UntypedResultSet.Row> iter = resultSet.iterator();
         UntypedResultSet.Row r1 = iter.next();
         assertEquals(1, r1.getInt("k"));
-        assertEquals(2, r1.getInt("c1"));
-        assertEquals(3, r1.getInt("c2"));
-        assertEquals("a", r1.getString("v"));
+        assertEquals(4, r1.getInt("c1"));
+        assertEquals(5, r1.getInt("c2"));
+        assertEquals("b", r1.getString("v"));
         assertFalse(iter.hasNext());
     }
     @Test

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -1125,9 +1125,9 @@ public class CQLSSTableWriterTest
         long then = now - 1000;
         final String schema = "CREATE TABLE " + qualifiedTable + " ("
                               + "  k int,"
-                              + "  c1 int,"
-                              + "  c2 int,"
-                              + "  v text,"
+                              + "  v1 int,"
+                              + "  v2 int,"
+                              + "  v3 text,"
                               + "  PRIMARY KEY (k)"
                               + ")";
 
@@ -1135,7 +1135,7 @@ public class CQLSSTableWriterTest
                                                   .inDirectory(dataDir)
                                                   .forTable(schema)
                                                   .using("INSERT INTO " + qualifiedTable +
-                                                         " (k, c1, c2, v) VALUES (?,?,?,?) using timestamp ?" )
+                                                         " (k, v1, v2, v3) VALUES (?,?,?,?) using timestamp ?" )
                                                   .build();
 
         // Note that, all other things being equal, Cassandra will sort these rows lexicographically, so we use "higher" values in the
@@ -1151,9 +1151,9 @@ public class CQLSSTableWriterTest
         Iterator<UntypedResultSet.Row> iter = resultSet.iterator();
         UntypedResultSet.Row r1 = iter.next();
         assertEquals(1, r1.getInt("k"));
-        assertEquals(4, r1.getInt("c1"));
-        assertEquals(5, r1.getInt("c2"));
-        assertEquals("b", r1.getString("v"));
+        assertEquals(4, r1.getInt("v1"));
+        assertEquals(5, r1.getInt("v2"));
+        assertEquals("b", r1.getString("v3"));
         assertFalse(iter.hasNext());
     }
     @Test
@@ -1161,9 +1161,9 @@ public class CQLSSTableWriterTest
     {
         final String schema = "CREATE TABLE " + qualifiedTable + " ("
                               + "  k int,"
-                              + "  c1 int,"
-                              + "  c2 int,"
-                              + "  v text,"
+                              + "  v1 int,"
+                              + "  v2 int,"
+                              + "  v3 text,"
                               + "  PRIMARY KEY (k)"
                               + ")";
 
@@ -1171,7 +1171,7 @@ public class CQLSSTableWriterTest
                                                          .inDirectory(dataDir)
                                                          .forTable(schema)
                                                          .using("INSERT INTO " + qualifiedTable +
-                                                                " (k, c1, c2, v) VALUES (?,?,?,?) using TTL ?");
+                                                                " (k, v1, v2, v3) VALUES (?,?,?,?) using TTL ?");
         CQLSSTableWriter writer = builder.build();
         // add a row that _should_ show up - 1 hour TTL
         writer.addRow( 1, 2, 3, "a", 3600);
@@ -1187,9 +1187,9 @@ public class CQLSSTableWriterTest
         Iterator<UntypedResultSet.Row> iter = resultSet.iterator();
         UntypedResultSet.Row r1 = iter.next();
         assertEquals(1, r1.getInt("k"));
-        assertEquals(2, r1.getInt("c1"));
-        assertEquals(3, r1.getInt("c2"));
-        assertEquals("a", r1.getString("v"));
+        assertEquals(2, r1.getInt("v1"));
+        assertEquals(3, r1.getInt("v2"));
+        assertEquals("a", r1.getString("v3"));
         assertFalse(iter.hasNext());
     }
     @Test
@@ -1197,9 +1197,9 @@ public class CQLSSTableWriterTest
     {
         final String schema = "CREATE TABLE " + qualifiedTable + " ("
                               + "  k int,"
-                              + "  c1 int,"
-                              + "  c2 int,"
-                              + "  v text,"
+                              + "  v1 int,"
+                              + "  v2 int,"
+                              + "  v3 text,"
                               + "  PRIMARY KEY (k)"
                               + ")";
 
@@ -1207,7 +1207,7 @@ public class CQLSSTableWriterTest
                                                   .inDirectory(dataDir)
                                                   .forTable(schema)
                                                   .using("INSERT INTO " + qualifiedTable +
-                                                         " (k, c1, c2, v) VALUES (?,?,?,?) using timestamp ? AND TTL ?" )
+                                                         " (k, v1, v2, v3) VALUES (?,?,?,?) using timestamp ? AND TTL ?" )
                                                   .build();
         // NOTE: It would be easier to make this a timestamp in the past, but Cassandra also has a _local_ deletion time
         // which is based on the server's timestamp, so simply setting the timestamp to some time in the past
@@ -1228,9 +1228,9 @@ public class CQLSSTableWriterTest
         Iterator<UntypedResultSet.Row> iter = resultSet.iterator();
         UntypedResultSet.Row r1 = iter.next();
         assertEquals(1, r1.getInt("k"));
-        assertEquals(2, r1.getInt("c1"));
-        assertEquals(3, r1.getInt("c2"));
-        assertEquals("a", r1.getString("v"));
+        assertEquals(2, r1.getInt("v1"));
+        assertEquals(3, r1.getInt("v2"));
+        assertEquals("a", r1.getString("v3"));
         assertFalse(iter.hasNext());
     }
 

--- a/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/CQLSSTableWriterTest.java
@@ -1221,7 +1221,6 @@ public class CQLSSTableWriterTest
         writer.close();
         loadSSTables(dataDir, keyspace);
         UntypedResultSet resultSet = QueryProcessor.executeInternal("SELECT * FROM " + qualifiedTable);
-        assertEquals(2, resultSet.size());
         Thread.sleep(1200);
         resultSet = QueryProcessor.executeInternal("SELECT * FROM " + qualifiedTable);
         assertEquals(1, resultSet.size());


### PR DESCRIPTION
CQLSSTableWriter supports per-row setting of both timestamp and TTL values, but it’s not tested or documented today. Add tests to cover setting both TTL and Timestamp values for rows using the CQLSSTableWriter.


