### PR TITLE
CASSANDRA-18068 trunk: Allow to attach native masking functions to table columns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -110,7 +110,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -120,7 +120,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -143,7 +143,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -201,7 +201,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -211,7 +211,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -267,7 +267,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -277,7 +277,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -298,10 +298,10 @@ jobs:
   j8_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -378,7 +378,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -388,7 +388,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -408,10 +408,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -534,7 +534,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -544,7 +544,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -565,7 +565,7 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -621,7 +621,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -631,7 +631,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -654,7 +654,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -740,7 +740,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -750,7 +750,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -814,7 +814,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -824,7 +824,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -847,7 +847,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -905,7 +905,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -915,7 +915,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -936,10 +936,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1016,7 +1016,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1026,7 +1026,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1050,7 +1050,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1108,7 +1108,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1118,7 +1118,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1138,10 +1138,10 @@ jobs:
   j8_jvm_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1227,7 +1227,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1237,7 +1237,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1260,7 +1260,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1318,7 +1318,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1328,7 +1328,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1351,7 +1351,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1437,7 +1437,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1447,7 +1447,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1468,10 +1468,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1548,7 +1548,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1558,7 +1558,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1578,10 +1578,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1658,7 +1658,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1668,7 +1668,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1692,7 +1692,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1750,7 +1750,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1760,7 +1760,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1784,7 +1784,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1947,7 +1947,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1957,7 +1957,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -1978,7 +1978,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2034,7 +2034,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2044,7 +2044,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2065,10 +2065,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2169,7 +2169,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2179,7 +2179,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2200,10 +2200,10 @@ jobs:
   j8_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2280,7 +2280,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2290,7 +2290,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2310,10 +2310,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2390,7 +2390,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2400,7 +2400,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2421,7 +2421,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2477,7 +2477,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2487,7 +2487,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2511,7 +2511,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2569,7 +2569,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2579,7 +2579,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2600,10 +2600,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2680,7 +2680,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2690,7 +2690,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2710,10 +2710,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2790,7 +2790,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2800,7 +2800,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2856,7 +2856,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2866,7 +2866,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -2889,7 +2889,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2975,7 +2975,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2985,7 +2985,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3049,7 +3049,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3059,7 +3059,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3083,7 +3083,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3169,7 +3169,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3179,7 +3179,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3199,10 +3199,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3303,7 +3303,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3313,7 +3313,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3333,10 +3333,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3437,7 +3437,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3447,7 +3447,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3468,10 +3468,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3572,7 +3572,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3582,7 +3582,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3602,10 +3602,10 @@ jobs:
   j11_jvm_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3691,7 +3691,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3701,7 +3701,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3807,7 +3807,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3817,7 +3817,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3840,7 +3840,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3926,7 +3926,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3936,7 +3936,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -3999,7 +3999,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4009,7 +4009,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4033,7 +4033,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4091,7 +4091,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4101,7 +4101,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4121,7 +4121,7 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -4177,7 +4177,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4187,7 +4187,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4292,7 +4292,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4302,7 +4302,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4366,7 +4366,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4376,7 +4376,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4397,10 +4397,10 @@ jobs:
   j8_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4477,7 +4477,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4487,7 +4487,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4507,10 +4507,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4611,7 +4611,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4621,7 +4621,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4644,7 +4644,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4702,7 +4702,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4712,7 +4712,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4733,10 +4733,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4859,7 +4859,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4869,7 +4869,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4893,7 +4893,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4951,7 +4951,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4961,7 +4961,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -4984,7 +4984,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5042,7 +5042,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5052,7 +5052,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5075,7 +5075,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5161,7 +5161,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5171,7 +5171,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5192,10 +5192,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5272,7 +5272,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5282,7 +5282,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5302,10 +5302,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5382,7 +5382,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5392,7 +5392,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5416,7 +5416,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5474,7 +5474,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5484,7 +5484,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5504,10 +5504,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5584,7 +5584,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5594,7 +5594,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5618,7 +5618,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5676,7 +5676,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5686,7 +5686,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5709,7 +5709,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5795,7 +5795,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5805,7 +5805,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5826,10 +5826,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5930,7 +5930,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5940,7 +5940,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -5964,7 +5964,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6050,7 +6050,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6060,7 +6060,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6080,10 +6080,10 @@ jobs:
   j8_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6160,7 +6160,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6170,7 +6170,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6193,7 +6193,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6251,7 +6251,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6261,7 +6261,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6281,10 +6281,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6385,7 +6385,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6395,7 +6395,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6415,10 +6415,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6495,7 +6495,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6505,7 +6505,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6526,10 +6526,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6582,7 +6582,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6592,7 +6592,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6612,10 +6612,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6690,7 +6690,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6700,7 +6700,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6721,10 +6721,10 @@ jobs:
   j8_jvm_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6782,7 +6782,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6792,7 +6792,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6812,10 +6812,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6892,7 +6892,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6902,7 +6902,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -6926,7 +6926,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6984,7 +6984,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6994,7 +6994,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7018,7 +7018,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7076,7 +7076,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7086,7 +7086,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7110,7 +7110,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7168,7 +7168,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7178,7 +7178,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7199,10 +7199,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7279,7 +7279,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7289,7 +7289,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7313,7 +7313,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7371,7 +7371,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7381,7 +7381,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7401,10 +7401,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7457,7 +7457,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7467,7 +7467,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7490,7 +7490,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7576,7 +7576,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7586,7 +7586,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7606,10 +7606,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7695,7 +7695,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7705,7 +7705,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7729,7 +7729,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7787,7 +7787,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7797,7 +7797,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7896,7 +7896,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7906,7 +7906,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -7927,10 +7927,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7983,7 +7983,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7993,7 +7993,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8013,10 +8013,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8069,7 +8069,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8079,7 +8079,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8133,7 +8133,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8143,7 +8143,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8167,7 +8167,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8225,7 +8225,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8235,7 +8235,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8255,10 +8255,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8333,7 +8333,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8343,7 +8343,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8367,7 +8367,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8530,7 +8530,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8540,7 +8540,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8603,7 +8603,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8613,7 +8613,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8636,7 +8636,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8722,7 +8722,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8732,7 +8732,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8752,10 +8752,10 @@ jobs:
   j8_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8832,7 +8832,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8842,7 +8842,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8862,10 +8862,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8966,7 +8966,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8976,7 +8976,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -8996,10 +8996,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9085,7 +9085,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9095,7 +9095,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9193,7 +9193,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9203,7 +9203,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9223,10 +9223,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9303,7 +9303,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9313,7 +9313,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9336,7 +9336,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9394,7 +9394,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9404,7 +9404,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9468,7 +9468,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9478,7 +9478,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9532,7 +9532,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9542,7 +9542,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9562,10 +9562,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9640,7 +9640,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9650,7 +9650,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9674,7 +9674,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9732,7 +9732,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9742,7 +9742,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9762,10 +9762,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9866,7 +9866,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9876,7 +9876,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -9899,7 +9899,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9957,7 +9957,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9967,7 +9967,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -10063,7 +10063,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10073,7 +10073,7 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
@@ -10105,6 +10105,12 @@ workflows:
         requires:
         - start_j8_unit_tests
         - j8_build
+    - start_j8_unit_tests_repeat:
+        type: approval
+    - j8_unit_tests_repeat:
+        requires:
+        - start_j8_unit_tests_repeat
+        - j8_build
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
@@ -10117,6 +10123,18 @@ workflows:
         requires:
         - start_j8_jvm_dtests_vnode
         - j8_build
+    - start_j8_jvm_dtests_repeat:
+        type: approval
+    - j8_jvm_dtests_repeat:
+        requires:
+        - start_j8_jvm_dtests_repeat
+        - j8_build
+    - start_j8_jvm_dtests_vnode_repeat:
+        type: approval
+    - j8_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j8_jvm_dtests_vnode_repeat
+        - j8_build
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
@@ -10128,6 +10146,18 @@ workflows:
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
+        - j8_build
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
+        - j8_build
+    - start_j11_jvm_dtests_vnode_repeat:
+        type: approval
+    - j11_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j11_jvm_dtests_vnode_repeat
         - j8_build
     - start_j8_simulator_dtests:
         type: approval
@@ -10165,6 +10195,12 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j8_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j8_build
     - start_j8_utests_long:
         type: approval
     - j8_utests_long:
@@ -10189,6 +10225,18 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j8_build
+    - start_j8_utests_cdc_repeat:
+        type: approval
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_j8_utests_cdc_repeat
+        - j8_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j8_build
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -10201,6 +10249,18 @@ workflows:
         requires:
         - start_j11_utests_compression
         - j8_build
+    - start_j8_utests_compression_repeat:
+        type: approval
+    - j8_utests_compression_repeat:
+        requires:
+        - start_j8_utests_compression_repeat
+        - j8_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j8_build
     - start_j8_utests_trie:
         type: approval
     - j8_utests_trie:
@@ -10212,6 +10272,18 @@ workflows:
     - j11_utests_trie:
         requires:
         - start_j11_utests_trie
+        - j8_build
+    - start_j8_utests_trie_repeat:
+        type: approval
+    - j8_utests_trie_repeat:
+        requires:
+        - start_j8_utests_trie_repeat
+        - j8_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
         - j8_build
     - start_j8_utests_stress:
         type: approval
@@ -10248,6 +10320,18 @@ workflows:
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
+        - j8_build
+    - start_j8_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j8_utests_system_keyspace_directory_repeat
+        - j8_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
         - j8_build
     - start_j8_dtest_jars_build:
         type: approval
@@ -10417,19 +10501,34 @@ workflows:
     - j8_unit_tests:
         requires:
         - j8_build
+    - j8_unit_tests_repeat:
+        requires:
+        - j8_build
     - j8_simulator_dtests:
         requires:
         - j8_build
     - j8_jvm_dtests:
         requires:
         - j8_build
+    - j8_jvm_dtests_repeat:
+        requires:
+        - j8_build
     - j8_jvm_dtests_vnode:
+        requires:
+        - j8_build
+    - j8_jvm_dtests_vnode_repeat:
         requires:
         - j8_build
     - j11_jvm_dtests:
         requires:
         - j8_build
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j8_build
     - j11_jvm_dtests_vnode:
+        requires:
+        - j8_build
+    - j11_jvm_dtests_vnode_repeat:
         requires:
         - j8_build
     - j8_cqlshlib_tests:
@@ -10445,6 +10544,9 @@ workflows:
         requires:
         - j8_build
     - j11_unit_tests:
+        requires:
+        - j8_build
+    - j11_unit_tests_repeat:
         requires:
         - j8_build
     - start_utests_long:
@@ -10467,6 +10569,14 @@ workflows:
         requires:
         - start_utests_cdc
         - j8_build
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -10477,6 +10587,14 @@ workflows:
         requires:
         - start_utests_compression
         - j8_build
+    - j8_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
     - start_utests_trie:
         type: approval
     - j8_utests_trie:
@@ -10484,6 +10602,14 @@ workflows:
         - start_utests_trie
         - j8_build
     - j11_utests_trie:
+        requires:
+        - start_utests_trie
+        - j8_build
+    - j8_utests_trie_repeat:
+        requires:
+        - start_utests_trie
+        - j8_build
+    - j11_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j8_build
@@ -10513,6 +10639,13 @@ workflows:
         requires:
         - j8_build
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j8_build
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - j8_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
@@ -10652,6 +10785,12 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j11_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
@@ -10663,6 +10802,18 @@ workflows:
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
+        - j11_build
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
+        - j11_build
+    - start_j11_jvm_dtests_vnode_repeat:
+        type: approval
+    - j11_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j11_jvm_dtests_vnode_repeat
         - j11_build
     - start_j11_simulator_dtests:
         type: approval
@@ -10764,17 +10915,35 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j11_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
     - start_j11_utests_trie:
         type: approval
     - j11_utests_trie:
         requires:
         - start_j11_utests_trie
+        - j11_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
         - j11_build
     - start_j11_utests_stress:
         type: approval
@@ -10794,6 +10963,12 @@ workflows:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10804,10 +10979,19 @@ workflows:
     - j11_unit_tests:
         requires:
         - j11_build
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests:
         requires:
         - j11_build
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests_vnode:
+        requires:
+        - j11_build
+    - j11_jvm_dtests_vnode_repeat:
         requires:
         - j11_build
     - j11_simulator_dtests:
@@ -10885,15 +11069,27 @@ workflows:
         requires:
         - start_utests_cdc
         - j11_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
     - start_utests_trie:
         type: approval
     - j11_utests_trie:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j11_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j11_build
@@ -10912,6 +11108,10 @@ workflows:
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * Add masking functions to column metadata (CASSANDRA-18068)
  * Gossip stateMapOrdering does not have correct ordering when both EndpointState are in the bootstrapping set (CASSANDRA-18292)
  * Snapshot only sstables containing mismatching ranges on preview repair mismatch (CASSANDRA-17561)
  * More accurate skipping of sstables in read path (CASSANDRA-18134)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -126,6 +126,9 @@ New features
       normally require it, except `system_views.system_logs`.
     - More accurate skipping of sstables in read path due to better handling of min/max clustering and lower bound;
       SSTable format has been bumped to 'nc' because there are new fields in stats metadata
+    - Added support for attaching CQL dynamic data masking functions to table columns on the schema. These masking
+      functions can be attached to or dettached from columns with CREATE/ALTER TABLE statements. The functions obscure
+      the masked data during queries, but they don't change the stored data.
 
 Upgrading
 ---------

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -252,8 +252,10 @@ bc(syntax)..
                           '(' <column-definition> ( ',' <column-definition> )* ')'
                           ( WITH <option> ( AND <option>)* )?
 
-<column-definition> ::= <identifier> <type> ( STATIC )? ( PRIMARY KEY )?
+<column-definition> ::= <identifier> <type> ( STATIC )? ( <column_mask> )? ( PRIMARY KEY )?
                       | PRIMARY KEY '(' <partition-key> ( ',' <identifier> )* ')'
+
+<column-mask> ::= MASKED WITH ( DEFAULT | <function> '(' ( <term> (',' <term>)* )?  ')' )
 
 <partition-key> ::= <identifier>
                   | '(' <identifier> (',' <identifier> )* ')'
@@ -413,11 +415,15 @@ __Syntax:__
 bc(syntax).. 
 <alter-table-stmt> ::= ALTER (TABLE | COLUMNFAMILY) (IF NOT EXISTS)? <tablename> <instruction>
 
-<instruction> ::= ADD (IF NOT EXISTS)? ( <identifier> <type> ( , <identifier> <type> )* )
+<instruction> ::= ADD (IF NOT EXISTS)? ( <identifier> <type> ( <column-mask> )?
+                                       ( , <identifier> <type> ( <column-mask> )? )* )
                 | DROP  (IF EXISTS)? ( <identifier> ( , <identifier> )* )
+                | ALTER <identifier> ( <column-mask> | DROP MASKED )
                 | RENAME (IF EXISTS)? <identifier> to <identifier> (AND <identifier> to <identifier>)*
                 | DROP COMPACT STORAGE
                 | WITH  <option> ( AND <option> )*
+
+<column-mask> ::= MASKED WITH ( DEFAULT | <function> '(' ( <term> (',' <term>)* )?  ')' )
 p. 
 __Sample:__
 
@@ -437,6 +443,7 @@ If the table does not exist, the statement will return an error, unless @IF EXIS
 The @<tablename>@ is the table name optionally preceded by the keyspace name.  The @<instruction>@ defines the alteration to perform:
 * @ADD@: Adds a new column to the table. The @<identifier>@ for the new column must not conflict with an existing column. Moreover, columns cannot be added to tables defined with the @COMPACT STORAGE@ option. If the new column already exists, the statement will return an error, unless @IF NOT EXISTS@ is used in which case the operation is a no-op.
 * @DROP@: Removes a column from the table. Dropped columns will immediately become unavailable in the queries and will not be included in compacted sstables in the future. If a column is readded, queries won't return values written before the column was last dropped. It is assumed that timestamps represent actual time, so if this is not your case, you should NOT readd previously dropped columns. Columns can't be dropped from tables defined with the @COMPACT STORAGE@ option. If the dropped column does not already exist, the statement will return an error, unless @IF EXISTS@ is used in which case the operation is a no-op.
+* @ALTER@: Alters an existing column. It can be used to set its data mask, or to set it as unmasked. The data mask is any function meant to obscure the real values of the column.
 * @RENAME@ a primary key column of a table. Non primary key columns cannot be renamed. Furthermore, renaming a column to another name which already exists isn't allowed. It's important to keep in mind that renamed columns shouldn't have dependent secondary indexes. If the renamed column does not already exist, the statement will return an error, unless @IF EXISTS@ is used in which case the operation is a no-op.
 * @DROP COMPACT STORAGE@: Removes Thrift compatibility mode from the table.
 * @WITH@: Allows to update the options of the table. The "supported @<option>@":#createTableOptions (and syntax) are the same as for the @CREATE TABLE@ statement except that @COMPACT STORAGE@ is not supported. Note that setting any @compaction@ sub-options has the effect of erasing all previous @compaction@ options, so you  need to re-specify all the sub-options if you want to keep them. The same note applies to the set of @compression@ sub-options.
@@ -2489,6 +2496,7 @@ CQL distinguishes between _reserved_ and _non-reserved_ keywords. Reserved keywo
 | @LIST@         | no  |
 | @LOGIN@        | no  |
 | @MAP@          | no  |
+| @MASKED@       | no  |
 | @MATERIALIZED@ | yes |
 | @MBEAN@        | yes |
 | @MBEANS@       | yes |
@@ -2553,7 +2561,7 @@ CQL distinguishes between _reserved_ and _non-reserved_ keywords. Reserved keywo
 | @WHERE@        | yes |
 | @WITH@         | yes |
 | @WRITETIME@    | no  |
-| @MAXWRITETIME@    | no  |
+| @MAXWRITETIME@ | no  |
 
 h2(#appendixB). Appendix B: CQL Reserved Types
 

--- a/doc/modules/cassandra/examples/BNF/alter_table.bnf
+++ b/doc/modules/cassandra/examples/BNF/alter_table.bnf
@@ -1,5 +1,8 @@
 alter_table_statement::= ALTER TABLE [ IF EXISTS ] table_name alter_table_instruction
-alter_table_instruction::= ADD [ IF NOT EXISTS ] column_name cql_type ( ',' column_name cql_type )*
+alter_table_instruction::= ADD [ IF NOT EXISTS ] column_definition ( ',' column_definition)*
 	| DROP [ IF EXISTS ] column_name ( ',' column_name )*
 	| RENAME [ IF EXISTS ] column_name to column_name (AND column_name to column_name)*
+	| ALTER [ IF EXISTS ] column_name ( column_mask | DROP MASKED )
 	| WITH options
+column_definition::= column_name cql_type [ column_mask]
+column_mask::= MASKED WITH ( DEFAULT | function_name '(' term ( ',' term )* ')' )

--- a/doc/modules/cassandra/examples/BNF/create_table.bnf
+++ b/doc/modules/cassandra/examples/BNF/create_table.bnf
@@ -2,11 +2,12 @@ create_table_statement::= CREATE TABLE [ IF NOT EXISTS ] table_name '('
 	column_definition  ( ',' column_definition )*  
 	[ ',' PRIMARY KEY '(' primary_key ')' ] 
 	 ')' [ WITH table_options ] 
-column_definition::= column_name cql_type [ STATIC ] [ PRIMARY KEY] 
+column_definition::= column_name cql_type [ STATIC ] [ column_mask ] [ PRIMARY KEY]
+column_mask::= MASKED WITH ( DEFAULT | function_name '(' term ( ',' term )* ')' )
 primary_key::= partition_key [ ',' clustering_columns ] 
 partition_key::= column_name  | '(' column_name ( ',' column_name )* ')' 
 clustering_columns::= column_name ( ',' column_name )* 
-table_options:=: COMPACT STORAGE [ AND table_options ]  
+table_options::= COMPACT STORAGE [ AND table_options ]
 	| CLUSTERING ORDER BY '(' clustering_order ')' 
 	[ AND table_options ]  | options
 clustering_order::= column_name (ASC | DESC) ( ',' column_name (ASC | DESC) )*

--- a/doc/modules/cassandra/examples/CQL/ddm_alter_mask.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_alter_mask.cql
@@ -1,0 +1,1 @@
+ALTER TABLE patients ALTER name MASKED WITH mask_default();

--- a/doc/modules/cassandra/examples/CQL/ddm_create_table.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_create_table.cql
@@ -1,0 +1,5 @@
+CREATE TABLE patients (
+   id timeuuid PRIMARY KEY,
+   name text MASKED WITH mask_inner(1, null),
+   birth date MASKED WITH mask_default()
+);

--- a/doc/modules/cassandra/examples/CQL/ddm_drop_mask.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_drop_mask.cql
@@ -1,0 +1,1 @@
+ALTER TABLE patients ALTER name DROP MASKED;

--- a/doc/modules/cassandra/examples/CQL/ddm_insert_data.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_insert_data.cql
@@ -1,0 +1,2 @@
+INSERT INTO patients(id, name, birth) VALUES (now(), 'alice', '1984-01-02');
+INSERT INTO patients(id, name, birth) VALUES (now(), 'bob', '1982-02-03');

--- a/doc/modules/cassandra/examples/CQL/ddm_select_with_masked_columns.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_select_with_masked_columns.cql
@@ -1,0 +1,6 @@
+SELECT name, birth FROM patients;
+
+//  name  | birth
+// -------+------------
+//  a**** | 1970-01-01
+//    b** | 1970-01-01

--- a/doc/modules/cassandra/examples/CQL/select_with_mask_functions.cql
+++ b/doc/modules/cassandra/examples/CQL/select_with_mask_functions.cql
@@ -1,0 +1,15 @@
+CREATE TABLE patients (
+   id timeuuid PRIMARY KEY,
+   name text,
+   birth date
+);
+
+INSERT INTO patients(id, name, birth) VALUES (now(), 'alice', '1982-01-02');
+INSERT INTO patients(id, name, birth) VALUES (now(), 'bob', '1982-01-02');
+
+SELECT mask_inner(name, 1, null), mask_default(birth) FROM patients;
+
+//   system.mask_inner(name, 1, NULL) | system.mask_default(birth)
+// -----------------------------------+----------------------------
+//                                b** |                 1970-01-01
+//                              a**** |                 1970-01-01

--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -39,6 +39,7 @@
 *** xref:cql/functions.adoc[Functions]
 *** xref:cql/json.adoc[JSON]
 *** xref:cql/security.adoc[Security]
+*** xref:cql/dynamic_data_masking.adoc[Dynamic data masking]
 *** xref:cql/triggers.adoc[Triggers]
 *** xref:cql/appendices.adoc[Appendices]
 *** xref:cql/changes.adoc[Changes]

--- a/doc/modules/cassandra/pages/cql/appendices.adoc
+++ b/doc/modules/cassandra/pages/cql/appendices.adoc
@@ -82,6 +82,7 @@ or not.
 |`LIST` |no
 |`LOGIN` |no
 |`MAP` |no
+|`MASKED` |no
 |`MODIFY` |yes
 |`NAN` |yes
 |`NOLOGIN` |no

--- a/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
@@ -3611,6 +3611,7 @@ or not.
 |`LIST` |no
 |`LOGIN` |no
 |`MAP` |no
+|`MASKED` |no
 |`MATERIALIZED` |yes
 |`MBEAN` |yes
 |`MBEANS` |yes

--- a/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
+++ b/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
@@ -1,0 +1,69 @@
+= Dynamic Data Masking
+
+Dynamic data masking (DDM) allows to obscure sensitive information while still allowing access to the masked columns.
+DDM doesn't change the stored data. Instead, it just presents the data on their obscured form during `SELECT` queries.
+This aims to provide some degree of protection against accidental data exposure. However, it's important to know that
+anyone with direct access to the sstable files will be able to read the clear data.
+
+== Masking functions
+
+DDM is based on a set of CQL native functions that obscure sensitive information. The available functions are:
+
+include::partial$masking_functions.adoc[]
+
+Those functions can be discretionarily used on `SELECT` queries to get an obscured view of the data. For example:
+
+[source,cql]
+----
+include::example$CQL/select_with_mask_functions.cql[]
+----
+
+== Attaching masking functions to table columns
+
+The masking functions can be permanently attached to the columns of a table.
+In that case, `SELECT` queries will always return the column values in their masked form.
+The masking will be transparent for the users running `SELECT` queries,
+so their only way to know that a column is masked will be consulting the table definition.
+
+The masks of the columns of a table can be defined on `CREATE TABLE` queries:
+
+[source,cql]
+----
+include::example$CQL/ddm_create_table.cql[]
+----
+
+Note that in the example above we are referencing the `mask_inner` function with two arguments.
+However, that CQL function actually has three arguments when explicitely used on `SELECT` queries.
+The first argument is always ommitted when attaching the function to a schema column.
+The value of that first argument is always interpreted as the value of the masked column, in this case a `text` column.
+For the same reason the call to `mask_default` attached to the column doesn't have any argument,
+even when that function requires one argument when explicitely used on `SELECT` queries.
+
+Data can be inserted into the masked table as usual. For example:
+
+[source,cql]
+----
+include::example$CQL/ddm_insert_data.cql[]
+----
+
+The attached column masks will make `SELECT` queries automatically return masked data,
+without the need of including the masking function on the query:
+
+[source,cql]
+----
+include::example$CQL/ddm_select_with_masked_columns.cql[]
+----
+
+The masking function attached to a column can be changed with an `ALTER TABLE` query:
+
+[source,cql]
+----
+include::example$CQL/ddm_alter_mask.cql[]
+----
+
+In a similar way, a masking function can be dettached from a column with an `ALTER TABLE` query:
+
+[source,cql]
+----
+include::example$CQL/ddm_drop_mask.cql[]
+----

--- a/doc/modules/cassandra/pages/cql/functions.adoc
+++ b/doc/modules/cassandra/pages/cql/functions.adoc
@@ -281,71 +281,12 @@ A number of functions are provided to operate on collection columns.
 | `collection_avg` | numeric `set` or `list` | Computes the average of the elements in the collection argument. The average of an empty collection returns zero. The returned value is of the same type as the input collection elements, which might include rounding and truncations. For example `collection_avg([1, 2])` returns `1` instead of `1.5`.
 |===
 
+[[data-masking-functions]]
 ===== Data masking functions
 
 A number of functions allow to obscure the real contents of a column containing sensitive data.
 
-[cols=",",options="header",]
-|===
-|Function | Description
-
-| `mask_null(value)` | Replaces the first argument by a `null` column. The returned value is always an absent column, as it didn't exist, and not a not-null column representing a `null` value.
-
-Examples:
-
-`mask_null('Alice')` -> `null`
-
-`mask_null(123)` -> `null`
-
-| `mask_default(value)` | Replaces its argument by an arbitrary, fixed default value of the same type. This will be `\***\***` for text values, zero for numeric values, `false` for booleans, etc.
-
-Examples:
-
-`mask_default('Alice')` -> `'\****'`
-
-`mask_default(123)` -> `0`
-
-| `mask_replace(value, replacement])` | Replaces the first argument by the replacement value on the second argument. The replacement value needs to have the same type as the replaced value.
-
-Examples:
-
-`mask_replace('Alice', 'REDACTED')` -> `'REDACTED'`
-
-`mask_replace(123, -1)` -> `-1`
-
-| `mask_inner(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing each character except the first and last ones by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
-
-Examples:
-
-`mask_inner('Alice', 1, 2)` -> `'A**ce'`
-
-`mask_inner('Alice', 1, null)` -> `'A****'`
-
-`mask_inner('Alice', null, 2)` -> `'***ce'`
-
-`mask_inner('Alice', 2, 1, '\#')` -> `'Al##e'`
-
-| `mask_outer(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing the first and last character by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
-
-Examples:
-
-`mask_outer('Alice', 1, 2)` -> `'*li**'`
-
-`mask_outer('Alice', 1, null)` -> `'*lice'`
-
-`mask_outer('Alice', null, 2)` -> `'Ali**'`
-
-`mask_outer('Alice', 2, 1, '\#')` -> `'##ic#'`
-
-| `mask_hash(value, [algorithm])` | Returns a `blob` containing the hash of the first argument. The optional 2nd argument is the hashing algorithm to be used, according the available Java security provider. The default hashing algorithm is `SHA-256`.
-
-Examples:
-
-`mask_hash('Alice')`
-
-`mask_hash('Alice', 'SHA-512')`
-
-|===
+include::partial$masking_functions.adoc[]
 
 [[user-defined-scalar-functions]]
 ==== User-defined functions

--- a/doc/modules/cassandra/pages/cql/index.adoc
+++ b/doc/modules/cassandra/pages/cql/index.adoc
@@ -19,6 +19,7 @@ For that reason, when used in this document, these terms (tables, rows and colum
 * xref:cql/functions.adoc[Functions]
 * xref:cql/json.adoc[JSON]
 * xref:cql/security.adoc[CQL security]
+* xref:cql/dynamic_data_masking.adoc[Dynamic data masking]
 * xref:cql/triggers.adoc[Triggers]
 * xref:cql/appendices.adoc[Appendices]
 * xref:cql/changes.adoc[Changes]

--- a/doc/modules/cassandra/partials/masking_functions.adoc
+++ b/doc/modules/cassandra/partials/masking_functions.adoc
@@ -1,0 +1,61 @@
+[cols=",",options="header",]
+|===
+|Function | Description
+
+| `mask_null(value)` | Replaces the first argument by a `null` column. The returned value is always an absent column, as it didn't exist, and not a not-null column representing a `null` value.
+
+Examples:
+
+`mask_null('Alice')` -> `null`
+
+`mask_null(123)` -> `null`
+
+| `mask_default(value)` | Replaces its argument by an arbitrary, fixed default value of the same type. This will be `\***\***` for text values, zero for numeric values, `false` for booleans, etc.
+
+Examples:
+
+`mask_default('Alice')` -> `'\****'`
+
+`mask_default(123)` -> `0`
+
+| `mask_replace(value, replacement])` | Replaces the first argument by the replacement value on the second argument. The replacement value needs to have the same type as the replaced value.
+
+Examples:
+
+`mask_replace('Alice', 'REDACTED')` -> `'REDACTED'`
+
+`mask_replace(123, -1)` -> `-1`
+
+| `mask_inner(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing each character except the first and last ones by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
+
+Examples:
+
+`mask_inner('Alice', 1, 2)` -> `'A**ce'`
+
+`mask_inner('Alice', 1, null)` -> `'A****'`
+
+`mask_inner('Alice', null, 2)` -> `'***ce'`
+
+`mask_inner('Alice', 2, 1, '\#')` -> `'Al##e'`
+
+| `mask_outer(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing the first and last character by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
+
+Examples:
+
+`mask_outer('Alice', 1, 2)` -> `'*li**'`
+
+`mask_outer('Alice', 1, null)` -> `'*lice'`
+
+`mask_outer('Alice', null, 2)` -> `'Ali**'`
+
+`mask_outer('Alice', 2, 1, '\#')` -> `'##ic#'`
+
+| `mask_hash(value, [algorithm])` | Returns a `blob` containing the hash of the first argument. The optional 2nd argument is the hashing algorithm to be used, according the available Java security provider. The default hashing algorithm is `SHA-256`.
+
+Examples:
+
+`mask_hash('Alice')`
+
+`mask_hash('Alice', 'SHA-512')`
+
+|===

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -313,7 +313,9 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
 
 <userType> ::= utname=<cfOrKsName> ;
 
-<storageType> ::= <simpleStorageType> | <collectionType> | <frozenCollectionType> | <userType> ;
+<storageType> ::= ( <simpleStorageType> | <collectionType> | <frozenCollectionType> | <userType> ) ( <column_mask> )? ;
+
+<column_mask> ::= "MASKED" "WITH" ( "DEFAULT" | <functionName> <selectionFunctionArguments> );
 
 # Note: autocomplete for frozen collection types does not handle nesting past depth 1 properly,
 # but that's a lot of work to fix for little benefit.
@@ -1428,6 +1430,7 @@ syntax_rules += r'''
                       | "WITH" <cfamProperty> ( "AND" <cfamProperty> )*
                       | "RENAME" ("IF" "EXISTS")? existcol=<cident> "TO" newcol=<cident>
                          ( "AND" existcol=<cident> "TO" newcol=<cident> )*
+                      | "ALTER" ("IF" "EXISTS")? existcol=<cident> ( <column_mask> | "DROP" "MASKED" )
                       ;
 
 <alterUserTypeStatement> ::= "ALTER" "TYPE" ("IF" "EXISTS")? ut=<userTypeName>

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -620,7 +620,12 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions(prefix + ' new_table (col_a ine',
                             immediate='t ')
         self.trycompletions(prefix + ' new_table (col_a int ',
-                            choices=[',', 'PRIMARY'])
+                            choices=[',', 'MASKED', 'PRIMARY'])
+        self.trycompletions(prefix + ' new_table (col_a int M',
+                            immediate='ASKED WITH ')
+        self.trycompletions(prefix + ' new_table (col_a int MASKED WITH ',
+                            choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
+                            other_choices_ok=True)
         self.trycompletions(prefix + ' new_table (col_a int P',
                             immediate='RIMARY KEY ')
         self.trycompletions(prefix + ' new_table (col_a int PRIMARY KEY ',
@@ -963,9 +968,23 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('ALTER TABLE IF EXISTS new_table ADD ', choices=['<new_column_name>', 'IF'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table ADD IF NOT EXISTS ', choices=['<new_column_name>'])
         self.trycompletions('ALTER TABLE new_table ADD IF NOT EXISTS ', choices=['<new_column_name>'])
+        self.trycompletions('ALTER TABLE new_table ADD col int ', choices=[';', 'MASKED', 'static'])
+        self.trycompletions('ALTER TABLE new_table ADD col int M', immediate='ASKED WITH ')
+        self.trycompletions('ALTER TABLE new_table ADD col int MASKED WITH ',
+                            choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
+                            other_choices_ok=True)
         self.trycompletions('ALTER TABLE IF EXISTS new_table RENAME ', choices=['IF', '<quotedName>', '<identifier>'])
         self.trycompletions('ALTER TABLE new_table RENAME ', choices=['IF', '<quotedName>', '<identifier>'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table DROP ', choices=['IF', '<quotedName>', '<identifier>'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER ', choices=['IF', '<quotedName>', '<identifier>'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF E', immediate='XISTS ')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col ', choices=['MASKED', 'DROP'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col M', immediate='ASKED WITH ')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col MASKED WITH ',
+                            choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
+                            other_choices_ok=True)
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col D', immediate='ROP MASKED ;')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col DROP M', immediate='ASKED ;')
 
     def test_complete_in_alter_type(self):
         self.trycompletions('ALTER TYPE I', immediate='F EXISTS ')

--- a/src/antlr/Cql.g
+++ b/src/antlr/Cql.g
@@ -39,6 +39,7 @@ import Parser,Lexer;
     import org.apache.cassandra.auth.*;
     import org.apache.cassandra.cql3.conditions.*;
     import org.apache.cassandra.cql3.functions.*;
+    import org.apache.cassandra.cql3.functions.masking.*;
     import org.apache.cassandra.cql3.restrictions.CustomIndexExpression;
     import org.apache.cassandra.cql3.selection.*;
     import org.apache.cassandra.cql3.statements.*;

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -218,6 +218,8 @@ K_DEFAULT:     D E F A U L T;
 K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
 
+K_MASKED:      M A S K E D;
+
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');
 fragment B: ('b'|'B');

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -782,9 +782,19 @@ tableDefinition[CreateTableStatement.Raw stmt]
 
 tableColumns[CreateTableStatement.Raw stmt]
     @init { boolean isStatic = false; }
-    : k=ident v=comparatorType (K_STATIC { isStatic = true; })? { $stmt.addColumn(k, v, isStatic); }
+    : k=ident v=comparatorType (K_STATIC { isStatic = true; })? (mask=columnMask)? { $stmt.addColumn(k, v, isStatic, mask); }
         (K_PRIMARY K_KEY { $stmt.setPartitionKeyColumn(k); })?
     | K_PRIMARY K_KEY '(' tablePartitionKey[stmt] (',' c=ident { $stmt.markClusteringColumn(c); } )* ')'
+    ;
+
+columnMask returns [ColumnMask.Raw mask]
+    @init { List<Term.Raw> arguments = new ArrayList<>(); }
+    : K_MASKED K_WITH name=functionName columnMaskArguments[arguments] { $mask = new ColumnMask.Raw(name, arguments); }
+    | K_MASKED K_WITH K_DEFAULT { $mask = new ColumnMask.Raw(FunctionName.nativeFunction("mask_default"), arguments); }
+    ;
+
+columnMaskArguments[List<Term.Raw> arguments]
+    : '('  ')' | '(' c=term { arguments.add(c); } (',' cn=term { arguments.add(cn); })* ')'
     ;
 
 tablePartitionKey[CreateTableStatement.Raw stmt]
@@ -929,7 +939,9 @@ alterKeyspaceStatement returns [AlterKeyspaceStatement.Raw stmt]
 
 /**
  * ALTER TABLE <table> ALTER <column> TYPE <newtype>;
- * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] <column> <newtype>; | ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] (<column> <newtype>,<column1> <newtype1>..... <column n> <newtype n>)
+ * ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> MASKED WITH <maskFunction>);
+ * ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> DROP MASKED;
+ * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] <column> <newtype> <maskFunction>; | ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] (<column> <newtype> <maskFunction>, <column1> <newtype1>  <maskFunction1>..... <column n> <newtype n>  <maskFunction n>)
  * ALTER TABLE [IF EXISTS] <table> DROP [IF EXISTS] <column>; | ALTER TABLE [IF EXISTS] <table> DROP [IF EXISTS] ( <column>,<column1>.....<column n>)
  * ALTER TABLE [IF EXISTS] <table> RENAME [IF EXISTS] <column> TO <column>;
  * ALTER TABLE [IF EXISTS] <table> WITH <property> = <value>;
@@ -941,10 +953,14 @@ alterTableStatement returns [AlterTableStatement.Raw stmt]
       (
         K_ALTER id=cident K_TYPE v=comparatorType { $stmt.alter(id, v); }
 
+      | K_ALTER ( K_IF K_EXISTS { $stmt.ifColumnExists(true); } )? id=cident
+              ( mask=columnMask { $stmt.mask(id, mask); }
+              | K_DROP K_MASKED { $stmt.mask(id, null); } )
+
       | K_ADD ( K_IF K_NOT K_EXISTS { $stmt.ifColumnNotExists(true); } )?
-              (        id=ident  v=comparatorType  b=isStaticColumn { $stmt.add(id,  v,  b);  }
-               | ('('  id1=ident v1=comparatorType b1=isStaticColumn { $stmt.add(id1, v1, b1); }
-                 ( ',' idn=ident vn=comparatorType bn=isStaticColumn { $stmt.add(idn, vn, bn); } )* ')') )
+              (        id=ident  v=comparatorType  b=isStaticColumn (m=columnMask)? { $stmt.add(id,  v,  b, m);  }
+               | ('('  id1=ident v1=comparatorType b1=isStaticColumn (m1=columnMask)? { $stmt.add(id1, v1, b1, m1); }
+                 ( ',' idn=ident vn=comparatorType bn=isStaticColumn (mn=columnMask)? { $stmt.add(idn, vn, bn, mn); mn=null; } )* ')') )
 
       | K_DROP ( K_IF K_EXISTS { $stmt.ifColumnExists(true); } )?
                (       id=ident { $stmt.drop(id);  }
@@ -1940,5 +1956,6 @@ basic_unreserved_keyword returns [String str]
         | K_MBEANS
         | K_REPLACE
         | K_UNSET
+        | K_MASKED
         ) { $str = $k.text; }
     ;

--- a/src/java/org/apache/cassandra/cql3/functions/masking/ColumnMask.java
+++ b/src/java/org/apache/cassandra/cql3/functions/masking/ColumnMask.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
+
+import org.apache.cassandra.cql3.AssignmentTestable;
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.cql3.Terms;
+import org.apache.cassandra.cql3.functions.Function;
+import org.apache.cassandra.cql3.functions.FunctionName;
+import org.apache.cassandra.cql3.functions.FunctionResolver;
+import org.apache.cassandra.cql3.functions.ScalarFunction;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ReversedType;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
+
+/**
+ * Dynamic data mask that can be applied to a schema column.
+ * <p>
+ * It consists on a partial application of a certain {@link MaskingFunction} to the values of a column, with the
+ * precondition that the type of any masked column is compatible with the type of the first argument of the function.
+ * <p>
+ * This partial application is meant to be associated to specific columns in the schema, acting as a mask for the values
+ * of those columns. It's associated to queries such as:
+ * <pre>
+ *    CREATE TABLE %t (k int PRIMARY KEY, v int MASKED WITH mask_inner(1, 1));
+ *    ALTER TABLE t ALTER v MASKED WITH mask_inner(2, 1);
+ *    ALTER TABLE t ALTER v DROP MASKED;
+ * </pre>
+ * Note that in the example above we are referencing the {@code mask_inner} function with two arguments. However, that
+ * CQL function actually has three arguments. The first argument is always ommitted when attaching the function to a
+ * schema column. The value of that first argument is always the value of the masked column, in this case an int.
+ */
+public class ColumnMask
+{
+    /** The CQL function used for masking. */
+    public final ScalarFunction function;
+
+    /** The values of the arguments of the partially applied masking function. */
+    public final List<ByteBuffer> partialArgumentValues;
+
+    public ColumnMask(ScalarFunction function, List<ByteBuffer> partialArgumentValues)
+    {
+        assert function.argTypes().size() == partialArgumentValues.size() + 1;
+        this.function = function;
+        this.partialArgumentValues = partialArgumentValues;
+    }
+
+    /**
+     * @return The types of the arguments of the partially applied masking function.
+     */
+    public List<AbstractType<?>> partialArgumentTypes()
+    {
+        List<AbstractType<?>> argTypes = function.argTypes();
+        return argTypes.size() == 1
+               ? Collections.emptyList()
+               : argTypes.subList(1, argTypes.size());
+    }
+
+    /**
+     * @return A copy of this mask for a version of its masked column that has its type reversed.
+     */
+    public ColumnMask withReversedType()
+    {
+        AbstractType<?> reversed = ReversedType.getInstance(function.argTypes().get(0));
+        List<AbstractType<?>> args = ImmutableList.<AbstractType<?>>builder()
+                                                  .add(reversed)
+                                                  .addAll(partialArgumentTypes())
+                                                  .build();
+        Function newFunction = FunctionResolver.get(function.name().keyspace, function.name(), args, null, null, null);
+        assert newFunction != null;
+        return new ColumnMask((ScalarFunction) newFunction, partialArgumentValues);
+    }
+
+    /**
+     * @param protocolVersion the used version of the transport protocol
+     * @param value           a column value to be masked
+     * @return the specified value after having been masked by the masked function
+     */
+    public ByteBuffer mask(ProtocolVersion protocolVersion, ByteBuffer value)
+    {
+        List<ByteBuffer> args = new ArrayList<>(partialArgumentValues.size() + 1);
+        args.add(value);
+        args.addAll(partialArgumentValues);
+        return function.execute(protocolVersion, args);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ColumnMask mask = (ColumnMask) o;
+        return function.name().equals(mask.function.name())
+               && partialArgumentValues.equals(mask.partialArgumentValues);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(function.name(), partialArgumentValues);
+    }
+
+    @Override
+    public String toString()
+    {
+        List<AbstractType<?>> types = partialArgumentTypes();
+        List<String> arguments = new ArrayList<>(types.size());
+        for (int i = 0; i < types.size(); i++)
+        {
+            CQL3Type type = types.get(i).asCQL3Type();
+            ByteBuffer value = partialArgumentValues.get(i);
+            arguments.add(type.toCQLLiteral(value, ProtocolVersion.CURRENT));
+        }
+        return format("%s(%s)", function.name(), StringUtils.join(arguments, ", "));
+    }
+
+    public void appendCqlTo(CqlBuilder builder)
+    {
+        builder.append(" MASKED WITH ").append(toString());
+    }
+
+    /**
+     * A parsed but not prepared column mask.
+     */
+    public final static class Raw
+    {
+        public final FunctionName name;
+        public final List<Term.Raw> rawPartialArguments;
+
+        public Raw(FunctionName name, List<Term.Raw> rawPartialArguments)
+        {
+            this.name = name;
+            this.rawPartialArguments = rawPartialArguments;
+        }
+
+        public ColumnMask prepare(String keyspace, String table, ColumnIdentifier column, AbstractType<?> type)
+        {
+            ScalarFunction function = findMaskingFunction(keyspace, table, column, type);
+
+            List<ByteBuffer> partialArguments = preparePartialArguments(keyspace, function);
+
+            return new ColumnMask(function, partialArguments);
+        }
+
+        private ScalarFunction findMaskingFunction(String keyspace, String table, ColumnIdentifier column, AbstractType<?> type)
+        {
+            List<AssignmentTestable> args = new ArrayList<>(rawPartialArguments.size() + 1);
+            args.add(type);
+            args.addAll(rawPartialArguments);
+
+            Function function = FunctionResolver.get(keyspace, name, args, keyspace, table, type);
+
+            if (function == null)
+                throw invalidRequest("Unable to find masking function for %s, " +
+                                     "no declared function matches the signature %s",
+                                     column, this);
+
+            if (function.isAggregate())
+                throw invalidRequest("Aggregate function %s cannot be used for masking table columns", this);
+
+            if (!function.isNative())
+                throw invalidRequest("User defined function %s cannot be used for masking table columns", this);
+
+            if (!(function instanceof MaskingFunction))
+                throw invalidRequest("Not-masking function %s cannot be used for masking table columns", this);
+
+            if (!function.returnType().equals(type))
+                throw invalidRequest("Masking function %s return type is %s. " +
+                                     "This is different to the type of the masked column %s of type %s. " +
+                                     "Masking functions can only be attached to table columns " +
+                                     "if they return the same data type as the masked column.",
+                                     this, function.returnType().asCQL3Type(), column, type.asCQL3Type());
+
+            return (ScalarFunction) function;
+        }
+
+        private List<ByteBuffer> preparePartialArguments(String keyspace, ScalarFunction function)
+        {
+            // Note that there could be null arguments
+            List<ByteBuffer> arguments = new ArrayList<>(rawPartialArguments.size());
+
+            for (int i = 0; i < rawPartialArguments.size(); i++)
+            {
+                String term = rawPartialArguments.get(i).toString();
+                AbstractType<?> type = function.argTypes().get(i + 1);
+                arguments.add(Terms.asBytes(keyspace, term, type));
+            }
+
+            return arguments;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", name, StringUtils.join(rawPartialArguments, ", "));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/selection/Selectable.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selectable.java
@@ -79,7 +79,7 @@ public interface Selectable extends AssignmentTestable
      */
     public default boolean processesSelection()
     {
-        // ColumnMetadata is the only case that returns false and override this
+        // ColumnMetadata is the only case that returns false (if the column is not masked) and overrides this
         return true;
     }
 
@@ -322,7 +322,7 @@ public interface Selectable extends AssignmentTestable
             @Override
             public WritetimeOrTTL prepare(TableMetadata table)
             {
-                return new WritetimeOrTTL(column.prepare(table), selected.prepare(table), kind);
+                return new WritetimeOrTTL((ColumnMetadata) column.prepare(table), selected.prepare(table), kind);
             }
         }
     }
@@ -1240,10 +1240,15 @@ public interface Selectable extends AssignmentTestable
             this.quoted = quoted;
         }
 
-        @Override
-        public ColumnMetadata prepare(TableMetadata cfm)
+        public ColumnMetadata columnMetadata(TableMetadata cfm)
         {
             return cfm.getExistingColumn(ColumnIdentifier.getInterned(text, quoted));
+        }
+
+        @Override
+        public Selectable prepare(TableMetadata cfm)
+        {
+            return columnMetadata(cfm);
         }
 
         public FieldIdentifier toFieldIdentifier()

--- a/src/java/org/apache/cassandra/cql3/selection/SelectorFactories.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SelectorFactories.java
@@ -147,7 +147,7 @@ final class SelectorFactories implements Iterable<Selector.Factory>
      */
     public void addSelectorForOrdering(ColumnMetadata def, int index)
     {
-        factories.add(SimpleSelector.newFactory(def, index));
+        factories.add(SimpleSelector.newFactory(def, index, true));
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -23,8 +23,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
@@ -40,6 +43,7 @@ import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.QualifiedName;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -159,6 +163,68 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     }
 
     /**
+     * ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> ( MASKED WITH <newMask> | DROP MASKED )
+     */
+    public static class MaskColumn extends AlterTableStatement
+    {
+        private final ColumnIdentifier columnName;
+        @Nullable
+        private final ColumnMask.Raw rawMask;
+        private final boolean ifColumnExists;
+
+        MaskColumn(String keyspaceName,
+                   String tableName,
+                   ColumnIdentifier columnName,
+                   @Nullable ColumnMask.Raw rawMask,
+                   boolean ifTableExists,
+                   boolean ifColumnExists)
+        {
+            super(keyspaceName, tableName, ifTableExists);
+            this.columnName = columnName;
+            this.rawMask = rawMask;
+            this.ifColumnExists = ifColumnExists;
+        }
+
+        @Override
+        public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
+        {
+            ColumnMetadata column = table.getColumn(columnName);
+
+            if (column == null)
+            {
+                if (!ifColumnExists)
+                    throw ire("Column with name '%s' doesn't exist on table '%s'", columnName, tableName);
+
+                return keyspace;
+            }
+
+            ColumnMask oldMask = table.getColumn(columnName).getMask();
+            ColumnMask newMask = rawMask == null ? null : rawMask.prepare(keyspace.name, table.name, columnName, column.type);
+
+            if (Objects.equals(oldMask, newMask))
+                return keyspace;
+
+            TableMetadata.Builder tableBuilder = table.unbuild();
+            tableBuilder.alterColumnMask(columnName, newMask);
+            TableMetadata newTable = tableBuilder.build();
+            newTable.validate();
+
+            // Update any reference on materialized views, so the mask is consistent among the base table and its views.
+            Views.Builder viewsBuilder = keyspace.views.unbuild();
+            for (ViewMetadata view : keyspace.views.forTable(table.id))
+            {
+                if (view.includes(columnName))
+                {
+                    viewsBuilder.put(viewsBuilder.get(view.name()).withNewColumnMask(columnName, newMask));
+                }
+            }
+
+            return keyspace.withSwapped(keyspace.tables.withSwapped(newTable))
+                           .withSwapped(viewsBuilder.build());
+        }
+    }
+
+    /**
      * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] <column> <newtype>
      * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] (<column> <newtype>, <column1> <newtype1>, ... <columnn> <newtypen>)
      */
@@ -169,12 +235,15 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             private final ColumnIdentifier name;
             private final CQL3Type.Raw type;
             private final boolean isStatic;
+            @Nullable
+            private final ColumnMask.Raw mask;
 
-            Column(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic)
+            Column(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic, @Nullable ColumnMask.Raw mask)
             {
                 this.name = name;
                 this.type = type;
                 this.isStatic = isStatic;
+                this.mask = mask;
             }
         }
 
@@ -186,12 +255,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             super(keyspaceName, tableName, ifTableExists);
             this.newColumns = newColumns;
             this.ifColumnNotExists = ifColumnNotExists;
-        }
-
-        @Override
-        public void validate(ClientState state)
-        {
-            super.validate(state);
         }
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
@@ -220,6 +283,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             ColumnIdentifier name = column.name;
             AbstractType<?> type = column.type.prepare(keyspaceName, keyspace.types).getType();
             boolean isStatic = column.isStatic;
+            ColumnMask mask = column.mask == null ? null : column.mask.prepare(keyspaceName, tableName, name, type);
 
             if (null != tableBuilder.getColumn(name)) {
                 if (!ifColumnNotExists)
@@ -260,9 +324,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             }
 
             if (isStatic)
-                tableBuilder.addStaticColumn(name, type);
+                tableBuilder.addStaticColumn(name, type, mask);
             else
-                tableBuilder.addRegularColumn(name, type);
+                tableBuilder.addRegularColumn(name, type, mask);
 
             if (!isStatic)
             {
@@ -270,7 +334,8 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                 {
                     if (view.includeAllColumns)
                     {
-                        ColumnMetadata viewColumn = ColumnMetadata.regularColumn(view.metadata, name.bytes, type);
+                        ColumnMetadata viewColumn = ColumnMetadata.regularColumn(view.metadata, name.bytes, type)
+                                                                  .withNewMask(mask);
                         viewsBuilder.put(viewsBuilder.get(view.name()).withAddedRegularColumn(viewColumn));
                     }
                 }
@@ -582,7 +647,13 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     {
         private enum Kind
         {
-            ALTER_COLUMN, ADD_COLUMNS, DROP_COLUMNS, RENAME_COLUMNS, ALTER_OPTIONS, DROP_COMPACT_STORAGE
+            ALTER_COLUMN,
+            MASK_COLUMN,
+            ADD_COLUMNS,
+            DROP_COLUMNS,
+            RENAME_COLUMNS,
+            ALTER_OPTIONS,
+            DROP_COMPACT_STORAGE
         }
 
         private final QualifiedName name;
@@ -594,6 +665,10 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
         // ADD
         private final List<AddColumns.Column> addedColumns = new ArrayList<>();
+
+        // ALTER MASK
+        private ColumnIdentifier maskedColumn = null;
+        private ColumnMask.Raw rawMask = null;
 
         // DROP
         private final Set<ColumnIdentifier> droppedColumns = new HashSet<>();
@@ -619,6 +694,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             switch (kind)
             {
                 case          ALTER_COLUMN: return new AlterColumn(keyspaceName, tableName, ifTableExists);
+                case           MASK_COLUMN: return new MaskColumn(keyspaceName, tableName, maskedColumn, rawMask, ifTableExists, ifColumnExists);
                 case           ADD_COLUMNS: return new AddColumns(keyspaceName, tableName, addedColumns, ifTableExists, ifColumnNotExists);
                 case          DROP_COLUMNS: return new DropColumns(keyspaceName, tableName, droppedColumns, ifTableExists, ifColumnExists, timestamp);
                 case        RENAME_COLUMNS: return new RenameColumns(keyspaceName, tableName, renamedColumns, ifTableExists, ifColumnExists);
@@ -634,10 +710,17 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             kind = Kind.ALTER_COLUMN;
         }
 
-        public void add(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic)
+        public void mask(ColumnIdentifier name, ColumnMask.Raw mask)
+        {
+            kind = Kind.MASK_COLUMN;
+            maskedColumn = name;
+            rawMask = mask;
+        }
+
+        public void add(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic, @Nullable ColumnMask.Raw mask)
         {
             kind = Kind.ADD_COLUMNS;
-            addedColumns.add(new AddColumns.Column(name, type, isStatic));
+            addedColumns.add(new AddColumns.Column(name, type, isStatic, mask));
         }
 
         public void drop(ColumnIdentifier name)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.cql3.statements.schema;
 
 import java.util.*;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableSet;
 
 import org.apache.commons.lang3.StringUtils;
@@ -33,6 +35,7 @@ import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.*;
@@ -54,7 +57,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
     private static final Logger logger = LoggerFactory.getLogger(CreateTableStatement.class);
     private final String tableName;
 
-    private final Map<ColumnIdentifier, CQL3Type.Raw> rawColumns;
+    private final Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns;
     private final Set<ColumnIdentifier> staticColumns;
     private final List<ColumnIdentifier> partitionKeyColumns;
     private final List<ColumnIdentifier> clusteringColumns;
@@ -67,15 +70,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
     public CreateTableStatement(String keyspaceName,
                                 String tableName,
-
-                                Map<ColumnIdentifier, CQL3Type.Raw> rawColumns,
+                                Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns,
                                 Set<ColumnIdentifier> staticColumns,
                                 List<ColumnIdentifier> partitionKeyColumns,
                                 List<ColumnIdentifier> clusteringColumns,
-
                                 LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
                                 TableAttributes attrs,
-
                                 boolean ifNotExists,
                                 boolean useCompactStorage)
     {
@@ -186,15 +186,16 @@ public final class CreateTableStatement extends AlterSchemaStatement
         TableParams params = attrs.asNewTableParams();
 
         // use a TreeMap to preserve ordering across JDK versions (see CASSANDRA-9492) - important for stable unit tests
-        Map<ColumnIdentifier, CQL3Type> columns = new TreeMap<>(comparing(o -> o.bytes));
-        rawColumns.forEach((column, type) -> columns.put(column, type.prepare(keyspaceName, types)));
+        Map<ColumnIdentifier, ColumnProperties> columns = new TreeMap<>(comparing(o -> o.bytes));
+        rawColumns.forEach((column, properties) -> columns.put(column, properties.prepare(keyspaceName, tableName, column, types)));
 
         // check for nested non-frozen UDTs or collections in a non-frozen UDT
-        columns.forEach((column, type) ->
+        columns.forEach((column, properties) ->
         {
-            if (type.isUDT() && type.getType().isMultiCell())
+            AbstractType<?> type = properties.type;
+            if (type.isUDT() && type.isMultiCell())
             {
-                ((UserType) type.getType()).fieldTypes().forEach(field ->
+                ((UserType) type).fieldTypes().forEach(field ->
                 {
                     if (field.isMultiCell())
                         throw ire("Non-frozen UDTs with nested non-frozen collections are not supported");
@@ -209,45 +210,47 @@ public final class CreateTableStatement extends AlterSchemaStatement
         HashSet<ColumnIdentifier> primaryKeyColumns = new HashSet<>();
         concat(partitionKeyColumns, clusteringColumns).forEach(column ->
         {
-            CQL3Type type = columns.get(column);
-            if (null == type)
+            ColumnProperties properties = columns.get(column);
+            if (null == properties)
                 throw ire("Unknown column '%s' referenced in PRIMARY KEY for table '%s'", column, tableName);
 
             if (!primaryKeyColumns.add(column))
                 throw ire("Duplicate column '%s' in PRIMARY KEY clause for table '%s'", column, tableName);
 
-            if (type.getType().isMultiCell())
+            AbstractType<?> type = properties.type;
+            if (type.isMultiCell())
             {
+                CQL3Type cqlType = properties.cqlType;
                 if (type.isCollection())
-                    throw ire("Invalid non-frozen collection type %s for PRIMARY KEY column '%s'", type, column);
+                    throw ire("Invalid non-frozen collection type %s for PRIMARY KEY column '%s'", cqlType, column);
                 else
-                    throw ire("Invalid non-frozen user-defined type %s for PRIMARY KEY column '%s'", type, column);
+                    throw ire("Invalid non-frozen user-defined type %s for PRIMARY KEY column '%s'", cqlType, column);
             }
 
-            if (type.getType().isCounter())
+            if (type.isCounter())
                 throw ire("counter type is not supported for PRIMARY KEY column '%s'", column);
 
-            if (type.getType().referencesDuration())
+            if (type.referencesDuration())
                 throw ire("duration type is not supported for PRIMARY KEY column '%s'", column);
 
             if (staticColumns.contains(column))
                 throw ire("Static column '%s' cannot be part of the PRIMARY KEY", column);
         });
 
-        List<AbstractType<?>> partitionKeyTypes = new ArrayList<>();
-        List<AbstractType<?>> clusteringTypes = new ArrayList<>();
+        List<ColumnProperties> partitionKeyColumnProperties = new ArrayList<>();
+        List<ColumnProperties> clusteringColumnProperties = new ArrayList<>();
 
         partitionKeyColumns.forEach(column ->
         {
-            CQL3Type type = columns.remove(column);
-            partitionKeyTypes.add(type.getType());
+            ColumnProperties columnProperties = columns.remove(column);
+            partitionKeyColumnProperties.add(columnProperties);
         });
 
         clusteringColumns.forEach(column ->
         {
-            CQL3Type type = columns.remove(column);
+            ColumnProperties columnProperties = columns.remove(column);
             boolean reverse = !clusteringOrder.getOrDefault(column, true);
-            clusteringTypes.add(reverse ? ReversedType.getInstance(type.getType()) : type.getType());
+            clusteringColumnProperties.add(reverse ? columnProperties.withReversedType() : columnProperties);
         });
 
         if (clusteringOrder.size() > clusteringColumns.size())
@@ -270,7 +273,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         // For COMPACT STORAGE, we reject any "feature" that we wouldn't be able to translate back to thrift.
         if (useCompactStorage)
         {
-            validateCompactTable(clusteringTypes, columns);
+            validateCompactTable(clusteringColumnProperties, columns);
         }
         else
         {
@@ -283,12 +286,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
          * Counter table validation
          */
 
-        boolean hasCounters = rawColumns.values().stream().anyMatch(CQL3Type.Raw::isCounter);
+        boolean hasCounters = rawColumns.values().stream().anyMatch(c -> c.rawType.isCounter());
         if (hasCounters)
         {
             // We've handled anything that is not a PRIMARY KEY so columns only contains NON-PK columns. So
             // if it's a counter table, make sure we don't have non-counter types
-            if (columns.values().stream().anyMatch(t -> !t.getType().isCounter()))
+            if (columns.values().stream().anyMatch(t -> !t.type.isCounter()))
                 throw ire("Cannot mix counter and non counter columns in the same table");
 
             if (params.defaultTimeToLive > 0)
@@ -308,38 +311,44 @@ public final class CreateTableStatement extends AlterSchemaStatement
                .params(params);
 
         for (int i = 0; i < partitionKeyColumns.size(); i++)
-            builder.addPartitionKeyColumn(partitionKeyColumns.get(i), partitionKeyTypes.get(i));
+        {
+            ColumnProperties properties = partitionKeyColumnProperties.get(i);
+            builder.addPartitionKeyColumn(partitionKeyColumns.get(i), properties.type, properties.mask);
+        }
 
         for (int i = 0; i < clusteringColumns.size(); i++)
-            builder.addClusteringColumn(clusteringColumns.get(i), clusteringTypes.get(i));
+        {
+            ColumnProperties properties = clusteringColumnProperties.get(i);
+            builder.addClusteringColumn(clusteringColumns.get(i), properties.type, properties.mask);
+        }
 
         if (useCompactStorage)
         {
-            fixupCompactTable(clusteringTypes, columns, hasCounters, builder);
+            fixupCompactTable(clusteringColumnProperties, columns, hasCounters, builder);
         }
         else
         {
-            columns.forEach((column, type) -> {
+            columns.forEach((column, properties) -> {
                 if (staticColumns.contains(column))
-                    builder.addStaticColumn(column, type.getType());
+                    builder.addStaticColumn(column, properties.type, properties.mask);
                 else
-                    builder.addRegularColumn(column, type.getType());
+                    builder.addRegularColumn(column, properties.type, properties.mask);
             });
         }
         return builder;
     }
 
-    private void validateCompactTable(List<AbstractType<?>> clusteringTypes,
-                                      Map<ColumnIdentifier, CQL3Type> columns)
+    private void validateCompactTable(List<ColumnProperties> clusteringColumnProperties,
+                                      Map<ColumnIdentifier, ColumnProperties> columns)
     {
-        boolean isDense = !clusteringTypes.isEmpty();
+        boolean isDense = !clusteringColumnProperties.isEmpty();
 
-        if (columns.values().stream().anyMatch(c -> c.getType().isMultiCell()))
+        if (columns.values().stream().anyMatch(c -> c.type.isMultiCell()))
             throw ire("Non-frozen collections and UDTs are not supported with COMPACT STORAGE");
         if (!staticColumns.isEmpty())
             throw ire("Static columns are not supported in COMPACT STORAGE tables");
 
-        if (clusteringTypes.isEmpty())
+        if (clusteringColumnProperties.isEmpty())
         {
             // It's a thrift "static CF" so there should be some columns definition
             if (columns.isEmpty())
@@ -361,8 +370,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
         }
     }
 
-    private void fixupCompactTable(List<AbstractType<?>> clusteringTypes,
-                                   Map<ColumnIdentifier, CQL3Type> columns,
+    private void fixupCompactTable(List<ColumnProperties> clusteringTypes,
+                                   Map<ColumnIdentifier, ColumnProperties> columns,
                                    boolean hasCounters,
                                    TableMetadata.Builder builder)
     {
@@ -381,12 +390,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
         builder.flags(flags);
 
-        columns.forEach((name, type) -> {
+        columns.forEach((name, properties) -> {
             // Note that for "static" no-clustering compact storage we use static for the defined columns
             if (staticColumns.contains(name) || isStaticCompact)
-                builder.addStaticColumn(name, type.getType());
+                builder.addStaticColumn(name, properties.type, properties.mask);
             else
-                builder.addRegularColumn(name, type.getType());
+                builder.addRegularColumn(name, properties.type, properties.mask);
         });
 
         DefaultNames names = new DefaultNames(builder.columnNames());
@@ -471,7 +480,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         private final boolean ifNotExists;
 
         private boolean useCompactStorage = false;
-        private final Map<ColumnIdentifier, CQL3Type.Raw> rawColumns = new HashMap<>();
+        private final Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns = new HashMap<>();
         private final Set<ColumnIdentifier> staticColumns = new HashSet<>();
         private final List<ColumnIdentifier> clusteringColumns = new ArrayList<>();
 
@@ -495,15 +504,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
             return new CreateTableStatement(keyspaceName,
                                             name.getName(),
-
                                             rawColumns,
                                             staticColumns,
                                             partitionKeyColumns,
                                             clusteringColumns,
-
                                             clusteringOrder,
                                             attrs,
-
                                             ifNotExists,
                                             useCompactStorage);
         }
@@ -524,9 +530,10 @@ public final class CreateTableStatement extends AlterSchemaStatement
             return name.getName();
         }
 
-        public void addColumn(ColumnIdentifier column, CQL3Type.Raw type, boolean isStatic)
+        public void addColumn(ColumnIdentifier column, CQL3Type.Raw type, boolean isStatic, ColumnMask.Raw mask)
         {
-            if (null != rawColumns.put(column, type))
+
+            if (null != rawColumns.put(column, new ColumnProperties.Raw(type, mask)))
                 throw ire("Duplicate column '%s' declaration for table '%s'", column, name);
 
             if (isStatic)
@@ -560,6 +567,54 @@ public final class CreateTableStatement extends AlterSchemaStatement
         {
             if (null != clusteringOrder.put(column, ascending))
                 throw ire("Duplicate column '%s' in CLUSTERING ORDER BY clause for table '%s'", column, name);
+        }
+    }
+
+    /**
+     * Class encapsulating the properties of a column, which are its type and mask.
+     */
+    private final static class ColumnProperties
+    {
+        public final AbstractType<?> type;
+        public final CQL3Type cqlType; // we keep the original CQL type for printing fully qualified user type names
+
+        @Nullable
+        public final ColumnMask mask;
+
+        public ColumnProperties(AbstractType<?> type, CQL3Type cqlType, @Nullable ColumnMask mask)
+        {
+            this.type = type;
+            this.cqlType = cqlType;
+            this.mask = mask;
+        }
+
+        public ColumnProperties withReversedType()
+        {
+            return new ColumnProperties(ReversedType.getInstance(type),
+                                        cqlType,
+                                        mask == null ? null : mask.withReversedType());
+        }
+
+        public final static class Raw
+        {
+            public final CQL3Type.Raw rawType;
+
+            @Nullable
+            public final ColumnMask.Raw rawMask;
+
+            public Raw(CQL3Type.Raw rawType, @Nullable ColumnMask.Raw rawMask)
+            {
+                this.rawType = rawType;
+                this.rawMask = rawMask;
+            }
+
+            public ColumnProperties prepare(String keyspace, String table, ColumnIdentifier column, Types udts)
+            {
+                CQL3Type cqlType = rawType.prepare(keyspace, udts);
+                AbstractType<?> type = cqlType.getType();
+                ColumnMask mask = rawMask == null ? null : rawMask.prepare(keyspace, table, column, type);
+                return new ColumnProperties(type, cqlType, mask);
+            }
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -61,7 +61,8 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                            ColumnIdentifier.getInterned(ByteBufferUtil.EMPTY_BYTE_BUFFER, UTF8Type.instance),
                            SetType.getInstance(UTF8Type.instance, true),
                            ColumnMetadata.NO_POSITION,
-                           ColumnMetadata.Kind.STATIC);
+                           ColumnMetadata.Kind.STATIC,
+                           null);
 
     public static final ColumnMetadata FIRST_COMPLEX_REGULAR =
         new ColumnMetadata("",
@@ -69,7 +70,8 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                            ColumnIdentifier.getInterned(ByteBufferUtil.EMPTY_BYTE_BUFFER, UTF8Type.instance),
                            SetType.getInstance(UTF8Type.instance, true),
                            ColumnMetadata.NO_POSITION,
-                           ColumnMetadata.Kind.REGULAR);
+                           ColumnMetadata.Kind.REGULAR,
+                           null);
 
     private final Object[] columns;
     private final int complexIdx; // Index of the first complex column

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -182,6 +182,12 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         assert name != null && type != null && kind != null;
         assert (position == NO_POSITION) == !kind.isPrimaryKeyKind(); // The position really only make sense for partition and clustering columns (and those must have one),
                                                                       // so make sure we don't sneak it for something else since it'd breaks equals()
+
+        // The propagation of system distributed keyspaces at startup can be problematic for old nodes without DDM,
+        // since those won't know what to do with the mask mutations. Thus, we don't support DDM on those keyspaces.
+        if (mask != null && SchemaConstants.isReplicatedSystemKeyspace(ksName))
+            throw new AssertionError("DDM is not supported on system distributed keyspaces");
+
         this.kind = kind;
         this.position = position;
         this.cellPathComparator = makeCellPathComparator(kind, type);

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -21,11 +21,14 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.Predicate;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Collections2;
 
 import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.cql3.selection.Selectable;
 import org.apache.cassandra.cql3.selection.Selector;
 import org.apache.cassandra.cql3.selection.SimpleSelector;
@@ -95,6 +98,12 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
      */
     private final long comparisonOrder;
 
+    /**
+     * Masking function used to dynamically mask the contents of this column.
+     */
+    @Nullable
+    private final ColumnMask mask;
+
     private static long comparisonOrder(Kind kind, boolean isComplex, long position, ColumnIdentifier name)
     {
         assert position >= 0 && position < 1 << 12;
@@ -106,52 +115,58 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
 
     public static ColumnMetadata partitionKeyColumn(TableMetadata table, ByteBuffer name, AbstractType<?> type, int position)
     {
-        return new ColumnMetadata(table, name, type, position, Kind.PARTITION_KEY);
+        return new ColumnMetadata(table, name, type, position, Kind.PARTITION_KEY, null);
     }
 
     public static ColumnMetadata partitionKeyColumn(String keyspace, String table, String name, AbstractType<?> type, int position)
     {
-        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, position, Kind.PARTITION_KEY);
+        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, position, Kind.PARTITION_KEY, null);
     }
 
     public static ColumnMetadata clusteringColumn(TableMetadata table, ByteBuffer name, AbstractType<?> type, int position)
     {
-        return new ColumnMetadata(table, name, type, position, Kind.CLUSTERING);
+        return new ColumnMetadata(table, name, type, position, Kind.CLUSTERING, null);
     }
 
     public static ColumnMetadata clusteringColumn(String keyspace, String table, String name, AbstractType<?> type, int position)
     {
-        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, position, Kind.CLUSTERING);
+        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, position, Kind.CLUSTERING, null);
     }
 
     public static ColumnMetadata regularColumn(TableMetadata table, ByteBuffer name, AbstractType<?> type)
     {
-        return new ColumnMetadata(table, name, type, NO_POSITION, Kind.REGULAR);
+        return new ColumnMetadata(table, name, type, NO_POSITION, Kind.REGULAR, null);
     }
 
     public static ColumnMetadata regularColumn(String keyspace, String table, String name, AbstractType<?> type)
     {
-        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, NO_POSITION, Kind.REGULAR);
+        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, NO_POSITION, Kind.REGULAR, null);
     }
 
     public static ColumnMetadata staticColumn(TableMetadata table, ByteBuffer name, AbstractType<?> type)
     {
-        return new ColumnMetadata(table, name, type, NO_POSITION, Kind.STATIC);
+        return new ColumnMetadata(table, name, type, NO_POSITION, Kind.STATIC, null);
     }
 
     public static ColumnMetadata staticColumn(String keyspace, String table, String name, AbstractType<?> type)
     {
-        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, NO_POSITION, Kind.STATIC);
+        return new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, NO_POSITION, Kind.STATIC, null);
     }
 
-    public ColumnMetadata(TableMetadata table, ByteBuffer name, AbstractType<?> type, int position, Kind kind)
+    public ColumnMetadata(TableMetadata table,
+                          ByteBuffer name,
+                          AbstractType<?> type,
+                          int position,
+                          Kind kind,
+                          @Nullable ColumnMask mask)
     {
         this(table.keyspace,
              table.name,
              ColumnIdentifier.getInterned(name, UTF8Type.instance),
              type,
              position,
-             kind);
+             kind,
+             mask);
     }
 
     @VisibleForTesting
@@ -160,7 +175,8 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
                           ColumnIdentifier name,
                           AbstractType<?> type,
                           int position,
-                          Kind kind)
+                          Kind kind,
+                          @Nullable ColumnMask mask)
     {
         super(ksName, cfName, name, type);
         assert name != null && type != null && kind != null;
@@ -172,6 +188,7 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         this.cellComparator = cellPathComparator == null ? ColumnData.comparator : (a, b) -> cellPathComparator.compare(a.path(), b.path());
         this.asymmetricCellPathComparator = cellPathComparator == null ? null : (a, b) -> cellPathComparator.compare(((Cell<?>)a).path(), (CellPath) b);
         this.comparisonOrder = comparisonOrder(kind, isComplex(), Math.max(0, position), name);
+        this.mask = mask;
     }
 
     private static Comparator<CellPath> makeCellPathComparator(Kind kind, AbstractType<?> type)
@@ -203,17 +220,22 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
 
     public ColumnMetadata copy()
     {
-        return new ColumnMetadata(ksName, cfName, name, type, position, kind);
+        return new ColumnMetadata(ksName, cfName, name, type, position, kind, mask);
     }
 
     public ColumnMetadata withNewName(ColumnIdentifier newName)
     {
-        return new ColumnMetadata(ksName, cfName, newName, type, position, kind);
+        return new ColumnMetadata(ksName, cfName, newName, type, position, kind, mask);
     }
 
     public ColumnMetadata withNewType(AbstractType<?> newType)
     {
-        return new ColumnMetadata(ksName, cfName, name, newType, position, kind);
+        return new ColumnMetadata(ksName, cfName, name, newType, position, kind, mask);
+    }
+
+    public ColumnMetadata withNewMask(@Nullable ColumnMask newMask)
+    {
+        return new ColumnMetadata(ksName, cfName, name, type, position, kind, newMask);
     }
 
     public boolean isPartitionKey()
@@ -229,6 +251,11 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
     public boolean isStatic()
     {
         return kind == Kind.STATIC;
+    }
+
+    public boolean isMasked()
+    {
+        return mask != null;
     }
 
     public boolean isRegular()
@@ -247,6 +274,12 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
     public int position()
     {
         return position;
+    }
+
+    @Nullable
+    public ColumnMask getMask()
+    {
+        return mask;
     }
 
     @Override
@@ -269,7 +302,8 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
             && kind == other.kind
             && position == other.position
             && ksName.equals(other.ksName)
-            && cfName.equals(other.cfName);
+            && cfName.equals(other.cfName)
+            && Objects.equals(mask, other.mask);
     }
 
     Optional<Difference> compare(ColumnMetadata other)
@@ -299,6 +333,7 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
             result = 31 * result + (type == null ? 0 : type.hashCode());
             result = 31 * result + (kind == null ? 0 : kind.hashCode());
             result = 31 * result + position;
+            result = 31 * result + (mask == null ? 0 : mask.hashCode());
             hash = result;
         }
         return result;
@@ -334,7 +369,7 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
     @Override
     public boolean processesSelection()
     {
-        return false;
+        return isMasked();
     }
 
     /**
@@ -433,6 +468,9 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
 
         if (isStatic())
             builder.append(" static");
+
+        if (isMasked())
+            mask.appendCqlTo(builder);
     }
 
     public static String toCQLString(Iterable<ColumnMetadata> defs)
@@ -488,7 +526,7 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
 
     public Selector.Factory newSelectorFactory(TableMetadata table, AbstractType<?> expectedType, List<ColumnMetadata> defs, VariableSpecifications boundNames) throws InvalidRequestException
     {
-        return SimpleSelector.newFactory(this, addAndGetIndex(this, defs));
+        return SimpleSelector.newFactory(this, addAndGetIndex(this, defs), false);
     }
 
     public AbstractType<?> getExactTypeIfKnown(String keyspace)

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -35,6 +35,8 @@ import org.antlr.runtime.RecognitionException;
 import org.apache.cassandra.config.*;
 import org.apache.cassandra.cql3.*;
 import org.apache.cassandra.cql3.functions.*;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
+import org.apache.cassandra.cql3.functions.masking.MaskingFunction;
 import org.apache.cassandra.cql3.statements.schema.CreateTableStatement;
 import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.filter.ColumnFilter;
@@ -138,6 +140,20 @@ public final class SchemaKeyspace
               + "position int,"
               + "type text,"
               + "PRIMARY KEY ((keyspace_name), table_name, column_name))");
+
+    private static final TableMetadata ColumnMasks =
+    parse(COLUMN_MASKS,
+          "column dynamic data masks",
+          "CREATE TABLE %s ("
+          + "keyspace_name text,"
+          + "table_name text,"
+          + "column_name text,"
+          + "function_keyspace text,"
+          + "function_name text,"
+          + "function_argument_types frozen<list<text>>,"
+          + "function_argument_values frozen<list<text>>,"
+          + "function_argument_nulls frozen<list<boolean>>," // arguments that are null
+          + "PRIMARY KEY ((keyspace_name), table_name, column_name))");
 
     private static final TableMetadata DroppedColumns =
         parse(DROPPED_COLUMNS,
@@ -245,7 +261,7 @@ public final class SchemaKeyspace
               + "PRIMARY KEY ((keyspace_name), aggregate_name, argument_types))");
 
     private static final List<TableMetadata> ALL_TABLE_METADATA =
-        ImmutableList.of(Keyspaces, Tables, Columns, Triggers, DroppedColumns, Views, Types, Functions, Aggregates, Indexes);
+        ImmutableList.of(Keyspaces, Tables, Columns, ColumnMasks, Triggers, DroppedColumns, Views, Types, Functions, Aggregates, Indexes);
 
     private static TableMetadata parse(String name, String description, String cql)
     {
@@ -688,7 +704,7 @@ public final class SchemaKeyspace
     {
         AbstractType<?> type = column.type;
         if (type instanceof ReversedType)
-            type = ((ReversedType) type).baseType;
+            type = ((ReversedType<?>) type).baseType;
 
         builder.update(Columns)
                .row(table.name, column.name.toString())
@@ -697,6 +713,40 @@ public final class SchemaKeyspace
                .add("position", column.position())
                .add("clustering_order", column.clusteringOrder().toString().toLowerCase())
                .add("type", type.asCQL3Type().toString());
+
+        ColumnMask mask = column.getMask();
+        Row.SimpleBuilder maskBuilder = builder.update(ColumnMasks).row(table.name, column.name.toString());
+        if (mask == null)
+        {
+            maskBuilder.delete();
+        }
+        else
+        {
+            FunctionName maskFunctionName = mask.function.name();
+
+            // Some arguments of the masking function can be null, but the CQL's list type that stores them doesn't
+            // accept nulls, so we use a parallel list of booleans to store what arguments are null.
+            int numArgs = mask.partialArgumentValues.size();
+            List<String> types = new ArrayList<>(numArgs);
+            List<String> values = new ArrayList<>(numArgs);
+            List<Boolean> nulls = new ArrayList<>(numArgs);
+            for (int i = 0; i < numArgs; i++)
+            {
+                AbstractType<?> argType = mask.partialArgumentTypes().get(i);
+                types.add(argType.asCQL3Type().toString());
+
+                ByteBuffer argValue = mask.partialArgumentValues.get(i);
+                boolean isNull = argValue == null;
+                nulls.add(isNull);
+                values.add(isNull ? "" : argType.getString(argValue));
+            }
+
+            maskBuilder.add("function_keyspace", maskFunctionName.keyspace)
+                       .add("function_name", maskFunctionName.name)
+                       .add("function_argument_types", types)
+                       .add("function_argument_values", values)
+                       .add("function_argument_nulls", nulls);
+        }
     }
 
     private static void dropColumnFromSchemaMutation(TableMetadata table, ColumnMetadata column, Mutation.SimpleBuilder builder)
@@ -1019,7 +1069,7 @@ public final class SchemaKeyspace
     }
 
     @VisibleForTesting
-    static ColumnMetadata createColumnFromRow(UntypedResultSet.Row row, Types types)
+    public static ColumnMetadata createColumnFromRow(UntypedResultSet.Row row, Types types)
     {
         String keyspace = row.getString("keyspace_name");
         String table = row.getString("table_name");
@@ -1035,7 +1085,48 @@ public final class SchemaKeyspace
 
         ColumnIdentifier name = new ColumnIdentifier(row.getBytes("column_name_bytes"), row.getString("column_name"));
 
-        return new ColumnMetadata(keyspace, table, name, type, position, kind);
+        ColumnMask mask = null;
+        String query = format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ? AND column_name = ?",
+                              SchemaConstants.SCHEMA_KEYSPACE_NAME, COLUMN_MASKS);
+        UntypedResultSet columnMasks = query(query, keyspace, table, name.toString());
+        if (!columnMasks.isEmpty())
+        {
+            UntypedResultSet.Row maskRow = columnMasks.one();
+            FunctionName functionName = new FunctionName(maskRow.getString("function_keyspace"), maskRow.getString("function_name"));
+
+            List<String> partialArgumentTypes = maskRow.getFrozenList("function_argument_types", UTF8Type.instance);
+            List<AbstractType<?>> argumentTypes = new ArrayList<>(1 + partialArgumentTypes.size());
+            argumentTypes.add(type);
+            for (String argumentType : partialArgumentTypes)
+            {
+                argumentTypes.add(CQLTypeParser.parse(keyspace, argumentType, types));
+            }
+
+            Function function = FunctionResolver.get(keyspace, functionName, argumentTypes, null, null, null);
+            if (!(function instanceof MaskingFunction))
+            {
+                throw new AssertionError(format("Column %s.%s.%s is unexpectedly masked with function %s " +
+                                                "which is not a known native masking function",
+                                                keyspace, table, name, function));
+            }
+
+            // Some arguments of the masking function can be null, but the CQL's list type that stores them doesn't
+            // accept nulls, so we use a parallel list of booleans to store what arguments are null.
+            List<Boolean> nulls = maskRow.getFrozenList("function_argument_nulls", BooleanType.instance);
+            List<String> valuesAsCQL = maskRow.getFrozenList("function_argument_values", UTF8Type.instance);
+            List<ByteBuffer> values = new ArrayList<>(valuesAsCQL.size());
+            for (int i = 0; i < valuesAsCQL.size(); i++)
+            {
+                if (nulls.get(i))
+                    values.add(null);
+                else
+                    values.add(argumentTypes.get(i + 1).fromString(valuesAsCQL.get(i)));
+            }
+
+            mask = new ColumnMask((MaskingFunction) function, values);
+        }
+
+        return new ColumnMetadata(keyspace, table, name, type, position, kind, mask);
     }
 
     private static Map<ByteBuffer, DroppedColumn> fetchDroppedColumns(String keyspace, String table)
@@ -1067,7 +1158,7 @@ public final class SchemaKeyspace
         assert kind == ColumnMetadata.Kind.REGULAR || kind == ColumnMetadata.Kind.STATIC
             : "Unexpected dropped column kind: " + kind;
 
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind, null);
         long droppedTime = TimeUnit.MILLISECONDS.toMicros(row.getLong("dropped_time"));
         return new DroppedColumn(column, droppedTime);
     }

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspaceTables.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspaceTables.java
@@ -24,6 +24,7 @@ public class SchemaKeyspaceTables
     public static final String KEYSPACES = "keyspaces";
     public static final String TABLES = "tables";
     public static final String COLUMNS = "columns";
+    public static final String COLUMN_MASKS = "column_masks";
     public static final String DROPPED_COLUMNS = "dropped_columns";
     public static final String TRIGGERS = "triggers";
     public static final String VIEWS = "views";
@@ -45,7 +46,8 @@ public class SchemaKeyspaceTables
      *
      * See CASSANDRA-12213 for more details.
      */
-    public static final ImmutableList<String> ALL = ImmutableList.of(COLUMNS,
+    public static final ImmutableList<String> ALL = ImmutableList.of(COLUMN_MASKS,
+                                                                     COLUMNS,
                                                                      DROPPED_COLUMNS,
                                                                      TRIGGERS,
                                                                      TYPES,

--- a/src/java/org/apache/cassandra/schema/ViewMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ViewMetadata.java
@@ -20,10 +20,13 @@ package org.apache.cassandra.schema;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.marshal.UserType;
 
 public final class ViewMetadata implements SchemaElement
@@ -156,6 +159,15 @@ public final class ViewMetadata implements SchemaElement
                                 includeAllColumns,
                                 whereClause,
                                 metadata.unbuild().addColumn(column).build());
+    }
+
+    public ViewMetadata withNewColumnMask(ColumnIdentifier name, @Nullable ColumnMask mask)
+    {
+        return new ViewMetadata(baseTableId,
+                                baseTableName,
+                                includeAllColumns,
+                                whereClause,
+                                metadata.unbuild().alterColumnMask(name, mask).build());
     }
 
     public void appendCqlTo(CqlBuilder builder,

--- a/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
+++ b/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
@@ -212,7 +212,7 @@ public class NativeSSTableLoaderClient extends SSTableLoader.Client
 
         int position = row.getInt("position");
         org.apache.cassandra.schema.ColumnMetadata.Kind kind = ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase());
-        return new ColumnMetadata(keyspace, table, name, type, position, kind);
+        return new ColumnMetadata(keyspace, table, name, type, position, kind, null);
     }
 
     private static DroppedColumn createDroppedColumnFromRow(Row row, String keyspace, String table)
@@ -220,7 +220,7 @@ public class NativeSSTableLoaderClient extends SSTableLoader.Client
         String name = row.getString("column_name");
         AbstractType<?> type = CQLTypeParser.parse(keyspace, row.getString("type"), Types.none());
         ColumnMetadata.Kind kind = ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase());
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind, null);
         long droppedTime = row.getTimestamp("dropped_time").getTime();
         return new DroppedColumn(column, droppedTime);
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+/**
+ * Tests for dynamic data masking.
+ */
+public class ColumnMaskTest extends TestBaseImpl
+{
+    private static final String SELECT = withKeyspace("SELECT * FROM %s.t");
+
+    /**
+     * Tests that column masks are propagated to all nodes in the cluster.
+     */
+    @Test
+    public void testMaskPropagation() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build().withNodes(3).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, v text MASKED WITH DEFAULT) WITH read_repair='NONE'"));
+            cluster.get(1).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (1, 'secret1')"));
+            cluster.get(2).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (2, 'secret2')"));
+            cluster.get(3).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (3, 'secret3')"));
+
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "****"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "****"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "****"));
+            assertRowsInAllCoordinators(cluster, row(1, "****"), row(2, "****"), row(3, "****"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v DROP MASKED"));
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "secret1"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "secret2"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "secret3"));
+            assertRowsInAllCoordinators(cluster, row(1, "secret1"), row(2, "secret2"), row(3, "secret3"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(null, 1)"));
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "******1"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "******2"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "******3"));
+            assertRowsInAllCoordinators(cluster, row(1, "******1"), row(2, "******2"), row(3, "******3"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(3, null)"));
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "sec****"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "sec****"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "sec****"));
+            assertRowsInAllCoordinators(cluster, row(1, "sec****"), row(2, "sec****"), row(3, "sec****"));
+        }
+    }
+
+    private static void assertRowsInAllCoordinators(Cluster cluster, Object[]... expectedRows)
+    {
+        for (int i = 1; i < cluster.size(); i++)
+        {
+            assertRows(cluster.coordinator(i).execute(SELECT, ALL), expectedRows);
+        }
+    }
+
+    /**
+     * Tests that column masks are properly loaded at startup.
+     */
+    @Test
+    public void testMaskLoading() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build().withNodes(1).start()))
+        {
+            IInvokableInstance node = cluster.get(1);
+
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, v text MASKED WITH DEFAULT) "));
+            node.executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (1, 'secret1')"));
+            node.executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (2, 'secret2')"));
+
+            assertRowsWithRestart(node, row(1, "****"), row(2, "****"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v DROP MASKED"));
+            assertRowsWithRestart(node, row(1, "secret1"), row(2, "secret2"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(null, 1)"));
+            assertRowsWithRestart(node, row(1, "******1"), row(2, "******2"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(3, null)"));
+            assertRowsWithRestart(node, row(1, "sec****"), row(2, "sec****"));
+        }
+    }
+
+    private static void assertRowsWithRestart(IInvokableInstance node, Object[]... expectedRows) throws Throwable
+    {
+        // test querying with in-memory column definitions
+        assertRows(node.executeInternal(SELECT), expectedRows);
+
+        // restart the nodes to reload the column definitions from disk
+        node.shutdown().get();
+        node.startup();
+
+        // test querying with the column definitions loaded from disk
+        assertRows(node.executeInternal(SELECT), expectedRows);
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/btree/AtomicBTreePartitionUpdateBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/btree/AtomicBTreePartitionUpdateBench.java
@@ -561,7 +561,13 @@ public class AtomicBTreePartitionUpdateBench
     private static ColumnMetadata[] columns(AbstractType<?> type, ColumnMetadata.Kind kind, int count, String prefix)
     {
         return IntStream.range(0, count)
-                        .mapToObj(i -> new ColumnMetadata("", "", new ColumnIdentifier(prefix + i, true), type, kind != ColumnMetadata.Kind.REGULAR ? i : ColumnMetadata.NO_POSITION, kind))
+                        .mapToObj(i -> new ColumnMetadata("",
+                                                          "",
+                                                          new ColumnIdentifier(prefix + i, true),
+                                                          type,
+                                                          kind != ColumnMetadata.Kind.REGULAR ? i : ColumnMetadata.NO_POSITION,
+                                                          kind,
+                                                          null))
                         .toArray(ColumnMetadata[]::new);
     }
 

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -299,7 +299,8 @@ public class SchemaLoader
                                   ColumnIdentifier.getInterned(IntegerType.instance.fromString("42"), IntegerType.instance),
                                   UTF8Type.instance,
                                   ColumnMetadata.NO_POSITION,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     public static ColumnMetadata utf8Column(String ksName, String cfName)
@@ -309,7 +310,8 @@ public class SchemaLoader
                                   ColumnIdentifier.getInterned("fortytwo", true),
                                   UTF8Type.instance,
                                   ColumnMetadata.NO_POSITION,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     public static TableMetadata perRowIndexedCFMD(String ksName, String cfName)

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionTester.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ColumnMaskTester} verifying that masks can be applied to columns in any position (partition key columns,
+ * clustering key columns, static columns and regular columns). The columns of any depending materialized views should
+ * be udpated accordingly.
+ */
+@RunWith(Parameterized.class)
+public abstract class ColumnMaskInAnyPositionTester extends ColumnMaskTester
+{
+    /** The column mask as expressed in CQL statements right after the {@code MASKED WITH} keywords. */
+    @Parameterized.Parameter
+    public String mask;
+
+    /** The type of the masked column */
+    @Parameterized.Parameter(1)
+    public String type;
+
+    /** The types of the tested masking function partial arguments. */
+    @Parameterized.Parameter(2)
+    public List<AbstractType<?>> argumentTypes;
+
+    /** The serialized values of the tested masking function partial arguments. */
+    @Parameterized.Parameter(3)
+    public List<ByteBuffer> argumentValues;
+
+    @Test
+    public void testCreateTableWithMaskedColumns() throws Throwable
+    {
+        // Nothing is masked
+        createTable("CREATE TABLE %s (k int, c int, r int, s int static, PRIMARY KEY(k, c))");
+        assertTableColumnsAreNotMasked("k", "c", "r", "s");
+
+        // Masked partition key
+        createTable(format("CREATE TABLE %%s (k %s MASKED WITH %s PRIMARY KEY, r int)", type, mask));
+        assertTableColumnsAreMasked("k");
+        assertTableColumnsAreNotMasked("r");
+
+        // Masked partition key component
+        createTable(format("CREATE TABLE %%s (k1 int, k2 %s MASKED WITH %s, r int, PRIMARY KEY(k1, k2))", type, mask));
+        assertTableColumnsAreMasked("k2");
+        assertTableColumnsAreNotMasked("k1", "r");
+
+        // Masked clustering key
+        createTable(format("CREATE TABLE %%s (k int, c %s MASKED WITH %s, r int, PRIMARY KEY (k, c))", type, mask));
+        assertTableColumnsAreMasked("c");
+        assertTableColumnsAreNotMasked("k", "r");
+
+        // Masked clustering key with reverse order
+        createTable(format("CREATE TABLE %%s (k int, c %s MASKED WITH %s, r int, PRIMARY KEY (k, c)) " +
+                           "WITH CLUSTERING ORDER BY (c DESC)", type, mask));
+        assertTableColumnsAreMasked("c");
+        assertTableColumnsAreNotMasked("k", "r");
+
+        // Masked clustering key component
+        createTable(format("CREATE TABLE %%s (k int, c1 int, c2 %s MASKED WITH %s, r int, PRIMARY KEY (k, c1, c2))", type, mask));
+        assertTableColumnsAreMasked("c2");
+        assertTableColumnsAreNotMasked("k", "c1", "r");
+
+        // Masked regular column
+        createTable(format("CREATE TABLE %%s (k int PRIMARY KEY, r1 %s MASKED WITH %s, r2 int)", type, mask));
+        assertTableColumnsAreMasked("r1");
+        assertTableColumnsAreNotMasked("k", "r2");
+
+        // Masked static column
+        createTable(format("CREATE TABLE %%s (k int, c int, r int, s %s STATIC MASKED WITH %s, PRIMARY KEY (k, c))", type, mask));
+        assertTableColumnsAreMasked("s");
+        assertTableColumnsAreNotMasked("k", "c", "r");
+
+        // Multiple masked columns
+        createTable(format("CREATE TABLE %%s (" +
+                           "k1 int, k2 %s MASKED WITH %s, " +
+                           "c1 int, c2 %s MASKED WITH %s, " +
+                           "r1 int, r2 %s MASKED WITH %s, " +
+                           "s1 int static, s2 %s static MASKED WITH %s, " +
+                           "PRIMARY KEY((k1, k2), c1, c2))",
+                           type, mask, type, mask, type, mask, type, mask));
+        assertTableColumnsAreMasked("k2", "c2", "r2", "s2");
+        assertTableColumnsAreNotMasked("k1", "c1", "r1", "s1");
+    }
+
+    @Test
+    public void testCreateTableWithMaskedColumnsAndMaterializedView() throws Throwable
+    {
+        createTable(format("CREATE TABLE %%s (" +
+                           "k1 int, k2 %s MASKED WITH %s, " +
+                           "c1 int, c2 %s MASKED WITH %s, " +
+                           "r1 int, r2 %s MASKED WITH %s, " +
+                           "s1 int static, s2 %s static MASKED WITH %s, " +
+                           "PRIMARY KEY((k1, k2), c1, c2))",
+                           type, mask, type, mask, type, mask, type, mask));
+        createView("CREATE MATERIALIZED VIEW %s AS SELECT k1, k2, c1, c2, r1, r2 FROM %s " +
+                   "WHERE k1 IS NOT NULL AND k2 IS NOT NULL " +
+                   "AND c1 IS NOT NULL AND c2 IS NOT NULL " +
+                   "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
+                   "PRIMARY KEY (r2, c2, c1, k2, k1)");
+
+        assertTableColumnsAreMasked("k2", "c2", "r2", "s2");
+        assertTableColumnsAreNotMasked("k1", "c1", "r1", "s1");
+
+        assertViewColumnsAreMasked("k2", "c2", "r2");
+        assertViewColumnsAreNotMasked("k1", "c1", "r1");
+    }
+
+    @Test
+    public void testAlterTableWithMaskedColumns() throws Throwable
+    {
+        // Create the table to be altered
+        createTable(format("CREATE TABLE %%s (k %s, c %<s, r1 %<s, r2 %<s MASKED WITH %s, r3 %s, s %<s static, " +
+                           "PRIMARY KEY (k, c))", type, mask, type));
+        assertTableColumnsAreMasked("r2");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r3", "s");
+
+        // Add new masked column
+        alterTable(format("ALTER TABLE %%s ADD r4 %s MASKED WITH %s", type, mask));
+        assertTableColumnsAreMasked("r2", "r4");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r3", "s");
+
+        // Set mask for an existing but unmasked column
+        alterTable(format("ALTER TABLE %%s ALTER r1 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("r1", "r2", "r4");
+
+        // Unmask a masked column
+        alterTable("ALTER TABLE %s ALTER r1 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r2 DROP MASKED");
+        assertTableColumnsAreMasked("r4");
+        assertTableColumnsAreNotMasked("r1", "r2", "r3");
+
+        // Mask and disable mask for primary key
+        alterTable(format("ALTER TABLE %%s ALTER k MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("k");
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        assertTableColumnsAreNotMasked("k");
+
+        // Mask and disable mask for clustering key
+        alterTable(format("ALTER TABLE %%s ALTER c MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("c");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        assertTableColumnsAreNotMasked("c");
+
+        // Mask and disable mask for static column
+        alterTable(format("ALTER TABLE %%s ALTER s MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("s");
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        assertTableColumnsAreNotMasked("s");
+
+        // Add multiple masked columns within the same query
+        alterTable(format("ALTER TABLE %%s ADD (" +
+                          "r5 %s MASKED WITH %s, " +
+                          "r6 %s, " +
+                          "r7 %s MASKED WITH %s, " +
+                          "r8 %s)",
+                          type, mask, type, type, mask, type));
+        assertTableColumnsAreMasked("r5", "r7");
+        assertTableColumnsAreNotMasked("r6", "r8");
+    }
+
+    @Test
+    public void testAlterTableWithMaskedColumnsAndMaterializedView() throws Throwable
+    {
+        createTable(format("CREATE TABLE %%s (" +
+                           "k %s, c %<s, r1 %<s, r2 %<s, s1 %<s static, s2 %<s static, " +
+                           "PRIMARY KEY(k, c))", type));
+        createView("CREATE MATERIALIZED VIEW %s AS SELECT k, c, r2 FROM %s " +
+                   "WHERE k IS NOT NULL AND c IS NOT NULL " +
+                   "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
+                   "PRIMARY KEY (r2, c, k)");
+
+        // Adding a column to the table doesn't have an effect on the view
+        alterTable(format("ALTER TABLE %%s ADD r3 %s MASKED WITH %s", type, mask));
+        assertTableColumnsAreMasked("r3");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r2", "s1", "s2");
+        assertViewColumnsAreNotMasked("k", "c", "r2");
+
+        // Masking a column that is not part of the view doesn't have an effect on the view
+        alterTable(format("ALTER TABLE %%s ALTER r1 MASKED WITH %s", mask));
+        alterTable(format("ALTER TABLE %%s ALTER s1 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("r1", "r3", "s1");
+        assertTableColumnsAreNotMasked("k", "c", "r2", "s2");
+        assertViewColumnsAreNotMasked("k", "c", "r2");
+
+        // Masking a column that is part of the view should have an effect on the view
+        alterTable(format("ALTER TABLE %%s ALTER r2 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("r1", "r2", "r3", "s1");
+        assertTableColumnsAreNotMasked("k", "c", "s2");
+        assertViewColumnsAreMasked("r2");
+        assertViewColumnsAreNotMasked("k", "c");
+
+        // Mask the rest of the columns
+        alterTable(format("ALTER TABLE %%s ALTER k MASKED WITH %s", mask));
+        alterTable(format("ALTER TABLE %%s ALTER c MASKED WITH %s", mask));
+        alterTable(format("ALTER TABLE %%s ALTER s2 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("k", "c", "r1", "r2", "r3", "s1", "s2");
+        assertViewColumnsAreMasked("k", "c", "r2");
+
+        // Unmask a column that is part of the view
+        alterTable("ALTER TABLE %s ALTER r2 DROP MASKED");
+        assertTableColumnsAreMasked("k", "c", "r1", "r3", "s1", "s2");
+        assertTableColumnsAreNotMasked("r2");
+        assertViewColumnsAreMasked("k", "c");
+        assertViewColumnsAreNotMasked("r2");
+
+        // Unmask the rest of the columns
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r1 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r3 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s1 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s2 DROP MASKED");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r2", "r3", "s1", "s2");
+        assertViewColumnsAreNotMasked("k", "c", "r2");
+    }
+
+    private String functionName()
+    {
+        return mask.equals("DEFAULT") ? "mask_default" : StringUtils.substringBefore(mask, "(");
+    }
+
+    private void assertTableColumnsAreMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsMasked(currentTable(), column, functionName(), argumentTypes, argumentValues);
+        }
+    }
+
+    private void assertViewColumnsAreMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsMasked(currentView(), column, functionName(), argumentTypes, argumentValues);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithDefaultTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithDefaultTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link DefaultMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithDefaultTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "DEFAULT", "int", emptyList(), emptyList() },
+        { "DEFAULT", "text", emptyList(), emptyList() },
+        { "DEFAULT", "frozen<list<uuid>>", emptyList(), emptyList() },
+        { "mask_default()", "int", emptyList(), emptyList() },
+        { "mask_default()", "text", emptyList(), emptyList() },
+        { "mask_default()", "frozen<list<uuid>>", emptyList(), emptyList() },
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithNullTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithNullTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link NullMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithNullTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_null()", "int", emptyList(), emptyList() },
+        { "mask_null()", "text", emptyList(), emptyList() },
+        { "mask_null()", "frozen<list<uuid>>", emptyList(), emptyList() },
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithPartialTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithPartialTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+
+import static java.util.Arrays.asList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link PartialMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithPartialTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_inner(1, 2)", "text",
+          asList(Int32Type.instance, Int32Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2)) },
+        { "mask_outer(1, 2)", "text",
+          asList(Int32Type.instance, Int32Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2)) },
+        { "mask_inner(1, 2, '#')", "text",
+          asList(Int32Type.instance, Int32Type.instance, UTF8Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2), UTF8Type.instance.decompose("#")) },
+        { "mask_outer(1, 2, '#')", "text",
+          asList(Int32Type.instance, Int32Type.instance, UTF8Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2), UTF8Type.instance.decompose("#")) }
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithReplaceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithReplaceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link ReplaceMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithReplaceTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_replace(0)", "int",
+          singletonList(Int32Type.instance),
+          singletonList(Int32Type.instance.decompose(0)) },
+        { "mask_replace('redacted')", "text",
+          singletonList(UTF8Type.instance),
+          singletonList(UTF8Type.instance.decompose("redacted")) },
+        { "mask_replace([])", "frozen<list<int>>",
+          singletonList(ListType.getInstance(Int32Type.instance, false)),
+          singletonList(ListType.getInstance(Int32Type.instance, false).decompose(emptyList())) },
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskNativeTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskNativeTypesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.CQL3Type;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+/**
+ * {@link ColumnMaskTester} verifying that we can attach column masks to table columns with any native data type.
+ */
+@RunWith(Parameterized.class)
+public class ColumnMaskNativeTypesTest extends ColumnMaskTester
+{
+    /** The type of the column. */
+    @Parameterized.Parameter
+    public CQL3Type.Native type;
+
+    @Parameterized.Parameters(name = "type={0}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> parameters = new ArrayList<>();
+        for (CQL3Type.Native type : CQL3Type.Native.values())
+        {
+            if (type != CQL3Type.Native.EMPTY)
+                parameters.add(new Object[]{ type });
+        }
+        return parameters;
+    }
+
+    @Test
+    public void testNativeDataTypes() throws Throwable
+    {
+        String def = format("%s MASKED WITH DEFAULT", type);
+        String keyDef = type == CQL3Type.Native.COUNTER || type == CQL3Type.Native.DURATION
+                        ? "int MASKED WITH DEFAULT" : def;
+        String staticDef = format("%s STATIC MASKED WITH DEFAULT", type);
+
+        // Create table with masks
+        String table = createTable(format("CREATE TABLE %%s (k %s, c %<s, r %s, s %s, PRIMARY KEY(k, c))", keyDef, def, staticDef));
+        assertColumnIsMasked(table, "k", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "c", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "r", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "s", "mask_default", emptyList(), emptyList());
+
+        // Alter column masks
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER r MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER s MASKED WITH mask_null()");
+        assertColumnIsMasked(table, "k", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "c", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "r", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "s", "mask_null", emptyList(), emptyList());
+
+        // Drop masks
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        assertTableColumnsAreNotMasked("k", "c", "r", "s");
+    }
+}
+

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryTester.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+
+import static java.lang.String.format;
+
+/**
+ * Test queries on columns that have attached a dynamic data masking function.
+ */
+@RunWith(Parameterized.class)
+public abstract class ColumnMaskQueryTester extends ColumnMaskTester
+{
+    @Parameterized.Parameter
+    public String order;
+
+    @Parameterized.Parameter(1)
+    public String mask;
+
+    @Parameterized.Parameter(2)
+    public String columnType;
+
+    @Parameterized.Parameter(3)
+    public Object columnValue;
+
+    @Parameterized.Parameter(4)
+    public Object maskedValue;
+
+    @Before
+    public void setupSchema() throws Throwable
+    {
+        createTable("CREATE TABLE %s (" +
+                    format("k1 %s, k2 %<s MASKED WITH %s, ", columnType, mask) +
+                    format("c1 %s, c2 %<s MASKED WITH %s, ", columnType, mask) +
+                    format("r1 %s, r2 %<s MASKED WITH %s, ", columnType, mask) +
+                    format("s1 %s static, s2 %<s static MASKED WITH %s, ", columnType, mask) +
+                    format("PRIMARY KEY((k1, k2), c1, c2)) WITH CLUSTERING ORDER BY (c1 %s, c2 %<s)", order));
+
+        createView("CREATE MATERIALIZED VIEW %s AS SELECT k2, k1, c2, c1, r2, r1 FROM %s " +
+                   "WHERE k1 IS NOT NULL AND k2 IS NOT NULL " +
+                   "AND c1 IS NOT NULL AND c2 IS NOT NULL " +
+                   "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
+                   "PRIMARY KEY ((c2, c1), k2, k1)");
+
+        execute("INSERT INTO %s(k1, k2, c1, c2, r1, r2, s1, s2) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue);
+    }
+
+    @Test
+    public void testSelectWithWilcard() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT * FROM %s");
+        assertColumnNames(rs, "k1", "k2", "c1", "c2", "s1", "s2", "r1", "r2");
+        assertRows(rs, row(columnValue, maskedValue,
+                           columnValue, maskedValue,
+                           columnValue, maskedValue,
+                           columnValue, maskedValue));
+
+        rs = execute(format("SELECT * FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "c2", "c1", "k2", "k1", "r1", "r2");
+        assertRows(rs, row(maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           columnValue, maskedValue));
+    }
+
+    @Test
+    public void testSelectWithAllColumnNames() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT c2, c1, k2, k1, r2, r1, s2, s1 FROM %s");
+        assertColumnNames(rs, "c2", "c1", "k2", "k1", "r2", "r1", "s2", "s1");
+        assertRows(rs, row(maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           maskedValue, columnValue));
+
+        rs = execute(format("SELECT c2, c1, k2, k1, r2, r1 FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "c2", "c1", "k2", "k1", "r2", "r1");
+        assertRows(rs, row(maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           maskedValue, columnValue));
+    }
+
+    @Test
+    public void testSelectOnlyMaskedColumns() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT k2, c2, s2, r2 FROM %s");
+        assertColumnNames(rs, "k2", "c2", "s2", "r2");
+        assertRows(rs, row(maskedValue, maskedValue, maskedValue, maskedValue));
+
+        rs = execute(format("SELECT k2, c2, r2 FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "k2", "c2", "r2");
+        assertRows(rs, row(maskedValue, maskedValue, maskedValue));
+    }
+
+    @Test
+    public void testSelectOnlyNotMaskedColumns() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT k1, c1, s1, r1 FROM %s");
+        assertColumnNames(rs, "k1", "c1", "s1", "r1");
+        assertRows(rs, row(columnValue, columnValue, columnValue, columnValue));
+
+        rs = execute(format("SELECT k1, c1, r1 FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "k1", "c1", "r1");
+        assertRows(rs, row(columnValue, columnValue, columnValue));
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithDefaultTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithDefaultTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link DefaultMaskingFunction}.
+ */
+public class ColumnMaskQueryWithDefaultTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "DEFAULT", "text", "abc", "****" });
+            options.add(new Object[]{ order, "DEFAULT", "int", 123, 0 });
+            options.add(new Object[]{ order, "mask_default()", "text", "abc", "****" });
+            options.add(new Object[]{ order, "mask_default()", "int", 123, 0, });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithNullTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithNullTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link NullMaskingFunction}.
+ */
+public class ColumnMaskQueryWithNullTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "mask_null()", "text", "abc", null });
+            options.add(new Object[]{ order, "mask_null()", "int", 123, null });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithPartialTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithPartialTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link PartialMaskingFunction}.
+ */
+public class ColumnMaskQueryWithPartialTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "mask_inner(null, null)", "text", "abcdef", "******" });
+            options.add(new Object[]{ order, "mask_inner(1, 2)", "text", "abcdef", "a***ef" });
+            options.add(new Object[]{ order, "mask_inner(1, 2, '#')", "text", "abcdef", "a###ef" });
+            options.add(new Object[]{ order, "mask_outer(1, null)", "text", "abcdef", "*bcdef" });
+            options.add(new Object[]{ order, "mask_outer(1, 2)", "text", "abcdef", "*bcd**" });
+            options.add(new Object[]{ order, "mask_outer(1, 2, '#')", "text", "abcdef", "#bcd##", });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithReplaceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithReplaceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link ReplaceMaskingFunction}.
+ */
+public class ColumnMaskQueryWithReplaceTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "mask_replace(null)", "int", 123, null });
+            options.add(new Object[]{ order, "mask_replace('redacted')", "ascii", "abc", "redacted" });
+            options.add(new Object[]{ order, "mask_replace('redacted')", "text", "abc", "redacted" });
+            options.add(new Object[]{ order, "mask_replace(0)", "int", 123, 0 });
+            options.add(new Object[]{ order, "mask_replace(0)", "bigint", 123L, 0L });
+            options.add(new Object[]{ order, "mask_replace(0)", "varint", BigInteger.valueOf(123), BigInteger.ZERO });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTest.java
@@ -1,0 +1,547 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.functions.FunctionFactory;
+import org.apache.cassandra.cql3.functions.FunctionParameter;
+import org.apache.cassandra.cql3.functions.NativeFunction;
+import org.apache.cassandra.cql3.functions.NativeFunctions;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+/**
+ * Tests schema altering queries ({@code CREATE TABLE}, {@code ALTER TABLE}, etc.) that attach/dettach dynamic data
+ * masking functions to column definitions.
+ */
+public class ColumnMaskTest extends ColumnMaskTester
+{
+    @Test
+    public void testCollections() throws Throwable
+    {
+        // Create table with masks
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, " +
+                                   "s set<int> MASKED WITH DEFAULT, " +
+                                   "l list<int> MASKED WITH DEFAULT, " +
+                                   "m map<int, int> MASKED WITH DEFAULT, " +
+                                   "fs frozen<set<int>> MASKED WITH DEFAULT, " +
+                                   "fl frozen<list<int>> MASKED WITH DEFAULT, " +
+                                   "fm frozen<map<int, int>> MASKED WITH DEFAULT)");
+        assertColumnIsMasked(table, "s", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "l", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "m", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fs", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fl", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fm", "mask_default", emptyList(), emptyList());
+
+        // Alter column masks
+        alterTable("ALTER TABLE %s ALTER s MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER l MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER m MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER fs MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER fl MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER fm MASKED WITH mask_null()");
+        assertColumnIsMasked(table, "s", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "l", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "m", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fs", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fl", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fm", "mask_null", emptyList(), emptyList());
+
+        // Drop masks
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER l DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER m DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER fs DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER fl DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER fm DROP MASKED");
+        assertTableColumnsAreNotMasked("s", "l", "m", "fs", "fl", "fm");
+    }
+
+    @Test
+    public void testUDTs() throws Throwable
+    {
+        String type = createType("CREATE TYPE %s (a1 varint, a2 varint, a3 varint);");
+
+        // Create table with mask
+        String table = createTable(format("CREATE TABLE %%s (k int PRIMARY KEY, v %s MASKED WITH DEFAULT)", type));
+        assertColumnIsMasked(table, "v", "mask_default", emptyList(), emptyList());
+
+        // Alter column mask
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_null()");
+        assertColumnIsMasked(table, "v", "mask_null", emptyList(), emptyList());
+
+        // Drop mask
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertTableColumnsAreNotMasked("v");
+    }
+
+    @Test
+    public void testAlterTableAddMaskingToNonExistingColumn() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("ALTER TABLE %s ALTER IF EXISTS unknown MASKED WITH DEFAULT");
+        assertInvalidMessage(format("Column with name 'unknown' doesn't exist on table '%s'", table),
+                             formatQuery("ALTER TABLE %s ALTER unknown MASKED WITH DEFAULT"));
+    }
+
+    @Test
+    public void testAlterTableRemoveMaskingFromNonExistingColumn() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("ALTER TABLE %s ALTER IF EXISTS unknown DROP MASKED");
+        assertInvalidMessage(format("Column with name 'unknown' doesn't exist on table '%s'", table),
+                             formatQuery("ALTER TABLE %s ALTER unknown DROP MASKED"));
+    }
+
+    @Test
+    public void testAlterTableRemoveMaskFromUnmaskedColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("ALTER TABLE %s ALTER v DROP MASKED");
+        assertTableColumnsAreNotMasked("v");
+    }
+
+    @Test
+    public void testInvalidMaskingFunctionName() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Unable to find masking function for v, no declared function matches the signature mask_missing()",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v int MASKED WITH mask_missing())"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        assertInvalidMessage("Unable to find masking function for v, no declared function matches the signature mask_missing()",
+                             "ALTER TABLE %s ALTER v MASKED WITH mask_missing()");
+
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testInvalidMaskingFunctionArguments() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Invalid number of arguments for function system.mask_default(any)",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v int MASKED WITH mask_default(1))"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        assertInvalidMessage("Invalid number of arguments for function system.mask_default(any)",
+                             "ALTER TABLE %s ALTER v MASKED WITH mask_default(1)");
+
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testInvalidMaskingFunctionArgumentTypes() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Function system.mask_inner requires an argument of type int, but found argument 'a' of type ascii",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v text MASKED WITH mask_inner('a', 'b'))"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertInvalidMessage("Function system.mask_inner requires an argument of type int, but found argument 'a' of type ascii",
+                             "ALTER TABLE %s ALTER v MASKED WITH mask_inner('a', 'b')");
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testColumnMaskingWithNotMaskingFunction() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Not-masking function tojson() cannot be used for masking table columns",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v text MASKED WITH tojson())"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertInvalidMessage("Not-masking function tojson() cannot be used for masking table columns",
+                             "ALTER TABLE %s ALTER v MASKED WITH tojson()");
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testColumnMaskingWithNotNativeFunction() throws Throwable
+    {
+        String udf = createFunction(KEYSPACE,
+                                    "text",
+                                    "CREATE FUNCTION %s(k text) " +
+                                    "CALLED ON NULL INPUT " +
+                                    "RETURNS text " +
+                                    "LANGUAGE java AS $$return k;$$");
+
+        // create table
+        assertInvalidMessage(format("User defined function %s() cannot be used for masking table columns", udf),
+                             format("CREATE TABLE %s.%s (k int PRIMARY KEY, v text MASKED WITH %s())",
+                                    keyspace(), createTableName(), udf));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertInvalidMessage(format("User defined function %s() cannot be used for masking table columns", udf),
+                             format("ALTER TABLE %%s ALTER v MASKED WITH %s()", udf));
+
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void testPreparedStatement() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text MASKED WITH DEFAULT)");
+        execute("INSERT INTO %s (k, v) VALUES (0, 'sensitive')");
+
+        Session session = sessionNet();
+        PreparedStatement prepared = session.prepare(formatQuery("SELECT v FROM %s WHERE k = ?"));
+        BoundStatement bound = prepared.bind(0);
+        assertRowsNet(session.execute(bound), row("****"));
+
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRowsNet(session.execute(bound), row("sensitive"));
+
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRowsNet(session.execute(bound), row("redacted"));
+    }
+
+    @Test
+    public void testViews() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text MASKED WITH mask_replace('redacted'), PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT * FROM %s " +
+                                 "WHERE k IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL " +
+                                 "PRIMARY KEY (v, k, c)");
+        waitForViewMutations();
+        assertRows(execute(format("SELECT v FROM %s.%s", KEYSPACE, view)), row("redacted"));
+        assertRows(execute(format("SELECT v FROM %s.%s WHERE v='sensitive'", KEYSPACE, view)), row("redacted"));
+        assertEmpty(execute(format("SELECT v FROM %s.%s WHERE v='redacted'", KEYSPACE, view)));
+
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRows(execute(format("SELECT v FROM %s.%s", KEYSPACE, view)), row("sensitive"));
+        assertRows(execute(format("SELECT v FROM %s.%s WHERE v='sensitive'", KEYSPACE, view)), row("sensitive"));
+        assertEmpty(execute(format("SELECT v FROM %s.%s WHERE v='redacted'", KEYSPACE, view)));
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void testPreparedStatementOnView() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text MASKED WITH DEFAULT, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT * FROM %s " +
+                                 "WHERE k IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL " +
+                                 "PRIMARY KEY (v, k, c)");
+        waitForViewMutations();
+
+        Session session = sessionNet();
+        PreparedStatement prepared = session.prepare(format("SELECT v FROM %s.%s WHERE v=?", KEYSPACE, view));
+        BoundStatement bound = prepared.bind("sensitive");
+        assertRowsNet(session.execute(bound), row("****"));
+
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRowsNet(session.execute(bound), row("sensitive"));
+
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRowsNet(session.execute(bound), row("redacted"));
+    }
+
+    @Test
+    public void testGroupBy() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 'sensitive')");
+
+        // without masks
+        String query = "SELECT * FROM %s GROUP BY k";
+        assertRows(execute(query), row(1, 0, "sensitive"), row(0, 0, "sensitive"));
+
+        // with masked regular column
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRows(execute(query), row(1, 0, "redacted"), row(0, 0, "redacted"));
+
+        // with masked clustering key
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_replace(-1)");
+        assertRows(execute(query), row(1, -1, "redacted"), row(0, -1, "redacted"));
+
+        // with masked partition key
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH mask_replace(-1)");
+        assertRows(execute(query), row(-1, -1, "redacted"), row(-1, -1, "redacted"));
+
+        // again without masks
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRows(execute(query), row(1, 0, "sensitive"), row(0, 0, "sensitive"));
+    }
+
+    @Test
+    public void testPaging() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 'sensitive')");
+
+        // without masks
+        assertRowsWithPaging("SELECT * FROM %s", row(1, 0, "sensitive"), row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, 0, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, 1, "sensitive"));
+
+        // with masked regular column
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRowsWithPaging("SELECT * FROM %s", row(1, 0, "redacted"), row(0, 0, "redacted"), row(0, 1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, 0, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, 0, "redacted"), row(0, 1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, 1, "redacted"));
+
+        // with masked clustering key
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_replace(-1)");
+        assertRowsWithPaging("SELECT * FROM %s", row(1, -1, "redacted"), row(0, -1, "redacted"), row(0, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, -1, "redacted"), row(0, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, -1, "redacted"));
+
+        // with masked partition key
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH mask_replace(-1)");
+        assertRowsWithPaging("SELECT * FROM %s", row(-1, -1, "redacted"), row(-1, -1, "redacted"), row(-1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(-1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(-1, -1, "redacted"), row(-1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(-1, -1, "redacted"));
+
+        // again without masks
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRowsWithPaging("SELECT * FROM %s", row(1, 0, "sensitive"), row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, 0, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, 1, "sensitive"));
+    }
+
+    /**
+     * Tests that rows are always ordered according to the clear values of the columns, even for the post-ordering done
+     * for queries with {@code IN} restrictions and {@code ORDER BY} clauses.
+     */
+    @Test
+    public void testPostOrdering() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 0)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 3)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 4)");
+        execute("INSERT INTO %s (k, c, v) VALUES (2, 0, 6)");
+        execute("INSERT INTO %s (k, c, v) VALUES (2, 1, 7)");
+        NativeFunctions.instance.add(NEGATIVE);
+
+        // Test ordering without masking, just for reference
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, 0, 0),
+                   row(0, 1, 1),
+                   row(1, 0, 3),
+                   row(1, 1, 4),
+                   row(2, 0, 6),
+                   row(2, 1, 7));
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, 0, 0),
+                   row(1, 0, 3),
+                   row(2, 0, 6),
+                   row(0, 1, 1),
+                   row(1, 1, 4),
+                   row(2, 1, 7));
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, 1, 1),
+                   row(1, 1, 4),
+                   row(2, 1, 7),
+                   row(0, 0, 0),
+                   row(1, 0, 3),
+                   row(2, 0, 6));
+
+        // Test ordering with manually applied masking function, just for reference
+        assertRows(execute("SELECT k, mask_negative(c), v FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, mask_negative(c), v FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, mask_negative(c), v FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7), // (2, 1, 7)
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6)); // (2, 0, 6)
+
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_negative()");
+
+        // Test ordering of wildcard queries with masked column
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7), // (2, 1, 7)
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6)); // (2, 0, 6)
+
+        // Test ordering of column selection queries with masked column
+        assertRows(execute("SELECT k, c, v FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, c, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, c, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7), // (2, 1, 7)
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6)); // (2, 0, 6)
+
+        // Test ordering of column selection queries with masked column, without selecting the ordered column
+        assertRows(execute("SELECT k, v FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, 0), // (0, 0, 0)
+                   row(0, 1), // (0, 1, 1)
+                   row(1, 3), // (1, 0, 3)
+                   row(1, 4), // (1, 1, 4)
+                   row(2, 6), // (2, 0, 6)
+                   row(2, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, 0), // (0, 0, 0)
+                   row(1, 3), // (1, 0, 3)
+                   row(2, 6), // (2, 0, 6)
+                   row(0, 1), // (0, 1, 1)
+                   row(1, 4), // (1, 1, 4)
+                   row(2, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, 1), // (0, 1, 1)
+                   row(1, 4), // (1, 1, 4)
+                   row(2, 7), // (2, 1, 7)
+                   row(0, 0), // (0, 0, 0)
+                   row(1, 3), // (1, 0, 3)
+                   row(2, 6)); // (2, 0, 6)
+
+        // Test ordering of wildcard JSON queries with masked column
+        assertRows(execute("SELECT JSON * FROM %s WHERE k IN (0, 1, 2)"),
+                   row("{\"k\": 0, \"c\": 0, \"v\": 0}"), // (0, 0, 0)
+                   row("{\"k\": 0, \"c\": -1, \"v\": 1}"), // (0, 1, 1)
+                   row("{\"k\": 1, \"c\": 0, \"v\": 3}"), // (1, 0, 3)
+                   row("{\"k\": 1, \"c\": -1, \"v\": 4}"), // (1, 1, 4)
+                   row("{\"k\": 2, \"c\": 0, \"v\": 6}"), // (2, 0, 6)
+                   row("{\"k\": 2, \"c\": -1, \"v\": 7}")); // (2, 1, 7)
+        assertRows(execute("SELECT JSON * FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row("{\"k\": 0, \"c\": 0, \"v\": 0}"), // (0, 0, 0)
+                   row("{\"k\": 1, \"c\": 0, \"v\": 3}"), // (1, 0, 3)
+                   row("{\"k\": 2, \"c\": 0, \"v\": 6}"), // (2, 0, 6)
+                   row("{\"k\": 0, \"c\": -1, \"v\": 1}"), // (0, 1, 1)
+                   row("{\"k\": 1, \"c\": -1, \"v\": 4}"), // (1, 1, 4)
+                   row("{\"k\": 2, \"c\": -1, \"v\": 7}")); // (2, 1, 7)
+        assertRows(execute("SELECT JSON * FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row("{\"k\": 0, \"c\": -1, \"v\": 1}"), // (0, 1, 1)
+                   row("{\"k\": 1, \"c\": -1, \"v\": 4}"), // (1, 1, 4)
+                   row("{\"k\": 2, \"c\": -1, \"v\": 7}"), // (2, 1, 7)
+                   row("{\"k\": 0, \"c\": 0, \"v\": 0}"), // (0, 0, 0)
+                   row("{\"k\": 1, \"c\": 0, \"v\": 3}"), // (1, 0, 3)
+                   row("{\"k\": 2, \"c\": 0, \"v\": 6}")); // (2, 0, 6)
+    }
+
+    private void assertRowsWithPaging(String query, Object[]... rows)
+    {
+        for (int pageSize : Arrays.asList(1, 2, 3, 4, 5, 100))
+        {
+            assertRowsNet(executeNetWithPaging(query, pageSize), rows);
+
+            for (int limit : Arrays.asList(1, 2, 3, 4, 5, 100))
+            {
+                assertRowsNet(executeNetWithPaging(query + " LIMIT " + limit, pageSize),
+                              Arrays.copyOfRange(rows, 0, Math.min(limit, rows.length)));
+            }
+        }
+    }
+
+    private static final FunctionFactory NEGATIVE = new FunctionFactory("mask_negative", FunctionParameter.fixed(CQL3Type.Native.INT))
+    {
+        @Override
+        protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+        {
+            return new MaskingFunction(name, argTypes.get(0), argTypes.get(0))
+            {
+                @Override
+                public ByteBuffer execute(ProtocolVersion protocol, List<ByteBuffer> parameters)
+                {
+                    ByteBuffer bb = parameters.get(0);
+                    if (bb == null)
+                        return null;
+                    Integer value = Int32Type.instance.compose(bb) * -1;
+                    return Int32Type.instance.decompose(value);
+                }
+            };
+        }
+    };
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTester.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.cql3.functions.ScalarFunction;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ReversedType;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.schema.SchemaKeyspace;
+import org.apache.cassandra.schema.SchemaKeyspaceTables;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests table columns with attached dynamic data masking functions.
+ */
+public class ColumnMaskTester extends CQLTester
+{
+    @BeforeClass
+    public static void beforeClass()
+    {
+        CQLTester.setUpClass();
+        requireNetwork();
+    }
+
+    protected void assertTableColumnsAreNotMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsNotMasked(currentTable(), column);
+        }
+    }
+
+    protected void assertViewColumnsAreNotMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsNotMasked(currentView(), column);
+        }
+    }
+
+    protected void assertColumnIsNotMasked(String table, String column) throws Throwable
+    {
+        ColumnMask mask = getColumnMask(table, column);
+        assertNull(format("Mask for column '%s'", column), mask);
+
+        assertRows(execute(format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ? AND column_name = ?",
+                                  SchemaConstants.SCHEMA_KEYSPACE_NAME, SchemaKeyspaceTables.COLUMN_MASKS),
+                           KEYSPACE, table, column));
+    }
+
+    protected void assertColumnIsMasked(String table,
+                                        String column,
+                                        String functionName,
+                                        List<AbstractType<?>> partialArgumentTypes,
+                                        List<ByteBuffer> partialArgumentValues) throws Throwable
+    {
+        KeyspaceMetadata keyspaceMetadata = Keyspace.open(KEYSPACE).getMetadata();
+        TableMetadata tableMetadata = keyspaceMetadata.getTableOrViewNullable(table);
+        assertNotNull(tableMetadata);
+        ColumnMetadata columnMetadata = tableMetadata.getColumn(ColumnIdentifier.getInterned(column, false));
+        assertNotNull(columnMetadata);
+        AbstractType<?> columnType = columnMetadata.type;
+
+        // Verify the column mask in the in-memory schema
+        ColumnMask mask = getColumnMask(table, column);
+        assertNotNull(mask);
+        assertThat(mask.partialArgumentTypes()).isEqualTo(columnType.isReversed() && functionName.equals("mask_replace")
+                                                          ? Collections.singletonList(ReversedType.getInstance(partialArgumentTypes.get(0)))
+                                                          : partialArgumentTypes);
+        assertThat(mask.partialArgumentValues).isEqualTo(partialArgumentValues);
+
+        // Verify the function in the column mask
+        ScalarFunction function = mask.function;
+        assertNotNull(function);
+        assertTrue(function.isNative());
+        assertThat(function.name().name).isEqualTo(functionName);
+        assertThat(function.argTypes().get(0)).isEqualTo(columnMetadata.type);
+        assertThat(function.argTypes().size()).isEqualTo(partialArgumentTypes.size() + 1);
+
+        // Retrieve the persisted column metadata
+        UntypedResultSet columnRows = execute("SELECT * FROM system_schema.columns " +
+                                              "WHERE keyspace_name = ? AND table_name = ? AND column_name = ?",
+                                              KEYSPACE, table, column);
+        ColumnMetadata persistedColumn = SchemaKeyspace.createColumnFromRow(columnRows.one(), keyspaceMetadata.types);
+
+        // Verify the column mask in the persisted schema
+        ColumnMask savedMask = persistedColumn.getMask();
+        assertNotNull(savedMask);
+        assertThat(mask).isEqualTo(savedMask);
+        assertThat(mask.function.argTypes()).isEqualTo(savedMask.function.argTypes());
+    }
+
+    @Nullable
+    protected ColumnMask getColumnMask(String table, String column)
+    {
+        TableMetadata tableMetadata = Schema.instance.getTableMetadata(KEYSPACE, table);
+        assertNotNull(tableMetadata);
+        ColumnMetadata columnMetadata = tableMetadata.getColumn(ColumnIdentifier.getInterned(column, false));
+
+        if (columnMetadata == null)
+            fail(format("Unknown column '%s'", column));
+
+        return columnMetadata.getMask();
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskWithTypeAlteringFunctionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskWithTypeAlteringFunctionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.CQL3Type;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.cql3.CQL3Type.Native.ASCII;
+import static org.apache.cassandra.cql3.CQL3Type.Native.BIGINT;
+import static org.apache.cassandra.cql3.CQL3Type.Native.BLOB;
+import static org.apache.cassandra.cql3.CQL3Type.Native.INT;
+import static org.apache.cassandra.cql3.CQL3Type.Native.TEXT;
+import static org.apache.cassandra.cql3.CQL3Type.Native.VARINT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link ColumnMaskTester} for masks using functions that might return values with a type different to the type of the
+ * masked column. Those queries should fail.
+ */
+@RunWith(Parameterized.class)
+public class ColumnMaskWithTypeAlteringFunctionTest extends ColumnMaskTester
+{
+    /** The column mask as expressed in CQL statements right after the {@code MASKED WITH} keywords. */
+    @Parameterized.Parameter
+    public String mask;
+
+    /** The type of the masked column. */
+    @Parameterized.Parameter(1)
+    public CQL3Type.Native type;
+
+    /** The type returned by the tested masking function. */
+    @Parameterized.Parameter(2)
+    public CQL3Type returnedType;
+
+    private boolean shouldSucceed;
+    private String errorMessage;
+
+    @Parameterized.Parameters(name = "mask={0} type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_default()", INT, INT },
+        { "mask_default()", TEXT, TEXT },
+        { "mask_null()", INT, INT },
+        { "mask_null()", TEXT, TEXT },
+        { "mask_hash()", INT, BLOB },
+        { "mask_hash('SHA-512')", INT, BLOB },
+        { "mask_inner(1,2)", TEXT, TEXT },
+        { "mask_outer(1,2)", TEXT, TEXT },
+        { "mask_replace(0)", INT, INT },
+        { "mask_replace(0)", BIGINT, BIGINT },
+        { "mask_replace(0)", VARINT, VARINT },
+        { "mask_replace('redacted')", ASCII, ASCII },
+        { "mask_replace('redacted')", TEXT, TEXT } });
+    }
+
+    @Before
+    public void before()
+    {
+        shouldSucceed = returnedType == type;
+        errorMessage = shouldSucceed ? null : format("Masking function %s return type is %s.", mask, returnedType);
+    }
+
+    @Test
+    public void testTypeAlteringFunctionOnCreateTable()
+    {
+        testOnCreateTable("CREATE TABLE %s.%s (k int PRIMARY KEY, v %s MASKED WITH %s)");
+        testOnCreateTable("CREATE TABLE %s.%s (k %s MASKED WITH %s PRIMARY KEY, v int)");
+        testOnCreateTable("CREATE TABLE %s.%s (k1 int, k2 %s MASKED WITH %s, PRIMARY KEY((k1, k2)))");
+        testOnCreateTable("CREATE TABLE %s.%s (k int, c %s MASKED WITH %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c ASC)");
+        testOnCreateTable("CREATE TABLE %s.%s (k int, c %s MASKED WITH %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c DESC)");
+        testOnCreateTable("CREATE TABLE %s.%s (k int, c int, s %s STATIC MASKED WITH %s, PRIMARY KEY(k, c))");
+    }
+
+    private void testOnCreateTable(String query)
+    {
+        String formattedQuery = format(query, KEYSPACE, createTableName(), type, mask);
+        if (shouldSucceed)
+            createTable(formattedQuery);
+        else
+            assertThatThrownBy(() -> execute(formattedQuery)).hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    public void testTypeAlteringFunctionOnMaskColumn()
+    {
+        testOnAlterColumn("CREATE TABLE %s.%s (k int PRIMARY KEY, v %s)",
+                          "ALTER TABLE %s.%s ALTER v MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k %s PRIMARY KEY, v int)",
+                          "ALTER TABLE %s.%s ALTER k MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k1 int, k2 %s, PRIMARY KEY((k1, k2)))",
+                          "ALTER TABLE %s.%s ALTER k2 MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k int, c %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c ASC)",
+                          "ALTER TABLE %s.%s ALTER c MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k int, c %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c DESC)",
+                          "ALTER TABLE %s.%s ALTER c MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k int, c int, s %s STATIC, PRIMARY KEY(k, c))",
+                          "ALTER TABLE %s.%s ALTER s MASKED WITH %s");
+    }
+
+    private void testOnAlterColumn(String createQuery, String alterQuery)
+    {
+        String table = createTableName();
+        createTable(format(createQuery, KEYSPACE, table, type));
+
+        String formattedQuery = format(alterQuery, KEYSPACE, table, mask);
+        if (shouldSucceed)
+            alterTable(formattedQuery);
+        else
+            assertThatThrownBy(() -> execute(formattedQuery)).hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    public void testTypeAlteringFunctionOnAddColumn()
+    {
+        String table = createTable(format("CREATE TABLE %%s (k int PRIMARY KEY, v %s)", type));
+        String query = format("ALTER TABLE %s.%s ADD n %s MASKED WITH %s", KEYSPACE, table, type, mask);
+        if (shouldSucceed)
+            alterTable(query);
+        else
+            assertThatThrownBy(() -> execute(query)).hasMessageContaining(errorMessage);
+    }
+}
+

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/MaskingFunctionTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/MaskingFunctionTester.java
@@ -192,7 +192,7 @@ public abstract class MaskingFunctionTester extends CQLTester
      * Tests the native masking function for the specified column type and values on all possible types of column.
      * That is, when the column is part of the primary key, or a regular column, or a static column.
      *
-     * @param type  the type of the tested column
+     * @param type the type of the tested column
      * @param values the values of the tested column
      */
     private void testMaskingOnAllColumns(CQL3Type type, Object... values) throws Throwable
@@ -222,7 +222,7 @@ public abstract class MaskingFunctionTester extends CQLTester
      * Tests the native masking function for the specified column type and values when the column isn't part of the
      * primary key. That is, when the column is either a regular column or a static column.
      *
-     * @param type  the type of the tested column
+     * @param type the type of the tested column
      * @param values the values of the tested column
      */
     private void testMaskingOnNotKeyColumns(CQL3Type type, Object... values) throws Throwable
@@ -265,8 +265,8 @@ public abstract class MaskingFunctionTester extends CQLTester
      * Tests the native masking function for the specified column type and value.
      * This assumes that the table is already created.
      *
-     * @param name  the name of the tested column
-     * @param type  the type of the tested column
+     * @param name the name of the tested column
+     * @param type the type of the tested column
      * @param value the value of the tested column
      */
     protected abstract void testMaskingOnColumn(String name, CQL3Type type, Object value) throws Throwable;

--- a/test/unit/org/apache/cassandra/db/CellTest.java
+++ b/test/unit/org/apache/cassandra/db/CellTest.java
@@ -76,7 +76,8 @@ public class CellTest
                                   ColumnIdentifier.getInterned(name, false),
                                   type,
                                   ColumnMetadata.NO_POSITION,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/ColumnsTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnsTest.java
@@ -496,7 +496,7 @@ public class ColumnsTest
 
     private static ColumnMetadata def(String name, AbstractType<?> type, ColumnMetadata.Kind kind)
     {
-        return new ColumnMetadata(TABLE_METADATA, bytes(name), type, ColumnMetadata.NO_POSITION, kind);
+        return new ColumnMetadata(TABLE_METADATA, bytes(name), type, ColumnMetadata.NO_POSITION, kind, null);
     }
 
     private static TableMetadata mock(Columns columns)

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -118,7 +118,8 @@ public class NativeCellTest
                                   ColumnIdentifier.getInterned(uuid.toString(), false),
                                     isComplex ? new SetType<>(BytesType.instance, true) : BytesType.instance,
                                   -1,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     private static Cell<?> rndcell(ColumnMetadata col)

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableHeaderFixTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableHeaderFixTest.java
@@ -386,7 +386,7 @@ public class SSTableHeaderFixTest
             ColumnMetadata cd = getColDef(col);
             AbstractType<?> dropType = cd.type.expandUserTypes();
             cols.removeRegularOrStaticColumn(ci)
-                .recordColumnDrop(new ColumnMetadata(cd.ksName, cd.cfName, cd.name, dropType, cd.position(), cd.kind), FBUtilities.timestampMicros());
+                .recordColumnDrop(new ColumnMetadata(cd.ksName, cd.cfName, cd.name, dropType, cd.position(), cd.kind, cd.getMask()), FBUtilities.timestampMicros());
         }
         tableMetadata = cols.build();
 

--- a/test/unit/org/apache/cassandra/utils/CassandraGenerators.java
+++ b/test/unit/org/apache/cassandra/utils/CassandraGenerators.java
@@ -212,7 +212,7 @@ public final class CassandraGenerators
         }
         ColumnIdentifier name = new ColumnIdentifier(str, true);
         int position = !kind.isPrimaryKeyKind() ? -1 : (int) rnd.next(Constraint.between(0, 30));
-        return new ColumnMetadata(ks, table, name, typeGen.generate(rnd), position, kind);
+        return new ColumnMetadata(ks, table, name, typeGen.generate(rnd), position, kind, null);
     }
 
     public static Gen<ByteBuffer> partitionKeyDataGen(TableMetadata metadata)


### PR DESCRIPTION
This should be merged to a feature branch. We shouldn't include DDM with attached columns into trunk until we have CASSANDRA-18069 and, possibly, CASSANDRA-18070