### PR TITLE
LIST command outputs permissions for SUPERUSER role. (CASSANDRA-18018)

### DIFF
--- a/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/CassandraAuthorizer.java
@@ -330,11 +330,37 @@ public class CassandraAuthorizer implements IAuthorizer
         if (null == grantee)
             return listPermissionsForRole(permissions, resource, null);
 
-        Set<RoleResource> roles = DatabaseDescriptor.getRoleManager().getRoles(grantee, true);
+        IRoleManager roleManager = DatabaseDescriptor.getRoleManager();
+        Set<RoleResource> roles = roleManager.getRoles(grantee, true);
         Set<PermissionDetails> details = new HashSet<>();
         for (RoleResource role : roles)
-            details.addAll(listPermissionsForRole(permissions, resource, role));
+            details.addAll(roleManager.isSuper(role) ? listPermissionsForSuperRole(permissions, resource, role) : listPermissionsForRole(permissions, resource, role));
+        
+        return details;
+    }
 
+    private Set<PermissionDetails> listPermissionsForSuperRole(Set<Permission> permissions,
+                                                                IResource resource,
+                                                                RoleResource role)
+    {
+        Set<PermissionDetails> details = new HashSet<>();
+        Map<IResource, List<Permission>> resourceToRelevantPermissions = new HashMap<IResource, List<Permission>>();
+        for (IResource rootLevelResource : Resources.getAllRootLevelResources())
+        {
+            resourceToRelevantPermissions.put(
+                rootLevelResource,
+                rootLevelResource.applicablePermissions()
+                    .stream()
+                    .filter(permission -> permissions.contains(permission))
+                    .collect(Collectors.toList())
+            );
+        }
+        for (Map.Entry<IResource, List<Permission>> entry : resourceToRelevantPermissions.entrySet())
+        {
+            IResource rootLevelResource = entry.getKey();
+            for (Permission permission : entry.getValue())
+                details.add(new PermissionDetails(role.getRoleName(), rootLevelResource, permission));
+        }
         return details;
     }
 

--- a/src/java/org/apache/cassandra/auth/Resources.java
+++ b/src/java/org/apache/cassandra/auth/Resources.java
@@ -64,6 +64,16 @@ public final class Resources
             throw new IllegalArgumentException(String.format("Name %s is not valid for any resource type", name));
     }
 
+    public static List<IResource> getAllRootLevelResources()
+    {
+        List<IResource> result = new ArrayList<IResource>();
+        result.add(RoleResource.root());
+        result.add(DataResource.root());
+        result.add(FunctionResource.root());
+        result.add(JMXResource.root());
+        return result;
+    }
+
     @Deprecated
     public final static String ROOT = "cassandra";
     @Deprecated

--- a/test/unit/org/apache/cassandra/cql3/statements/ListPermissionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/ListPermissionsTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.statements;
+
+import org.junit.Test;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.FunctionResource;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.JMXResource;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.auth.RoleResource;
+import org.apache.cassandra.cql3.CQLTester;
+
+import org.junit.BeforeClass;
+import static org.junit.Assert.assertTrue;
+
+public class ListPermissionsTest extends CQLTester
+{
+    @BeforeClass
+    public static void startup()
+    {
+        requireAuthentication();
+        requireNetwork();
+    }
+
+    @Test
+    public void showAllPermissionsForSuperUserTest() throws Throwable
+    {
+        useSuperUser();
+        executeCommandsForNewSuperUser();
+        List<Map<String,String>> expectedCqlRowsForAllKeyspaces = expectedSuperRoleCqlRows("jane", "jane", "<all keyspaces>", null);
+        List<Map<String,String>> expectedCqlRowsForAllFunctions = expectedSuperRoleCqlRows("jane", "jane", "<all functions>", null);
+        List<Map<String,String>> expectedCqlRowsForAllRoles = expectedSuperRoleCqlRows("jane", "jane", "<all roles>", null);
+        List<Map<String,String>> expectedCqlRowsForAllMBeans = expectedSuperRoleCqlRows("jane", "jane", "<all mbeans>", null);
+        try
+        {
+            List<Map<String,String>> nonExpectedCqlRows = executeNet("LIST ALL PERMISSIONS OF jane")
+                .all()
+                .stream()
+                .map(
+                    actualRow -> {
+                        Map<String,String> actualCqlRow = new HashMap<String,String>();
+                        actualCqlRow.put("role", actualRow.getString("role"));
+                        actualCqlRow.put("username", actualRow.getString("username"));
+                        actualCqlRow.put("resource", actualRow.getString("resource"));
+                        actualCqlRow.put("permission", actualRow.getString("permission"));
+                        return actualCqlRow;
+                    }
+                )
+                .filter(
+                    actualCqlRow -> {
+                        if (expectedCqlRowsForAllKeyspaces.remove(actualCqlRow))
+                            return false;
+                        if (expectedCqlRowsForAllFunctions.remove(actualCqlRow))
+                            return false;
+                        if (expectedCqlRowsForAllRoles.remove(actualCqlRow))
+                            return false;
+                        if (expectedCqlRowsForAllMBeans.remove(actualCqlRow))
+                            return false;
+                        return true;
+                    }
+                )
+                .collect(Collectors.toList());
+            
+            assertTrue(nonExpectedCqlRows.isEmpty());
+            assertTrue(expectedCqlRowsForAllKeyspaces.isEmpty());
+            assertTrue(expectedCqlRowsForAllFunctions.isEmpty());
+            assertTrue(expectedCqlRowsForAllRoles.isEmpty());
+            assertTrue(expectedCqlRowsForAllMBeans.isEmpty());
+        }
+        finally
+        {
+            executeCommandsToRemoveNewSuperUser();
+        }
+    }
+
+    @Test
+    public void showASinglePermissionForSuperUserTest() throws Throwable
+    {
+        useSuperUser();
+        executeCommandsForNewSuperUser();
+        Permission queriedPermissions[] = new Permission[] { Permission.MODIFY, Permission.AUTHORIZE };
+        try
+        {
+            for (int i = 0; i < queriedPermissions.length; i++)
+            {
+                Set<Permission> expectedPermissions = EnumSet.of(queriedPermissions[i]);
+                List<Map<String,String>> expectedCqlRowsForAllKeyspaces = expectedSuperRoleCqlRows("jane", "jane", "<all keyspaces>", expectedPermissions);
+                List<Map<String,String>> expectedCqlRowsForAllFunctions = expectedSuperRoleCqlRows("jane", "jane", "<all functions>", expectedPermissions);
+                List<Map<String,String>> expectedCqlRowsForAllRoles = expectedSuperRoleCqlRows("jane", "jane", "<all roles>", expectedPermissions);
+                List<Map<String,String>> expectedCqlRowsForAllMBeans = expectedSuperRoleCqlRows("jane", "jane", "<all mbeans>", expectedPermissions);
+                List<Map<String,String>> nonExpectedCqlRows = executeNet(String.format("LIST %s OF jane", queriedPermissions[i].name()))
+                    .all()
+                    .stream()
+                    .map(
+                        actualRow -> {
+                            Map<String,String> actualCqlRow = new HashMap<String,String>();
+                            actualCqlRow.put("role", actualRow.getString("role"));
+                            actualCqlRow.put("username", actualRow.getString("username"));
+                            actualCqlRow.put("resource", actualRow.getString("resource"));
+                            actualCqlRow.put("permission", actualRow.getString("permission"));
+                            return actualCqlRow;
+                        }
+                    )
+                    .filter(
+                        actualCqlRow -> {
+                            if (expectedCqlRowsForAllKeyspaces.remove(actualCqlRow))
+                                return false;
+                            if (expectedCqlRowsForAllFunctions.remove(actualCqlRow))
+                                return false;
+                            if (expectedCqlRowsForAllRoles.remove(actualCqlRow))
+                                return false;
+                            if (expectedCqlRowsForAllMBeans.remove(actualCqlRow))
+                                return false;
+                            return true;
+                        }
+                    )
+                    .collect(Collectors.toList());
+                
+                assertTrue(nonExpectedCqlRows.isEmpty());
+                assertTrue(expectedCqlRowsForAllKeyspaces.isEmpty());
+                assertTrue(expectedCqlRowsForAllFunctions.isEmpty());
+                assertTrue(expectedCqlRowsForAllRoles.isEmpty());
+                assertTrue(expectedCqlRowsForAllMBeans.isEmpty());
+            }
+        }
+        finally
+        {
+            executeCommandsToRemoveNewSuperUser();
+        }
+    }
+
+    @Test
+    public void showACoupleOfPermissionsForSuperUserTest() throws Throwable
+    {
+        useSuperUser();
+        executeCommandsForNewSuperUser();
+        Permission queriedPermissions[][] = new Permission[][] { {Permission.ALTER, Permission.EXECUTE}, {Permission.MODIFY, Permission.DROP} };
+        try
+        {
+            for (int i = 0; i < queriedPermissions.length; i++)
+            {
+                Set<Permission> expectedPermissions = EnumSet.of(queriedPermissions[i][0], queriedPermissions[i][1]);
+                List<Map<String,String>> expectedCqlRowsForAllKeyspaces = expectedSuperRoleCqlRows("jane", "jane", "<all keyspaces>", expectedPermissions);
+                List<Map<String,String>> expectedCqlRowsForAllFunctions = expectedSuperRoleCqlRows("jane", "jane", "<all functions>", expectedPermissions);
+                List<Map<String,String>> expectedCqlRowsForAllRoles = expectedSuperRoleCqlRows("jane", "jane", "<all roles>", expectedPermissions);
+                List<Map<String,String>> expectedCqlRowsForAllMBeans = expectedSuperRoleCqlRows("jane", "jane", "<all mbeans>", expectedPermissions);            
+                List<Map<String,String>> nonExpectedCqlRows = executeNet(String.format("LIST %s,%s OF jane", queriedPermissions[i][0].name(), queriedPermissions[i][1].name()))
+                    .all()
+                    .stream()
+                    .map(
+                        actualRow -> {
+                            Map<String,String> actualCqlRow = new HashMap<String,String>();
+                            actualCqlRow.put("role", actualRow.getString("role"));
+                            actualCqlRow.put("username", actualRow.getString("username"));
+                            actualCqlRow.put("resource", actualRow.getString("resource"));
+                            actualCqlRow.put("permission", actualRow.getString("permission"));
+                            return actualCqlRow;
+                        }
+                    )
+                    .filter(
+                        actualCqlRow -> {
+                            if (expectedCqlRowsForAllKeyspaces.remove(actualCqlRow))
+                                return false;
+                            if (expectedCqlRowsForAllFunctions.remove(actualCqlRow))
+                                return false;
+                            if (expectedCqlRowsForAllRoles.remove(actualCqlRow))
+                                return false;
+                            if (expectedCqlRowsForAllMBeans.remove(actualCqlRow))
+                                return false;
+                            return true;
+                        }
+                    )
+                    .collect(Collectors.toList());
+                
+                assertTrue(nonExpectedCqlRows.isEmpty());
+                assertTrue(expectedCqlRowsForAllKeyspaces.isEmpty());
+                assertTrue(expectedCqlRowsForAllFunctions.isEmpty());
+                assertTrue(expectedCqlRowsForAllRoles.isEmpty());
+                assertTrue(expectedCqlRowsForAllMBeans.isEmpty());
+            }
+        }
+        finally
+        {
+            executeCommandsToRemoveNewSuperUser();
+        }
+    }
+
+    @Test
+    public void showPermissionsForRevokedSuperRoleTest() throws Throwable
+    {
+        useSuperUser();
+        executeCommandsForNewSuperUser();
+        executeNet("GRANT CREATE ON ALL KEYSPACES TO jane");
+        executeNet("ALTER ROLE jane WITH SUPERUSER=false");
+        try
+        {
+            List<Map<String,String>> nonExpectedCqlRows = executeNet("LIST ALL PERMISSIONS OF jane")
+                .all()
+                .stream()
+                .map(
+                    actualRow -> {
+                        Map<String,String> actualCqlRow = new HashMap<String,String>();
+                        actualCqlRow.put("role", actualRow.getString("role"));
+                        actualCqlRow.put("username", actualRow.getString("username"));
+                        actualCqlRow.put("resource", actualRow.getString("resource"));
+                        actualCqlRow.put("permission", actualRow.getString("permission"));
+                        return actualCqlRow;
+                    }
+                )
+                .filter(
+                    actualCqlRow -> {
+                        if (actualCqlRow.get("permission").equals(Permission.CREATE.name()))
+                            return false;
+                        return true;
+                    }
+                )
+                .collect(Collectors.toList());
+            assertTrue(nonExpectedCqlRows.isEmpty());
+        }
+        finally
+        {
+            executeCommandsToRemoveNewSuperUser();
+        }
+    }
+
+    private void executeCommandsForNewSuperUser() throws Throwable
+    {
+        executeNet("CREATE KEYSPACE IF NOT EXISTS test_keyspace WITH replication = {'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1};");
+        executeNet("CREATE TABLE IF NOT EXISTS test_keyspace.test_table (a text, b int, primary key (b));");
+        executeNet("CREATE FUNCTION IF NOT EXISTS test_keyspace.test_function ( arg int ) RETURNS NULL on NULL INPUT RETURNS int LANGUAGE java AS $$ return arg; $$;");
+        executeNet("CREATE ROLE IF NOT EXISTS jane WITH SUPERUSER = true AND LOGIN = true AND PASSWORD = 'super'");
+    }
+
+    private void executeCommandsToRemoveNewSuperUser() throws Throwable
+    {
+        executeNet("DROP TABLE IF EXISTS test_keyspace.test_table");
+        executeNet("DROP FUNCTION IF EXISTS test_keyspace.test_function");
+        executeNet("DROP KEYSPACE IF EXISTS test_keyspace");
+        executeNet("DROP ROLE IF EXISTS jane");
+    }
+
+    private List<Map<String, String>> expectedSuperRoleCqlRows(String role, String username, String resource, Set<Permission> expectedPermissions)
+    {
+        IResource rootResource = null;
+        switch (resource)
+        {
+            case "<all keyspaces>":
+                rootResource = DataResource.root();
+                break;
+            case "<all functions>":
+                rootResource = FunctionResource.root();
+                break;
+            case "<all roles>":
+                rootResource = RoleResource.root();
+                break;
+            case "<all mbeans>":
+                rootResource = JMXResource.root();
+                break;
+        }
+        return rootResource
+        .applicablePermissions()
+        .stream()
+        .map(
+            permission -> {
+                if (expectedPermissions == null || expectedPermissions.contains(permission))
+                {
+                    Map<String,String> expectedCqlRow = new HashMap<String,String>();
+                    expectedCqlRow.put("role", role);
+                    expectedCqlRow.put("username", username);
+                    expectedCqlRow.put("resource", resource);
+                    expectedCqlRow.put("permission", permission.name());
+                    return expectedCqlRow;
+                }
+                return null;
+            }
+        )
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
A fix for [List command output not correct for super user, after grant command ([CASSANDRA-18018](https://issues.apache.org/jira/browse/CASSANDRA-18018)).

A short example of the new functionality.

(1) Let's create a new SUPERUSER role, `joe`.
```
maxim@b51f5bc1452d:~$ ./cassandra-dev/bin/cqlsh -ucassandra
Password: 
Connected to Test Cluster at 127.0.0.1:9042
[cqlsh 6.1.0 | Cassandra 4.1-beta2-SNAPSHOT | CQL spec 3.4.6 | Native protocol v5]
Use HELP for help.
cassandra@cqlsh> CREATE ROLE IF NOT EXISTS joe WITH SUPERUSER = true AND LOGIN = true AND PASSWORD = 'super';
```

(2) Let's list all permissions for the new role.
```
cassandra@cqlsh> LIST ALL PERMISSIONS OF joe;

 role | username | resource        | permission
------+----------+-----------------+------------
  joe |      joe | <all keyspaces> |     CREATE
  joe |      joe | <all keyspaces> |      ALTER
  joe |      joe | <all keyspaces> |       DROP
  joe |      joe | <all keyspaces> |     SELECT
  joe |      joe | <all keyspaces> |     MODIFY
  joe |      joe | <all keyspaces> |  AUTHORIZE
  joe |      joe | <all functions> |     CREATE
  joe |      joe | <all functions> |      ALTER
  joe |      joe | <all functions> |       DROP
  joe |      joe | <all functions> |  AUTHORIZE
  joe |      joe | <all functions> |    EXECUTE
  joe |      joe |    <all mbeans> |     SELECT
  joe |      joe |    <all mbeans> |     MODIFY
  joe |      joe |    <all mbeans> |  AUTHORIZE
  joe |      joe |    <all mbeans> |   DESCRIBE
  joe |      joe |    <all mbeans> |    EXECUTE
  joe |      joe |     <all roles> |     CREATE
  joe |      joe |     <all roles> |      ALTER
  joe |      joe |     <all roles> |       DROP
  joe |      joe |     <all roles> |  AUTHORIZE
  joe |      joe |     <all roles> |   DESCRIBE

(21 rows)
```

As you can see, there is no need to grant any permission explicitly.  
SUPERUSER role always has all the relevant permissions on all the resources in accordance with the SUPERUSER role definition.

patch by Maxim Chanturiay; reviewed by <Reviewers> for CASSANDRA-18018

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

