### PR TITLE
Add cache type information for maximum memory usage warning message

### DIFF
--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -441,7 +441,7 @@ public class BufferPool
                 {
                     if (memoryUsageThreshold > 0)
                     {
-                        noSpamLogger.info("Maximum memory usage reached ({}) for {}, cannot allocate chunk of {}",
+                        noSpamLogger.info("Maximum memory usage reached ({}) for {} buffer pool, cannot allocate chunk of {}",
                                           readableMemoryUsageThreshold, name, READABLE_MACRO_CHUNK_SIZE);
                     }
                     return null;

--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -441,8 +441,8 @@ public class BufferPool
                 {
                     if (memoryUsageThreshold > 0)
                     {
-                        noSpamLogger.info("Maximum memory usage reached ({}), cannot allocate chunk of {}",
-                                          readableMemoryUsageThreshold, READABLE_MACRO_CHUNK_SIZE);
+                        noSpamLogger.info("Maximum memory usage reached ({}) for {}, cannot allocate chunk of {}",
+                                          readableMemoryUsageThreshold, name, READABLE_MACRO_CHUNK_SIZE);
                     }
                     return null;
                 }


### PR DESCRIPTION
Add cache type information for maximum memory usage warning message

Tested on one server by setting the networking_cache_size to 1MiB. The new INFO message looks like below in the system log:
`INFO  [Messaging-EventLoop-3-1] 2023-02-01 09:00:47,673 NoSpamLogger.java:105 - Maximum memory usage reached (1.000MiB) for networking, cannot allocate chunk of 8.000MiB`

patch by Yong Jiang; reviewed by <Reviewers> for CASSANDRA-18184
The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

