### PR TITLE
use equals() rather than reference equality for excluding ourselves from the dependency builder

### DIFF
--- a/.build/include-accord.sh
+++ b/.build/include-accord.sh
@@ -25,7 +25,7 @@ set -o nounset
 bin="$(cd "$(dirname "$0")" > /dev/null; pwd)"
 
 accord_repo='https://github.com/apache/cassandra-accord.git'
-accord_branch='1230eceb077c928123e6bf848a103964fe90c9f7'
+accord_branch='0cc9e273b2eaa37d82a1ae1ac2681aec65aa0f6d'
 accord_src="$bin/cassandra-accord"
 
 checkout() {


### PR DESCRIPTION
patch by Benedict; reviewed by Caleb Rackliffe for CASSANDRA-18218