### PR TITLE
Fixing the output of FQL dump tool to properly separate entries

### DIFF
--- a/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Dump.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/commands/Dump.java
@@ -219,7 +219,6 @@ public class Dump implements Runnable
 
     private static void appendValuesToStringBuilder(List<ByteBuffer> values, StringBuilder sb)
     {
-        boolean first = true;
         for (ByteBuffer value : values)
         {
             if (null == value)
@@ -237,14 +236,7 @@ public class Dump implements Runnable
                 }
             }
 
-            if (first)
-            {
-                first = false;
-            }
-            else
-            {
-                sb.append("-----").append(System.lineSeparator());
-            }
+            sb.append("-----").append(System.lineSeparator());
         }
     }
 


### PR DESCRIPTION
FQL tool dump is not adding value separator for the first two values. Fixed to print the separator for each value.

fqltool dump output before:

```
Type: single-query
Query start time: 1675448458550
Protocol version: 5
Generated timestamp:-9223372036854775808
Generated nowInSeconds:1675448458
Query: INSERT INTO ks1.t1 (id, v1, v2, v3) VALUES (?, ?, ?, ?)
Values: 
00000000 00 00 00 01                                      ····             
00000000 00 00 00 01                                      ····             
-----
00000000 00 00 00 01                                      ····             
-----
00000000 00 00 00 01                                      ····             
-----
```

after:
```
Type: single-query
Query start time: 1675448458550
Protocol version: 5
Generated timestamp:-9223372036854775808
Generated nowInSeconds:1675448458
Query: INSERT INTO ks1.t1 (id, v1, v2, v3) VALUES (?, ?, ?, ?)
Values: 
00000000 00 00 00 01                                      ····             
-----
00000000 00 00 00 01                                      ····             
-----
00000000 00 00 00 01                                      ····             
-----
00000000 00 00 00 01                                      ····             
-----

```

CASSANDRA-18215
