### PR TITLE
Cassandra 18143 fix for v 3.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -352,7 +352,7 @@
 	         <exclusion groupId="org.apache.httpcomponents" artifactId="httpclient"/>
 	         <exclusion groupId="org.apache.httpcomponents" artifactId="httpcore"/>
           </dependency>
-          <dependency groupId="junit" artifactId="junit" version="4.6" scope="test">
+          <dependency groupId="junit" artifactId="junit" version="4.13" scope="test">
             <exclusion groupId="org.hamcrest" artifactId="hamcrest-core"/>
           </dependency>
           <dependency groupId="org.apache.rat" artifactId="apache-rat" version="0.10">

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -692,7 +692,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean
         Set<SSTableReader> newSSTables = new HashSet<>();
 
         Directories.SSTableLister lister = getDirectories().sstableLister(Directories.OnTxnErr.IGNORE).skipTemporary(true);
-        for (Map.Entry<Descriptor, Set<Component>> entry : lister.list().entrySet())
+        for (Map.Entry<Descriptor, Set<Component>> entry : lister.sortedList().entrySet())
         {
             Descriptor descriptor = entry.getKey();
 

--- a/src/java/org/apache/cassandra/db/Directories.java
+++ b/src/java/org/apache/cassandra/db/Directories.java
@@ -671,6 +671,18 @@ public class Directories
             return ImmutableMap.copyOf(components);
         }
 
+        /**
+         * Returns a sorted version of the {@code list} method.
+         * Descriptors are sorted by generation.
+         * @return a SortedMap of descriptors to their components.
+         */
+        public SortedMap<Descriptor, Set<Component>> sortedList()
+        {
+            SortedMap<Descriptor, Set<Component>> selected = new TreeMap<Descriptor,Set<Component>>((t1,t2) -> Integer.compare( t1.generation, t2.generation));
+            selected.putAll(list());
+            return selected;
+        }
+
         public List<File> listFiles()
         {
             filter();

--- a/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
+++ b/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
@@ -45,7 +45,7 @@ public class StandaloneUpgrader
     private static final String HELP_OPTION  = "help";
     private static final String KEEP_SOURCE = "keep-source";
 
-    public static <Compraatpor> void main(String args[])
+    public static void main(String args[])
     {
         Options options = Options.parseArgs(args);
         Util.initDatabaseDescriptor();
@@ -73,9 +73,7 @@ public class StandaloneUpgrader
             Collection<SSTableReader> readers = new ArrayList<>();
 
             // Upgrade sstables in SSTableId order
-            SortedMap<Descriptor, Set<Component>> selected = new TreeMap<Descriptor,Set<Component>>((t1,t2) -> Integer.compare( t1.generation, t2.generation));
-            selected.putAll(lister.list());
-            for (Map.Entry<Descriptor, Set<Component>> entry : selected.entrySet())
+            for (Map.Entry<Descriptor, Set<Component>> entry : lister.sortedList().entrySet())
             {
                 Set<Component> components = entry.getValue();
                 if (!components.contains(Component.DATA) || !components.contains(Component.PRIMARY_INDEX))

--- a/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
+++ b/src/java/org/apache/cassandra/tools/StandaloneUpgrader.java
@@ -45,7 +45,7 @@ public class StandaloneUpgrader
     private static final String HELP_OPTION  = "help";
     private static final String KEEP_SOURCE = "keep-source";
 
-    public static void main(String args[])
+    public static <Compraatpor> void main(String args[])
     {
         Options options = Options.parseArgs(args);
         Util.initDatabaseDescriptor();
@@ -72,8 +72,10 @@ public class StandaloneUpgrader
 
             Collection<SSTableReader> readers = new ArrayList<>();
 
-            // Upgrade sstables
-            for (Map.Entry<Descriptor, Set<Component>> entry : lister.list().entrySet())
+            // Upgrade sstables in SSTableId order
+            SortedMap<Descriptor, Set<Component>> selected = new TreeMap<Descriptor,Set<Component>>((t1,t2) -> Integer.compare( t1.generation, t2.generation));
+            selected.putAll(lister.list());
+            for (Map.Entry<Descriptor, Set<Component>> entry : selected.entrySet())
             {
                 Set<Component> components = entry.getValue();
                 if (!components.contains(Component.DATA) || !components.contains(Component.PRIMARY_INDEX))

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -649,6 +649,13 @@ public class Util
         return () -> DisallowedDirectories.clearUnwritableUnsafe();
     }
 
+    /**
+     * Finds the first instance where a supplied object is inserted in the default HashSet before a preceeding
+     * instance.
+     * @param supplier The supplier of the objects to test.
+     * @return The last object created, the one that inserts before a previous instance.
+     * @param <T> the type of object returned by the supplier.
+     */
     public static <T> T findFirstUnordered(java.util.function.Supplier<T> supplier)
     {
         HashSet<T> set = new HashSet<>(2);

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -648,4 +648,22 @@ public class Util
         }
         return () -> DisallowedDirectories.clearUnwritableUnsafe();
     }
+
+    public static <T> T findFirstUnordered(java.util.function.Supplier<T> supplier)
+    {
+        HashSet<T> set = new HashSet<>(2);
+        T first = supplier.get();
+        while (true)
+        {
+            set.clear();
+            T second = supplier.get();
+            set.add(first);
+            set.add(second);
+            if (set.iterator().next() != first)
+                return second;
+
+            first = second;
+        }
+    }
+
 }

--- a/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
@@ -954,7 +954,7 @@ public class LegacySSTableTest
         File directory = new File(System.getProperty("java.io.tmpdir"));
 
         Util.findFirstUnordered(() -> {
-            return new Descriptor(legacyVersion, directory, ksname, cfname, generation[0], formatType);
+            return new Descriptor(legacyVersion, directory, ksname, cfname, ++generation[0], formatType);
         });
         return generation[0];
     }
@@ -990,7 +990,7 @@ public class LegacySSTableTest
                 if (file.isFile())
                 {
                     String[] fileNameParts = file.getName().split("-");
-                    String targetName = String.format("%s-%s-%s-%s", legacyVersion, start + i, fileNameParts[2], fileNameParts[3]);
+                    String targetName = String.format("%s-%s-%s-%s-%s", fileNameParts[0],tableName, fileNameParts[2], start + i,  fileNameParts[4]);
                     logger.info("creating legacy sstable {}", targetName);
                     File target = new File(cfDir, targetName);
                     org.apache.commons.io.FileUtils.copyFile(file,target);

--- a/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSSTablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSSTablesTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.db.Directories;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.StartupException;
+import org.apache.cassandra.io.sstable.LegacySSTableTest;
+import org.apache.cassandra.service.StorageService;
+import org.assertj.core.api.Assertions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/*
+ * SStableUpdater should be run with the server shutdown, but we need to set up a certain env to be able to
+ * load/swap/drop sstable files under the test's feet. Hence why we need a separate file vs StandaloneUpgraderTest.
+ *
+ * Caution: heavy hacking ahead.
+ */
+public class StandaloneUpgraderOnSStablesTest
+{
+
+    static final String EXECUTABLE = StandaloneUpgrader.class.getClassLoader().getResource( StandaloneUpgrader.class.getCanonicalName()).getFile();
+    String legacyId = LegacySSTableTest.legacyVersions[LegacySSTableTest.legacyVersions.length - 1];
+
+    @BeforeClass
+    public static void defineSchema() throws ConfigurationException
+    {
+        LegacySSTableTest.defineSchema();
+        //System.setProperty(Util.ALLOW_TOOL_REINIT_FOR_TEST, "true"); // Necessary for testing
+    }
+
+    @AfterClass
+    public static void clearClassEnv()
+    {
+        //System.clearProperty(Util.ALLOW_TOOL_REINIT_FOR_TEST);
+    }
+
+    class ToolResult {
+        private int exitValue;
+        private String stdout;
+        private String stderr;
+
+        public ToolResult(int exitValue, String stdout, String stderr)
+        {
+            this.exitValue = exitValue;
+            this.stdout = stdout;
+            this.stderr = stderr;
+        }
+
+        public int getExitValue()
+        {
+            return exitValue;
+        }
+
+        public String getStdout()
+        {
+            return stdout;
+        }
+
+        public String getStderr()
+        {
+            return stderr;
+        }
+
+        public boolean assertOnCleanExit() {
+            return exitValue == 0;
+        }
+    }
+
+    private ToolResult execTool( int waitFor, String... args) throws InterruptedException, IOException
+    {
+        List<String> command = new ArrayList<>();
+        command.add( EXECUTABLE );
+        command.addAll(Arrays.asList(args ));
+        Process process =  new ProcessBuilder( command ).start();
+        if (!process.waitFor(waitFor, TimeUnit.SECONDS))
+        {
+            process.destroyForcibly();
+        }
+
+        StringWriter stdout = new StringWriter();
+        org.apache.commons.io.IOUtils.copy(process.getInputStream(), stdout, StandardCharsets.UTF_8 );
+        StringWriter stderr = new StringWriter();
+        org.apache.commons.io.IOUtils.copy(process.getErrorStream(), stderr, StandardCharsets.UTF_8 );
+        return new ToolResult(process.exitValue(), stdout.toString(), stderr.toString());
+    }
+
+    @Test
+    public void testUpgradeKeepFiles() throws Throwable
+    {
+        LegacySSTableTest.truncateLegacyTables(legacyId);
+        LegacySSTableTest.loadLegacyTables(legacyId);
+
+        List<String> origFiles = getSStableFiles("legacy_tables", "legacy_" + legacyId + "_simple");
+        ToolResult tool = execTool(5,
+                                            "-k",
+                                                 "legacy_tables",
+                                                 "legacy_" + legacyId + "_simple");
+        Assertions.assertThat(tool.getStdout()).contains("Found 1 sstables that need upgrading.");
+        Assertions.assertThat(tool.getStdout()).contains("legacy_tables/legacy_" + legacyId + "_simple");
+        Assertions.assertThat(tool.getStdout()).contains("-Data.db");
+        tool.assertOnCleanExit();
+
+        List<String> newFiles = getSStableFiles("legacy_tables", "legacy_" + legacyId + "_simple");
+        origFiles.removeAll(newFiles);
+        assertEquals(0, origFiles.size()); // check previous version files are kept
+
+        // need to make sure the new sstables are live, so that they get truncated later
+        Keyspace.open("legacy_tables").getColumnFamilyStore("legacy_" + legacyId + "_simple").loadNewSSTables();
+    }
+
+    @Test
+    public void testUpgradeSnapshot() throws Throwable
+    {
+        LegacySSTableTest.truncateLegacyTables(legacyId);
+        LegacySSTableTest.loadLegacyTables(legacyId);
+        StorageService.instance.takeSnapshot("testsnapshot",
+                                             Collections.emptyMap(),
+                                             "legacy_tables.legacy_" + legacyId + "_simple");
+
+        ToolResult tool = execTool(5,
+                                                 "-k",
+                                                 "legacy_tables",
+                                                 "legacy_" + legacyId + "_simple",
+                                                 "wrongsnapshot");
+        Assertions.assertThat(tool.getStdout()).contains("Found 0 sstables that need upgrading.");
+
+        tool = execTool(5,
+                                      "legacy_tables",
+                                      "legacy_" + legacyId + "_simple",
+                                      "testsnapshot");
+        Assertions.assertThat(tool.getStdout()).contains("Found 1 sstables that need upgrading.");
+        Assertions.assertThat(tool.getStdout()).contains("legacy_tables/legacy_" + legacyId + "_simple");
+        Assertions.assertThat(tool.getStdout()).contains("-Data.db");
+        tool.assertOnCleanExit();
+    }
+
+    @Test
+    public void testUpgrade() throws Throwable
+    {
+        LegacySSTableTest.truncateLegacyTables(legacyId);
+        LegacySSTableTest.loadLegacyTables(legacyId);
+
+        List<String> origFiles = getSStableFiles("legacy_tables", "legacy_" + legacyId + "_simple");
+        ToolResult tool = execTool(5,
+                                                 "legacy_tables",
+                                                 "legacy_" + legacyId + "_simple");
+        Assertions.assertThat(tool.getStdout()).contains("Found 1 sstables that need upgrading.");
+        Assertions.assertThat(tool.getStdout()).contains("legacy_tables/legacy_" + legacyId + "_simple");
+        Assertions.assertThat(tool.getStdout()).contains("-Data.db");
+        tool.assertOnCleanExit();
+
+        List<String> newFiles = getSStableFiles("legacy_tables", "legacy_" + legacyId + "_simple");
+        int origSize = origFiles.size();
+        origFiles.removeAll(newFiles);
+        assertEquals(origSize, origFiles.size()); // check previous version files are gone
+        // need to make sure the new sstables are live, so that they get truncated later
+        Keyspace.open("legacy_tables").getColumnFamilyStore("legacy_" + legacyId + "_simple").loadNewSSTables();
+    }
+
+    @Test
+    public void testUpgradeSequence() throws Throwable
+    {
+        int startGeneration = LegacySSTableTest.generateMultipleTables(legacyId);
+
+        String tableName = "legacy_" + legacyId + "_multiple";
+
+        List<String> origFiles = getSStableFiles("legacy_tables", tableName);
+        // verify that the files are not returned in the correct order.
+        Set<String> treeSet = new TreeSet<>();
+        treeSet.addAll(origFiles);
+        assertNotEquals("Initial data was not in the incorret order", treeSet.toArray(), origFiles.toArray());
+
+        ToolResult tool = execTool(5,
+                                                 "legacy_tables",
+                                                 tableName);
+        Assertions.assertThat(tool.getStdout()).contains("Found 3 sstables that need upgrading.");
+        Assertions.assertThat(tool.getStdout()).contains("legacy_tables/" + tableName);
+        int[] loc = new int[3];
+        for (int i = 0; i < 3; i++)
+        {
+            String fileName = String.format("%s-%s-big-Data.db", legacyId, startGeneration + i);
+            Assertions.assertThat(tool.getStdout()).contains(fileName);
+            loc[i] = tool.getStdout().lastIndexOf(fileName);
+        }
+        Assertions.assertThat(loc).isSorted();
+        tool.assertOnCleanExit();
+
+        List<String> newFiles = getSStableFiles("legacy_tables", tableName);
+        int origSize = origFiles.size();
+        origFiles.removeAll(newFiles);
+        assertEquals(origSize, origFiles.size()); // check previous version files are gone
+        // need to make sure the new sstables are live, so that they get truncated later
+        Keyspace.open("legacy_tables").getColumnFamilyStore(tableName).loadNewSSTables();
+    }
+
+    /**
+     * Gets sstable names  for the keyspace in the order returned by Directories.SSTableLister
+     * @param ks the keyspace to read.
+     * @param table the name to read.
+     * @return a list of sstable names.
+     * @throws StartupException
+     */
+    private List<String> getSStableFiles(String ks, String table) throws StartupException
+    {
+        ColumnFamilyStore cfs = Keyspace.open(ks).getColumnFamilyStore(table);
+        cfs.forceBlockingFlush();
+        ColumnFamilyStore.scrubDataDirectories(cfs.metadata);
+
+        Directories.SSTableLister lister = cfs.getDirectories().sstableLister(Directories.OnTxnErr.THROW);
+        lister.includeBackups(false);
+        return lister.list().keySet().stream().map( s -> s.toString()).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Adds ordering by generation to sstable updates and rewrites.

Added method to retrieve sstable names in order.
Used method in ComlumFamilyStore and StandaloneUpgrader
Added unit test cases and util methods in support of same.

Issue is expressed by StandaloneUpgrader upgrading tables out of generation order.  Test will create an example to show that fix works.
