### PR TITLE
CASSANDRA-18070 trunk: Add SELECT_MASKED permission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -105,13 +105,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -120,12 +120,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -143,7 +143,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -196,13 +196,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -211,12 +211,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -262,13 +262,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -277,12 +277,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -298,10 +298,10 @@ jobs:
   j8_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -373,13 +373,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -388,12 +388,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -408,10 +408,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -529,13 +529,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -544,12 +544,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -565,7 +565,7 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -616,13 +616,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -631,12 +631,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -654,7 +654,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -735,13 +735,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -750,12 +750,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -809,13 +809,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -824,12 +824,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -847,7 +847,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -900,13 +900,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -915,12 +915,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -936,10 +936,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1011,13 +1011,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1026,12 +1026,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1050,7 +1050,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1103,13 +1103,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1118,12 +1118,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1138,10 +1138,10 @@ jobs:
   j8_jvm_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1222,13 +1222,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1237,12 +1237,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1260,7 +1260,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1313,13 +1313,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1328,12 +1328,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1351,7 +1351,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1432,13 +1432,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1447,12 +1447,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1468,10 +1468,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1543,13 +1543,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1558,12 +1558,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1578,10 +1578,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1653,13 +1653,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1668,12 +1668,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1692,7 +1692,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1745,13 +1745,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1760,12 +1760,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1784,7 +1784,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1942,13 +1942,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -1957,12 +1957,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -1978,7 +1978,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2029,13 +2029,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2044,12 +2044,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2065,10 +2065,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2164,13 +2164,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2179,12 +2179,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2200,10 +2200,10 @@ jobs:
   j8_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2275,13 +2275,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2290,12 +2290,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2310,10 +2310,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2385,13 +2385,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2400,12 +2400,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2421,7 +2421,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2472,13 +2472,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2487,12 +2487,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2511,7 +2511,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2564,13 +2564,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2579,12 +2579,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2600,10 +2600,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2675,13 +2675,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2690,12 +2690,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2710,10 +2710,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2785,13 +2785,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2800,12 +2800,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2851,13 +2851,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2866,12 +2866,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -2889,7 +2889,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2970,13 +2970,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -2985,12 +2985,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3044,13 +3044,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3059,12 +3059,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3083,7 +3083,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3164,13 +3164,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3179,12 +3179,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3199,10 +3199,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3298,13 +3298,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3313,12 +3313,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3333,10 +3333,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3432,13 +3432,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3447,12 +3447,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3468,10 +3468,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3567,13 +3567,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3582,12 +3582,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3602,10 +3602,10 @@ jobs:
   j11_jvm_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3686,13 +3686,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3701,12 +3701,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3802,13 +3802,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3817,12 +3817,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3840,7 +3840,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3921,13 +3921,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -3936,12 +3936,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -3994,13 +3994,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4009,12 +4009,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4033,7 +4033,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4086,13 +4086,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4101,12 +4101,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4121,7 +4121,7 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -4172,13 +4172,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4187,12 +4187,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4287,13 +4287,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4302,12 +4302,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4361,13 +4361,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4376,12 +4376,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4397,10 +4397,10 @@ jobs:
   j8_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4472,13 +4472,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4487,12 +4487,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4507,10 +4507,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4606,13 +4606,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4621,12 +4621,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4644,7 +4644,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4697,13 +4697,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4712,12 +4712,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4733,10 +4733,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4854,13 +4854,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4869,12 +4869,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4893,7 +4893,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4946,13 +4946,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -4961,12 +4961,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -4984,7 +4984,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5037,13 +5037,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5052,12 +5052,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5075,7 +5075,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5156,13 +5156,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5171,12 +5171,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5192,10 +5192,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5267,13 +5267,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5282,12 +5282,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5302,10 +5302,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5377,13 +5377,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5392,12 +5392,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5416,7 +5416,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5469,13 +5469,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5484,12 +5484,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5504,10 +5504,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5579,13 +5579,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5594,12 +5594,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5618,7 +5618,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5671,13 +5671,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5686,12 +5686,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5709,7 +5709,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5790,13 +5790,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5805,12 +5805,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5826,10 +5826,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5925,13 +5925,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -5940,12 +5940,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -5964,7 +5964,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6045,13 +6045,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6060,12 +6060,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6080,10 +6080,10 @@ jobs:
   j8_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6155,13 +6155,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6170,12 +6170,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6193,7 +6193,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6246,13 +6246,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6261,12 +6261,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6281,10 +6281,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6380,13 +6380,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6395,12 +6395,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6415,10 +6415,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6490,13 +6490,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6505,12 +6505,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6526,10 +6526,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6577,13 +6577,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6592,12 +6592,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6612,10 +6612,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6685,13 +6685,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6700,12 +6700,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6721,10 +6721,10 @@ jobs:
   j8_jvm_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6777,13 +6777,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6792,12 +6792,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6812,10 +6812,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6887,13 +6887,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6902,12 +6902,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -6926,7 +6926,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6979,13 +6979,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -6994,12 +6994,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7018,7 +7018,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7071,13 +7071,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7086,12 +7086,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7110,7 +7110,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7163,13 +7163,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7178,12 +7178,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7199,10 +7199,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7274,13 +7274,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7289,12 +7289,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7313,7 +7313,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7366,13 +7366,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7381,12 +7381,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7401,10 +7401,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7452,13 +7452,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7467,12 +7467,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7490,7 +7490,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7571,13 +7571,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7586,12 +7586,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7606,10 +7606,10 @@ jobs:
   j11_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7690,13 +7690,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7705,12 +7705,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7729,7 +7729,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7782,13 +7782,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7797,12 +7797,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7891,13 +7891,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7906,12 +7906,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -7927,10 +7927,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7978,13 +7978,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -7993,12 +7993,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8013,10 +8013,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8064,13 +8064,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8079,12 +8079,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8128,13 +8128,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8143,12 +8143,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8167,7 +8167,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8220,13 +8220,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8235,12 +8235,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8255,10 +8255,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8328,13 +8328,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8343,12 +8343,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8367,7 +8367,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8525,13 +8525,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8540,12 +8540,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8598,13 +8598,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8613,12 +8613,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8636,7 +8636,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8717,13 +8717,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8732,12 +8732,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8752,10 +8752,10 @@ jobs:
   j8_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8827,13 +8827,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8842,12 +8842,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8862,10 +8862,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8961,13 +8961,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -8976,12 +8976,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -8996,10 +8996,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9080,13 +9080,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9095,12 +9095,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9188,13 +9188,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9203,12 +9203,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9223,10 +9223,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9298,13 +9298,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9313,12 +9313,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9336,7 +9336,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9389,13 +9389,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9404,12 +9404,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9463,13 +9463,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9478,12 +9478,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9527,13 +9527,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9542,12 +9542,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9562,10 +9562,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9635,13 +9635,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9650,12 +9650,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9674,7 +9674,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9727,13 +9727,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9742,12 +9742,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9762,10 +9762,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9861,13 +9861,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9876,12 +9876,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -9899,7 +9899,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9952,13 +9952,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -9967,12 +9967,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -10058,13 +10058,13 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/adelapena/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18070
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableHeaderFixTest,org.apache.cassandra.db.NativeCellTest,org.apache.cassandra.db.ColumnsTest,org.apache.cassandra.db.CellTest,org.apache.cassandra.cql3.statements.DescribeStatementTest,org.apache.cassandra.cql3.functions.masking.UnmaskPermissionTest,org.apache.cassandra.cql3.functions.masking.SelectMaskedPermissionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskWithTypeAlteringFunctionTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskQueryWithDefaultTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskNativeTypesTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithReplaceTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithPartialTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithNullTest,org.apache.cassandra.cql3.functions.masking.ColumnMaskInAnyPositionWithDefaultTest,org.apache.cassandra.auth.CreateAndAlterRoleTest
+    - REPEATED_UTESTS_COUNT: 100
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
@@ -10073,12 +10073,12 @@ jobs:
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ColumnMaskTest
+    - REPEATED_JVM_DTESTS_COUNT: 100
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: auth_test.py
+    - REPEATED_DTESTS_COUNT: 10
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
     - REPEATED_UPGRADE_DTESTS: null
@@ -10105,6 +10105,12 @@ workflows:
         requires:
         - start_j8_unit_tests
         - j8_build
+    - start_j8_unit_tests_repeat:
+        type: approval
+    - j8_unit_tests_repeat:
+        requires:
+        - start_j8_unit_tests_repeat
+        - j8_build
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
@@ -10117,6 +10123,18 @@ workflows:
         requires:
         - start_j8_jvm_dtests_vnode
         - j8_build
+    - start_j8_jvm_dtests_repeat:
+        type: approval
+    - j8_jvm_dtests_repeat:
+        requires:
+        - start_j8_jvm_dtests_repeat
+        - j8_build
+    - start_j8_jvm_dtests_vnode_repeat:
+        type: approval
+    - j8_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j8_jvm_dtests_vnode_repeat
+        - j8_build
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
@@ -10128,6 +10146,18 @@ workflows:
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
+        - j8_build
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
+        - j8_build
+    - start_j11_jvm_dtests_vnode_repeat:
+        type: approval
+    - j11_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j11_jvm_dtests_vnode_repeat
         - j8_build
     - start_j8_simulator_dtests:
         type: approval
@@ -10165,6 +10195,12 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j8_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j8_build
     - start_j8_utests_long:
         type: approval
     - j8_utests_long:
@@ -10189,6 +10225,18 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j8_build
+    - start_j8_utests_cdc_repeat:
+        type: approval
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_j8_utests_cdc_repeat
+        - j8_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j8_build
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -10201,6 +10249,18 @@ workflows:
         requires:
         - start_j11_utests_compression
         - j8_build
+    - start_j8_utests_compression_repeat:
+        type: approval
+    - j8_utests_compression_repeat:
+        requires:
+        - start_j8_utests_compression_repeat
+        - j8_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j8_build
     - start_j8_utests_trie:
         type: approval
     - j8_utests_trie:
@@ -10212,6 +10272,18 @@ workflows:
     - j11_utests_trie:
         requires:
         - start_j11_utests_trie
+        - j8_build
+    - start_j8_utests_trie_repeat:
+        type: approval
+    - j8_utests_trie_repeat:
+        requires:
+        - start_j8_utests_trie_repeat
+        - j8_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
         - j8_build
     - start_j8_utests_stress:
         type: approval
@@ -10249,6 +10321,18 @@ workflows:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j8_build
+    - start_j8_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j8_utests_system_keyspace_directory_repeat
+        - j8_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j8_build
     - start_j8_dtest_jars_build:
         type: approval
     - j8_dtest_jars_build:
@@ -10279,6 +10363,12 @@ workflows:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+    - start_j8_dtests_offheap_repeat:
+        type: approval
+    - j8_dtests_offheap_repeat:
+        requires:
+        - start_j8_dtests_offheap_repeat
+        - j8_build
     - start_j11_dtests:
         type: approval
     - j11_dtests:
@@ -10296,6 +10386,12 @@ workflows:
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
+        - j8_build
+    - start_j11_dtests_offheap_repeat:
+        type: approval
+    - j11_dtests_offheap_repeat:
+        requires:
+        - start_j11_dtests_offheap_repeat
         - j8_build
     - start_j8_dtests_large:
         type: approval
@@ -10407,6 +10503,30 @@ workflows:
         requires:
         - start_j11_cqlsh_tests_offheap
         - j8_build
+    - start_j8_dtests_repeat:
+        type: approval
+    - j8_dtests_repeat:
+        requires:
+        - start_j8_dtests_repeat
+        - j8_build
+    - start_j8_dtests_vnode_repeat:
+        type: approval
+    - j8_dtests_vnode_repeat:
+        requires:
+        - start_j8_dtests_vnode_repeat
+        - j8_build
+    - start_j11_dtests_repeat:
+        type: approval
+    - j11_dtests_repeat:
+        requires:
+        - start_j11_dtests_repeat
+        - j8_build
+    - start_j11_dtests_vnode_repeat:
+        type: approval
+    - j11_dtests_vnode_repeat:
+        requires:
+        - start_j11_dtests_vnode_repeat
+        - j8_build
   java8_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10417,19 +10537,34 @@ workflows:
     - j8_unit_tests:
         requires:
         - j8_build
+    - j8_unit_tests_repeat:
+        requires:
+        - j8_build
     - j8_simulator_dtests:
         requires:
         - j8_build
     - j8_jvm_dtests:
         requires:
         - j8_build
+    - j8_jvm_dtests_repeat:
+        requires:
+        - j8_build
     - j8_jvm_dtests_vnode:
+        requires:
+        - j8_build
+    - j8_jvm_dtests_vnode_repeat:
         requires:
         - j8_build
     - j11_jvm_dtests:
         requires:
         - j8_build
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j8_build
     - j11_jvm_dtests_vnode:
+        requires:
+        - j8_build
+    - j11_jvm_dtests_vnode_repeat:
         requires:
         - j8_build
     - j8_cqlshlib_tests:
@@ -10445,6 +10580,9 @@ workflows:
         requires:
         - j8_build
     - j11_unit_tests:
+        requires:
+        - j8_build
+    - j11_unit_tests_repeat:
         requires:
         - j8_build
     - start_utests_long:
@@ -10467,6 +10605,14 @@ workflows:
         requires:
         - start_utests_cdc
         - j8_build
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -10477,6 +10623,14 @@ workflows:
         requires:
         - start_utests_compression
         - j8_build
+    - j8_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
     - start_utests_trie:
         type: approval
     - j8_utests_trie:
@@ -10484,6 +10638,14 @@ workflows:
         - start_utests_trie
         - j8_build
     - j11_utests_trie:
+        requires:
+        - start_utests_trie
+        - j8_build
+    - j8_utests_trie_repeat:
+        requires:
+        - start_utests_trie
+        - j8_build
+    - j11_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j8_build
@@ -10516,6 +10678,13 @@ workflows:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - j8_build
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j8_build
     - start_jvm_upgrade_dtests:
         type: approval
     - j8_dtest_jars_build:
@@ -10528,7 +10697,13 @@ workflows:
     - j8_dtests:
         requires:
         - j8_build
+    - j8_dtests_repeat:
+        requires:
+        - j8_build
     - j8_dtests_vnode:
+        requires:
+        - j8_build
+    - j8_dtests_vnode_repeat:
         requires:
         - j8_build
     - start_j8_dtests_offheap:
@@ -10537,15 +10712,29 @@ workflows:
         requires:
         - start_j8_dtests_offheap
         - j8_build
+    - j8_dtests_offheap_repeat:
+        requires:
+        - start_j8_dtests_offheap
+        - j8_build
     - j11_dtests:
+        requires:
+        - j8_build
+    - j11_dtests_repeat:
         requires:
         - j8_build
     - j11_dtests_vnode:
         requires:
         - j8_build
+    - j11_dtests_vnode_repeat:
+        requires:
+        - j8_build
     - start_j11_dtests_offheap:
         type: approval
     - j11_dtests_offheap:
+        requires:
+        - start_j11_dtests_offheap
+        - j8_build
+    - j11_dtests_offheap_repeat:
         requires:
         - start_j11_dtests_offheap
         - j8_build
@@ -10652,6 +10841,12 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j11_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
@@ -10663,6 +10858,18 @@ workflows:
     - j11_jvm_dtests_vnode:
         requires:
         - start_j11_jvm_dtests_vnode
+        - j11_build
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
+        - j11_build
+    - start_j11_jvm_dtests_vnode_repeat:
+        type: approval
+    - j11_jvm_dtests_vnode_repeat:
+        requires:
+        - start_j11_jvm_dtests_vnode_repeat
         - j11_build
     - start_j11_simulator_dtests:
         type: approval
@@ -10699,6 +10906,12 @@ workflows:
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
+        - j11_build
+    - start_j11_dtests_offheap_repeat:
+        type: approval
+    - j11_dtests_offheap_repeat:
+        requires:
+        - start_j11_dtests_offheap_repeat
         - j11_build
     - start_j11_dtests_large:
         type: approval
@@ -10764,17 +10977,35 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j11_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
     - start_j11_utests_trie:
         type: approval
     - j11_utests_trie:
         requires:
         - start_j11_utests_trie
+        - j11_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
         - j11_build
     - start_j11_utests_stress:
         type: approval
@@ -10794,6 +11025,24 @@ workflows:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+    - start_j11_dtests_repeat:
+        type: approval
+    - j11_dtests_repeat:
+        requires:
+        - start_j11_dtests_repeat
+        - j11_build
+    - start_j11_dtests_vnode_repeat:
+        type: approval
+    - j11_dtests_vnode_repeat:
+        requires:
+        - start_j11_dtests_vnode_repeat
+        - j11_build
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10804,10 +11053,19 @@ workflows:
     - j11_unit_tests:
         requires:
         - j11_build
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests:
         requires:
         - j11_build
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests_vnode:
+        requires:
+        - j11_build
+    - j11_jvm_dtests_vnode_repeat:
         requires:
         - j11_build
     - j11_simulator_dtests:
@@ -10822,7 +11080,13 @@ workflows:
     - j11_dtests:
         requires:
         - j11_build
+    - j11_dtests_repeat:
+        requires:
+        - j11_build
     - j11_dtests_vnode:
+        requires:
+        - j11_build
+    - j11_dtests_vnode_repeat:
         requires:
         - j11_build
     - start_j11_dtests_offheap:
@@ -10830,6 +11094,12 @@ workflows:
     - j11_dtests_offheap:
         requires:
         - start_j11_dtests_offheap
+        - j11_build
+    - start_j11_dtests_offheap_repeat:
+        type: approval
+    - j11_dtests_offheap_repeat:
+        requires:
+        - start_j11_dtests_offheap_repeat
         - j11_build
     - start_j11_dtests_large:
         type: approval
@@ -10885,15 +11155,27 @@ workflows:
         requires:
         - start_utests_cdc
         - j11_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
     - start_utests_trie:
         type: approval
     - j11_utests_trie:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j11_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j11_build
@@ -10912,6 +11194,10 @@ workflows:
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * Add UNMASK permission (CASSANDRA-18069)
  * Add masking functions to column metadata (CASSANDRA-18068)
  * Gossip stateMapOrdering does not have correct ordering when both EndpointState are in the bootstrapping set (CASSANDRA-18292)
  * Snapshot only sstables containing mismatching ranges on preview repair mismatch (CASSANDRA-17561)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * Add SELECT_MASKED permission (CASSANDRA-18070)
  * Add UNMASK permission (CASSANDRA-18069)
  * Add masking functions to column metadata (CASSANDRA-18068)
  * Gossip stateMapOrdering does not have correct ordering when both EndpointState are in the bootstrapping set (CASSANDRA-18292)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.2
+ * Add masking functions to column metadata (CASSANDRA-18068)
  * Gossip stateMapOrdering does not have correct ordering when both EndpointState are in the bootstrapping set (CASSANDRA-18292)
  * Snapshot only sstables containing mismatching ranges on preview repair mismatch (CASSANDRA-17561)
  * More accurate skipping of sstables in read path (CASSANDRA-18134)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -131,6 +131,8 @@ New features
       the masked data during queries, but they don't change the stored data.
     - Added new UNMASK permission. It allows to see the clear data of columns with an attached mask. Superusers have it
       by default, whereas regular users don't have it by default.
+    - Added new SELECT_MASKED permission. It allows to run SELECT queries selecting the clear values of masked columns.
+      Superusers have it by default, whereas regular users don't have it by default.
 
 Upgrading
 ---------

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -126,6 +126,9 @@ New features
       normally require it, except `system_views.system_logs`.
     - More accurate skipping of sstables in read path due to better handling of min/max clustering and lower bound;
       SSTable format has been bumped to 'nc' because there are new fields in stats metadata
+    - Added support for attaching CQL dynamic data masking functions to table columns on the schema. These masking
+      functions can be attached to or dettached from columns with CREATE/ALTER TABLE statements. The functions obscure
+      the masked data during queries, but they don't change the stored data.
 
 Upgrading
 ---------

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -129,6 +129,8 @@ New features
     - Added support for attaching CQL dynamic data masking functions to table columns on the schema. These masking
       functions can be attached to or dettached from columns with CREATE/ALTER TABLE statements. The functions obscure
       the masked data during queries, but they don't change the stored data.
+    - Added new UNMASK permission. It allows to see the clear data of columns with an attached mask. Superusers have it
+      by default, whereas regular users don't have it by default.
 
 Upgrading
 ---------

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -1529,6 +1529,7 @@ The full set of available permissions is:
 * @DESCRIBE@
 * @EXECUTE@
 * @UNMASK@
+* @SELECT_MASKED@
 
 Not all permissions are applicable to every type of resource. For instance, @EXECUTE@ is only relevant in the context of functions or mbeans; granting @EXECUTE@ on a resource representing a table is nonsensical. Attempting to @GRANT@ a permission on resource to which it cannot be applied results in an error response. The following illustrates which permissions can be granted on which types of resource, and which statements are enabled by that permission.
 
@@ -1591,6 +1592,9 @@ Not all permissions are applicable to every type of resource. For instance, @EXE
 | @UNMASK@     | @ALL KEYSPACES@              |See the clear contents of masked columns on any table|
 | @UNMASK@     | @KEYSPACE@                   |See the clear contents of masked columns on any table in keyspace|
 | @UNMASK@     | @TABLE@                      |See the clear contents of masked columns on the specified table|
+| @SELECT_MASKED@ | @ALL KEYSPACES@           |Select restricting masked columns on any table|
+| @SELECT_MASKED@ | @KEYSPACE@                |Select restricting masked columns on any table in keyspace|
+| @SELECT_MASKED@ | @TABLE@                   |Select restricting masked columns on the specified table|
 
 
 h3(#grantPermissionsStmt). GRANT PERMISSION
@@ -1600,7 +1604,7 @@ __Syntax:__
 bc(syntax).. 
 <grant-permission-stmt> ::= GRANT ( ALL ( PERMISSIONS )? | <permission> ( PERMISSION )? (, PERMISSION)* ) ON <resource> TO <identifier>
 
-<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE | UNMASK
+<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE | UNMASK | SELECT_MASKED
 
 <resource> ::= ALL KEYSPACES
              | KEYSPACE <identifier>
@@ -1657,7 +1661,7 @@ __Syntax:__
 bc(syntax).. 
 <revoke-permission-stmt> ::= REVOKE ( ALL ( PERMISSIONS )? | <permission> ( PERMISSION )? (, PERMISSION)* ) ON <resource> FROM <identifier>
 
-<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE | UNMASK
+<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE | UNMASK | SELECT_MASKED
 
 <resource> ::= ALL KEYSPACES
              | KEYSPACE <identifier>
@@ -2530,6 +2534,7 @@ CQL distinguishes between _reserved_ and _non-reserved_ keywords. Reserved keywo
 | @ROLES@        | no  |
 | @SCHEMA@       | yes |
 | @SELECT@       | yes |
+| @SELECT_MASKED@| no  |
 | @SET@          | yes |
 | @SFUNC@        | no  |
 | @SMALLINT@     | no  |

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -252,8 +252,10 @@ bc(syntax)..
                           '(' <column-definition> ( ',' <column-definition> )* ')'
                           ( WITH <option> ( AND <option>)* )?
 
-<column-definition> ::= <identifier> <type> ( STATIC )? ( PRIMARY KEY )?
+<column-definition> ::= <identifier> <type> ( STATIC )? ( <column_mask> )? ( PRIMARY KEY )?
                       | PRIMARY KEY '(' <partition-key> ( ',' <identifier> )* ')'
+
+<column-mask> ::= MASKED WITH ( DEFAULT | <function> '(' ( <term> (',' <term>)* )?  ')' )
 
 <partition-key> ::= <identifier>
                   | '(' <identifier> (',' <identifier> )* ')'
@@ -413,11 +415,15 @@ __Syntax:__
 bc(syntax).. 
 <alter-table-stmt> ::= ALTER (TABLE | COLUMNFAMILY) (IF NOT EXISTS)? <tablename> <instruction>
 
-<instruction> ::= ADD (IF NOT EXISTS)? ( <identifier> <type> ( , <identifier> <type> )* )
+<instruction> ::= ADD (IF NOT EXISTS)? ( <identifier> <type> ( <column-mask> )?
+                                       ( , <identifier> <type> ( <column-mask> )? )* )
                 | DROP  (IF EXISTS)? ( <identifier> ( , <identifier> )* )
+                | ALTER <identifier> ( <column-mask> | DROP MASKED )
                 | RENAME (IF EXISTS)? <identifier> to <identifier> (AND <identifier> to <identifier>)*
                 | DROP COMPACT STORAGE
                 | WITH  <option> ( AND <option> )*
+
+<column-mask> ::= MASKED WITH ( DEFAULT | <function> '(' ( <term> (',' <term>)* )?  ')' )
 p. 
 __Sample:__
 
@@ -437,6 +443,7 @@ If the table does not exist, the statement will return an error, unless @IF EXIS
 The @<tablename>@ is the table name optionally preceded by the keyspace name.  The @<instruction>@ defines the alteration to perform:
 * @ADD@: Adds a new column to the table. The @<identifier>@ for the new column must not conflict with an existing column. Moreover, columns cannot be added to tables defined with the @COMPACT STORAGE@ option. If the new column already exists, the statement will return an error, unless @IF NOT EXISTS@ is used in which case the operation is a no-op.
 * @DROP@: Removes a column from the table. Dropped columns will immediately become unavailable in the queries and will not be included in compacted sstables in the future. If a column is readded, queries won't return values written before the column was last dropped. It is assumed that timestamps represent actual time, so if this is not your case, you should NOT readd previously dropped columns. Columns can't be dropped from tables defined with the @COMPACT STORAGE@ option. If the dropped column does not already exist, the statement will return an error, unless @IF EXISTS@ is used in which case the operation is a no-op.
+* @ALTER@: Alters an existing column. It can be used to set its data mask, or to set it as unmasked. The data mask is any function meant to obscure the real values of the column.
 * @RENAME@ a primary key column of a table. Non primary key columns cannot be renamed. Furthermore, renaming a column to another name which already exists isn't allowed. It's important to keep in mind that renamed columns shouldn't have dependent secondary indexes. If the renamed column does not already exist, the statement will return an error, unless @IF EXISTS@ is used in which case the operation is a no-op.
 * @DROP COMPACT STORAGE@: Removes Thrift compatibility mode from the table.
 * @WITH@: Allows to update the options of the table. The "supported @<option>@":#createTableOptions (and syntax) are the same as for the @CREATE TABLE@ statement except that @COMPACT STORAGE@ is not supported. Note that setting any @compaction@ sub-options has the effect of erasing all previous @compaction@ options, so you  need to re-specify all the sub-options if you want to keep them. The same note applies to the set of @compression@ sub-options.
@@ -2489,6 +2496,7 @@ CQL distinguishes between _reserved_ and _non-reserved_ keywords. Reserved keywo
 | @LIST@         | no  |
 | @LOGIN@        | no  |
 | @MAP@          | no  |
+| @MASKED@       | no  |
 | @MATERIALIZED@ | yes |
 | @MBEAN@        | yes |
 | @MBEANS@       | yes |
@@ -2553,7 +2561,7 @@ CQL distinguishes between _reserved_ and _non-reserved_ keywords. Reserved keywo
 | @WHERE@        | yes |
 | @WITH@         | yes |
 | @WRITETIME@    | no  |
-| @MAXWRITETIME@    | no  |
+| @MAXWRITETIME@ | no  |
 
 h2(#appendixB). Appendix B: CQL Reserved Types
 

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -1528,6 +1528,7 @@ The full set of available permissions is:
 * @AUTHORIZE@
 * @DESCRIBE@
 * @EXECUTE@
+* @UNMASK@
 
 Not all permissions are applicable to every type of resource. For instance, @EXECUTE@ is only relevant in the context of functions or mbeans; granting @EXECUTE@ on a resource representing a table is nonsensical. Attempting to @GRANT@ a permission on resource to which it cannot be applied results in an error response. The following illustrates which permissions can be granted on which types of resource, and which statements are enabled by that permission.
 
@@ -1587,6 +1588,9 @@ Not all permissions are applicable to every type of resource. For instance, @EXE
 | @EXECUTE@    | @ALL MBEANS@                 |Execute operations on any mbean|
 | @EXECUTE@    | @MBEANS@                     |Execute operations on any mbean matching a wildcard pattern|
 | @EXECUTE@    | @MBEAN@                      |Execute operations on named mbean|
+| @UNMASK@     | @ALL KEYSPACES@              |See the clear contents of masked columns on any table|
+| @UNMASK@     | @KEYSPACE@                   |See the clear contents of masked columns on any table in keyspace|
+| @UNMASK@     | @TABLE@                      |See the clear contents of masked columns on the specified table|
 
 
 h3(#grantPermissionsStmt). GRANT PERMISSION
@@ -1596,7 +1600,7 @@ __Syntax:__
 bc(syntax).. 
 <grant-permission-stmt> ::= GRANT ( ALL ( PERMISSIONS )? | <permission> ( PERMISSION )? (, PERMISSION)* ) ON <resource> TO <identifier>
 
-<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE
+<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE | UNMASK
 
 <resource> ::= ALL KEYSPACES
              | KEYSPACE <identifier>
@@ -1653,7 +1657,7 @@ __Syntax:__
 bc(syntax).. 
 <revoke-permission-stmt> ::= REVOKE ( ALL ( PERMISSIONS )? | <permission> ( PERMISSION )? (, PERMISSION)* ) ON <resource> FROM <identifier>
 
-<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE
+<permission> ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | EXECUTE | UNMASK
 
 <resource> ::= ALL KEYSPACES
              | KEYSPACE <identifier>
@@ -2547,6 +2551,7 @@ CQL distinguishes between _reserved_ and _non-reserved_ keywords. Reserved keywo
 | @TUPLE@        | no  |
 | @TYPE@         | no  |
 | @UNLOGGED@     | yes |
+| @UNMASK@       | no  |
 | @UNSET@        | yes |
 | @UPDATE@       | yes |
 | @USE@          | yes |

--- a/doc/modules/cassandra/examples/BNF/alter_table.bnf
+++ b/doc/modules/cassandra/examples/BNF/alter_table.bnf
@@ -1,5 +1,8 @@
 alter_table_statement::= ALTER TABLE [ IF EXISTS ] table_name alter_table_instruction
-alter_table_instruction::= ADD [ IF NOT EXISTS ] column_name cql_type ( ',' column_name cql_type )*
+alter_table_instruction::= ADD [ IF NOT EXISTS ] column_definition ( ',' column_definition)*
 	| DROP [ IF EXISTS ] column_name ( ',' column_name )*
 	| RENAME [ IF EXISTS ] column_name to column_name (AND column_name to column_name)*
+	| ALTER [ IF EXISTS ] column_name ( column_mask | DROP MASKED )
 	| WITH options
+column_definition::= column_name cql_type [ column_mask]
+column_mask::= MASKED WITH ( DEFAULT | function_name '(' term ( ',' term )* ')' )

--- a/doc/modules/cassandra/examples/BNF/create_table.bnf
+++ b/doc/modules/cassandra/examples/BNF/create_table.bnf
@@ -2,11 +2,12 @@ create_table_statement::= CREATE TABLE [ IF NOT EXISTS ] table_name '('
 	column_definition  ( ',' column_definition )*  
 	[ ',' PRIMARY KEY '(' primary_key ')' ] 
 	 ')' [ WITH table_options ] 
-column_definition::= column_name cql_type [ STATIC ] [ PRIMARY KEY] 
+column_definition::= column_name cql_type [ STATIC ] [ column_mask ] [ PRIMARY KEY]
+column_mask::= MASKED WITH ( DEFAULT | function_name '(' term ( ',' term )* ')' )
 primary_key::= partition_key [ ',' clustering_columns ] 
 partition_key::= column_name  | '(' column_name ( ',' column_name )* ')' 
 clustering_columns::= column_name ( ',' column_name )* 
-table_options:=: COMPACT STORAGE [ AND table_options ]  
+table_options::= COMPACT STORAGE [ AND table_options ]
 	| CLUSTERING ORDER BY '(' clustering_order ')' 
 	[ AND table_options ]  | options
 clustering_order::= column_name (ASC | DESC) ( ',' column_name (ASC | DESC) )*

--- a/doc/modules/cassandra/examples/BNF/grant_permission_statement.bnf
+++ b/doc/modules/cassandra/examples/BNF/grant_permission_statement.bnf
@@ -1,6 +1,6 @@
 grant_permission_statement ::= GRANT permissions ON resource TO role_name
 permissions ::= ALL [ PERMISSIONS ] | permission [ PERMISSION ]
-permission ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESCRIBE | EXECUTE | UNMASK
+permission ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESCRIBE | EXECUTE | UNMASK | SELECT_MASKED
 resource ::=    ALL KEYSPACES
                 | KEYSPACE keyspace_name
                 | [ TABLE ] table_name

--- a/doc/modules/cassandra/examples/BNF/grant_permission_statement.bnf
+++ b/doc/modules/cassandra/examples/BNF/grant_permission_statement.bnf
@@ -1,6 +1,6 @@
 grant_permission_statement ::= GRANT permissions ON resource TO role_name
 permissions ::= ALL [ PERMISSIONS ] | permission [ PERMISSION ]
-permission ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESCRIBE | EXECUTE
+permission ::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESCRIBE | EXECUTE | UNMASK
 resource ::=    ALL KEYSPACES
                 | KEYSPACE keyspace_name
                 | [ TABLE ] table_name

--- a/doc/modules/cassandra/examples/CQL/ddm_alter_mask.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_alter_mask.cql
@@ -1,0 +1,1 @@
+ALTER TABLE patients ALTER name MASKED WITH mask_default();

--- a/doc/modules/cassandra/examples/CQL/ddm_create_table.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_create_table.cql
@@ -1,0 +1,5 @@
+CREATE TABLE patients (
+   id timeuuid PRIMARY KEY,
+   name text MASKED WITH mask_inner(1, null),
+   birth date MASKED WITH mask_default()
+);

--- a/doc/modules/cassandra/examples/CQL/ddm_create_users.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_create_users.cql
@@ -1,0 +1,6 @@
+CREATE USER privileged WITH PASSWORD 'xyz';
+GRANT SELECT ON TABLE patients TO privileged;
+GRANT UNMASK ON TABLE patients TO privileged;
+
+CREATE USER unprivileged WITH PASSWORD 'xyz';
+GRANT SELECT ON TABLE patients TO unprivileged;

--- a/doc/modules/cassandra/examples/CQL/ddm_drop_mask.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_drop_mask.cql
@@ -1,0 +1,1 @@
+ALTER TABLE patients ALTER name DROP MASKED;

--- a/doc/modules/cassandra/examples/CQL/ddm_insert_data.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_insert_data.cql
@@ -1,0 +1,2 @@
+INSERT INTO patients(id, name, birth) VALUES (now(), 'alice', '1984-01-02');
+INSERT INTO patients(id, name, birth) VALUES (now(), 'bob', '1982-02-03');

--- a/doc/modules/cassandra/examples/CQL/ddm_revoke_unmask.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_revoke_unmask.cql
@@ -1,0 +1,1 @@
+REVOKE UNMASK ON TABLE patients FROM privileged;

--- a/doc/modules/cassandra/examples/CQL/ddm_select_with_masked_columns.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_select_with_masked_columns.cql
@@ -1,0 +1,6 @@
+SELECT name, birth FROM patients;
+
+//  name  | birth
+// -------+------------
+//  a**** | 1970-01-01
+//    b** | 1970-01-01

--- a/doc/modules/cassandra/examples/CQL/ddm_select_with_select_masked.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_select_with_select_masked.cql
@@ -1,0 +1,8 @@
+CREATE USER trusted_user WITH PASSWORD 'xyz';
+GRANT SELECT, SELECT_MASKED ON TABLE patients TO trusted_user;
+LOGIN trusted_user
+SELECT name, birth FROM patients WHERE name = 'Alice' ALLOW FILTERING;
+
+//  name  | birth
+// -------+------------
+//  a**** | 1970-01-01

--- a/doc/modules/cassandra/examples/CQL/ddm_select_with_unmask_permission.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_select_with_unmask_permission.cql
@@ -1,0 +1,7 @@
+LOGIN privileged
+SELECT name, birth FROM patients;
+
+//  name  | birth
+// -------+------------
+//  alice | 1984-01-02
+//    bob | 1982-02-03

--- a/doc/modules/cassandra/examples/CQL/ddm_select_without_select_masked.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_select_without_select_masked.cql
@@ -1,0 +1,6 @@
+CREATE USER untrusted_user WITH PASSWORD 'xyz';
+GRANT SELECT ON TABLE patients TO untrusted_user;
+LOGIN untrusted_user
+SELECT name, birth FROM patients WHERE name = 'Alice' ALLOW FILTERING;
+
+// Unauthorized: Error from server: code=2100 [Unauthorized] message="User untrusted_user has no UNMASK nor SELECT_UNMASK permission on table k.patients"

--- a/doc/modules/cassandra/examples/CQL/ddm_select_without_unmask_permission.cql
+++ b/doc/modules/cassandra/examples/CQL/ddm_select_without_unmask_permission.cql
@@ -1,0 +1,7 @@
+LOGIN unprivileged
+SELECT name, birth FROM patients;
+
+//  name  | birth
+// -------+------------
+//  a**** | 1970-01-01
+//    b** | 1970-01-01

--- a/doc/modules/cassandra/examples/CQL/select_with_mask_functions.cql
+++ b/doc/modules/cassandra/examples/CQL/select_with_mask_functions.cql
@@ -1,0 +1,15 @@
+CREATE TABLE patients (
+   id timeuuid PRIMARY KEY,
+   name text,
+   birth date
+);
+
+INSERT INTO patients(id, name, birth) VALUES (now(), 'alice', '1982-01-02');
+INSERT INTO patients(id, name, birth) VALUES (now(), 'bob', '1982-01-02');
+
+SELECT mask_inner(name, 1, null), mask_default(birth) FROM patients;
+
+//   system.mask_inner(name, 1, NULL) | system.mask_default(birth)
+// -----------------------------------+----------------------------
+//                                b** |                 1970-01-01
+//                              a**** |                 1970-01-01

--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -39,6 +39,7 @@
 *** xref:cql/functions.adoc[Functions]
 *** xref:cql/json.adoc[JSON]
 *** xref:cql/security.adoc[Security]
+*** xref:cql/dynamic_data_masking.adoc[Dynamic data masking]
 *** xref:cql/triggers.adoc[Triggers]
 *** xref:cql/appendices.adoc[Appendices]
 *** xref:cql/changes.adoc[Changes]

--- a/doc/modules/cassandra/pages/cql/appendices.adoc
+++ b/doc/modules/cassandra/pages/cql/appendices.adoc
@@ -128,6 +128,7 @@ or not.
 |`TUPLE` |no
 |`TYPE` |no
 |`UNLOGGED` |yes
+|`UNMASK` |no
 |`UPDATE` |yes
 |`USE` |yes
 |`USER` |no

--- a/doc/modules/cassandra/pages/cql/appendices.adoc
+++ b/doc/modules/cassandra/pages/cql/appendices.adoc
@@ -107,6 +107,7 @@ or not.
 |`ROLES` |no
 |`SCHEMA` |yes
 |`SELECT` |yes
+|`SELECT_MASKED` |no
 |`SET` |yes
 |`SFUNC` |no
 |`SMALLINT` |no

--- a/doc/modules/cassandra/pages/cql/appendices.adoc
+++ b/doc/modules/cassandra/pages/cql/appendices.adoc
@@ -82,6 +82,7 @@ or not.
 |`LIST` |no
 |`LOGIN` |no
 |`MAP` |no
+|`MASKED` |no
 |`MODIFY` |yes
 |`NAN` |yes
 |`NOLOGIN` |no

--- a/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
@@ -3611,6 +3611,7 @@ or not.
 |`LIST` |no
 |`LOGIN` |no
 |`MAP` |no
+|`MASKED` |no
 |`MATERIALIZED` |yes
 |`MBEAN` |yes
 |`MBEANS` |yes

--- a/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
@@ -2262,6 +2262,7 @@ The full set of available permissions is:
 * `AUTHORIZE`
 * `DESCRIBE`
 * `EXECUTE`
+* `UNMASK`
 
 Not all permissions are applicable to every type of resource. For
 instance, `EXECUTE` is only relevant in the context of functions or
@@ -2420,6 +2421,12 @@ use of function in `CREATE AGGREGATE` | | |
 wildcard pattern | | |
 
 |`EXECUTE` |`MBEAN` |Execute operations on named mbean | | |
+
+|`UNMASK` |`ALL KEYSPACES` |See the clear contents of masked columns on any table | | |
+
+|`UNMASK` |`KEYSPACE` |See the clear contents of masked columns on any table in keyspace | | |
+
+|`UNMASK` |`TABLE` |See the clear contents of masked columns on the specified table | | |
 |===
 
 [[grantPermissionsStmt]]
@@ -2430,7 +2437,7 @@ _Syntax:_
 bc(syntax).. +
 ::= GRANT ( ALL ( PERMISSIONS )? | ( PERMISSION )? ) ON TO
 
-::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE |
+::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | UNMASK
 EXECUTE
 
 ::= ALL KEYSPACES +
@@ -2502,7 +2509,7 @@ _Syntax:_
 bc(syntax).. +
 ::= REVOKE ( ALL ( PERMISSIONS )? | ( PERMISSION )? ) ON FROM
 
-::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE |
+::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | UNMASK
 EXECUTE
 
 ::= ALL KEYSPACES +
@@ -3662,6 +3669,7 @@ or not.
 |`TUPLE` |no
 |`TYPE` |no
 |`UNLOGGED` |yes
+|`UNMASK` |no
 |`UNSET` |yes
 |`UPDATE` |yes
 |`USE` |yes

--- a/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/cql/cql_singlefile.adoc
@@ -2263,6 +2263,7 @@ The full set of available permissions is:
 * `DESCRIBE`
 * `EXECUTE`
 * `UNMASK`
+* `SELECT_MASKED`
 
 Not all permissions are applicable to every type of resource. For
 instance, `EXECUTE` is only relevant in the context of functions or
@@ -2427,6 +2428,12 @@ wildcard pattern | | |
 |`UNMASK` |`KEYSPACE` |See the clear contents of masked columns on any table in keyspace | | |
 
 |`UNMASK` |`TABLE` |See the clear contents of masked columns on the specified table | | |
+
+|`SELECT_MASKED` | `ALL KEYSPACES` | `SELECT` restricting masked columns on any table | | |
+
+|`SELECT_MASKED` | `KEYSPACE` | `SELECT` restricting masked columns on any table in specified keyspace | | |
+
+|`SELECT_MASKED` | `TABLE` | `SELECT` restricting masked columns on the specified table | | |
 |===
 
 [[grantPermissionsStmt]]
@@ -2437,7 +2444,7 @@ _Syntax:_
 bc(syntax).. +
 ::= GRANT ( ALL ( PERMISSIONS )? | ( PERMISSION )? ) ON TO
 
-::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | UNMASK
+::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | UNMASK | SELECT_MASKED
 EXECUTE
 
 ::= ALL KEYSPACES +
@@ -2509,7 +2516,7 @@ _Syntax:_
 bc(syntax).. +
 ::= REVOKE ( ALL ( PERMISSIONS )? | ( PERMISSION )? ) ON FROM
 
-::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | UNMASK
+::= CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESRIBE | UNMASK | SELECT_MASKED
 EXECUTE
 
 ::= ALL KEYSPACES +
@@ -3648,6 +3655,7 @@ or not.
 |`ROLES` |no
 |`SCHEMA` |yes
 |`SELECT` |yes
+|`SELECT_MASKED` |no
 |`SET` |yes
 |`SFUNC` |no
 |`SMALLINT` |no

--- a/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
+++ b/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
@@ -1,0 +1,69 @@
+= Dynamic Data Masking
+
+Dynamic data masking (DDM) allows to obscure sensitive information while still allowing access to the masked columns.
+DDM doesn't change the stored data. Instead, it just presents the data on their obscured form during `SELECT` queries.
+This aims to provide some degree of protection against accidental data exposure. However, it's important to know that
+anyone with direct access to the sstable files will be able to read the clear data.
+
+== Masking functions
+
+DDM is based on a set of CQL native functions that obscure sensitive information. The available functions are:
+
+include::partial$masking_functions.adoc[]
+
+Those functions can be discretionarily used on `SELECT` queries to get an obscured view of the data. For example:
+
+[source,cql]
+----
+include::example$CQL/select_with_mask_functions.cql[]
+----
+
+== Attaching masking functions to table columns
+
+The masking functions can be permanently attached to the columns of a table.
+In that case, `SELECT` queries will always return the column values in their masked form.
+The masking will be transparent for the users running `SELECT` queries,
+so their only way to know that a column is masked will be consulting the table definition.
+
+The masks of the columns of a table can be defined on `CREATE TABLE` queries:
+
+[source,cql]
+----
+include::example$CQL/ddm_create_table.cql[]
+----
+
+Note that in the example above we are referencing the `mask_inner` function with two arguments.
+However, that CQL function actually has three arguments when explicitely used on `SELECT` queries.
+The first argument is always ommitted when attaching the function to a schema column.
+The value of that first argument is always interpreted as the value of the masked column, in this case a `text` column.
+For the same reason the call to `mask_default` attached to the column doesn't have any argument,
+even when that function requires one argument when explicitely used on `SELECT` queries.
+
+Data can be inserted into the masked table as usual. For example:
+
+[source,cql]
+----
+include::example$CQL/ddm_insert_data.cql[]
+----
+
+The attached column masks will make `SELECT` queries automatically return masked data,
+without the need of including the masking function on the query:
+
+[source,cql]
+----
+include::example$CQL/ddm_select_with_masked_columns.cql[]
+----
+
+The masking function attached to a column can be changed with an `ALTER TABLE` query:
+
+[source,cql]
+----
+include::example$CQL/ddm_alter_mask.cql[]
+----
+
+In a similar way, a masking function can be dettached from a column with an `ALTER TABLE` query:
+
+[source,cql]
+----
+include::example$CQL/ddm_drop_mask.cql[]
+----

--- a/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
+++ b/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
@@ -125,3 +125,23 @@ include::example$CQL/ddm_revoke_unmask.cql[]
 Please note that the anonymous user that is used when authentication is disabled has all the permissions.
 Since it includes the `UNMASK` permission, that anonymous user will always see the clear data.
 In other words, attaching data masking functions to columns only makes sense if authentication is enabled.
+
+Users without the `UNMASK` permission are not allowed to use masked columns in the `WHERE` clause of a `SELECT` query.
+This prevents malicious users from figuring out the clear data by running exhaustive queries. For instance:
+
+[source,cql]
+----
+include::example$CQL/ddm_select_without_select_masked.cql[]
+----
+
+However, there are some use cases where trusted database users just need a useful way to produce masked data
+that will be served to untrusted external users.
+For example, a trusted app can connect to the database and extract masked data that will be served to its end users.
+In that case the trusted user (the app) can be given the `SELECT_MASKED` permission.
+That permission allows to use masked columns in the `WHERE` clause of a `SELECT` query,
+while still seeing the masked data in the query results. For instance:
+
+[source,cql]
+----
+include::example$CQL/ddm_select_with_select_masked.cql[]
+----

--- a/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
+++ b/doc/modules/cassandra/pages/cql/dynamic_data_masking.adoc
@@ -67,3 +67,61 @@ In a similar way, a masking function can be dettached from a column with an `ALT
 ----
 include::example$CQL/ddm_drop_mask.cql[]
 ----
+
+== Permissions
+
+The `UNMASK` permission allows users to retrieve the unmasked values of masked columns.
+The masks will only be applied to the results of a `SELECT` query if the user doesn't have the `UNMASK` permission.
+Ordinary users are created without the `UNMASK` permission, whereas superusers do have it.
+
+As an example, suppose that we have a table with masked columns:
+
+[source,cql]
+----
+include::example$CQL/ddm_create_table.cql[]
+----
+
+And we insert some data into the table:
+
+[source,cql]
+----
+include::example$CQL/ddm_insert_data.cql[]
+----
+
+[source,cql]
+----
+include::example$CQL/ddm_select_without_unmask_permission.cql[]
+----
+
+Then we create two users with `SELECT` permission for the table, but we only grant the `UNMASK` permission to one of
+the users:
+
+[source,cql]
+----
+include::example$CQL/ddm_create_users.cql[]
+----
+
+We can now see that the user with the `UNMASK` permission can see the clear data, without any masking:
+
+[source,cql]
+----
+include::example$CQL/ddm_select_with_unmask_permission.cql[]
+----
+
+However, the user without the `UNMASK` permission can only see the masked data:
+
+[source,cql]
+----
+include::example$CQL/ddm_select_without_unmask_permission.cql[]
+----
+
+The `UNMASK` permission works as any other permission. Thus, it can be revoked in any moment:
+
+[source,cql]
+----
+include::example$CQL/ddm_revoke_unmask.cql[]
+----
+
+Please note that the anonymous user that is used when authentication is disabled has all the permissions.
+Since it includes the `UNMASK` permission, that anonymous user will always see the clear data.
+In other words, attaching data masking functions to columns only makes sense if authentication is enabled.

--- a/doc/modules/cassandra/pages/cql/functions.adoc
+++ b/doc/modules/cassandra/pages/cql/functions.adoc
@@ -281,71 +281,12 @@ A number of functions are provided to operate on collection columns.
 | `collection_avg` | numeric `set` or `list` | Computes the average of the elements in the collection argument. The average of an empty collection returns zero. The returned value is of the same type as the input collection elements, which might include rounding and truncations. For example `collection_avg([1, 2])` returns `1` instead of `1.5`.
 |===
 
+[[data-masking-functions]]
 ===== Data masking functions
 
 A number of functions allow to obscure the real contents of a column containing sensitive data.
 
-[cols=",",options="header",]
-|===
-|Function | Description
-
-| `mask_null(value)` | Replaces the first argument by a `null` column. The returned value is always an absent column, as it didn't exist, and not a not-null column representing a `null` value.
-
-Examples:
-
-`mask_null('Alice')` -> `null`
-
-`mask_null(123)` -> `null`
-
-| `mask_default(value)` | Replaces its argument by an arbitrary, fixed default value of the same type. This will be `\***\***` for text values, zero for numeric values, `false` for booleans, etc.
-
-Examples:
-
-`mask_default('Alice')` -> `'\****'`
-
-`mask_default(123)` -> `0`
-
-| `mask_replace(value, replacement])` | Replaces the first argument by the replacement value on the second argument. The replacement value needs to have the same type as the replaced value.
-
-Examples:
-
-`mask_replace('Alice', 'REDACTED')` -> `'REDACTED'`
-
-`mask_replace(123, -1)` -> `-1`
-
-| `mask_inner(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing each character except the first and last ones by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
-
-Examples:
-
-`mask_inner('Alice', 1, 2)` -> `'A**ce'`
-
-`mask_inner('Alice', 1, null)` -> `'A****'`
-
-`mask_inner('Alice', null, 2)` -> `'***ce'`
-
-`mask_inner('Alice', 2, 1, '\#')` -> `'Al##e'`
-
-| `mask_outer(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing the first and last character by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
-
-Examples:
-
-`mask_outer('Alice', 1, 2)` -> `'*li**'`
-
-`mask_outer('Alice', 1, null)` -> `'*lice'`
-
-`mask_outer('Alice', null, 2)` -> `'Ali**'`
-
-`mask_outer('Alice', 2, 1, '\#')` -> `'##ic#'`
-
-| `mask_hash(value, [algorithm])` | Returns a `blob` containing the hash of the first argument. The optional 2nd argument is the hashing algorithm to be used, according the available Java security provider. The default hashing algorithm is `SHA-256`.
-
-Examples:
-
-`mask_hash('Alice')`
-
-`mask_hash('Alice', 'SHA-512')`
-
-|===
+include::partial$masking_functions.adoc[]
 
 [[user-defined-scalar-functions]]
 ==== User-defined functions

--- a/doc/modules/cassandra/pages/cql/index.adoc
+++ b/doc/modules/cassandra/pages/cql/index.adoc
@@ -19,6 +19,7 @@ For that reason, when used in this document, these terms (tables, rows and colum
 * xref:cql/functions.adoc[Functions]
 * xref:cql/json.adoc[JSON]
 * xref:cql/security.adoc[CQL security]
+* xref:cql/dynamic_data_masking.adoc[Dynamic data masking]
 * xref:cql/triggers.adoc[Triggers]
 * xref:cql/appendices.adoc[Appendices]
 * xref:cql/changes.adoc[Changes]

--- a/doc/modules/cassandra/pages/cql/security.adoc
+++ b/doc/modules/cassandra/pages/cql/security.adoc
@@ -353,6 +353,7 @@ The full set of available permissions is:
 * `DESCRIBE`
 * `EXECUTE`
 * `UNMASK`
+* `SELECT_MASKED`
 
 Not all permissions are applicable to every type of resource. For
 instance, `EXECUTE` is only relevant in the context of functions or
@@ -484,6 +485,12 @@ and use of any function in keyspace in `CREATE AGGREGATE`
 |`UNMASK` |`KEYSPACE` | See the clear contents of masked columns on any table in keyspace
 
 |`UNMASK` |`TABLE` | See the clear contents of masked columns on the specified table
+
+|`SELECT_MASKED` | `ALL KEYSPACES` | `SELECT` restricting masked columns on any table
+
+|`SELECT_MASKED` | `KEYSPACE` | `SELECT` restricting masked columns on any table in specified keyspace
+
+|`SELECT_MASKED` | `TABLE` | `SELECT` restricting masked columns on the specified table
 |===
 
 [[grant-permission-statement]]

--- a/doc/modules/cassandra/pages/cql/security.adoc
+++ b/doc/modules/cassandra/pages/cql/security.adoc
@@ -352,6 +352,7 @@ The full set of available permissions is:
 * `AUTHORIZE`
 * `DESCRIBE`
 * `EXECUTE`
+* `UNMASK`
 
 Not all permissions are applicable to every type of resource. For
 instance, `EXECUTE` is only relevant in the context of functions or
@@ -477,6 +478,12 @@ and use of any function in keyspace in `CREATE AGGREGATE`
 | `EXECUTE` | `MBEANS` | Execute operations on any mbean matching a wildcard pattern
 
 | `EXECUTE` | `MBEAN` | Execute operations on named mbean
+
+|`UNMASK` |`ALL KEYSPACES` | See the clear contents of masked columns on any table
+
+|`UNMASK` |`KEYSPACE` | See the clear contents of masked columns on any table in keyspace
+
+|`UNMASK` |`TABLE` | See the clear contents of masked columns on the specified table
 |===
 
 [[grant-permission-statement]]

--- a/doc/modules/cassandra/partials/masking_functions.adoc
+++ b/doc/modules/cassandra/partials/masking_functions.adoc
@@ -1,0 +1,61 @@
+[cols=",",options="header",]
+|===
+|Function | Description
+
+| `mask_null(value)` | Replaces the first argument by a `null` column. The returned value is always an absent column, as it didn't exist, and not a not-null column representing a `null` value.
+
+Examples:
+
+`mask_null('Alice')` -> `null`
+
+`mask_null(123)` -> `null`
+
+| `mask_default(value)` | Replaces its argument by an arbitrary, fixed default value of the same type. This will be `\***\***` for text values, zero for numeric values, `false` for booleans, etc.
+
+Examples:
+
+`mask_default('Alice')` -> `'\****'`
+
+`mask_default(123)` -> `0`
+
+| `mask_replace(value, replacement])` | Replaces the first argument by the replacement value on the second argument. The replacement value needs to have the same type as the replaced value.
+
+Examples:
+
+`mask_replace('Alice', 'REDACTED')` -> `'REDACTED'`
+
+`mask_replace(123, -1)` -> `-1`
+
+| `mask_inner(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing each character except the first and last ones by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
+
+Examples:
+
+`mask_inner('Alice', 1, 2)` -> `'A**ce'`
+
+`mask_inner('Alice', 1, null)` -> `'A****'`
+
+`mask_inner('Alice', null, 2)` -> `'***ce'`
+
+`mask_inner('Alice', 2, 1, '\#')` -> `'Al##e'`
+
+| `mask_outer(value, begin, end, [padding])` | Returns a copy of the first `text`, `varchar` or `ascii` argument, replacing the first and last character by a padding character. The 2nd and 3rd arguments are the size of the exposed prefix and suffix. The optional 4th argument is the padding character, `\*` by default.
+
+Examples:
+
+`mask_outer('Alice', 1, 2)` -> `'*li**'`
+
+`mask_outer('Alice', 1, null)` -> `'*lice'`
+
+`mask_outer('Alice', null, 2)` -> `'Ali**'`
+
+`mask_outer('Alice', 2, 1, '\#')` -> `'##ic#'`
+
+| `mask_hash(value, [algorithm])` | Returns a `blob` containing the hash of the first argument. The optional 2nd argument is the hashing algorithm to be used, according the available Java security provider. The default hashing algorithm is `SHA-256`.
+
+Examples:
+
+`mask_hash('Alice')`
+
+`mask_hash('Alice', 'SHA-512')`
+
+|===

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -313,7 +313,9 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
 
 <userType> ::= utname=<cfOrKsName> ;
 
-<storageType> ::= <simpleStorageType> | <collectionType> | <frozenCollectionType> | <userType> ;
+<storageType> ::= ( <simpleStorageType> | <collectionType> | <frozenCollectionType> | <userType> ) ( <column_mask> )? ;
+
+<column_mask> ::= "MASKED" "WITH" ( "DEFAULT" | <functionName> <selectionFunctionArguments> );
 
 # Note: autocomplete for frozen collection types does not handle nesting past depth 1 properly,
 # but that's a lot of work to fix for little benefit.
@@ -1428,6 +1430,7 @@ syntax_rules += r'''
                       | "WITH" <cfamProperty> ( "AND" <cfamProperty> )*
                       | "RENAME" ("IF" "EXISTS")? existcol=<cident> "TO" newcol=<cident>
                          ( "AND" existcol=<cident> "TO" newcol=<cident> )*
+                      | "ALTER" ("IF" "EXISTS")? existcol=<cident> ( <column_mask> | "DROP" "MASKED" )
                       ;
 
 <alterUserTypeStatement> ::= "ALTER" "TYPE" ("IF" "EXISTS")? ut=<userTypeName>

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -1543,6 +1543,7 @@ syntax_rules += r'''
                | "MODIFY"
                | "DESCRIBE"
                | "EXECUTE"
+               | "UNMASK"
                ;
 
 <permissionExpr> ::= ( [newpermission]=<permission> "PERMISSION"? ( "," [newpermission]=<permission> "PERMISSION"? )* )

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -1544,6 +1544,7 @@ syntax_rules += r'''
                | "DESCRIBE"
                | "EXECUTE"
                | "UNMASK"
+               | "SELECT_MASKED"
                ;
 
 <permissionExpr> ::= ( [newpermission]=<permission> "PERMISSION"? ( "," [newpermission]=<permission> "PERMISSION"? )* )

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -890,7 +890,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("GR",
                             immediate='ANT ')
         self.trycompletions("GRANT ",
-                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT', 'UNMASK'],
+                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT', 'UNMASK', 'SELECT_MASKED'],
                             other_choices_ok=True)
         self.trycompletions("GRANT MODIFY ",
                             choices=[',', 'ON', 'PERMISSION'])
@@ -899,7 +899,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("GRANT MODIFY PERMISSION ",
                             choices=[',', 'ON'])
         self.trycompletions("GRANT MODIFY PERMISSION, ",
-                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT', 'UNMASK'])
+                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT', 'UNMASK', 'SELECT_MASKED'])
         self.trycompletions("GRANT MODIFY PERMISSION, D",
                             choices=['DESCRIBE', 'DROP'])
         self.trycompletions("GRANT MODIFY PERMISSION, DR",
@@ -921,7 +921,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("RE",
                             immediate='VOKE ')
         self.trycompletions("REVOKE ",
-                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT', 'UNMASK'],
+                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT', 'UNMASK', 'SELECT_MASKED'],
                             other_choices_ok=True)
         self.trycompletions("REVOKE MODIFY ",
                             choices=[',', 'ON', 'PERMISSION'])
@@ -930,7 +930,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("REVOKE MODIFY PERMISSION ",
                             choices=[',', 'ON'])
         self.trycompletions("REVOKE MODIFY PERMISSION, ",
-                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT', 'UNMASK'])
+                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT', 'UNMASK', 'SELECT_MASKED'])
         self.trycompletions("REVOKE MODIFY PERMISSION, D",
                             choices=['DESCRIBE', 'DROP'])
         self.trycompletions("REVOKE MODIFY PERMISSION, DR",
@@ -1019,7 +1019,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
 
 
     def test_complete_in_list(self):
-        self.trycompletions('LIST ', choices=['ALL', 'AUTHORIZE', 'DESCRIBE', 'EXECUTE', 'ROLES', 'USERS', 'ALTER', 'CREATE', 'DROP', 'MODIFY', 'SELECT', 'UNMASK'])
+        self.trycompletions('LIST ', choices=['ALL', 'AUTHORIZE', 'DESCRIBE', 'EXECUTE', 'ROLES', 'USERS', 'ALTER', 'CREATE', 'DROP', 'MODIFY', 'SELECT', 'UNMASK', 'SELECT_MASKED'])
 
 
     # Non-CQL Shell Commands

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -620,7 +620,12 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions(prefix + ' new_table (col_a ine',
                             immediate='t ')
         self.trycompletions(prefix + ' new_table (col_a int ',
-                            choices=[',', 'PRIMARY'])
+                            choices=[',', 'MASKED', 'PRIMARY'])
+        self.trycompletions(prefix + ' new_table (col_a int M',
+                            immediate='ASKED WITH ')
+        self.trycompletions(prefix + ' new_table (col_a int MASKED WITH ',
+                            choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
+                            other_choices_ok=True)
         self.trycompletions(prefix + ' new_table (col_a int P',
                             immediate='RIMARY KEY ')
         self.trycompletions(prefix + ' new_table (col_a int PRIMARY KEY ',
@@ -963,9 +968,23 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('ALTER TABLE IF EXISTS new_table ADD ', choices=['<new_column_name>', 'IF'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table ADD IF NOT EXISTS ', choices=['<new_column_name>'])
         self.trycompletions('ALTER TABLE new_table ADD IF NOT EXISTS ', choices=['<new_column_name>'])
+        self.trycompletions('ALTER TABLE new_table ADD col int ', choices=[';', 'MASKED', 'static'])
+        self.trycompletions('ALTER TABLE new_table ADD col int M', immediate='ASKED WITH ')
+        self.trycompletions('ALTER TABLE new_table ADD col int MASKED WITH ',
+                            choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
+                            other_choices_ok=True)
         self.trycompletions('ALTER TABLE IF EXISTS new_table RENAME ', choices=['IF', '<quotedName>', '<identifier>'])
         self.trycompletions('ALTER TABLE new_table RENAME ', choices=['IF', '<quotedName>', '<identifier>'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table DROP ', choices=['IF', '<quotedName>', '<identifier>'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER ', choices=['IF', '<quotedName>', '<identifier>'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF E', immediate='XISTS ')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col ', choices=['MASKED', 'DROP'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col M', immediate='ASKED WITH ')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col MASKED WITH ',
+                            choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
+                            other_choices_ok=True)
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col D', immediate='ROP MASKED ;')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col DROP M', immediate='ASKED ;')
 
     def test_complete_in_alter_type(self):
         self.trycompletions('ALTER TYPE I', immediate='F EXISTS ')

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -890,7 +890,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("GR",
                             immediate='ANT ')
         self.trycompletions("GRANT ",
-                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT'],
+                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT', 'UNMASK'],
                             other_choices_ok=True)
         self.trycompletions("GRANT MODIFY ",
                             choices=[',', 'ON', 'PERMISSION'])
@@ -899,7 +899,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("GRANT MODIFY PERMISSION ",
                             choices=[',', 'ON'])
         self.trycompletions("GRANT MODIFY PERMISSION, ",
-                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT'])
+                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT', 'UNMASK'])
         self.trycompletions("GRANT MODIFY PERMISSION, D",
                             choices=['DESCRIBE', 'DROP'])
         self.trycompletions("GRANT MODIFY PERMISSION, DR",
@@ -921,7 +921,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("RE",
                             immediate='VOKE ')
         self.trycompletions("REVOKE ",
-                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT'],
+                            choices=['ALL', 'ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'MODIFY', 'SELECT', 'UNMASK'],
                             other_choices_ok=True)
         self.trycompletions("REVOKE MODIFY ",
                             choices=[',', 'ON', 'PERMISSION'])
@@ -930,7 +930,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("REVOKE MODIFY PERMISSION ",
                             choices=[',', 'ON'])
         self.trycompletions("REVOKE MODIFY PERMISSION, ",
-                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT'])
+                            choices=['ALTER', 'AUTHORIZE', 'CREATE', 'DESCRIBE', 'DROP', 'EXECUTE', 'SELECT', 'UNMASK'])
         self.trycompletions("REVOKE MODIFY PERMISSION, D",
                             choices=['DESCRIBE', 'DROP'])
         self.trycompletions("REVOKE MODIFY PERMISSION, DR",
@@ -1019,7 +1019,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
 
 
     def test_complete_in_list(self):
-        self.trycompletions('LIST ', choices=['ALL', 'AUTHORIZE', 'DESCRIBE', 'EXECUTE', 'ROLES', 'USERS', 'ALTER', 'CREATE', 'DROP', 'MODIFY', 'SELECT'])
+        self.trycompletions('LIST ', choices=['ALL', 'AUTHORIZE', 'DESCRIBE', 'EXECUTE', 'ROLES', 'USERS', 'ALTER', 'CREATE', 'DROP', 'MODIFY', 'SELECT', 'UNMASK'])
 
 
     # Non-CQL Shell Commands

--- a/src/antlr/Cql.g
+++ b/src/antlr/Cql.g
@@ -39,6 +39,7 @@ import Parser,Lexer;
     import org.apache.cassandra.auth.*;
     import org.apache.cassandra.cql3.conditions.*;
     import org.apache.cassandra.cql3.functions.*;
+    import org.apache.cassandra.cql3.functions.masking.*;
     import org.apache.cassandra.cql3.restrictions.CustomIndexExpression;
     import org.apache.cassandra.cql3.selection.*;
     import org.apache.cassandra.cql3.statements.*;

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -218,6 +218,8 @@ K_DEFAULT:     D E F A U L T;
 K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
 
+K_MASKED:      M A S K E D;
+
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');
 fragment B: ('b'|'B');

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -220,6 +220,7 @@ K_LIKE:        L I K E;
 
 K_MASKED:      M A S K E D;
 K_UNMASK:      U N M A S K;
+K_SELECT_MASKED: S E L E C T '_' M A S K E D;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -219,6 +219,7 @@ K_UNSET:       U N S E T;
 K_LIKE:        L I K E;
 
 K_MASKED:      M A S K E D;
+K_UNMASK:      U N M A S K;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -782,9 +782,19 @@ tableDefinition[CreateTableStatement.Raw stmt]
 
 tableColumns[CreateTableStatement.Raw stmt]
     @init { boolean isStatic = false; }
-    : k=ident v=comparatorType (K_STATIC { isStatic = true; })? { $stmt.addColumn(k, v, isStatic); }
+    : k=ident v=comparatorType (K_STATIC { isStatic = true; })? (mask=columnMask)? { $stmt.addColumn(k, v, isStatic, mask); }
         (K_PRIMARY K_KEY { $stmt.setPartitionKeyColumn(k); })?
     | K_PRIMARY K_KEY '(' tablePartitionKey[stmt] (',' c=ident { $stmt.markClusteringColumn(c); } )* ')'
+    ;
+
+columnMask returns [ColumnMask.Raw mask]
+    @init { List<Term.Raw> arguments = new ArrayList<>(); }
+    : K_MASKED K_WITH name=functionName columnMaskArguments[arguments] { $mask = new ColumnMask.Raw(name, arguments); }
+    | K_MASKED K_WITH K_DEFAULT { $mask = new ColumnMask.Raw(FunctionName.nativeFunction("mask_default"), arguments); }
+    ;
+
+columnMaskArguments[List<Term.Raw> arguments]
+    : '('  ')' | '(' c=term { arguments.add(c); } (',' cn=term { arguments.add(cn); })* ')'
     ;
 
 tablePartitionKey[CreateTableStatement.Raw stmt]
@@ -929,7 +939,9 @@ alterKeyspaceStatement returns [AlterKeyspaceStatement.Raw stmt]
 
 /**
  * ALTER TABLE <table> ALTER <column> TYPE <newtype>;
- * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] <column> <newtype>; | ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] (<column> <newtype>,<column1> <newtype1>..... <column n> <newtype n>)
+ * ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> MASKED WITH <maskFunction>);
+ * ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> DROP MASKED;
+ * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] <column> <newtype> <maskFunction>; | ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] (<column> <newtype> <maskFunction>, <column1> <newtype1>  <maskFunction1>..... <column n> <newtype n>  <maskFunction n>)
  * ALTER TABLE [IF EXISTS] <table> DROP [IF EXISTS] <column>; | ALTER TABLE [IF EXISTS] <table> DROP [IF EXISTS] ( <column>,<column1>.....<column n>)
  * ALTER TABLE [IF EXISTS] <table> RENAME [IF EXISTS] <column> TO <column>;
  * ALTER TABLE [IF EXISTS] <table> WITH <property> = <value>;
@@ -941,10 +953,14 @@ alterTableStatement returns [AlterTableStatement.Raw stmt]
       (
         K_ALTER id=cident K_TYPE v=comparatorType { $stmt.alter(id, v); }
 
+      | K_ALTER ( K_IF K_EXISTS { $stmt.ifColumnExists(true); } )? id=cident
+              ( mask=columnMask { $stmt.mask(id, mask); }
+              | K_DROP K_MASKED { $stmt.mask(id, null); } )
+
       | K_ADD ( K_IF K_NOT K_EXISTS { $stmt.ifColumnNotExists(true); } )?
-              (        id=ident  v=comparatorType  b=isStaticColumn { $stmt.add(id,  v,  b);  }
-               | ('('  id1=ident v1=comparatorType b1=isStaticColumn { $stmt.add(id1, v1, b1); }
-                 ( ',' idn=ident vn=comparatorType bn=isStaticColumn { $stmt.add(idn, vn, bn); } )* ')') )
+              (        id=ident  v=comparatorType  b=isStaticColumn (m=columnMask)? { $stmt.add(id,  v,  b, m);  }
+               | ('('  id1=ident v1=comparatorType b1=isStaticColumn (m1=columnMask)? { $stmt.add(id1, v1, b1, m1); }
+                 ( ',' idn=ident vn=comparatorType bn=isStaticColumn (mn=columnMask)? { $stmt.add(idn, vn, bn, mn); mn=null; } )* ')') )
 
       | K_DROP ( K_IF K_EXISTS { $stmt.ifColumnExists(true); } )?
                (       id=ident { $stmt.drop(id);  }
@@ -1940,5 +1956,6 @@ basic_unreserved_keyword returns [String str]
         | K_MBEANS
         | K_REPLACE
         | K_UNSET
+        | K_MASKED
         ) { $str = $k.text; }
     ;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1128,7 +1128,7 @@ listPermissionsStatement returns [ListPermissionsStatement stmt]
     ;
 
 permission returns [Permission perm]
-    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE)
+    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE | K_UNMASK)
     { $perm = Permission.valueOf($p.text.toUpperCase()); }
     ;
 
@@ -1957,5 +1957,6 @@ basic_unreserved_keyword returns [String str]
         | K_REPLACE
         | K_UNSET
         | K_MASKED
+        | K_UNMASK
         ) { $str = $k.text; }
     ;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1128,7 +1128,7 @@ listPermissionsStatement returns [ListPermissionsStatement stmt]
     ;
 
 permission returns [Permission perm]
-    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE | K_UNMASK)
+    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE | K_UNMASK | K_SELECT_MASKED)
     { $perm = Permission.valueOf($p.text.toUpperCase()); }
     ;
 
@@ -1958,5 +1958,6 @@ basic_unreserved_keyword returns [String str]
         | K_UNSET
         | K_MASKED
         | K_UNMASK
+        | K_SELECT_MASKED
         ) { $str = $k.text; }
     ;

--- a/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
+++ b/src/java/org/apache/cassandra/auth/CassandraRoleManager.java
@@ -82,7 +82,7 @@ public class CassandraRoleManager implements IRoleManager
     private static final Logger logger = LoggerFactory.getLogger(CassandraRoleManager.class);
 
     public static final String DEFAULT_SUPERUSER_NAME = "cassandra";
-    static final String DEFAULT_SUPERUSER_PASSWORD = "cassandra";
+    public static final String DEFAULT_SUPERUSER_PASSWORD = "cassandra";
 
     /**
      * We need to treat the default superuser as a special case since during initial node startup, we may end up with

--- a/src/java/org/apache/cassandra/auth/DataResource.java
+++ b/src/java/org/apache/cassandra/auth/DataResource.java
@@ -46,7 +46,8 @@ public class DataResource implements IResource
                                                                                          Permission.DROP,
                                                                                          Permission.SELECT,
                                                                                          Permission.MODIFY,
-                                                                                         Permission.AUTHORIZE);
+                                                                                         Permission.AUTHORIZE,
+                                                                                         Permission.UNMASK);
 
     // permissions which may be granted on all tables of a given keyspace
     private static final Set<Permission> ALL_TABLES_LEVEL_PERMISSIONS = Sets.immutableEnumSet(Permission.CREATE,
@@ -54,7 +55,8 @@ public class DataResource implements IResource
                                                                                               Permission.DROP,
                                                                                               Permission.SELECT,
                                                                                               Permission.MODIFY,
-                                                                                              Permission.AUTHORIZE);
+                                                                                              Permission.AUTHORIZE,
+                                                                                              Permission.UNMASK);
 
     // permissions which may be granted on one or all keyspaces
     private static final Set<Permission> KEYSPACE_LEVEL_PERMISSIONS = Sets.immutableEnumSet(Permission.CREATE,
@@ -62,7 +64,8 @@ public class DataResource implements IResource
                                                                                             Permission.DROP,
                                                                                             Permission.SELECT,
                                                                                             Permission.MODIFY,
-                                                                                            Permission.AUTHORIZE);
+                                                                                            Permission.AUTHORIZE,
+                                                                                            Permission.UNMASK);
     private static final String ROOT_NAME = "data";
     private static final DataResource ROOT_RESOURCE = new DataResource(Level.ROOT, null, null);
 

--- a/src/java/org/apache/cassandra/auth/DataResource.java
+++ b/src/java/org/apache/cassandra/auth/DataResource.java
@@ -47,7 +47,8 @@ public class DataResource implements IResource
                                                                                          Permission.SELECT,
                                                                                          Permission.MODIFY,
                                                                                          Permission.AUTHORIZE,
-                                                                                         Permission.UNMASK);
+                                                                                         Permission.UNMASK,
+                                                                                         Permission.SELECT_MASKED);
 
     // permissions which may be granted on all tables of a given keyspace
     private static final Set<Permission> ALL_TABLES_LEVEL_PERMISSIONS = Sets.immutableEnumSet(Permission.CREATE,
@@ -56,7 +57,8 @@ public class DataResource implements IResource
                                                                                               Permission.SELECT,
                                                                                               Permission.MODIFY,
                                                                                               Permission.AUTHORIZE,
-                                                                                              Permission.UNMASK);
+                                                                                              Permission.UNMASK,
+                                                                                              Permission.SELECT_MASKED);
 
     // permissions which may be granted on one or all keyspaces
     private static final Set<Permission> KEYSPACE_LEVEL_PERMISSIONS = Sets.immutableEnumSet(Permission.CREATE,
@@ -65,7 +67,8 @@ public class DataResource implements IResource
                                                                                             Permission.SELECT,
                                                                                             Permission.MODIFY,
                                                                                             Permission.AUTHORIZE,
-                                                                                            Permission.UNMASK);
+                                                                                            Permission.UNMASK,
+                                                                                            Permission.SELECT_MASKED);
     private static final String ROOT_NAME = "data";
     private static final DataResource ROOT_RESOURCE = new DataResource(Level.ROOT, null, null);
 

--- a/src/java/org/apache/cassandra/auth/Permission.java
+++ b/src/java/org/apache/cassandra/auth/Permission.java
@@ -61,9 +61,11 @@ public enum Permission
     DESCRIBE, // required on the root-level RoleResource to list all Roles
 
     // UDF permissions
-    EXECUTE;  // required to invoke any user defined function or aggregate
+    EXECUTE,  // required to invoke any user defined function or aggregate
+
+    UNMASK; // required to see masked data
 
     public static final Set<Permission> ALL =
-            Sets.immutableEnumSet(EnumSet.range(Permission.CREATE, Permission.EXECUTE));
+            Sets.immutableEnumSet(EnumSet.range(Permission.CREATE, Permission.UNMASK));
     public static final Set<Permission> NONE = ImmutableSet.of();
 }

--- a/src/java/org/apache/cassandra/auth/Permission.java
+++ b/src/java/org/apache/cassandra/auth/Permission.java
@@ -63,9 +63,11 @@ public enum Permission
     // UDF permissions
     EXECUTE,  // required to invoke any user defined function or aggregate
 
-    UNMASK; // required to see masked data
+    UNMASK, // required to see masked data
+
+    SELECT_MASKED; // required for SELECT on a table with restictions on masked columns
 
     public static final Set<Permission> ALL =
-            Sets.immutableEnumSet(EnumSet.range(Permission.CREATE, Permission.UNMASK));
+            Sets.immutableEnumSet(EnumSet.range(Permission.CREATE, Permission.SELECT_MASKED));
     public static final Set<Permission> NONE = ImmutableSet.of();
 }

--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -483,7 +483,7 @@ public class QueryProcessor implements QueryHandler
                                                                                       .map(m -> MessagingService.instance().<ReadResponse>sendWithResult(m, address))
                                                                                       .collect(Collectors.toList()));
 
-            ResultSetBuilder result = new ResultSetBuilder(select.getResultMetadata(), select.getSelection().newSelectors(options), null);
+            ResultSetBuilder result = new ResultSetBuilder(select.getResultMetadata(), select.getSelection().newSelectors(options), false);
             return future.map(list -> {
                 int i = 0;
                 for (Message<ReadResponse> m : list)
@@ -611,17 +611,19 @@ public class QueryProcessor implements QueryHandler
         return select.executeRawInternal(makeInternalOptionsWithNowInSec(prepared.statement, nowInSec, values), internalQueryState().getClientState(), nowInSec);
     }
 
+    @VisibleForTesting
     public static UntypedResultSet resultify(String query, RowIterator partition)
     {
         return resultify(query, PartitionIterators.singletonIterator(partition));
     }
 
+    @VisibleForTesting
     public static UntypedResultSet resultify(String query, PartitionIterator partitions)
     {
         try (PartitionIterator iter = partitions)
         {
             SelectStatement ss = (SelectStatement) getStatement(query, null);
-            ResultSet cqlRows = ss.process(iter, FBUtilities.nowInSeconds());
+            ResultSet cqlRows = ss.process(iter, FBUtilities.nowInSeconds(), true);
             return UntypedResultSet.create(cqlRows);
         }
     }

--- a/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
+++ b/src/java/org/apache/cassandra/cql3/UntypedResultSet.java
@@ -221,7 +221,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
                         try (ReadExecutionController executionController = pager.executionController();
                              PartitionIterator iter = pager.fetchPageInternal(pageSize, executionController))
                         {
-                            currentPage = select.process(iter, nowInSec).rows.iterator();
+                            currentPage = select.process(iter, nowInSec, true).rows.iterator();
                         }
                     }
                     return new Row(metadata, currentPage.next());
@@ -286,7 +286,7 @@ public abstract class UntypedResultSet implements Iterable<UntypedResultSet.Row>
 
                         try (PartitionIterator iter = pager.fetchPage(pageSize, cl, clientState, nanoTime()))
                         {
-                            currentPage = select.process(iter, nowInSec).rows.iterator();
+                            currentPage = select.process(iter, nowInSec, true).rows.iterator();
                         }
                     }
                     return new Row(metadata, currentPage.next());

--- a/src/java/org/apache/cassandra/cql3/functions/masking/ColumnMask.java
+++ b/src/java/org/apache/cassandra/cql3/functions/masking/ColumnMask.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
+
+import org.apache.cassandra.cql3.AssignmentTestable;
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.cql3.Term;
+import org.apache.cassandra.cql3.Terms;
+import org.apache.cassandra.cql3.functions.Function;
+import org.apache.cassandra.cql3.functions.FunctionName;
+import org.apache.cassandra.cql3.functions.FunctionResolver;
+import org.apache.cassandra.cql3.functions.ScalarFunction;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ReversedType;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
+
+/**
+ * Dynamic data mask that can be applied to a schema column.
+ * <p>
+ * It consists on a partial application of a certain {@link MaskingFunction} to the values of a column, with the
+ * precondition that the type of any masked column is compatible with the type of the first argument of the function.
+ * <p>
+ * This partial application is meant to be associated to specific columns in the schema, acting as a mask for the values
+ * of those columns. It's associated to queries such as:
+ * <pre>
+ *    CREATE TABLE t (k int PRIMARY KEY, v int MASKED WITH mask_inner(1, 1));
+ *    ALTER TABLE t ALTER v MASKED WITH mask_inner(2, 1);
+ *    ALTER TABLE t ALTER v DROP MASKED;
+ * </pre>
+ * Note that in the example above we are referencing the {@code mask_inner} function with two arguments. However, that
+ * CQL function actually has three arguments. The first argument is always ommitted when attaching the function to a
+ * schema column. The value of that first argument is always the value of the masked column, in this case an int.
+ */
+public class ColumnMask
+{
+    /** The CQL function used for masking. */
+    public final ScalarFunction function;
+
+    /** The values of the arguments of the partially applied masking function. */
+    public final List<ByteBuffer> partialArgumentValues;
+
+    public ColumnMask(ScalarFunction function, List<ByteBuffer> partialArgumentValues)
+    {
+        assert function.argTypes().size() == partialArgumentValues.size() + 1;
+        this.function = function;
+        this.partialArgumentValues = partialArgumentValues;
+    }
+
+    /**
+     * @return The types of the arguments of the partially applied masking function.
+     */
+    public List<AbstractType<?>> partialArgumentTypes()
+    {
+        List<AbstractType<?>> argTypes = function.argTypes();
+        return argTypes.size() == 1
+               ? Collections.emptyList()
+               : argTypes.subList(1, argTypes.size());
+    }
+
+    /**
+     * @return A copy of this mask for a version of its masked column that has its type reversed.
+     */
+    public ColumnMask withReversedType()
+    {
+        AbstractType<?> reversed = ReversedType.getInstance(function.argTypes().get(0));
+        List<AbstractType<?>> args = ImmutableList.<AbstractType<?>>builder()
+                                                  .add(reversed)
+                                                  .addAll(partialArgumentTypes())
+                                                  .build();
+        Function newFunction = FunctionResolver.get(function.name().keyspace, function.name(), args, null, null, null);
+        assert newFunction != null;
+        return new ColumnMask((ScalarFunction) newFunction, partialArgumentValues);
+    }
+
+    /**
+     * @param protocolVersion the used version of the transport protocol
+     * @param value           a column value to be masked
+     * @return the specified value after having been masked by the masked function
+     */
+    public ByteBuffer mask(ProtocolVersion protocolVersion, ByteBuffer value)
+    {
+        List<ByteBuffer> args = new ArrayList<>(partialArgumentValues.size() + 1);
+        args.add(value);
+        args.addAll(partialArgumentValues);
+        return function.execute(protocolVersion, args);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ColumnMask mask = (ColumnMask) o;
+        return function.name().equals(mask.function.name())
+               && partialArgumentValues.equals(mask.partialArgumentValues);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(function.name(), partialArgumentValues);
+    }
+
+    @Override
+    public String toString()
+    {
+        List<AbstractType<?>> types = partialArgumentTypes();
+        List<String> arguments = new ArrayList<>(types.size());
+        for (int i = 0; i < types.size(); i++)
+        {
+            CQL3Type type = types.get(i).asCQL3Type();
+            ByteBuffer value = partialArgumentValues.get(i);
+            arguments.add(type.toCQLLiteral(value, ProtocolVersion.CURRENT));
+        }
+        return format("%s(%s)", function.name(), StringUtils.join(arguments, ", "));
+    }
+
+    public void appendCqlTo(CqlBuilder builder)
+    {
+        builder.append(" MASKED WITH ").append(toString());
+    }
+
+    /**
+     * A parsed but not prepared column mask.
+     */
+    public final static class Raw
+    {
+        public final FunctionName name;
+        public final List<Term.Raw> rawPartialArguments;
+
+        public Raw(FunctionName name, List<Term.Raw> rawPartialArguments)
+        {
+            this.name = name;
+            this.rawPartialArguments = rawPartialArguments;
+        }
+
+        public ColumnMask prepare(String keyspace, String table, ColumnIdentifier column, AbstractType<?> type)
+        {
+            ScalarFunction function = findMaskingFunction(keyspace, table, column, type);
+            List<ByteBuffer> partialArguments = preparePartialArguments(keyspace, function);
+            return new ColumnMask(function, partialArguments);
+        }
+
+        private ScalarFunction findMaskingFunction(String keyspace, String table, ColumnIdentifier column, AbstractType<?> type)
+        {
+            List<AssignmentTestable> args = new ArrayList<>(rawPartialArguments.size() + 1);
+            args.add(type);
+            args.addAll(rawPartialArguments);
+
+            Function function = FunctionResolver.get(keyspace, name, args, keyspace, table, type);
+
+            if (function == null)
+                throw invalidRequest("Unable to find masking function for %s, " +
+                                     "no declared function matches the signature %s",
+                                     column, this);
+
+            if (function.isAggregate())
+                throw invalidRequest("Aggregate function %s cannot be used for masking table columns", this);
+
+            if (!function.isNative())
+                throw invalidRequest("User defined function %s cannot be used for masking table columns", this);
+
+            if (!(function instanceof MaskingFunction))
+                throw invalidRequest("Not-masking function %s cannot be used for masking table columns", this);
+
+            if (!function.returnType().equals(type))
+                throw invalidRequest("Masking function %s return type is %s. " +
+                                     "This is different to the type of the masked column %s of type %s. " +
+                                     "Masking functions can only be attached to table columns " +
+                                     "if they return the same data type as the masked column.",
+                                     this, function.returnType().asCQL3Type(), column, type.asCQL3Type());
+
+            return (ScalarFunction) function;
+        }
+
+        private List<ByteBuffer> preparePartialArguments(String keyspace, ScalarFunction function)
+        {
+            // Note that there could be null arguments
+            List<ByteBuffer> arguments = new ArrayList<>(rawPartialArguments.size());
+
+            for (int i = 0; i < rawPartialArguments.size(); i++)
+            {
+                String term = rawPartialArguments.get(i).toString();
+                AbstractType<?> type = function.argTypes().get(i + 1);
+                arguments.add(Terms.asBytes(keyspace, term, type));
+            }
+
+            return arguments;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", name, StringUtils.join(rawPartialArguments, ", "));
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/selection/ResultSetBuilder.java
+++ b/src/java/org/apache/cassandra/cql3/selection/ResultSetBuilder.java
@@ -47,6 +47,11 @@ public final class ResultSetBuilder
      */
     private final GroupMaker groupMaker;
 
+    /**
+     * Whether masked columns should be unmasked.
+     */
+    private final boolean unmask;
+
     /*
      * We'll build CQL3 row one by one.
      */
@@ -55,16 +60,17 @@ public final class ResultSetBuilder
     private long size = 0;
     private boolean sizeWarningEmitted = false;
 
-    public ResultSetBuilder(ResultMetadata metadata, Selectors selectors)
+    public ResultSetBuilder(ResultMetadata metadata, Selectors selectors, boolean unmask)
     {
-        this(metadata, selectors, null);
+        this(metadata, selectors, unmask, null);
     }
 
-    public ResultSetBuilder(ResultMetadata metadata, Selectors selectors, GroupMaker groupMaker)
+    public ResultSetBuilder(ResultMetadata metadata, Selectors selectors, boolean unmask, GroupMaker groupMaker)
     {
-        this.resultSet = new ResultSet(metadata.copy(), new ArrayList<List<ByteBuffer>>());
+        this.resultSet = new ResultSet(metadata.copy(), new ArrayList<>());
         this.selectors = selectors;
         this.groupMaker = groupMaker;
+        this.unmask = unmask;
     }
 
     private void addSize(List<ByteBuffer> row)
@@ -139,6 +145,7 @@ public final class ResultSetBuilder
         {
             inputRow = new Selector.InputRow(protocolVersion,
                                              columns,
+                                             unmask,
                                              selectors.collectWritetimes(),
                                              selectors.collectTTLs());
         }

--- a/src/java/org/apache/cassandra/cql3/selection/Selectable.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selectable.java
@@ -79,7 +79,7 @@ public interface Selectable extends AssignmentTestable
      */
     public default boolean processesSelection()
     {
-        // ColumnMetadata is the only case that returns false and override this
+        // ColumnMetadata is the only case that returns false (if the column is not masked) and overrides this
         return true;
     }
 
@@ -322,7 +322,7 @@ public interface Selectable extends AssignmentTestable
             @Override
             public WritetimeOrTTL prepare(TableMetadata table)
             {
-                return new WritetimeOrTTL(column.prepare(table), selected.prepare(table), kind);
+                return new WritetimeOrTTL((ColumnMetadata) column.prepare(table), selected.prepare(table), kind);
             }
         }
     }
@@ -1240,10 +1240,15 @@ public interface Selectable extends AssignmentTestable
             this.quoted = quoted;
         }
 
-        @Override
-        public ColumnMetadata prepare(TableMetadata cfm)
+        public ColumnMetadata columnMetadata(TableMetadata cfm)
         {
             return cfm.getExistingColumn(ColumnIdentifier.getInterned(text, quoted));
+        }
+
+        @Override
+        public Selectable prepare(TableMetadata cfm)
+        {
+            return columnMetadata(cfm);
         }
 
         public FieldIdentifier toFieldIdentifier()

--- a/src/java/org/apache/cassandra/cql3/selection/Selector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/Selector.java
@@ -306,6 +306,7 @@ public abstract class Selector
     {
         private final ProtocolVersion protocolVersion;
         private final List<ColumnMetadata> columns;
+        private final boolean unmask;
         private final boolean collectWritetimes;
         private final boolean collectTTLs;
 
@@ -314,18 +315,20 @@ public abstract class Selector
         private RowTimestamps ttls;
         private int index;
 
-        public InputRow(ProtocolVersion protocolVersion, List<ColumnMetadata> columns)
+        public InputRow(ProtocolVersion protocolVersion, List<ColumnMetadata> columns, boolean unmask)
         {
-            this(protocolVersion, columns, false, false);
+            this(protocolVersion, columns, unmask, false, false);
         }
 
         public InputRow(ProtocolVersion protocolVersion,
                         List<ColumnMetadata> columns,
+                        boolean unmask,
                         boolean collectWritetimes,
                         boolean collectTTLs)
         {
             this.protocolVersion = protocolVersion;
             this.columns = columns;
+            this.unmask = unmask;
             this.collectWritetimes = collectWritetimes;
             this.collectTTLs = collectTTLs;
 
@@ -345,6 +348,11 @@ public abstract class Selector
         public ProtocolVersion getProtocolVersion()
         {
             return protocolVersion;
+        }
+
+        public boolean unmask()
+        {
+            return unmask;
         }
 
         public void add(ByteBuffer v)

--- a/src/java/org/apache/cassandra/cql3/selection/SelectorFactories.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SelectorFactories.java
@@ -147,7 +147,7 @@ final class SelectorFactories implements Iterable<Selector.Factory>
      */
     public void addSelectorForOrdering(ColumnMetadata def, int index)
     {
-        factories.add(SimpleSelector.newFactory(def, index));
+        factories.add(SimpleSelector.newFactory(def, index, true));
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/selection/SimpleSelector.java
+++ b/src/java/org/apache/cassandra/cql3/selection/SimpleSelector.java
@@ -57,13 +57,13 @@ public final class SimpleSelector extends Selector
     {
         private final int idx;
         private final ColumnMetadata column;
-        private final boolean unmask;
+        private final boolean useForPostOrdering;
 
-        private SimpleSelectorFactory(int idx, ColumnMetadata def, boolean unmask)
+        private SimpleSelectorFactory(int idx, ColumnMetadata def, boolean useForPostOrdering)
         {
             this.idx = idx;
             this.column = def;
-            this.unmask = unmask;
+            this.useForPostOrdering = useForPostOrdering;
         }
 
         @Override
@@ -86,7 +86,7 @@ public final class SimpleSelector extends Selector
         @Override
         public Selector newInstance(QueryOptions options)
         {
-            return new SimpleSelector(column, idx, unmask);
+            return new SimpleSelector(column, idx, useForPostOrdering);
         }
 
         @Override
@@ -119,15 +119,15 @@ public final class SimpleSelector extends Selector
 
     public final ColumnMetadata column;
     private final int idx;
-    private final boolean unmask;
+    private final boolean useForPostOrdering;
     private ByteBuffer current;
     private ColumnTimestamps writetimes;
     private ColumnTimestamps ttls;
     private boolean isSet;
 
-    public static Factory newFactory(final ColumnMetadata def, final int idx, boolean unmask)
+    public static Factory newFactory(final ColumnMetadata def, final int idx, boolean useForPostOrdering)
     {
-        return new SimpleSelectorFactory(idx, def, unmask);
+        return new SimpleSelectorFactory(idx, def, useForPostOrdering);
     }
 
     @Override
@@ -142,19 +142,24 @@ public final class SimpleSelector extends Selector
         if (!isSet)
         {
             isSet = true;
-            current = input.getValue(idx);
             writetimes = input.getWritetimes(idx);
             ttls = input.getTtls(idx);
+
+            /*
+            We apply the column mask of the column unless:
+            - The column doesn't have a mask
+            - This selector is for a query with ORDER BY post-ordering, indicated by this.useForPostOrdering
+            - The input row is for a user with UNMASK permission, indicated by input.unmask()
+             */
+            ColumnMask mask = useForPostOrdering || input.unmask() ? null : column.getMask();
+            ByteBuffer value = input.getValue(idx);
+            current = mask == null ? value : mask.mask(input.getProtocolVersion(), value);
         }
     }
 
     @Override
     public ByteBuffer getOutput(ProtocolVersion protocolVersion)
     {
-        ColumnMask mask = unmask ? null : column.getMask();
-        if (mask != null)
-            return mask.mask(protocolVersion, current);
-
         return current;
     }
 
@@ -191,12 +196,12 @@ public final class SimpleSelector extends Selector
         return column.name.toString();
     }
 
-    private SimpleSelector(ColumnMetadata column, int idx, boolean unmask)
+    private SimpleSelector(ColumnMetadata column, int idx, boolean useForPostOrdering)
     {
         super(Kind.SIMPLE_SELECTOR);
         this.column = column;
         this.idx = idx;
-        this.unmask = unmask;
+        this.useForPostOrdering = useForPostOrdering;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -659,7 +659,7 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         }
 
         Selectors selectors = selection.newSelectors(options);
-        ResultSetBuilder builder = new ResultSetBuilder(selection.getResultMetadata(), selectors);
+        ResultSetBuilder builder = new ResultSetBuilder(selection.getResultMetadata(), selectors, false);
         SelectStatement.forSelection(metadata, selection)
                        .processPartition(partition, options, builder, nowInSeconds);
 

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -82,6 +82,7 @@ import org.apache.cassandra.utils.NoSpamLogger;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import static java.lang.String.format;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNull;
@@ -241,6 +242,21 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         for (Function function : getFunctions())
             state.ensurePermission(Permission.EXECUTE, function);
+
+        if (!state.hasTablePermission(table, Permission.UNMASK) &&
+            !state.hasTablePermission(table, Permission.SELECT_MASKED))
+        {
+            List<ColumnMetadata> queriedMaskedColumns = table.columns()
+                                                             .stream()
+                                                             .filter(ColumnMetadata::isMasked)
+                                                             .filter(restrictions::isRestricted)
+                                                             .collect(Collectors.toList());
+
+            if (!queriedMaskedColumns.isEmpty())
+                throw new UnauthorizedException(format("User %s has no UNMASK nor SELECT_MASKED permission on table %s.%s, " +
+                                                       "cannot query masked columns %s",
+                                                       state.getUser().getName(), keyspace(), table(), queriedMaskedColumns));
+        }
     }
 
     public void validate(ClientState state) throws InvalidRequestException
@@ -261,7 +277,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
         int pageSize = options.getPageSize();
-        boolean unmask = !table.hasMaskedColumns() || state.getClientState().hasUnmaskPermission(table);
+        boolean unmask = !table.hasMaskedColumns() || state.getClientState().hasTablePermission(table, Permission.UNMASK);
 
         Selectors selectors = selection.newSelectors(options);
         AggregationSpecification aggregationSpec = getAggregationSpec(options);
@@ -504,7 +520,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
         int pageSize = options.getPageSize();
-        boolean unmask = state.getClientState().hasUnmaskPermission(table);
+        boolean unmask = state.getClientState().hasTablePermission(table, Permission.UNMASK);
 
         Selectors selectors = selection.newSelectors(options);
         AggregationSpecification aggregationSpec = getAggregationSpec(options);

--- a/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/SelectStatement.java
@@ -22,6 +22,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
@@ -96,7 +98,10 @@ import static org.apache.cassandra.utils.Clock.Global.nanoTime;
  * many of these are made accessible for the benefit of custom
  * QueryHandler implementations, so before reducing their accessibility
  * due consideration should be given.
+ *
+ * Note that select statements can be accessed by multiple threads, so we cannot rely on mutable attributes.
  */
+@ThreadSafe
 public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 {
     private static final Logger logger = LoggerFactory.getLogger(SelectStatement.class);
@@ -256,6 +261,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
         int pageSize = options.getPageSize();
+        boolean unmask = !table.hasMaskedColumns() || state.getClientState().hasUnmaskPermission(table);
 
         Selectors selectors = selection.newSelectors(options);
         AggregationSpecification aggregationSpec = getAggregationSpec(options);
@@ -268,7 +274,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
 
         if (aggregationSpec == null && (pageSize <= 0 || (query.limits().count() <= pageSize)))
         {
-            rows = execute(query, options, state.getClientState(), selectors, nowInSec, userLimit, null, queryStartNanoTime);
+            rows = execute(query, options, state.getClientState(), selectors, nowInSec, userLimit, null, queryStartNanoTime, unmask);
         }
         else
         {
@@ -282,7 +288,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                            nowInSec,
                            userLimit,
                            aggregationSpec,
-                           queryStartNanoTime);
+                           queryStartNanoTime,
+                           unmask);
         }
         if (!SchemaConstants.isSystemKeyspace(table.keyspace))
             ClientRequestSizeMetrics.recordReadResponseMetrics(rows, restrictions, selection);
@@ -335,11 +342,12 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        int nowInSec,
                                        int userLimit,
                                        AggregationSpecification aggregationSpec,
-                                       long queryStartNanoTime)
+                                       long queryStartNanoTime,
+                                       boolean unmask)
     {
         try (PartitionIterator data = query.execute(options.getConsistency(), state, queryStartNanoTime))
         {
-            return processResults(data, options, selectors, nowInSec, userLimit, aggregationSpec);
+            return processResults(data, options, selectors, nowInSec, userLimit, aggregationSpec, unmask);
         }
     }
 
@@ -424,7 +432,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                        int nowInSec,
                                        int userLimit,
                                        AggregationSpecification aggregationSpec,
-                                       long queryStartNanoTime)
+                                       long queryStartNanoTime,
+                                       boolean unmask)
     {
         Guardrails.pageSize.guard(pageSize, table(), false, state.getClientState());
 
@@ -453,7 +462,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         ResultMessage.Rows msg;
         try (PartitionIterator page = pager.fetchPage(pageSize, queryStartNanoTime))
         {
-            msg = processResults(page, options, selectors, nowInSec, userLimit, aggregationSpec);
+            msg = processResults(page, options, selectors, nowInSec, userLimit, aggregationSpec, unmask);
         }
 
         // Please note that the isExhausted state of the pager only gets updated when we've closed the page, so this
@@ -475,9 +484,10 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                                               Selectors selectors,
                                               int nowInSec,
                                               int userLimit,
-                                              AggregationSpecification aggregationSpec) throws RequestValidationException
+                                              AggregationSpecification aggregationSpec,
+                                              boolean unmask) throws RequestValidationException
     {
-        ResultSet rset = process(partitions, options, selectors, nowInSec, userLimit, aggregationSpec);
+        ResultSet rset = process(partitions, options, selectors, nowInSec, userLimit, aggregationSpec, unmask);
         return new ResultMessage.Rows(rset);
     }
 
@@ -494,6 +504,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         int userLimit = getLimit(options);
         int userPerPartitionLimit = getPerPartitionLimit(options);
         int pageSize = options.getPageSize();
+        boolean unmask = state.getClientState().hasUnmaskPermission(table);
 
         Selectors selectors = selection.newSelectors(options);
         AggregationSpecification aggregationSpec = getAggregationSpec(options);
@@ -512,7 +523,7 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
             {
                 try (PartitionIterator data = query.executeInternal(executionController))
                 {
-                    return processResults(data, options, selectors, nowInSec, userLimit, null);
+                    return processResults(data, options, selectors, nowInSec, userLimit, null, unmask);
                 }
             }
 
@@ -526,7 +537,8 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                            nowInSec,
                            userLimit,
                            aggregationSpec,
-                           queryStartNanoTime);
+                           queryStartNanoTime,
+                           unmask);
         }
     }
 
@@ -584,11 +596,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
         }
     }
 
-    public ResultSet process(PartitionIterator partitions, int nowInSec) throws InvalidRequestException
+    public ResultSet process(PartitionIterator partitions, int nowInSec, boolean unmask) throws InvalidRequestException
     {
         QueryOptions options = QueryOptions.DEFAULT;
         Selectors selectors = selection.newSelectors(options);
-        return process(partitions, options, selectors, nowInSec, getLimit(options), getAggregationSpec(options));
+        return process(partitions, options, selectors, nowInSec, getLimit(options), getAggregationSpec(options), unmask);
     }
 
     @Override
@@ -894,10 +906,11 @@ public class SelectStatement implements CQLStatement.SingleKeyspaceCqlStatement
                               Selectors selectors,
                               int nowInSec,
                               int userLimit,
-                              AggregationSpecification aggregationSpec) throws InvalidRequestException
+                              AggregationSpecification aggregationSpec,
+                              boolean unmask) throws InvalidRequestException
     {
         GroupMaker groupMaker = aggregationSpec == null ? null : aggregationSpec.newGroupMaker();
-        ResultSetBuilder result = new ResultSetBuilder(getResultMetadata(), selectors, groupMaker);
+        ResultSetBuilder result = new ResultSetBuilder(getResultMetadata(), selectors, unmask, groupMaker);
 
         while (partitions.hasNext())
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -23,8 +23,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
@@ -40,6 +43,7 @@ import org.apache.cassandra.cql3.CQL3Type;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.QualifiedName;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.AbstractType;
@@ -159,6 +163,68 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     }
 
     /**
+     * ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> ( MASKED WITH <newMask> | DROP MASKED )
+     */
+    public static class MaskColumn extends AlterTableStatement
+    {
+        private final ColumnIdentifier columnName;
+        @Nullable
+        private final ColumnMask.Raw rawMask;
+        private final boolean ifColumnExists;
+
+        MaskColumn(String keyspaceName,
+                   String tableName,
+                   ColumnIdentifier columnName,
+                   @Nullable ColumnMask.Raw rawMask,
+                   boolean ifTableExists,
+                   boolean ifColumnExists)
+        {
+            super(keyspaceName, tableName, ifTableExists);
+            this.columnName = columnName;
+            this.rawMask = rawMask;
+            this.ifColumnExists = ifColumnExists;
+        }
+
+        @Override
+        public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
+        {
+            ColumnMetadata column = table.getColumn(columnName);
+
+            if (column == null)
+            {
+                if (!ifColumnExists)
+                    throw ire("Column with name '%s' doesn't exist on table '%s'", columnName, tableName);
+
+                return keyspace;
+            }
+
+            ColumnMask oldMask = table.getColumn(columnName).getMask();
+            ColumnMask newMask = rawMask == null ? null : rawMask.prepare(keyspace.name, table.name, columnName, column.type);
+
+            if (Objects.equals(oldMask, newMask))
+                return keyspace;
+
+            TableMetadata.Builder tableBuilder = table.unbuild();
+            tableBuilder.alterColumnMask(columnName, newMask);
+            TableMetadata newTable = tableBuilder.build();
+            newTable.validate();
+
+            // Update any reference on materialized views, so the mask is consistent among the base table and its views.
+            Views.Builder viewsBuilder = keyspace.views.unbuild();
+            for (ViewMetadata view : keyspace.views.forTable(table.id))
+            {
+                if (view.includes(columnName))
+                {
+                    viewsBuilder.put(viewsBuilder.get(view.name()).withNewColumnMask(columnName, newMask));
+                }
+            }
+
+            return keyspace.withSwapped(keyspace.tables.withSwapped(newTable))
+                           .withSwapped(viewsBuilder.build());
+        }
+    }
+
+    /**
      * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] <column> <newtype>
      * ALTER TABLE [IF EXISTS] <table> ADD [IF NOT EXISTS] (<column> <newtype>, <column1> <newtype1>, ... <columnn> <newtypen>)
      */
@@ -169,12 +235,15 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             private final ColumnIdentifier name;
             private final CQL3Type.Raw type;
             private final boolean isStatic;
+            @Nullable
+            private final ColumnMask.Raw mask;
 
-            Column(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic)
+            Column(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic, @Nullable ColumnMask.Raw mask)
             {
                 this.name = name;
                 this.type = type;
                 this.isStatic = isStatic;
+                this.mask = mask;
             }
         }
 
@@ -186,12 +255,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             super(keyspaceName, tableName, ifTableExists);
             this.newColumns = newColumns;
             this.ifColumnNotExists = ifColumnNotExists;
-        }
-
-        @Override
-        public void validate(ClientState state)
-        {
-            super.validate(state);
         }
 
         public KeyspaceMetadata apply(KeyspaceMetadata keyspace, TableMetadata table)
@@ -220,6 +283,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             ColumnIdentifier name = column.name;
             AbstractType<?> type = column.type.prepare(keyspaceName, keyspace.types).getType();
             boolean isStatic = column.isStatic;
+            ColumnMask mask = column.mask == null ? null : column.mask.prepare(keyspaceName, tableName, name, type);
 
             if (null != tableBuilder.getColumn(name)) {
                 if (!ifColumnNotExists)
@@ -260,9 +324,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             }
 
             if (isStatic)
-                tableBuilder.addStaticColumn(name, type);
+                tableBuilder.addStaticColumn(name, type, mask);
             else
-                tableBuilder.addRegularColumn(name, type);
+                tableBuilder.addRegularColumn(name, type, mask);
 
             if (!isStatic)
             {
@@ -270,7 +334,8 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                 {
                     if (view.includeAllColumns)
                     {
-                        ColumnMetadata viewColumn = ColumnMetadata.regularColumn(view.metadata, name.bytes, type);
+                        ColumnMetadata viewColumn = ColumnMetadata.regularColumn(view.metadata, name.bytes, type)
+                                                                  .withNewMask(mask);
                         viewsBuilder.put(viewsBuilder.get(view.name()).withAddedRegularColumn(viewColumn));
                     }
                 }
@@ -582,7 +647,13 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     {
         private enum Kind
         {
-            ALTER_COLUMN, ADD_COLUMNS, DROP_COLUMNS, RENAME_COLUMNS, ALTER_OPTIONS, DROP_COMPACT_STORAGE
+            ALTER_COLUMN,
+            MASK_COLUMN,
+            ADD_COLUMNS,
+            DROP_COLUMNS,
+            RENAME_COLUMNS,
+            ALTER_OPTIONS,
+            DROP_COMPACT_STORAGE
         }
 
         private final QualifiedName name;
@@ -594,6 +665,10 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
 
         // ADD
         private final List<AddColumns.Column> addedColumns = new ArrayList<>();
+
+        // ALTER MASK
+        private ColumnIdentifier maskedColumn = null;
+        private ColumnMask.Raw rawMask = null;
 
         // DROP
         private final Set<ColumnIdentifier> droppedColumns = new HashSet<>();
@@ -619,6 +694,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             switch (kind)
             {
                 case          ALTER_COLUMN: return new AlterColumn(keyspaceName, tableName, ifTableExists);
+                case           MASK_COLUMN: return new MaskColumn(keyspaceName, tableName, maskedColumn, rawMask, ifTableExists, ifColumnExists);
                 case           ADD_COLUMNS: return new AddColumns(keyspaceName, tableName, addedColumns, ifTableExists, ifColumnNotExists);
                 case          DROP_COLUMNS: return new DropColumns(keyspaceName, tableName, droppedColumns, ifTableExists, ifColumnExists, timestamp);
                 case        RENAME_COLUMNS: return new RenameColumns(keyspaceName, tableName, renamedColumns, ifTableExists, ifColumnExists);
@@ -634,10 +710,17 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             kind = Kind.ALTER_COLUMN;
         }
 
-        public void add(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic)
+        public void mask(ColumnIdentifier name, ColumnMask.Raw mask)
+        {
+            kind = Kind.MASK_COLUMN;
+            maskedColumn = name;
+            rawMask = mask;
+        }
+
+        public void add(ColumnIdentifier name, CQL3Type.Raw type, boolean isStatic, @Nullable ColumnMask.Raw mask)
         {
             kind = Kind.ADD_COLUMNS;
-            addedColumns.add(new AddColumns.Column(name, type, isStatic));
+            addedColumns.add(new AddColumns.Column(name, type, isStatic, mask));
         }
 
         public void drop(ColumnIdentifier name)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.cql3.statements.schema;
 
 import java.util.*;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableSet;
 
 import org.apache.commons.lang3.StringUtils;
@@ -33,6 +35,7 @@ import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.*;
@@ -54,7 +57,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
     private static final Logger logger = LoggerFactory.getLogger(CreateTableStatement.class);
     private final String tableName;
 
-    private final Map<ColumnIdentifier, CQL3Type.Raw> rawColumns;
+    private final Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns;
     private final Set<ColumnIdentifier> staticColumns;
     private final List<ColumnIdentifier> partitionKeyColumns;
     private final List<ColumnIdentifier> clusteringColumns;
@@ -67,15 +70,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
     public CreateTableStatement(String keyspaceName,
                                 String tableName,
-
-                                Map<ColumnIdentifier, CQL3Type.Raw> rawColumns,
+                                Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns,
                                 Set<ColumnIdentifier> staticColumns,
                                 List<ColumnIdentifier> partitionKeyColumns,
                                 List<ColumnIdentifier> clusteringColumns,
-
                                 LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
                                 TableAttributes attrs,
-
                                 boolean ifNotExists,
                                 boolean useCompactStorage)
     {
@@ -186,15 +186,16 @@ public final class CreateTableStatement extends AlterSchemaStatement
         TableParams params = attrs.asNewTableParams();
 
         // use a TreeMap to preserve ordering across JDK versions (see CASSANDRA-9492) - important for stable unit tests
-        Map<ColumnIdentifier, CQL3Type> columns = new TreeMap<>(comparing(o -> o.bytes));
-        rawColumns.forEach((column, type) -> columns.put(column, type.prepare(keyspaceName, types)));
+        Map<ColumnIdentifier, ColumnProperties> columns = new TreeMap<>(comparing(o -> o.bytes));
+        rawColumns.forEach((column, properties) -> columns.put(column, properties.prepare(keyspaceName, tableName, column, types)));
 
         // check for nested non-frozen UDTs or collections in a non-frozen UDT
-        columns.forEach((column, type) ->
+        columns.forEach((column, properties) ->
         {
-            if (type.isUDT() && type.getType().isMultiCell())
+            AbstractType<?> type = properties.type;
+            if (type.isUDT() && type.isMultiCell())
             {
-                ((UserType) type.getType()).fieldTypes().forEach(field ->
+                ((UserType) type).fieldTypes().forEach(field ->
                 {
                     if (field.isMultiCell())
                         throw ire("Non-frozen UDTs with nested non-frozen collections are not supported");
@@ -209,45 +210,47 @@ public final class CreateTableStatement extends AlterSchemaStatement
         HashSet<ColumnIdentifier> primaryKeyColumns = new HashSet<>();
         concat(partitionKeyColumns, clusteringColumns).forEach(column ->
         {
-            CQL3Type type = columns.get(column);
-            if (null == type)
+            ColumnProperties properties = columns.get(column);
+            if (null == properties)
                 throw ire("Unknown column '%s' referenced in PRIMARY KEY for table '%s'", column, tableName);
 
             if (!primaryKeyColumns.add(column))
                 throw ire("Duplicate column '%s' in PRIMARY KEY clause for table '%s'", column, tableName);
 
-            if (type.getType().isMultiCell())
+            AbstractType<?> type = properties.type;
+            if (type.isMultiCell())
             {
+                CQL3Type cqlType = properties.cqlType;
                 if (type.isCollection())
-                    throw ire("Invalid non-frozen collection type %s for PRIMARY KEY column '%s'", type, column);
+                    throw ire("Invalid non-frozen collection type %s for PRIMARY KEY column '%s'", cqlType, column);
                 else
-                    throw ire("Invalid non-frozen user-defined type %s for PRIMARY KEY column '%s'", type, column);
+                    throw ire("Invalid non-frozen user-defined type %s for PRIMARY KEY column '%s'", cqlType, column);
             }
 
-            if (type.getType().isCounter())
+            if (type.isCounter())
                 throw ire("counter type is not supported for PRIMARY KEY column '%s'", column);
 
-            if (type.getType().referencesDuration())
+            if (type.referencesDuration())
                 throw ire("duration type is not supported for PRIMARY KEY column '%s'", column);
 
             if (staticColumns.contains(column))
                 throw ire("Static column '%s' cannot be part of the PRIMARY KEY", column);
         });
 
-        List<AbstractType<?>> partitionKeyTypes = new ArrayList<>();
-        List<AbstractType<?>> clusteringTypes = new ArrayList<>();
+        List<ColumnProperties> partitionKeyColumnProperties = new ArrayList<>();
+        List<ColumnProperties> clusteringColumnProperties = new ArrayList<>();
 
         partitionKeyColumns.forEach(column ->
         {
-            CQL3Type type = columns.remove(column);
-            partitionKeyTypes.add(type.getType());
+            ColumnProperties columnProperties = columns.remove(column);
+            partitionKeyColumnProperties.add(columnProperties);
         });
 
         clusteringColumns.forEach(column ->
         {
-            CQL3Type type = columns.remove(column);
+            ColumnProperties columnProperties = columns.remove(column);
             boolean reverse = !clusteringOrder.getOrDefault(column, true);
-            clusteringTypes.add(reverse ? ReversedType.getInstance(type.getType()) : type.getType());
+            clusteringColumnProperties.add(reverse ? columnProperties.withReversedType() : columnProperties);
         });
 
         if (clusteringOrder.size() > clusteringColumns.size())
@@ -270,7 +273,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         // For COMPACT STORAGE, we reject any "feature" that we wouldn't be able to translate back to thrift.
         if (useCompactStorage)
         {
-            validateCompactTable(clusteringTypes, columns);
+            validateCompactTable(clusteringColumnProperties, columns);
         }
         else
         {
@@ -283,12 +286,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
          * Counter table validation
          */
 
-        boolean hasCounters = rawColumns.values().stream().anyMatch(CQL3Type.Raw::isCounter);
+        boolean hasCounters = rawColumns.values().stream().anyMatch(c -> c.rawType.isCounter());
         if (hasCounters)
         {
             // We've handled anything that is not a PRIMARY KEY so columns only contains NON-PK columns. So
             // if it's a counter table, make sure we don't have non-counter types
-            if (columns.values().stream().anyMatch(t -> !t.getType().isCounter()))
+            if (columns.values().stream().anyMatch(t -> !t.type.isCounter()))
                 throw ire("Cannot mix counter and non counter columns in the same table");
 
             if (params.defaultTimeToLive > 0)
@@ -308,38 +311,44 @@ public final class CreateTableStatement extends AlterSchemaStatement
                .params(params);
 
         for (int i = 0; i < partitionKeyColumns.size(); i++)
-            builder.addPartitionKeyColumn(partitionKeyColumns.get(i), partitionKeyTypes.get(i));
+        {
+            ColumnProperties properties = partitionKeyColumnProperties.get(i);
+            builder.addPartitionKeyColumn(partitionKeyColumns.get(i), properties.type, properties.mask);
+        }
 
         for (int i = 0; i < clusteringColumns.size(); i++)
-            builder.addClusteringColumn(clusteringColumns.get(i), clusteringTypes.get(i));
+        {
+            ColumnProperties properties = clusteringColumnProperties.get(i);
+            builder.addClusteringColumn(clusteringColumns.get(i), properties.type, properties.mask);
+        }
 
         if (useCompactStorage)
         {
-            fixupCompactTable(clusteringTypes, columns, hasCounters, builder);
+            fixupCompactTable(clusteringColumnProperties, columns, hasCounters, builder);
         }
         else
         {
-            columns.forEach((column, type) -> {
+            columns.forEach((column, properties) -> {
                 if (staticColumns.contains(column))
-                    builder.addStaticColumn(column, type.getType());
+                    builder.addStaticColumn(column, properties.type, properties.mask);
                 else
-                    builder.addRegularColumn(column, type.getType());
+                    builder.addRegularColumn(column, properties.type, properties.mask);
             });
         }
         return builder;
     }
 
-    private void validateCompactTable(List<AbstractType<?>> clusteringTypes,
-                                      Map<ColumnIdentifier, CQL3Type> columns)
+    private void validateCompactTable(List<ColumnProperties> clusteringColumnProperties,
+                                      Map<ColumnIdentifier, ColumnProperties> columns)
     {
-        boolean isDense = !clusteringTypes.isEmpty();
+        boolean isDense = !clusteringColumnProperties.isEmpty();
 
-        if (columns.values().stream().anyMatch(c -> c.getType().isMultiCell()))
+        if (columns.values().stream().anyMatch(c -> c.type.isMultiCell()))
             throw ire("Non-frozen collections and UDTs are not supported with COMPACT STORAGE");
         if (!staticColumns.isEmpty())
             throw ire("Static columns are not supported in COMPACT STORAGE tables");
 
-        if (clusteringTypes.isEmpty())
+        if (clusteringColumnProperties.isEmpty())
         {
             // It's a thrift "static CF" so there should be some columns definition
             if (columns.isEmpty())
@@ -361,8 +370,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
         }
     }
 
-    private void fixupCompactTable(List<AbstractType<?>> clusteringTypes,
-                                   Map<ColumnIdentifier, CQL3Type> columns,
+    private void fixupCompactTable(List<ColumnProperties> clusteringTypes,
+                                   Map<ColumnIdentifier, ColumnProperties> columns,
                                    boolean hasCounters,
                                    TableMetadata.Builder builder)
     {
@@ -381,12 +390,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
         builder.flags(flags);
 
-        columns.forEach((name, type) -> {
+        columns.forEach((name, properties) -> {
             // Note that for "static" no-clustering compact storage we use static for the defined columns
             if (staticColumns.contains(name) || isStaticCompact)
-                builder.addStaticColumn(name, type.getType());
+                builder.addStaticColumn(name, properties.type, properties.mask);
             else
-                builder.addRegularColumn(name, type.getType());
+                builder.addRegularColumn(name, properties.type, properties.mask);
         });
 
         DefaultNames names = new DefaultNames(builder.columnNames());
@@ -471,7 +480,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         private final boolean ifNotExists;
 
         private boolean useCompactStorage = false;
-        private final Map<ColumnIdentifier, CQL3Type.Raw> rawColumns = new HashMap<>();
+        private final Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns = new HashMap<>();
         private final Set<ColumnIdentifier> staticColumns = new HashSet<>();
         private final List<ColumnIdentifier> clusteringColumns = new ArrayList<>();
 
@@ -495,15 +504,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
             return new CreateTableStatement(keyspaceName,
                                             name.getName(),
-
                                             rawColumns,
                                             staticColumns,
                                             partitionKeyColumns,
                                             clusteringColumns,
-
                                             clusteringOrder,
                                             attrs,
-
                                             ifNotExists,
                                             useCompactStorage);
         }
@@ -524,9 +530,10 @@ public final class CreateTableStatement extends AlterSchemaStatement
             return name.getName();
         }
 
-        public void addColumn(ColumnIdentifier column, CQL3Type.Raw type, boolean isStatic)
+        public void addColumn(ColumnIdentifier column, CQL3Type.Raw type, boolean isStatic, ColumnMask.Raw mask)
         {
-            if (null != rawColumns.put(column, type))
+
+            if (null != rawColumns.put(column, new ColumnProperties.Raw(type, mask)))
                 throw ire("Duplicate column '%s' declaration for table '%s'", column, name);
 
             if (isStatic)
@@ -560,6 +567,54 @@ public final class CreateTableStatement extends AlterSchemaStatement
         {
             if (null != clusteringOrder.put(column, ascending))
                 throw ire("Duplicate column '%s' in CLUSTERING ORDER BY clause for table '%s'", column, name);
+        }
+    }
+
+    /**
+     * Class encapsulating the properties of a column, which are its type and mask.
+     */
+    private final static class ColumnProperties
+    {
+        public final AbstractType<?> type;
+        public final CQL3Type cqlType; // we keep the original CQL type for printing fully qualified user type names
+
+        @Nullable
+        public final ColumnMask mask;
+
+        public ColumnProperties(AbstractType<?> type, CQL3Type cqlType, @Nullable ColumnMask mask)
+        {
+            this.type = type;
+            this.cqlType = cqlType;
+            this.mask = mask;
+        }
+
+        public ColumnProperties withReversedType()
+        {
+            return new ColumnProperties(ReversedType.getInstance(type),
+                                        cqlType,
+                                        mask == null ? null : mask.withReversedType());
+        }
+
+        public final static class Raw
+        {
+            public final CQL3Type.Raw rawType;
+
+            @Nullable
+            public final ColumnMask.Raw rawMask;
+
+            public Raw(CQL3Type.Raw rawType, @Nullable ColumnMask.Raw rawMask)
+            {
+                this.rawType = rawType;
+                this.rawMask = rawMask;
+            }
+
+            public ColumnProperties prepare(String keyspace, String table, ColumnIdentifier column, Types udts)
+            {
+                CQL3Type cqlType = rawType.prepare(keyspace, udts);
+                AbstractType<?> type = cqlType.getType();
+                ColumnMask mask = rawMask == null ? null : rawMask.prepare(keyspace, table, column, type);
+                return new ColumnProperties(type, cqlType, mask);
+            }
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -61,7 +61,8 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                            ColumnIdentifier.getInterned(ByteBufferUtil.EMPTY_BYTE_BUFFER, UTF8Type.instance),
                            SetType.getInstance(UTF8Type.instance, true),
                            ColumnMetadata.NO_POSITION,
-                           ColumnMetadata.Kind.STATIC);
+                           ColumnMetadata.Kind.STATIC,
+                           null);
 
     public static final ColumnMetadata FIRST_COMPLEX_REGULAR =
         new ColumnMetadata("",
@@ -69,7 +70,8 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                            ColumnIdentifier.getInterned(ByteBufferUtil.EMPTY_BYTE_BUFFER, UTF8Type.instance),
                            SetType.getInstance(UTF8Type.instance, true),
                            ColumnMetadata.NO_POSITION,
-                           ColumnMetadata.Kind.REGULAR);
+                           ColumnMetadata.Kind.REGULAR,
+                           null);
 
     private final Object[] columns;
     private final int complexIdx; // Index of the first complex column

--- a/src/java/org/apache/cassandra/db/aggregation/GroupMaker.java
+++ b/src/java/org/apache/cassandra/db/aggregation/GroupMaker.java
@@ -172,7 +172,7 @@ public abstract class GroupMaker
         {
             super(comparator, clusteringPrefixSize, state);
             this.selector = selector;
-            this.input = new Selector.InputRow(ProtocolVersion.CURRENT, columns);
+            this.input = new Selector.InputRow(ProtocolVersion.CURRENT, columns, false);
             this.lastOutput = lastClustering == null ? null :
                                                        executeSelector(lastClustering.bufferAt(clusteringPrefixSize - 1));
         }
@@ -184,7 +184,7 @@ public abstract class GroupMaker
         {
             super(comparator, clusteringPrefixSize);
             this.selector = selector;
-            this.input = new Selector.InputRow(ProtocolVersion.CURRENT, columns);
+            this.input = new Selector.InputRow(ProtocolVersion.CURRENT, columns, false);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspaceTables.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspaceTables.java
@@ -24,6 +24,7 @@ public class SchemaKeyspaceTables
     public static final String KEYSPACES = "keyspaces";
     public static final String TABLES = "tables";
     public static final String COLUMNS = "columns";
+    public static final String COLUMN_MASKS = "column_masks";
     public static final String DROPPED_COLUMNS = "dropped_columns";
     public static final String TRIGGERS = "triggers";
     public static final String VIEWS = "views";
@@ -45,7 +46,8 @@ public class SchemaKeyspaceTables
      *
      * See CASSANDRA-12213 for more details.
      */
-    public static final ImmutableList<String> ALL = ImmutableList.of(COLUMNS,
+    public static final ImmutableList<String> ALL = ImmutableList.of(COLUMN_MASKS,
+                                                                     COLUMNS,
                                                                      DROPPED_COLUMNS,
                                                                      TRIGGERS,
                                                                      TYPES,

--- a/src/java/org/apache/cassandra/schema/ViewMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ViewMetadata.java
@@ -20,10 +20,13 @@ package org.apache.cassandra.schema;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.marshal.UserType;
 
 public final class ViewMetadata implements SchemaElement
@@ -156,6 +159,15 @@ public final class ViewMetadata implements SchemaElement
                                 includeAllColumns,
                                 whereClause,
                                 metadata.unbuild().addColumn(column).build());
+    }
+
+    public ViewMetadata withNewColumnMask(ColumnIdentifier name, @Nullable ColumnMask mask)
+    {
+        return new ViewMetadata(baseTableId,
+                                baseTableName,
+                                includeAllColumns,
+                                whereClause,
+                                metadata.unbuild().alterColumnMask(name, mask).build());
     }
 
     public void appendCqlTo(CqlBuilder builder,

--- a/src/java/org/apache/cassandra/service/ClientState.java
+++ b/src/java/org/apache/cassandra/service/ClientState.java
@@ -414,6 +414,27 @@ public class ClientState
         ensurePermission(table.keyspace, perm, table.resource);
     }
 
+    public boolean hasUnmaskPermission(TableMetadata table)
+    {
+        if (isInternal)
+            return true;
+
+        validateLogin();
+
+        if (!DatabaseDescriptor.getAuthorizer().requireAuthorization())
+            return true;
+
+        List<? extends IResource> resources = Resources.chain(table.resource);
+        if (DatabaseDescriptor.getAuthFromRoot())
+            resources = Lists.reverse(resources);
+
+        for (IResource r : resources)
+            if (authorize(r).contains(Permission.UNMASK))
+                return true;
+
+        return false;
+    }
+
     private void ensurePermission(String keyspace, Permission perm, DataResource resource)
     {
         validateKeyspace(keyspace);

--- a/src/java/org/apache/cassandra/service/ClientState.java
+++ b/src/java/org/apache/cassandra/service/ClientState.java
@@ -414,7 +414,7 @@ public class ClientState
         ensurePermission(table.keyspace, perm, table.resource);
     }
 
-    public boolean hasUnmaskPermission(TableMetadata table)
+    public boolean hasTablePermission(TableMetadata table, Permission perm)
     {
         if (isInternal)
             return true;
@@ -429,7 +429,7 @@ public class ClientState
             resources = Lists.reverse(resources);
 
         for (IResource r : resources)
-            if (authorize(r).contains(Permission.UNMASK))
+            if (authorize(r).contains(perm))
                 return true;
 
         return false;

--- a/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
+++ b/src/java/org/apache/cassandra/utils/NativeSSTableLoaderClient.java
@@ -212,7 +212,7 @@ public class NativeSSTableLoaderClient extends SSTableLoader.Client
 
         int position = row.getInt("position");
         org.apache.cassandra.schema.ColumnMetadata.Kind kind = ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase());
-        return new ColumnMetadata(keyspace, table, name, type, position, kind);
+        return new ColumnMetadata(keyspace, table, name, type, position, kind, null);
     }
 
     private static DroppedColumn createDroppedColumnFromRow(Row row, String keyspace, String table)
@@ -220,7 +220,7 @@ public class NativeSSTableLoaderClient extends SSTableLoader.Client
         String name = row.getString("column_name");
         AbstractType<?> type = CQLTypeParser.parse(keyspace, row.getString("type"), Types.none());
         ColumnMetadata.Kind kind = ColumnMetadata.Kind.valueOf(row.getString("kind").toUpperCase());
-        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind);
+        ColumnMetadata column = new ColumnMetadata(keyspace, table, ColumnIdentifier.getInterned(name, true), type, ColumnMetadata.NO_POSITION, kind, null);
         long droppedTime = row.getTimestamp("dropped_time").getTime();
         return new DroppedColumn(column, droppedTime);
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+/**
+ * Tests for dynamic data masking.
+ */
+public class ColumnMaskTest extends TestBaseImpl
+{
+    private static final String SELECT = withKeyspace("SELECT * FROM %s.t");
+
+    /**
+     * Tests that column masks are propagated to all nodes in the cluster.
+     */
+    @Test
+    public void testMaskPropagation() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build().withNodes(3).start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, v text MASKED WITH DEFAULT) WITH read_repair='NONE'"));
+            cluster.get(1).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (1, 'secret1')"));
+            cluster.get(2).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (2, 'secret2')"));
+            cluster.get(3).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (3, 'secret3')"));
+
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "****"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "****"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "****"));
+            assertRowsInAllCoordinators(cluster, row(1, "****"), row(2, "****"), row(3, "****"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v DROP MASKED"));
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "secret1"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "secret2"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "secret3"));
+            assertRowsInAllCoordinators(cluster, row(1, "secret1"), row(2, "secret2"), row(3, "secret3"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(null, 1)"));
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "******1"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "******2"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "******3"));
+            assertRowsInAllCoordinators(cluster, row(1, "******1"), row(2, "******2"), row(3, "******3"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(3, null)"));
+            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "sec****"));
+            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "sec****"));
+            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "sec****"));
+            assertRowsInAllCoordinators(cluster, row(1, "sec****"), row(2, "sec****"), row(3, "sec****"));
+        }
+    }
+
+    private static void assertRowsInAllCoordinators(Cluster cluster, Object[]... expectedRows)
+    {
+        for (int i = 1; i < cluster.size(); i++)
+        {
+            assertRows(cluster.coordinator(i).execute(SELECT, ALL), expectedRows);
+        }
+    }
+
+    /**
+     * Tests that column masks are properly loaded at startup.
+     */
+    @Test
+    public void testMaskLoading() throws Throwable
+    {
+        try (Cluster cluster = init(Cluster.build().withNodes(1).start()))
+        {
+            IInvokableInstance node = cluster.get(1);
+
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, v text MASKED WITH DEFAULT) "));
+            node.executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (1, 'secret1')"));
+            node.executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (2, 'secret2')"));
+
+            assertRowsWithRestart(node, row(1, "****"), row(2, "****"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v DROP MASKED"));
+            assertRowsWithRestart(node, row(1, "secret1"), row(2, "secret2"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(null, 1)"));
+            assertRowsWithRestart(node, row(1, "******1"), row(2, "******2"));
+
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(3, null)"));
+            assertRowsWithRestart(node, row(1, "sec****"), row(2, "sec****"));
+        }
+    }
+
+    private static void assertRowsWithRestart(IInvokableInstance node, Object[]... expectedRows) throws Throwable
+    {
+        // test querying with in-memory column definitions
+        assertRows(node.executeInternal(SELECT), expectedRows);
+
+        // restart the nodes to reload the column definitions from disk
+        node.shutdown().get();
+        node.startup();
+
+        // test querying with the column definitions loaded from disk
+        assertRows(node.executeInternal(SELECT), expectedRows);
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnMaskTest.java
@@ -18,14 +18,35 @@
 
 package org.apache.cassandra.distributed.test;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.function.Consumer;
+
 import org.junit.Test;
 
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import org.apache.cassandra.auth.CassandraRoleManager;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.impl.RowUtil;
+import org.apache.cassandra.distributed.util.SingleHostLoadBalancingPolicy;
 
-import static org.apache.cassandra.distributed.api.ConsistencyLevel.ALL;
+import static com.datastax.driver.core.Cluster.Builder;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.cassandra.auth.CassandraRoleManager.DEFAULT_SUPERUSER_NAME;
+import static org.apache.cassandra.auth.CassandraRoleManager.DEFAULT_SUPERUSER_PASSWORD;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
 import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for dynamic data masking.
@@ -33,6 +54,8 @@ import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 public class ColumnMaskTest extends TestBaseImpl
 {
     private static final String SELECT = withKeyspace("SELECT * FROM %s.t");
+    private static final String USERNAME = "ddm_user";
+    private static final String PASSWORD = "ddm_password";
 
     /**
      * Tests that column masks are propagated to all nodes in the cluster.
@@ -40,43 +63,23 @@ public class ColumnMaskTest extends TestBaseImpl
     @Test
     public void testMaskPropagation() throws Throwable
     {
-        try (Cluster cluster = init(Cluster.build().withNodes(3).start()))
+        try (Cluster cluster = createClusterWithAuhentication(3))
         {
             cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, v text MASKED WITH DEFAULT) WITH read_repair='NONE'"));
             cluster.get(1).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (1, 'secret1')"));
             cluster.get(2).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (2, 'secret2')"));
             cluster.get(3).executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (3, 'secret3')"));
 
-            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "****"));
-            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "****"));
-            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "****"));
             assertRowsInAllCoordinators(cluster, row(1, "****"), row(2, "****"), row(3, "****"));
 
             cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v DROP MASKED"));
-            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "secret1"));
-            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "secret2"));
-            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "secret3"));
             assertRowsInAllCoordinators(cluster, row(1, "secret1"), row(2, "secret2"), row(3, "secret3"));
 
             cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(null, 1)"));
-            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "******1"));
-            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "******2"));
-            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "******3"));
             assertRowsInAllCoordinators(cluster, row(1, "******1"), row(2, "******2"), row(3, "******3"));
 
             cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(3, null)"));
-            assertRows(cluster.get(1).executeInternal(SELECT), row(1, "sec****"));
-            assertRows(cluster.get(2).executeInternal(SELECT), row(2, "sec****"));
-            assertRows(cluster.get(3).executeInternal(SELECT), row(3, "sec****"));
             assertRowsInAllCoordinators(cluster, row(1, "sec****"), row(2, "sec****"), row(3, "sec****"));
-        }
-    }
-
-    private static void assertRowsInAllCoordinators(Cluster cluster, Object[]... expectedRows)
-    {
-        for (int i = 1; i < cluster.size(); i++)
-        {
-            assertRows(cluster.coordinator(i).execute(SELECT, ALL), expectedRows);
         }
     }
 
@@ -86,37 +89,103 @@ public class ColumnMaskTest extends TestBaseImpl
     @Test
     public void testMaskLoading() throws Throwable
     {
-        try (Cluster cluster = init(Cluster.build().withNodes(1).start()))
+        try (Cluster cluster = createClusterWithAuhentication(1))
         {
             IInvokableInstance node = cluster.get(1);
 
-            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (k int PRIMARY KEY, v text MASKED WITH DEFAULT) "));
-            node.executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (1, 'secret1')"));
-            node.executeInternal(withKeyspace("INSERT INTO %s.t(k, v) VALUES (2, 'secret2')"));
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.t (" +
+                                              "a text MASKED WITH DEFAULT, " +
+                                              "b text MASKED WITH mask_replace('redacted'), " +
+                                              "c text MASKED WITH mask_inner(null, 1), " +
+                                              "d text MASKED WITH mask_inner(3, null), " +
+                                              "PRIMARY KEY (a, b))"));
+            node.executeInternal(withKeyspace("INSERT INTO %s.t(a, b, c, d) VALUES ('secret1', 'secret1', 'secret1', 'secret1')"));
+            node.executeInternal(withKeyspace("INSERT INTO %s.t(a, b, c, d) VALUES ('secret2', 'secret2', 'secret2', 'secret2')"));
+            assertRowsWithRestart(node,
+                                  row("****", "redacted", "******1", "sec****"),
+                                  row("****", "redacted", "******2", "sec****"));
 
-            assertRowsWithRestart(node, row(1, "****"), row(2, "****"));
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER a DROP MASKED"));
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER b MASKED WITH mask_null()"));
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER c MASKED WITH mask_inner(null, null, '#')"));
+            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER d MASKED WITH mask_inner(3, 1, '#')"));
+            assertRowsWithRestart(node,
+                                  row("secret1", null, "#######", "sec###1"),
+                                  row("secret2", null, "#######", "sec###2"));
+        }
+    }
 
-            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v DROP MASKED"));
-            assertRowsWithRestart(node, row(1, "secret1"), row(2, "secret2"));
+    private static Cluster createClusterWithAuhentication(int nodeCount) throws IOException
+    {
+        Cluster cluster = init(Cluster.build()
+                                      .withNodes(nodeCount)
+                                      .withConfig(conf -> conf.with(GOSSIP, NATIVE_PROTOCOL)
+                                                              .set("user_defined_functions_enabled", "true")
+                                                              .set("authenticator", "PasswordAuthenticator")
+                                                              .set("authorizer", "CassandraAuthorizer"))
+                                      .start());
 
-            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(null, 1)"));
-            assertRowsWithRestart(node, row(1, "******1"), row(2, "******2"));
+        // create a user without UNMASK permission
+        withAuthenticatedSession(cluster.get(1), DEFAULT_SUPERUSER_NAME, DEFAULT_SUPERUSER_PASSWORD, session -> {
+            session.execute(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", USERNAME, PASSWORD));
+            session.execute(format("GRANT ALL ON KEYSPACE %s TO %s", KEYSPACE, USERNAME));
+            session.execute(format("REVOKE UNMASK ON KEYSPACE %s FROM %s", KEYSPACE, USERNAME));
+        });
 
-            cluster.schemaChange(withKeyspace("ALTER TABLE %s.t ALTER v MASKED WITH mask_inner(3, null)"));
-            assertRowsWithRestart(node, row(1, "sec****"), row(2, "sec****"));
+        return cluster;
+    }
+
+    private static void assertRowsInAllCoordinators(Cluster cluster, Object[]... expectedRows)
+    {
+        for (int i = 1; i < cluster.size(); i++)
+        {
+            assertRowsWithAuthentication(cluster.get(i), expectedRows);
         }
     }
 
     private static void assertRowsWithRestart(IInvokableInstance node, Object[]... expectedRows) throws Throwable
     {
         // test querying with in-memory column definitions
-        assertRows(node.executeInternal(SELECT), expectedRows);
+        assertRowsWithAuthentication(node, expectedRows);
 
         // restart the nodes to reload the column definitions from disk
         node.shutdown().get();
         node.startup();
 
         // test querying with the column definitions loaded from disk
-        assertRows(node.executeInternal(SELECT), expectedRows);
+        assertRowsWithAuthentication(node, expectedRows);
+    }
+
+    private static void assertRowsWithAuthentication(IInvokableInstance node, Object[]... expectedRows)
+    {
+        withAuthenticatedSession(node, USERNAME, PASSWORD, session -> {
+            Statement statement = new SimpleStatement(SELECT).setConsistencyLevel(ConsistencyLevel.ALL);
+            ResultSet resultSet = session.execute(statement);
+            assertRows(RowUtil.toObjects(resultSet), expectedRows);
+        });
+    }
+
+    private static void withAuthenticatedSession(IInvokableInstance instance, String username, String password, Consumer<Session> consumer)
+    {
+        // wait for existing roles
+        await().pollDelay(1, SECONDS)
+               .pollInterval(1, SECONDS)
+               .atMost(1, MINUTES)
+               .until(() -> instance.callOnInstance(CassandraRoleManager::hasExistingRoles));
+
+        // use a load balancing policy that ensures that we actually connect to the desired node
+        InetAddress address = instance.broadcastAddress().getAddress();
+        LoadBalancingPolicy lbc = new SingleHostLoadBalancingPolicy(address);
+
+        Builder builder = com.datastax.driver.core.Cluster.builder()
+                                                          .addContactPoints(address)
+                                                          .withLoadBalancingPolicy(lbc)
+                                                          .withCredentials(username, password);
+
+        try (com.datastax.driver.core.Cluster cluster = builder.build();
+             Session session = cluster.connect())
+        {
+            consumer.accept(session);
+        }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/util/SingleHostLoadBalancingPolicy.java
+++ b/test/distributed/org/apache/cassandra/distributed/util/SingleHostLoadBalancingPolicy.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.util;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.google.common.collect.Iterators;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+
+/**
+ * A CQL driver {@link LoadBalancingPolicy} that only connects to a fixed host.
+ */
+public class SingleHostLoadBalancingPolicy implements LoadBalancingPolicy
+{
+    private final InetAddress address;
+    private Host host;
+
+    public SingleHostLoadBalancingPolicy(InetAddress address)
+    {
+        this.address = address;
+    }
+
+    protected final List<Host> hosts = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void init(Cluster cluster, Collection<Host> hosts)
+    {
+        host = hosts.stream()
+                    .filter(h -> h.getBroadcastAddress().equals(address)).findFirst()
+                    .orElseThrow(() -> new AssertionError("The host should be a contact point"));
+        this.hosts.add(host);
+    }
+
+    @Override
+    public HostDistance distance(Host host)
+    {
+        return HostDistance.LOCAL;
+    }
+
+    @Override
+    public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement)
+    {
+        return Iterators.singletonIterator(host);
+    }
+
+    @Override
+    public void onAdd(Host host)
+    {
+        // no-op
+    }
+
+    @Override
+    public void onUp(Host host)
+    {
+        // no-op
+    }
+
+    @Override
+    public void onDown(Host host)
+    {
+        // no-op
+    }
+
+    @Override
+    public void onRemove(Host host)
+    {
+        // no-op
+    }
+
+    @Override
+    public void close()
+    {
+        // no-op
+    }
+}

--- a/test/microbench/org/apache/cassandra/test/microbench/btree/AtomicBTreePartitionUpdateBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/btree/AtomicBTreePartitionUpdateBench.java
@@ -561,7 +561,13 @@ public class AtomicBTreePartitionUpdateBench
     private static ColumnMetadata[] columns(AbstractType<?> type, ColumnMetadata.Kind kind, int count, String prefix)
     {
         return IntStream.range(0, count)
-                        .mapToObj(i -> new ColumnMetadata("", "", new ColumnIdentifier(prefix + i, true), type, kind != ColumnMetadata.Kind.REGULAR ? i : ColumnMetadata.NO_POSITION, kind))
+                        .mapToObj(i -> new ColumnMetadata("",
+                                                          "",
+                                                          new ColumnIdentifier(prefix + i, true),
+                                                          type,
+                                                          kind != ColumnMetadata.Kind.REGULAR ? i : ColumnMetadata.NO_POSITION,
+                                                          kind,
+                                                          null))
                         .toArray(ColumnMetadata[]::new);
     }
 

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -299,7 +299,8 @@ public class SchemaLoader
                                   ColumnIdentifier.getInterned(IntegerType.instance.fromString("42"), IntegerType.instance),
                                   UTF8Type.instance,
                                   ColumnMetadata.NO_POSITION,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     public static ColumnMetadata utf8Column(String ksName, String cfName)
@@ -309,7 +310,8 @@ public class SchemaLoader
                                   ColumnIdentifier.getInterned("fortytwo", true),
                                   UTF8Type.instance,
                                   ColumnMetadata.NO_POSITION,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     public static TableMetadata perRowIndexedCFMD(String ksName, String cfName)

--- a/test/unit/org/apache/cassandra/auth/CreateAndAlterRoleTest.java
+++ b/test/unit/org/apache/cassandra/auth/CreateAndAlterRoleTest.java
@@ -21,11 +21,9 @@ package org.apache.cassandra.auth;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.datastax.driver.core.exceptions.AuthenticationException;
-import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 
-import static org.junit.Assert.assertTrue;
 import static org.mindrot.jbcrypt.BCrypt.gensalt;
 import static org.mindrot.jbcrypt.BCrypt.hashpw;
 
@@ -34,6 +32,10 @@ public class CreateAndAlterRoleTest extends CQLTester
     @BeforeClass
     public static void setUpClass()
     {
+        DatabaseDescriptor.setPermissionsValidity(0);
+        DatabaseDescriptor.setRolesValidity(0);
+        DatabaseDescriptor.setCredentialsValidity(0);
+
         CQLTester.setUpClass();
         requireAuthentication();
         requireNetwork();
@@ -62,11 +64,11 @@ public class CreateAndAlterRoleTest extends CQLTester
 
         useUser(user1, plainTextPwd);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
 
         useUser(user2, plainTextPwd);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
 
         useSuperUser();
 
@@ -78,11 +80,11 @@ public class CreateAndAlterRoleTest extends CQLTester
 
         useUser(user1, plainTextPwd2);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
 
         useUser(user2, plainTextPwd2);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
     }
 
     @Test
@@ -105,11 +107,11 @@ public class CreateAndAlterRoleTest extends CQLTester
 
         useUser(user1, plainTextPwd);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
 
         useUser(user2, plainTextPwd);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
 
         useSuperUser();
 
@@ -118,32 +120,10 @@ public class CreateAndAlterRoleTest extends CQLTester
 
         useUser(user1, plainTextPwd2);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
+        executeNet("SELECT key FROM system.local");
 
         useUser(user2, plainTextPwd2);
 
-        executeNetWithAuthSpin("SELECT key FROM system.local");
-    }
-
-    /**
-     * Altering or creating auth may take some time to be effective
-     *
-     * @param query
-     */
-    void executeNetWithAuthSpin(String query)
-    {
-        Util.spinAssertEquals(true, () -> {
-            try
-            {
-                executeNet(query);
-                return true;
-            }
-            catch (Throwable e)
-            {
-                assertTrue("Unexpected exception: " + e, e instanceof AuthenticationException);
-                reinitializeNetwork();
-                return false;
-            }
-        }, 10);
+        executeNet("SELECT key FROM system.local");
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -1276,6 +1276,11 @@ public abstract class CQLTester
         return sessionNet().execute(new SimpleStatement(formatQuery(query)).setFetchSize(pageSize));
     }
 
+    protected com.datastax.driver.core.ResultSet executeNetWithoutPaging(String query)
+    {
+        return executeNetWithPaging(query, Integer.MAX_VALUE);
+    }
+
     protected Session sessionNet()
     {
         return sessionNet(getDefaultVersion());
@@ -1718,6 +1723,24 @@ public abstract class CQLTester
         {
             ColumnSpecification columnSpec = metadata.get(i);
             Assert.assertEquals(expectedColumnNames[i], columnSpec.name.toString());
+        }
+    }
+
+    protected void assertColumnNames(ResultSet result, String... expectedColumnNames)
+    {
+        if (result == null)
+        {
+            Assert.fail("No rows returned by query.");
+            return;
+        }
+
+        ColumnDefinitions columnDefinitions = result.getColumnDefinitions();
+        Assert.assertEquals("Got less columns than expected.", expectedColumnNames.length, columnDefinitions.size());
+
+        for (int i = 0, m = columnDefinitions.size(); i < m; i++)
+        {
+            String columnName = columnDefinitions.getName(i);
+            Assert.assertEquals(expectedColumnNames[i], columnName);
         }
     }
 

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionTester.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+
+import static java.lang.String.format;
+
+/**
+ * {@link ColumnMaskTester} verifying that masks can be applied to columns in any position (partition key columns,
+ * clustering key columns, static columns and regular columns). The columns of any depending materialized views should
+ * be udpated accordingly.
+ */
+@RunWith(Parameterized.class)
+public abstract class ColumnMaskInAnyPositionTester extends ColumnMaskTester
+{
+    /** The column mask as expressed in CQL statements right after the {@code MASKED WITH} keywords. */
+    @Parameterized.Parameter
+    public String mask;
+
+    /** The type of the masked column */
+    @Parameterized.Parameter(1)
+    public String type;
+
+    /** The types of the tested masking function partial arguments. */
+    @Parameterized.Parameter(2)
+    public List<AbstractType<?>> argumentTypes;
+
+    /** The serialized values of the tested masking function partial arguments. */
+    @Parameterized.Parameter(3)
+    public List<ByteBuffer> argumentValues;
+
+    @Test
+    public void testCreateTableWithMaskedColumns() throws Throwable
+    {
+        // Nothing is masked
+        createTable("CREATE TABLE %s (k int, c int, r int, s int static, PRIMARY KEY(k, c))");
+        assertTableColumnsAreNotMasked("k", "c", "r", "s");
+
+        // Masked partition key
+        createTable(format("CREATE TABLE %%s (k %s MASKED WITH %s PRIMARY KEY, r int)", type, mask));
+        assertTableColumnsAreMasked("k");
+        assertTableColumnsAreNotMasked("r");
+
+        // Masked partition key component
+        createTable(format("CREATE TABLE %%s (k1 int, k2 %s MASKED WITH %s, r int, PRIMARY KEY(k1, k2))", type, mask));
+        assertTableColumnsAreMasked("k2");
+        assertTableColumnsAreNotMasked("k1", "r");
+
+        // Masked clustering key
+        createTable(format("CREATE TABLE %%s (k int, c %s MASKED WITH %s, r int, PRIMARY KEY (k, c))", type, mask));
+        assertTableColumnsAreMasked("c");
+        assertTableColumnsAreNotMasked("k", "r");
+
+        // Masked clustering key with reverse order
+        createTable(format("CREATE TABLE %%s (k int, c %s MASKED WITH %s, r int, PRIMARY KEY (k, c)) " +
+                           "WITH CLUSTERING ORDER BY (c DESC)", type, mask));
+        assertTableColumnsAreMasked("c");
+        assertTableColumnsAreNotMasked("k", "r");
+
+        // Masked clustering key component
+        createTable(format("CREATE TABLE %%s (k int, c1 int, c2 %s MASKED WITH %s, r int, PRIMARY KEY (k, c1, c2))", type, mask));
+        assertTableColumnsAreMasked("c2");
+        assertTableColumnsAreNotMasked("k", "c1", "r");
+
+        // Masked regular column
+        createTable(format("CREATE TABLE %%s (k int PRIMARY KEY, r1 %s MASKED WITH %s, r2 int)", type, mask));
+        assertTableColumnsAreMasked("r1");
+        assertTableColumnsAreNotMasked("k", "r2");
+
+        // Masked static column
+        createTable(format("CREATE TABLE %%s (k int, c int, r int, s %s STATIC MASKED WITH %s, PRIMARY KEY (k, c))", type, mask));
+        assertTableColumnsAreMasked("s");
+        assertTableColumnsAreNotMasked("k", "c", "r");
+
+        // Multiple masked columns
+        createTable(format("CREATE TABLE %%s (" +
+                           "k1 int, k2 %s MASKED WITH %s, " +
+                           "c1 int, c2 %s MASKED WITH %s, " +
+                           "r1 int, r2 %s MASKED WITH %s, " +
+                           "s1 int static, s2 %s static MASKED WITH %s, " +
+                           "PRIMARY KEY((k1, k2), c1, c2))",
+                           type, mask, type, mask, type, mask, type, mask));
+        assertTableColumnsAreMasked("k2", "c2", "r2", "s2");
+        assertTableColumnsAreNotMasked("k1", "c1", "r1", "s1");
+    }
+
+    @Test
+    public void testCreateTableWithMaskedColumnsAndMaterializedView() throws Throwable
+    {
+        createTable(format("CREATE TABLE %%s (" +
+                           "k1 int, k2 %s MASKED WITH %s, " +
+                           "c1 int, c2 %s MASKED WITH %s, " +
+                           "r1 int, r2 %s MASKED WITH %s, " +
+                           "s1 int static, s2 %s static MASKED WITH %s, " +
+                           "PRIMARY KEY((k1, k2), c1, c2))",
+                           type, mask, type, mask, type, mask, type, mask));
+        createView("CREATE MATERIALIZED VIEW %s AS SELECT k1, k2, c1, c2, r1, r2 FROM %s " +
+                   "WHERE k1 IS NOT NULL AND k2 IS NOT NULL " +
+                   "AND c1 IS NOT NULL AND c2 IS NOT NULL " +
+                   "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
+                   "PRIMARY KEY (r2, c2, c1, k2, k1)");
+
+        assertTableColumnsAreMasked("k2", "c2", "r2", "s2");
+        assertTableColumnsAreNotMasked("k1", "c1", "r1", "s1");
+
+        assertViewColumnsAreMasked("k2", "c2", "r2");
+        assertViewColumnsAreNotMasked("k1", "c1", "r1");
+    }
+
+    @Test
+    public void testAlterTableWithMaskedColumns() throws Throwable
+    {
+        // Create the table to be altered
+        createTable(format("CREATE TABLE %%s (k %s, c %<s, r1 %<s, r2 %<s MASKED WITH %s, r3 %s, s %<s static, " +
+                           "PRIMARY KEY (k, c))", type, mask, type));
+        assertTableColumnsAreMasked("r2");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r3", "s");
+
+        // Add new masked column
+        alterTable(format("ALTER TABLE %%s ADD r4 %s MASKED WITH %s", type, mask));
+        assertTableColumnsAreMasked("r2", "r4");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r3", "s");
+
+        // Set mask for an existing but unmasked column
+        alterTable(format("ALTER TABLE %%s ALTER r1 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("r1", "r2", "r4");
+
+        // Unmask a masked column
+        alterTable("ALTER TABLE %s ALTER r1 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r2 DROP MASKED");
+        assertTableColumnsAreMasked("r4");
+        assertTableColumnsAreNotMasked("r1", "r2", "r3");
+
+        // Mask and disable mask for primary key
+        alterTable(format("ALTER TABLE %%s ALTER k MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("k");
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        assertTableColumnsAreNotMasked("k");
+
+        // Mask and disable mask for clustering key
+        alterTable(format("ALTER TABLE %%s ALTER c MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("c");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        assertTableColumnsAreNotMasked("c");
+
+        // Mask and disable mask for static column
+        alterTable(format("ALTER TABLE %%s ALTER s MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("s");
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        assertTableColumnsAreNotMasked("s");
+
+        // Add multiple masked columns within the same query
+        alterTable(format("ALTER TABLE %%s ADD (" +
+                          "r5 %s MASKED WITH %s, " +
+                          "r6 %s, " +
+                          "r7 %s MASKED WITH %s, " +
+                          "r8 %s)",
+                          type, mask, type, type, mask, type));
+        assertTableColumnsAreMasked("r5", "r7");
+        assertTableColumnsAreNotMasked("r6", "r8");
+    }
+
+    @Test
+    public void testAlterTableWithMaskedColumnsAndMaterializedView() throws Throwable
+    {
+        createTable(format("CREATE TABLE %%s (" +
+                           "k %s, c %<s, r1 %<s, r2 %<s, s1 %<s static, s2 %<s static, " +
+                           "PRIMARY KEY(k, c))", type));
+        createView("CREATE MATERIALIZED VIEW %s AS SELECT k, c, r2 FROM %s " +
+                   "WHERE k IS NOT NULL AND c IS NOT NULL " +
+                   "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
+                   "PRIMARY KEY (r2, c, k)");
+
+        // Adding a column to the table doesn't have an effect on the view
+        alterTable(format("ALTER TABLE %%s ADD r3 %s MASKED WITH %s", type, mask));
+        assertTableColumnsAreMasked("r3");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r2", "s1", "s2");
+        assertViewColumnsAreNotMasked("k", "c", "r2");
+
+        // Masking a column that is not part of the view doesn't have an effect on the view
+        alterTable(format("ALTER TABLE %%s ALTER r1 MASKED WITH %s", mask));
+        alterTable(format("ALTER TABLE %%s ALTER s1 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("r1", "r3", "s1");
+        assertTableColumnsAreNotMasked("k", "c", "r2", "s2");
+        assertViewColumnsAreNotMasked("k", "c", "r2");
+
+        // Masking a column that is part of the view should have an effect on the view
+        alterTable(format("ALTER TABLE %%s ALTER r2 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("r1", "r2", "r3", "s1");
+        assertTableColumnsAreNotMasked("k", "c", "s2");
+        assertViewColumnsAreMasked("r2");
+        assertViewColumnsAreNotMasked("k", "c");
+
+        // Mask the rest of the columns
+        alterTable(format("ALTER TABLE %%s ALTER k MASKED WITH %s", mask));
+        alterTable(format("ALTER TABLE %%s ALTER c MASKED WITH %s", mask));
+        alterTable(format("ALTER TABLE %%s ALTER s2 MASKED WITH %s", mask));
+        assertTableColumnsAreMasked("k", "c", "r1", "r2", "r3", "s1", "s2");
+        assertViewColumnsAreMasked("k", "c", "r2");
+
+        // Unmask a column that is part of the view
+        alterTable("ALTER TABLE %s ALTER r2 DROP MASKED");
+        assertTableColumnsAreMasked("k", "c", "r1", "r3", "s1", "s2");
+        assertTableColumnsAreNotMasked("r2");
+        assertViewColumnsAreMasked("k", "c");
+        assertViewColumnsAreNotMasked("r2");
+
+        // Unmask the rest of the columns
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r1 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r3 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s1 DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s2 DROP MASKED");
+        assertTableColumnsAreNotMasked("k", "c", "r1", "r2", "r3", "s1", "s2");
+        assertViewColumnsAreNotMasked("k", "c", "r2");
+    }
+
+    private String functionName()
+    {
+        return mask.equals("DEFAULT") ? "mask_default" : StringUtils.substringBefore(mask, "(");
+    }
+
+    private void assertTableColumnsAreMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsMasked(currentTable(), column, functionName(), argumentTypes, argumentValues);
+        }
+    }
+
+    private void assertViewColumnsAreMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsMasked(currentView(), column, functionName(), argumentTypes, argumentValues);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithDefaultTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithDefaultTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link DefaultMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithDefaultTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "DEFAULT", "int", emptyList(), emptyList() },
+        { "DEFAULT", "text", emptyList(), emptyList() },
+        { "DEFAULT", "frozen<list<uuid>>", emptyList(), emptyList() },
+        { "mask_default()", "int", emptyList(), emptyList() },
+        { "mask_default()", "text", emptyList(), emptyList() },
+        { "mask_default()", "frozen<list<uuid>>", emptyList(), emptyList() },
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithNullTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithNullTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link NullMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithNullTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_null()", "int", emptyList(), emptyList() },
+        { "mask_null()", "text", emptyList(), emptyList() },
+        { "mask_null()", "frozen<list<uuid>>", emptyList(), emptyList() },
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithPartialTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithPartialTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+
+import static java.util.Arrays.asList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link PartialMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithPartialTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_inner(1, 2)", "text",
+          asList(Int32Type.instance, Int32Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2)) },
+        { "mask_outer(1, 2)", "text",
+          asList(Int32Type.instance, Int32Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2)) },
+        { "mask_inner(1, 2, '#')", "text",
+          asList(Int32Type.instance, Int32Type.instance, UTF8Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2), UTF8Type.instance.decompose("#")) },
+        { "mask_outer(1, 2, '#')", "text",
+          asList(Int32Type.instance, Int32Type.instance, UTF8Type.instance),
+          asList(Int32Type.instance.decompose(1), Int32Type.instance.decompose(2), UTF8Type.instance.decompose("#")) }
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithReplaceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskInAnyPositionWithReplaceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.ListType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+/**
+ * {@link ColumnMaskInAnyPositionTester} for {@link ReplaceMaskingFunction}.
+ */
+public class ColumnMaskInAnyPositionWithReplaceTest extends ColumnMaskInAnyPositionTester
+{
+    @Parameterized.Parameters(name = "mask={0}, type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_replace(0)", "int",
+          singletonList(Int32Type.instance),
+          singletonList(Int32Type.instance.decompose(0)) },
+        { "mask_replace('redacted')", "text",
+          singletonList(UTF8Type.instance),
+          singletonList(UTF8Type.instance.decompose("redacted")) },
+        { "mask_replace([])", "frozen<list<int>>",
+          singletonList(ListType.getInstance(Int32Type.instance, false)),
+          singletonList(ListType.getInstance(Int32Type.instance, false).decompose(emptyList())) },
+        });
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskNativeTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskNativeTypesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.CQL3Type;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+/**
+ * {@link ColumnMaskTester} verifying that we can attach column masks to table columns with any native data type.
+ */
+@RunWith(Parameterized.class)
+public class ColumnMaskNativeTypesTest extends ColumnMaskTester
+{
+    /** The type of the column. */
+    @Parameterized.Parameter
+    public CQL3Type.Native type;
+
+    @Parameterized.Parameters(name = "type={0}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> parameters = new ArrayList<>();
+        for (CQL3Type.Native type : CQL3Type.Native.values())
+        {
+            if (type != CQL3Type.Native.EMPTY)
+                parameters.add(new Object[]{ type });
+        }
+        return parameters;
+    }
+
+    @Test
+    public void testNativeDataTypes() throws Throwable
+    {
+        String def = format("%s MASKED WITH DEFAULT", type);
+        String keyDef = type == CQL3Type.Native.COUNTER || type == CQL3Type.Native.DURATION
+                        ? "int MASKED WITH DEFAULT" : def;
+        String staticDef = format("%s STATIC MASKED WITH DEFAULT", type);
+
+        // Create table with masks
+        String table = createTable(format("CREATE TABLE %%s (k %s, c %<s, r %s, s %s, PRIMARY KEY(k, c))", keyDef, def, staticDef));
+        assertColumnIsMasked(table, "k", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "c", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "r", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "s", "mask_default", emptyList(), emptyList());
+
+        // Alter column masks
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER r MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER s MASKED WITH mask_null()");
+        assertColumnIsMasked(table, "k", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "c", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "r", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "s", "mask_null", emptyList(), emptyList());
+
+        // Drop masks
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER r DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        assertTableColumnsAreNotMasked("k", "c", "r", "s");
+    }
+}
+

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryTester.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+
+import static java.lang.String.format;
+
+/**
+ * Test queries on columns that have attached a dynamic data masking function.
+ */
+@RunWith(Parameterized.class)
+public abstract class ColumnMaskQueryTester extends ColumnMaskTester
+{
+    @Parameterized.Parameter
+    public String order;
+
+    @Parameterized.Parameter(1)
+    public String mask;
+
+    @Parameterized.Parameter(2)
+    public String columnType;
+
+    @Parameterized.Parameter(3)
+    public Object columnValue;
+
+    @Parameterized.Parameter(4)
+    public Object maskedValue;
+
+    @Before
+    public void setupSchema() throws Throwable
+    {
+        createTable("CREATE TABLE %s (" +
+                    format("k1 %s, k2 %<s MASKED WITH %s, ", columnType, mask) +
+                    format("c1 %s, c2 %<s MASKED WITH %s, ", columnType, mask) +
+                    format("r1 %s, r2 %<s MASKED WITH %s, ", columnType, mask) +
+                    format("s1 %s static, s2 %<s static MASKED WITH %s, ", columnType, mask) +
+                    format("PRIMARY KEY((k1, k2), c1, c2)) WITH CLUSTERING ORDER BY (c1 %s, c2 %<s)", order));
+
+        createView("CREATE MATERIALIZED VIEW %s AS SELECT k2, k1, c2, c1, r2, r1 FROM %s " +
+                   "WHERE k1 IS NOT NULL AND k2 IS NOT NULL " +
+                   "AND c1 IS NOT NULL AND c2 IS NOT NULL " +
+                   "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
+                   "PRIMARY KEY ((c2, c1), k2, k1)");
+
+        execute("INSERT INTO %s(k1, k2, c1, c2, r1, r2, s1, s2) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue);
+    }
+
+    @Test
+    public void testSelectWithWilcard() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT * FROM %s");
+        assertColumnNames(rs, "k1", "k2", "c1", "c2", "s1", "s2", "r1", "r2");
+        assertRows(rs, row(columnValue, maskedValue,
+                           columnValue, maskedValue,
+                           columnValue, maskedValue,
+                           columnValue, maskedValue));
+
+        rs = execute(format("SELECT * FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "c2", "c1", "k2", "k1", "r1", "r2");
+        assertRows(rs, row(maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           columnValue, maskedValue));
+    }
+
+    @Test
+    public void testSelectWithAllColumnNames() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT c2, c1, k2, k1, r2, r1, s2, s1 FROM %s");
+        assertColumnNames(rs, "c2", "c1", "k2", "k1", "r2", "r1", "s2", "s1");
+        assertRows(rs, row(maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           maskedValue, columnValue));
+
+        rs = execute(format("SELECT c2, c1, k2, k1, r2, r1 FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "c2", "c1", "k2", "k1", "r2", "r1");
+        assertRows(rs, row(maskedValue, columnValue,
+                           maskedValue, columnValue,
+                           maskedValue, columnValue));
+    }
+
+    @Test
+    public void testSelectOnlyMaskedColumns() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT k2, c2, s2, r2 FROM %s");
+        assertColumnNames(rs, "k2", "c2", "s2", "r2");
+        assertRows(rs, row(maskedValue, maskedValue, maskedValue, maskedValue));
+
+        rs = execute(format("SELECT k2, c2, r2 FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "k2", "c2", "r2");
+        assertRows(rs, row(maskedValue, maskedValue, maskedValue));
+    }
+
+    @Test
+    public void testSelectOnlyNotMaskedColumns() throws Throwable
+    {
+        UntypedResultSet rs = execute("SELECT k1, c1, s1, r1 FROM %s");
+        assertColumnNames(rs, "k1", "c1", "s1", "r1");
+        assertRows(rs, row(columnValue, columnValue, columnValue, columnValue));
+
+        rs = execute(format("SELECT k1, c1, r1 FROM %s.%s", KEYSPACE, currentView()));
+        assertColumnNames(rs, "k1", "c1", "r1");
+        assertRows(rs, row(columnValue, columnValue, columnValue));
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryTester.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.cassandra.cql3.UntypedResultSet;
+import com.datastax.driver.core.ResultSet;
 
 import static java.lang.String.format;
 
@@ -64,65 +64,65 @@ public abstract class ColumnMaskQueryTester extends ColumnMaskTester
                    "AND r1 IS NOT NULL AND r2 IS NOT NULL " +
                    "PRIMARY KEY ((c2, c1), k2, k1)");
 
-        execute("INSERT INTO %s(k1, k2, c1, c2, r1, r2, s1, s2) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue);
+        executeNet("INSERT INTO %s(k1, k2, c1, c2, r1, r2, s1, s2) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                   columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue, columnValue);
     }
 
     @Test
     public void testSelectWithWilcard() throws Throwable
     {
-        UntypedResultSet rs = execute("SELECT * FROM %s");
+        ResultSet rs = executeNet("SELECT * FROM %s");
         assertColumnNames(rs, "k1", "k2", "c1", "c2", "s1", "s2", "r1", "r2");
-        assertRows(rs, row(columnValue, maskedValue,
-                           columnValue, maskedValue,
-                           columnValue, maskedValue,
-                           columnValue, maskedValue));
+        assertRowsNet(rs, row(columnValue, maskedValue,
+                              columnValue, maskedValue,
+                              columnValue, maskedValue,
+                              columnValue, maskedValue));
 
-        rs = execute(format("SELECT * FROM %s.%s", KEYSPACE, currentView()));
+        rs = executeNet(format("SELECT * FROM %s.%s", KEYSPACE, currentView()));
         assertColumnNames(rs, "c2", "c1", "k2", "k1", "r1", "r2");
-        assertRows(rs, row(maskedValue, columnValue,
-                           maskedValue, columnValue,
-                           columnValue, maskedValue));
+        assertRowsNet(rs, row(maskedValue, columnValue,
+                              maskedValue, columnValue,
+                              columnValue, maskedValue));
     }
 
     @Test
     public void testSelectWithAllColumnNames() throws Throwable
     {
-        UntypedResultSet rs = execute("SELECT c2, c1, k2, k1, r2, r1, s2, s1 FROM %s");
+        ResultSet rs = executeNet("SELECT c2, c1, k2, k1, r2, r1, s2, s1 FROM %s");
         assertColumnNames(rs, "c2", "c1", "k2", "k1", "r2", "r1", "s2", "s1");
-        assertRows(rs, row(maskedValue, columnValue,
-                           maskedValue, columnValue,
-                           maskedValue, columnValue,
-                           maskedValue, columnValue));
+        assertRowsNet(rs, row(maskedValue, columnValue,
+                              maskedValue, columnValue,
+                              maskedValue, columnValue,
+                              maskedValue, columnValue));
 
-        rs = execute(format("SELECT c2, c1, k2, k1, r2, r1 FROM %s.%s", KEYSPACE, currentView()));
+        rs = executeNet(format("SELECT c2, c1, k2, k1, r2, r1 FROM %s.%s", KEYSPACE, currentView()));
         assertColumnNames(rs, "c2", "c1", "k2", "k1", "r2", "r1");
-        assertRows(rs, row(maskedValue, columnValue,
-                           maskedValue, columnValue,
-                           maskedValue, columnValue));
+        assertRowsNet(rs, row(maskedValue, columnValue,
+                              maskedValue, columnValue,
+                              maskedValue, columnValue));
     }
 
     @Test
     public void testSelectOnlyMaskedColumns() throws Throwable
     {
-        UntypedResultSet rs = execute("SELECT k2, c2, s2, r2 FROM %s");
+        ResultSet rs = executeNet("SELECT k2, c2, s2, r2 FROM %s");
         assertColumnNames(rs, "k2", "c2", "s2", "r2");
-        assertRows(rs, row(maskedValue, maskedValue, maskedValue, maskedValue));
+        assertRowsNet(rs, row(maskedValue, maskedValue, maskedValue, maskedValue));
 
-        rs = execute(format("SELECT k2, c2, r2 FROM %s.%s", KEYSPACE, currentView()));
+        rs = executeNet(format("SELECT k2, c2, r2 FROM %s.%s", KEYSPACE, currentView()));
         assertColumnNames(rs, "k2", "c2", "r2");
-        assertRows(rs, row(maskedValue, maskedValue, maskedValue));
+        assertRowsNet(rs, row(maskedValue, maskedValue, maskedValue));
     }
 
     @Test
     public void testSelectOnlyNotMaskedColumns() throws Throwable
     {
-        UntypedResultSet rs = execute("SELECT k1, c1, s1, r1 FROM %s");
+        ResultSet rs = executeNet("SELECT k1, c1, s1, r1 FROM %s");
         assertColumnNames(rs, "k1", "c1", "s1", "r1");
-        assertRows(rs, row(columnValue, columnValue, columnValue, columnValue));
+        assertRowsNet(rs, row(columnValue, columnValue, columnValue, columnValue));
 
-        rs = execute(format("SELECT k1, c1, r1 FROM %s.%s", KEYSPACE, currentView()));
+        rs = executeNet(format("SELECT k1, c1, r1 FROM %s.%s", KEYSPACE, currentView()));
         assertColumnNames(rs, "k1", "c1", "r1");
-        assertRows(rs, row(columnValue, columnValue, columnValue));
+        assertRowsNet(rs, row(columnValue, columnValue, columnValue));
     }
 }

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithDefaultTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithDefaultTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link DefaultMaskingFunction}.
+ */
+public class ColumnMaskQueryWithDefaultTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "DEFAULT", "text", "abc", "****" });
+            options.add(new Object[]{ order, "DEFAULT", "int", 123, 0 });
+            options.add(new Object[]{ order, "mask_default()", "text", "abc", "****" });
+            options.add(new Object[]{ order, "mask_default()", "int", 123, 0, });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithNullTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithNullTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link NullMaskingFunction}.
+ */
+public class ColumnMaskQueryWithNullTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "mask_null()", "text", "abc", null });
+            options.add(new Object[]{ order, "mask_null()", "int", 123, null });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithPartialTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithPartialTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link PartialMaskingFunction}.
+ */
+public class ColumnMaskQueryWithPartialTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "mask_inner(null, null)", "text", "abcdef", "******" });
+            options.add(new Object[]{ order, "mask_inner(1, 2)", "text", "abcdef", "a***ef" });
+            options.add(new Object[]{ order, "mask_inner(1, 2, '#')", "text", "abcdef", "a###ef" });
+            options.add(new Object[]{ order, "mask_outer(1, null)", "text", "abcdef", "*bcdef" });
+            options.add(new Object[]{ order, "mask_outer(1, 2)", "text", "abcdef", "*bcd**" });
+            options.add(new Object[]{ order, "mask_outer(1, 2, '#')", "text", "abcdef", "#bcd##", });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithReplaceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskQueryWithReplaceTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+
+/**
+ * {@link ColumnMaskQueryTester} for {@link ReplaceMaskingFunction}.
+ */
+public class ColumnMaskQueryWithReplaceTest extends ColumnMaskQueryTester
+{
+    @Parameterized.Parameters(name = "order={0}, mask={1}, type={2}, value={3}")
+    public static Collection<Object[]> options()
+    {
+        List<Object[]> options = new ArrayList<>();
+        for (String order : Arrays.asList("ASC", "DESC"))
+        {
+            options.add(new Object[]{ order, "mask_replace(null)", "int", 123, null });
+            options.add(new Object[]{ order, "mask_replace('redacted')", "ascii", "abc", "redacted" });
+            options.add(new Object[]{ order, "mask_replace('redacted')", "text", "abc", "redacted" });
+            options.add(new Object[]{ order, "mask_replace(0)", "int", 123, 0 });
+            options.add(new Object[]{ order, "mask_replace(0)", "bigint", 123L, 0L });
+            options.add(new Object[]{ order, "mask_replace(0)", "varint", BigInteger.valueOf(123), BigInteger.ZERO });
+        }
+        return options;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTest.java
@@ -1,0 +1,547 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.cql3.CQL3Type;
+import org.apache.cassandra.cql3.functions.FunctionFactory;
+import org.apache.cassandra.cql3.functions.FunctionParameter;
+import org.apache.cassandra.cql3.functions.NativeFunction;
+import org.apache.cassandra.cql3.functions.NativeFunctions;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+/**
+ * Tests schema altering queries ({@code CREATE TABLE}, {@code ALTER TABLE}, etc.) that attach/dettach dynamic data
+ * masking functions to column definitions.
+ */
+public class ColumnMaskTest extends ColumnMaskTester
+{
+    @Test
+    public void testCollections() throws Throwable
+    {
+        // Create table with masks
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, " +
+                                   "s set<int> MASKED WITH DEFAULT, " +
+                                   "l list<int> MASKED WITH DEFAULT, " +
+                                   "m map<int, int> MASKED WITH DEFAULT, " +
+                                   "fs frozen<set<int>> MASKED WITH DEFAULT, " +
+                                   "fl frozen<list<int>> MASKED WITH DEFAULT, " +
+                                   "fm frozen<map<int, int>> MASKED WITH DEFAULT)");
+        assertColumnIsMasked(table, "s", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "l", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "m", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fs", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fl", "mask_default", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fm", "mask_default", emptyList(), emptyList());
+
+        // Alter column masks
+        alterTable("ALTER TABLE %s ALTER s MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER l MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER m MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER fs MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER fl MASKED WITH mask_null()");
+        alterTable("ALTER TABLE %s ALTER fm MASKED WITH mask_null()");
+        assertColumnIsMasked(table, "s", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "l", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "m", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fs", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fl", "mask_null", emptyList(), emptyList());
+        assertColumnIsMasked(table, "fm", "mask_null", emptyList(), emptyList());
+
+        // Drop masks
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER l DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER m DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER fs DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER fl DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER fm DROP MASKED");
+        assertTableColumnsAreNotMasked("s", "l", "m", "fs", "fl", "fm");
+    }
+
+    @Test
+    public void testUDTs() throws Throwable
+    {
+        String type = createType("CREATE TYPE %s (a1 varint, a2 varint, a3 varint);");
+
+        // Create table with mask
+        String table = createTable(format("CREATE TABLE %%s (k int PRIMARY KEY, v %s MASKED WITH DEFAULT)", type));
+        assertColumnIsMasked(table, "v", "mask_default", emptyList(), emptyList());
+
+        // Alter column mask
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_null()");
+        assertColumnIsMasked(table, "v", "mask_null", emptyList(), emptyList());
+
+        // Drop mask
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertTableColumnsAreNotMasked("v");
+    }
+
+    @Test
+    public void testAlterTableAddMaskingToNonExistingColumn() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("ALTER TABLE %s ALTER IF EXISTS unknown MASKED WITH DEFAULT");
+        assertInvalidMessage(format("Column with name 'unknown' doesn't exist on table '%s'", table),
+                             formatQuery("ALTER TABLE %s ALTER unknown MASKED WITH DEFAULT"));
+    }
+
+    @Test
+    public void testAlterTableRemoveMaskingFromNonExistingColumn() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("ALTER TABLE %s ALTER IF EXISTS unknown DROP MASKED");
+        assertInvalidMessage(format("Column with name 'unknown' doesn't exist on table '%s'", table),
+                             formatQuery("ALTER TABLE %s ALTER unknown DROP MASKED"));
+    }
+
+    @Test
+    public void testAlterTableRemoveMaskFromUnmaskedColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        execute("ALTER TABLE %s ALTER v DROP MASKED");
+        assertTableColumnsAreNotMasked("v");
+    }
+
+    @Test
+    public void testInvalidMaskingFunctionName() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Unable to find masking function for v, no declared function matches the signature mask_missing()",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v int MASKED WITH mask_missing())"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        assertInvalidMessage("Unable to find masking function for v, no declared function matches the signature mask_missing()",
+                             "ALTER TABLE %s ALTER v MASKED WITH mask_missing()");
+
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testInvalidMaskingFunctionArguments() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Invalid number of arguments for function system.mask_default(any)",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v int MASKED WITH mask_default(1))"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        assertInvalidMessage("Invalid number of arguments for function system.mask_default(any)",
+                             "ALTER TABLE %s ALTER v MASKED WITH mask_default(1)");
+
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testInvalidMaskingFunctionArgumentTypes() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Function system.mask_inner requires an argument of type int, but found argument 'a' of type ascii",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v text MASKED WITH mask_inner('a', 'b'))"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertInvalidMessage("Function system.mask_inner requires an argument of type int, but found argument 'a' of type ascii",
+                             "ALTER TABLE %s ALTER v MASKED WITH mask_inner('a', 'b')");
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testColumnMaskingWithNotMaskingFunction() throws Throwable
+    {
+        // create table
+        createTableName();
+        assertInvalidMessage("Not-masking function tojson() cannot be used for masking table columns",
+                             formatQuery("CREATE TABLE %s (k int PRIMARY KEY, v text MASKED WITH tojson())"));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertInvalidMessage("Not-masking function tojson() cannot be used for masking table columns",
+                             "ALTER TABLE %s ALTER v MASKED WITH tojson()");
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    public void testColumnMaskingWithNotNativeFunction() throws Throwable
+    {
+        String udf = createFunction(KEYSPACE,
+                                    "text",
+                                    "CREATE FUNCTION %s(k text) " +
+                                    "CALLED ON NULL INPUT " +
+                                    "RETURNS text " +
+                                    "LANGUAGE java AS $$return k;$$");
+
+        // create table
+        assertInvalidMessage(format("User defined function %s() cannot be used for masking table columns", udf),
+                             format("CREATE TABLE %s.%s (k int PRIMARY KEY, v text MASKED WITH %s())",
+                                    keyspace(), createTableName(), udf));
+
+        // alter table
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertInvalidMessage(format("User defined function %s() cannot be used for masking table columns", udf),
+                             format("ALTER TABLE %%s ALTER v MASKED WITH %s()", udf));
+
+        assertTableColumnsAreNotMasked("k", "v");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void testPreparedStatement() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text MASKED WITH DEFAULT)");
+        execute("INSERT INTO %s (k, v) VALUES (0, 'sensitive')");
+
+        Session session = sessionNet();
+        PreparedStatement prepared = session.prepare(formatQuery("SELECT v FROM %s WHERE k = ?"));
+        BoundStatement bound = prepared.bind(0);
+        assertRowsNet(session.execute(bound), row("****"));
+
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRowsNet(session.execute(bound), row("sensitive"));
+
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRowsNet(session.execute(bound), row("redacted"));
+    }
+
+    @Test
+    public void testViews() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text MASKED WITH mask_replace('redacted'), PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT * FROM %s " +
+                                 "WHERE k IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL " +
+                                 "PRIMARY KEY (v, k, c)");
+        waitForViewMutations();
+        assertRows(execute(format("SELECT v FROM %s.%s", KEYSPACE, view)), row("redacted"));
+        assertRows(execute(format("SELECT v FROM %s.%s WHERE v='sensitive'", KEYSPACE, view)), row("redacted"));
+        assertEmpty(execute(format("SELECT v FROM %s.%s WHERE v='redacted'", KEYSPACE, view)));
+
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRows(execute(format("SELECT v FROM %s.%s", KEYSPACE, view)), row("sensitive"));
+        assertRows(execute(format("SELECT v FROM %s.%s WHERE v='sensitive'", KEYSPACE, view)), row("sensitive"));
+        assertEmpty(execute(format("SELECT v FROM %s.%s WHERE v='redacted'", KEYSPACE, view)));
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void testPreparedStatementOnView() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text MASKED WITH DEFAULT, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        String view = createView("CREATE MATERIALIZED VIEW %s AS SELECT * FROM %s " +
+                                 "WHERE k IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL " +
+                                 "PRIMARY KEY (v, k, c)");
+        waitForViewMutations();
+
+        Session session = sessionNet();
+        PreparedStatement prepared = session.prepare(format("SELECT v FROM %s.%s WHERE v=?", KEYSPACE, view));
+        BoundStatement bound = prepared.bind("sensitive");
+        assertRowsNet(session.execute(bound), row("****"));
+
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRowsNet(session.execute(bound), row("sensitive"));
+
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRowsNet(session.execute(bound), row("redacted"));
+    }
+
+    @Test
+    public void testGroupBy() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 'sensitive')");
+
+        // without masks
+        String query = "SELECT * FROM %s GROUP BY k";
+        assertRows(execute(query), row(1, 0, "sensitive"), row(0, 0, "sensitive"));
+
+        // with masked regular column
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRows(execute(query), row(1, 0, "redacted"), row(0, 0, "redacted"));
+
+        // with masked clustering key
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_replace(-1)");
+        assertRows(execute(query), row(1, -1, "redacted"), row(0, -1, "redacted"));
+
+        // with masked partition key
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH mask_replace(-1)");
+        assertRows(execute(query), row(-1, -1, "redacted"), row(-1, -1, "redacted"));
+
+        // again without masks
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRows(execute(query), row(1, 0, "sensitive"), row(0, 0, "sensitive"));
+    }
+
+    @Test
+    public void testPaging() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v text, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 'sensitive')");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 'sensitive')");
+
+        // without masks
+        assertRowsWithPaging("SELECT * FROM %s", row(1, 0, "sensitive"), row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, 0, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, 1, "sensitive"));
+
+        // with masked regular column
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH mask_replace('redacted')");
+        assertRowsWithPaging("SELECT * FROM %s", row(1, 0, "redacted"), row(0, 0, "redacted"), row(0, 1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, 0, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, 0, "redacted"), row(0, 1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, 1, "redacted"));
+
+        // with masked clustering key
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_replace(-1)");
+        assertRowsWithPaging("SELECT * FROM %s", row(1, -1, "redacted"), row(0, -1, "redacted"), row(0, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, -1, "redacted"), row(0, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, -1, "redacted"));
+
+        // with masked partition key
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH mask_replace(-1)");
+        assertRowsWithPaging("SELECT * FROM %s", row(-1, -1, "redacted"), row(-1, -1, "redacted"), row(-1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(-1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(-1, -1, "redacted"), row(-1, -1, "redacted"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(-1, -1, "redacted"));
+
+        // again without masks
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+        assertRowsWithPaging("SELECT * FROM %s", row(1, 0, "sensitive"), row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 1", row(1, 0, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0", row(0, 0, "sensitive"), row(0, 1, "sensitive"));
+        assertRowsWithPaging("SELECT * FROM %s WHERE k = 0 AND c = 1", row(0, 1, "sensitive"));
+    }
+
+    /**
+     * Tests that rows are always ordered according to the clear values of the columns, even for the post-ordering done
+     * for queries with {@code IN} restrictions and {@code ORDER BY} clauses.
+     */
+    @Test
+    public void testPostOrdering() throws Throwable
+    {
+        createTable("CREATE TABLE %s (k int, c int, v int, PRIMARY KEY (k, c))");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 0, 0)");
+        execute("INSERT INTO %s (k, c, v) VALUES (0, 1, 1)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 0, 3)");
+        execute("INSERT INTO %s (k, c, v) VALUES (1, 1, 4)");
+        execute("INSERT INTO %s (k, c, v) VALUES (2, 0, 6)");
+        execute("INSERT INTO %s (k, c, v) VALUES (2, 1, 7)");
+        NativeFunctions.instance.add(NEGATIVE);
+
+        // Test ordering without masking, just for reference
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, 0, 0),
+                   row(0, 1, 1),
+                   row(1, 0, 3),
+                   row(1, 1, 4),
+                   row(2, 0, 6),
+                   row(2, 1, 7));
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, 0, 0),
+                   row(1, 0, 3),
+                   row(2, 0, 6),
+                   row(0, 1, 1),
+                   row(1, 1, 4),
+                   row(2, 1, 7));
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, 1, 1),
+                   row(1, 1, 4),
+                   row(2, 1, 7),
+                   row(0, 0, 0),
+                   row(1, 0, 3),
+                   row(2, 0, 6));
+
+        // Test ordering with manually applied masking function, just for reference
+        assertRows(execute("SELECT k, mask_negative(c), v FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, mask_negative(c), v FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, mask_negative(c), v FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7), // (2, 1, 7)
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6)); // (2, 0, 6)
+
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH mask_negative()");
+
+        // Test ordering of wildcard queries with masked column
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT * FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7), // (2, 1, 7)
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6)); // (2, 0, 6)
+
+        // Test ordering of column selection queries with masked column
+        assertRows(execute("SELECT k, c, v FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, c, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6), // (2, 0, 6)
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, c, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, -1, 1), // (0, 1, 1)
+                   row(1, -1, 4), // (1, 1, 4)
+                   row(2, -1, 7), // (2, 1, 7)
+                   row(0, -0, 0), // (0, 0, 0)
+                   row(1, -0, 3), // (1, 0, 3)
+                   row(2, -0, 6)); // (2, 0, 6)
+
+        // Test ordering of column selection queries with masked column, without selecting the ordered column
+        assertRows(execute("SELECT k, v FROM %s WHERE k IN (0, 1, 2)"),
+                   row(0, 0), // (0, 0, 0)
+                   row(0, 1), // (0, 1, 1)
+                   row(1, 3), // (1, 0, 3)
+                   row(1, 4), // (1, 1, 4)
+                   row(2, 6), // (2, 0, 6)
+                   row(2, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row(0, 0), // (0, 0, 0)
+                   row(1, 3), // (1, 0, 3)
+                   row(2, 6), // (2, 0, 6)
+                   row(0, 1), // (0, 1, 1)
+                   row(1, 4), // (1, 1, 4)
+                   row(2, 7)); // (2, 1, 7)
+        assertRows(execute("SELECT k, v FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row(0, 1), // (0, 1, 1)
+                   row(1, 4), // (1, 1, 4)
+                   row(2, 7), // (2, 1, 7)
+                   row(0, 0), // (0, 0, 0)
+                   row(1, 3), // (1, 0, 3)
+                   row(2, 6)); // (2, 0, 6)
+
+        // Test ordering of wildcard JSON queries with masked column
+        assertRows(execute("SELECT JSON * FROM %s WHERE k IN (0, 1, 2)"),
+                   row("{\"k\": 0, \"c\": 0, \"v\": 0}"), // (0, 0, 0)
+                   row("{\"k\": 0, \"c\": -1, \"v\": 1}"), // (0, 1, 1)
+                   row("{\"k\": 1, \"c\": 0, \"v\": 3}"), // (1, 0, 3)
+                   row("{\"k\": 1, \"c\": -1, \"v\": 4}"), // (1, 1, 4)
+                   row("{\"k\": 2, \"c\": 0, \"v\": 6}"), // (2, 0, 6)
+                   row("{\"k\": 2, \"c\": -1, \"v\": 7}")); // (2, 1, 7)
+        assertRows(execute("SELECT JSON * FROM %s WHERE k IN (0, 1, 2) ORDER BY c ASC"),
+                   row("{\"k\": 0, \"c\": 0, \"v\": 0}"), // (0, 0, 0)
+                   row("{\"k\": 1, \"c\": 0, \"v\": 3}"), // (1, 0, 3)
+                   row("{\"k\": 2, \"c\": 0, \"v\": 6}"), // (2, 0, 6)
+                   row("{\"k\": 0, \"c\": -1, \"v\": 1}"), // (0, 1, 1)
+                   row("{\"k\": 1, \"c\": -1, \"v\": 4}"), // (1, 1, 4)
+                   row("{\"k\": 2, \"c\": -1, \"v\": 7}")); // (2, 1, 7)
+        assertRows(execute("SELECT JSON * FROM %s WHERE k IN (0, 1, 2) ORDER BY c DESC"),
+                   row("{\"k\": 0, \"c\": -1, \"v\": 1}"), // (0, 1, 1)
+                   row("{\"k\": 1, \"c\": -1, \"v\": 4}"), // (1, 1, 4)
+                   row("{\"k\": 2, \"c\": -1, \"v\": 7}"), // (2, 1, 7)
+                   row("{\"k\": 0, \"c\": 0, \"v\": 0}"), // (0, 0, 0)
+                   row("{\"k\": 1, \"c\": 0, \"v\": 3}"), // (1, 0, 3)
+                   row("{\"k\": 2, \"c\": 0, \"v\": 6}")); // (2, 0, 6)
+    }
+
+    private void assertRowsWithPaging(String query, Object[]... rows)
+    {
+        for (int pageSize : Arrays.asList(1, 2, 3, 4, 5, 100))
+        {
+            assertRowsNet(executeNetWithPaging(query, pageSize), rows);
+
+            for (int limit : Arrays.asList(1, 2, 3, 4, 5, 100))
+            {
+                assertRowsNet(executeNetWithPaging(query + " LIMIT " + limit, pageSize),
+                              Arrays.copyOfRange(rows, 0, Math.min(limit, rows.length)));
+            }
+        }
+    }
+
+    private static final FunctionFactory NEGATIVE = new FunctionFactory("mask_negative", FunctionParameter.fixed(CQL3Type.Native.INT))
+    {
+        @Override
+        protected NativeFunction doGetOrCreateFunction(List<AbstractType<?>> argTypes, AbstractType<?> receiverType)
+        {
+            return new MaskingFunction(name, argTypes.get(0), argTypes.get(0))
+            {
+                @Override
+                public ByteBuffer execute(ProtocolVersion protocol, List<ByteBuffer> parameters)
+                {
+                    ByteBuffer bb = parameters.get(0);
+                    if (bb == null)
+                        return null;
+                    Integer value = Int32Type.instance.compose(bb) * -1;
+                    return Int32Type.instance.decompose(value);
+                }
+            };
+        }
+    };
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTester.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.cql3.functions.ScalarFunction;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.ReversedType;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.schema.SchemaKeyspace;
+import org.apache.cassandra.schema.SchemaKeyspaceTables;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests table columns with attached dynamic data masking functions.
+ */
+public class ColumnMaskTester extends CQLTester
+{
+    @BeforeClass
+    public static void beforeClass()
+    {
+        CQLTester.setUpClass();
+        requireNetwork();
+    }
+
+    protected void assertTableColumnsAreNotMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsNotMasked(currentTable(), column);
+        }
+    }
+
+    protected void assertViewColumnsAreNotMasked(String... columns) throws Throwable
+    {
+        for (String column : columns)
+        {
+            assertColumnIsNotMasked(currentView(), column);
+        }
+    }
+
+    protected void assertColumnIsNotMasked(String table, String column) throws Throwable
+    {
+        ColumnMask mask = getColumnMask(table, column);
+        assertNull(format("Mask for column '%s'", column), mask);
+
+        assertRows(execute(format("SELECT * FROM %s.%s WHERE keyspace_name = ? AND table_name = ? AND column_name = ?",
+                                  SchemaConstants.SCHEMA_KEYSPACE_NAME, SchemaKeyspaceTables.COLUMN_MASKS),
+                           KEYSPACE, table, column));
+    }
+
+    protected void assertColumnIsMasked(String table,
+                                        String column,
+                                        String functionName,
+                                        List<AbstractType<?>> partialArgumentTypes,
+                                        List<ByteBuffer> partialArgumentValues) throws Throwable
+    {
+        KeyspaceMetadata keyspaceMetadata = Keyspace.open(KEYSPACE).getMetadata();
+        TableMetadata tableMetadata = keyspaceMetadata.getTableOrViewNullable(table);
+        assertNotNull(tableMetadata);
+        ColumnMetadata columnMetadata = tableMetadata.getColumn(ColumnIdentifier.getInterned(column, false));
+        assertNotNull(columnMetadata);
+        AbstractType<?> columnType = columnMetadata.type;
+
+        // Verify the column mask in the in-memory schema
+        ColumnMask mask = getColumnMask(table, column);
+        assertNotNull(mask);
+        assertThat(mask.partialArgumentTypes()).isEqualTo(columnType.isReversed() && functionName.equals("mask_replace")
+                                                          ? Collections.singletonList(ReversedType.getInstance(partialArgumentTypes.get(0)))
+                                                          : partialArgumentTypes);
+        assertThat(mask.partialArgumentValues).isEqualTo(partialArgumentValues);
+
+        // Verify the function in the column mask
+        ScalarFunction function = mask.function;
+        assertNotNull(function);
+        assertTrue(function.isNative());
+        assertThat(function.name().name).isEqualTo(functionName);
+        assertThat(function.argTypes().get(0)).isEqualTo(columnMetadata.type);
+        assertThat(function.argTypes().size()).isEqualTo(partialArgumentTypes.size() + 1);
+
+        // Retrieve the persisted column metadata
+        UntypedResultSet columnRows = execute("SELECT * FROM system_schema.columns " +
+                                              "WHERE keyspace_name = ? AND table_name = ? AND column_name = ?",
+                                              KEYSPACE, table, column);
+        ColumnMetadata persistedColumn = SchemaKeyspace.createColumnFromRow(columnRows.one(), keyspaceMetadata.types);
+
+        // Verify the column mask in the persisted schema
+        ColumnMask savedMask = persistedColumn.getMask();
+        assertNotNull(savedMask);
+        assertThat(mask).isEqualTo(savedMask);
+        assertThat(mask.function.argTypes()).isEqualTo(savedMask.function.argTypes());
+    }
+
+    @Nullable
+    protected ColumnMask getColumnMask(String table, String column)
+    {
+        TableMetadata tableMetadata = Schema.instance.getTableMetadata(KEYSPACE, table);
+        assertNotNull(tableMetadata);
+        ColumnMetadata columnMetadata = tableMetadata.getColumn(ColumnIdentifier.getInterned(column, false));
+
+        if (columnMetadata == null)
+            fail(format("Unknown column '%s'", column));
+
+        return columnMetadata.getMask();
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskTester.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.cql3.CQLTester;
@@ -52,11 +53,25 @@ import static org.junit.Assert.fail;
  */
 public class ColumnMaskTester extends CQLTester
 {
+    protected static final String USERNAME = "ddm_user";
+    protected static final String PASSWORD = "ddm_password";
+
     @BeforeClass
     public static void beforeClass()
     {
         CQLTester.setUpClass();
+        requireAuthentication();
         requireNetwork();
+    }
+
+    @Before
+    public void before() throws Throwable
+    {
+        useSuperUser();
+        executeNet(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", USERNAME, PASSWORD));
+        executeNet(format("GRANT ALL ON KEYSPACE %s TO %s", KEYSPACE, USERNAME));
+        executeNet(format("REVOKE UNMASK ON KEYSPACE %s FROM %s", KEYSPACE, USERNAME));
+        useUser(USERNAME, PASSWORD);
     }
 
     protected void assertTableColumnsAreNotMasked(String... columns) throws Throwable

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskWithTypeAlteringFunctionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskWithTypeAlteringFunctionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.cql3.CQL3Type;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.cql3.CQL3Type.Native.ASCII;
+import static org.apache.cassandra.cql3.CQL3Type.Native.BIGINT;
+import static org.apache.cassandra.cql3.CQL3Type.Native.BLOB;
+import static org.apache.cassandra.cql3.CQL3Type.Native.INT;
+import static org.apache.cassandra.cql3.CQL3Type.Native.TEXT;
+import static org.apache.cassandra.cql3.CQL3Type.Native.VARINT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link ColumnMaskTester} for masks using functions that might return values with a type different to the type of the
+ * masked column. Those queries should fail.
+ */
+@RunWith(Parameterized.class)
+public class ColumnMaskWithTypeAlteringFunctionTest extends ColumnMaskTester
+{
+    /** The column mask as expressed in CQL statements right after the {@code MASKED WITH} keywords. */
+    @Parameterized.Parameter
+    public String mask;
+
+    /** The type of the masked column. */
+    @Parameterized.Parameter(1)
+    public CQL3Type.Native type;
+
+    /** The type returned by the tested masking function. */
+    @Parameterized.Parameter(2)
+    public CQL3Type returnedType;
+
+    private boolean shouldSucceed;
+    private String errorMessage;
+
+    @Parameterized.Parameters(name = "mask={0} type={1}")
+    public static Collection<Object[]> options()
+    {
+        return Arrays.asList(new Object[][]{
+        { "mask_default()", INT, INT },
+        { "mask_default()", TEXT, TEXT },
+        { "mask_null()", INT, INT },
+        { "mask_null()", TEXT, TEXT },
+        { "mask_hash()", INT, BLOB },
+        { "mask_hash('SHA-512')", INT, BLOB },
+        { "mask_inner(1,2)", TEXT, TEXT },
+        { "mask_outer(1,2)", TEXT, TEXT },
+        { "mask_replace(0)", INT, INT },
+        { "mask_replace(0)", BIGINT, BIGINT },
+        { "mask_replace(0)", VARINT, VARINT },
+        { "mask_replace('redacted')", ASCII, ASCII },
+        { "mask_replace('redacted')", TEXT, TEXT } });
+    }
+
+    @Before
+    public void before()
+    {
+        shouldSucceed = returnedType == type;
+        errorMessage = shouldSucceed ? null : format("Masking function %s return type is %s.", mask, returnedType);
+    }
+
+    @Test
+    public void testTypeAlteringFunctionOnCreateTable()
+    {
+        testOnCreateTable("CREATE TABLE %s.%s (k int PRIMARY KEY, v %s MASKED WITH %s)");
+        testOnCreateTable("CREATE TABLE %s.%s (k %s MASKED WITH %s PRIMARY KEY, v int)");
+        testOnCreateTable("CREATE TABLE %s.%s (k1 int, k2 %s MASKED WITH %s, PRIMARY KEY((k1, k2)))");
+        testOnCreateTable("CREATE TABLE %s.%s (k int, c %s MASKED WITH %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c ASC)");
+        testOnCreateTable("CREATE TABLE %s.%s (k int, c %s MASKED WITH %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c DESC)");
+        testOnCreateTable("CREATE TABLE %s.%s (k int, c int, s %s STATIC MASKED WITH %s, PRIMARY KEY(k, c))");
+    }
+
+    private void testOnCreateTable(String query)
+    {
+        String formattedQuery = format(query, KEYSPACE, createTableName(), type, mask);
+        if (shouldSucceed)
+            createTable(formattedQuery);
+        else
+            assertThatThrownBy(() -> execute(formattedQuery)).hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    public void testTypeAlteringFunctionOnMaskColumn()
+    {
+        testOnAlterColumn("CREATE TABLE %s.%s (k int PRIMARY KEY, v %s)",
+                          "ALTER TABLE %s.%s ALTER v MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k %s PRIMARY KEY, v int)",
+                          "ALTER TABLE %s.%s ALTER k MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k1 int, k2 %s, PRIMARY KEY((k1, k2)))",
+                          "ALTER TABLE %s.%s ALTER k2 MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k int, c %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c ASC)",
+                          "ALTER TABLE %s.%s ALTER c MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k int, c %s, PRIMARY KEY(k, c)) WITH CLUSTERING ORDER BY (c DESC)",
+                          "ALTER TABLE %s.%s ALTER c MASKED WITH %s");
+        testOnAlterColumn("CREATE TABLE %s.%s (k int, c int, s %s STATIC, PRIMARY KEY(k, c))",
+                          "ALTER TABLE %s.%s ALTER s MASKED WITH %s");
+    }
+
+    private void testOnAlterColumn(String createQuery, String alterQuery)
+    {
+        String table = createTableName();
+        createTable(format(createQuery, KEYSPACE, table, type));
+
+        String formattedQuery = format(alterQuery, KEYSPACE, table, mask);
+        if (shouldSucceed)
+            alterTable(formattedQuery);
+        else
+            assertThatThrownBy(() -> execute(formattedQuery)).hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    public void testTypeAlteringFunctionOnAddColumn()
+    {
+        String table = createTable(format("CREATE TABLE %%s (k int PRIMARY KEY, v %s)", type));
+        String query = format("ALTER TABLE %s.%s ADD n %s MASKED WITH %s", KEYSPACE, table, type, mask);
+        if (shouldSucceed)
+            alterTable(query);
+        else
+            assertThatThrownBy(() -> execute(query)).hasMessageContaining(errorMessage);
+    }
+}
+

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskWithTypeAlteringFunctionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/ColumnMaskWithTypeAlteringFunctionTest.java
@@ -79,7 +79,7 @@ public class ColumnMaskWithTypeAlteringFunctionTest extends ColumnMaskTester
     }
 
     @Before
-    public void before()
+    public void setupExpectedResults()
     {
         shouldSucceed = returnedType == type;
         errorMessage = shouldSucceed ? null : format("Masking function %s return type is %s.", mask, returnedType);

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/MaskingFunctionTester.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/MaskingFunctionTester.java
@@ -192,7 +192,7 @@ public abstract class MaskingFunctionTester extends CQLTester
      * Tests the native masking function for the specified column type and values on all possible types of column.
      * That is, when the column is part of the primary key, or a regular column, or a static column.
      *
-     * @param type  the type of the tested column
+     * @param type the type of the tested column
      * @param values the values of the tested column
      */
     private void testMaskingOnAllColumns(CQL3Type type, Object... values) throws Throwable
@@ -222,7 +222,7 @@ public abstract class MaskingFunctionTester extends CQLTester
      * Tests the native masking function for the specified column type and values when the column isn't part of the
      * primary key. That is, when the column is either a regular column or a static column.
      *
-     * @param type  the type of the tested column
+     * @param type the type of the tested column
      * @param values the values of the tested column
      */
     private void testMaskingOnNotKeyColumns(CQL3Type type, Object... values) throws Throwable
@@ -265,8 +265,8 @@ public abstract class MaskingFunctionTester extends CQLTester
      * Tests the native masking function for the specified column type and value.
      * This assumes that the table is already created.
      *
-     * @param name  the name of the tested column
-     * @param type  the type of the tested column
+     * @param name the name of the tested column
+     * @param type the type of the tested column
      * @param value the value of the tested column
      */
     protected abstract void testMaskingOnColumn(String name, CQL3Type type, Object value) throws Throwable;

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/SelectMaskedPermissionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/SelectMaskedPermissionTest.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.awaitility.core.ThrowingRunnable;
+
+import static java.lang.String.format;
+
+/**
+ * Tests the {@link org.apache.cassandra.auth.Permission#SELECT_MASKED} permission.
+ */
+public class SelectMaskedPermissionTest extends CQLTester
+{
+    private static final Object[] CLEAR_ROW = row(7, 7, 7, 7);
+
+    private static final String USER = "ddm_user"; // user that will have their permissions changed
+    private static final String PASSWORD = "ddm_password";
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        DatabaseDescriptor.setPermissionsValidity(0);
+        DatabaseDescriptor.setRolesValidity(0);
+        CQLTester.setUpClass();
+        requireAuthentication();
+        requireNetwork();
+    }
+
+    @Before
+    public void before() throws Throwable
+    {
+        useSuperUser();
+
+        createTable("CREATE TABLE %s (k int, c int, s int static, v int, PRIMARY KEY (k, c))");
+        executeNet("INSERT INTO %s(k, c, s, v) VALUES (?, ?, ?, ?)", CLEAR_ROW);
+
+        executeNet(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", USER, PASSWORD));
+        executeNet(format("GRANT SELECT ON ALL KEYSPACES TO %s", USER));
+    }
+
+    @After
+    public void after() throws Throwable
+    {
+        useSuperUser();
+        executeNet("DROP USER IF EXISTS " + USER);
+        alterTable("ALTER TABLE %s ALTER k DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER c DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER s DROP MASKED");
+        alterTable("ALTER TABLE %s ALTER v DROP MASKED");
+    }
+
+    @Test
+    public void testPartitionKeyColumn() throws Throwable
+    {
+        alterTable("ALTER TABLE %s ALTER k MASKED WITH DEFAULT");
+        Object[] maskedRow = row(0, 7, 7, 7);
+
+        // test queries with default permissions (no UNMASK nor SELECT_MASKED)
+        testPartitionKeyColumnWithDefaultPermissions(maskedRow);
+
+        // test queries with only SELECT_MASKED permission
+        executeNet(format("GRANT SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testPartitionKeyColumnWithOnlySelectMasked(maskedRow);
+
+        // test queries with only UNMASK permission (which includes SELECT_MASKED)
+        executeNet(format("REVOKE SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        executeNet(format("GRANT UNMASK ON ALL KEYSPACES TO %s", USER));
+        testPartitionKeyColumnWithUnmask();
+
+        // test queries with both UNMASK and SELECT_MASKED permissions
+        executeNet(format("GRANT UNMASK, SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testPartitionKeyColumnWithUnmask();
+
+        // test queries again without both UNMASK and SELECT_MASKED permissions
+        executeNet(format("REVOKE UNMASK, SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        testPartitionKeyColumnWithDefaultPermissions(maskedRow);
+    }
+
+    private void testPartitionKeyColumnWithDefaultPermissions(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE k = 7", "[k]");
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE k >= 7 ALLOW FILTERING", "[k]");
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", "[k]");
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE k = 7 AND v = 7 ALLOW FILTERING", "[k]");
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", "[k]");
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE token(k) >= token(7)", "[k]");
+        });
+    }
+
+    private void testPartitionKeyColumnWithOnlySelectMasked(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k >= 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND v = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) >= token(7)", maskedRow);
+        });
+    }
+
+    private void testPartitionKeyColumnWithUnmask() throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k >= 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND v = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) >= token(7)", CLEAR_ROW);
+        });
+    }
+
+    @Test
+    public void testClusteringKeyColumn() throws Throwable
+    {
+        alterTable("ALTER TABLE %s ALTER c MASKED WITH DEFAULT");
+        Object[] maskedRow = row(7, 0, 7, 7);
+
+        // test queries with default permissions (no UNMASK nor SELECT_MASKED)
+        testClusteringKeyColumnWithDefaultPermissions(maskedRow);
+
+        // test queries with only SELECT_MASKED permission
+        executeNet(format("GRANT SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testClusteringKeyColumnWithOnlySelectMasked(maskedRow);
+
+        // test queries with only UNMASK permission (which includes SELECT_MASKED)
+        executeNet(format("REVOKE SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        executeNet(format("GRANT UNMASK ON ALL KEYSPACES TO %s", USER));
+        testClusteringKeyColumnWithUnmask();
+
+        // test queries with both UNMASK and SELECT_MASKED permissions
+        executeNet(format("GRANT UNMASK, SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testClusteringKeyColumnWithUnmask();
+
+        // test queries again without both UNMASK and SELECT_MASKED permissions
+        executeNet(format("REVOKE UNMASK, SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        testClusteringKeyColumnWithDefaultPermissions(maskedRow);
+    }
+
+    private void testClusteringKeyColumnWithDefaultPermissions(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", "[c]");
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", "[c]");
+        });
+    }
+
+    private void testClusteringKeyColumnWithOnlySelectMasked(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", maskedRow);
+        });
+    }
+
+    private void testClusteringKeyColumnWithUnmask() throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", CLEAR_ROW);
+        });
+    }
+
+    @Test
+    public void testStaticColumn() throws Throwable
+    {
+        alterTable("ALTER TABLE %s ALTER s MASKED WITH DEFAULT");
+        Object[] maskedRow = row(7, 7, 0, 7);
+
+        // test queries with default permissions (no UNMASK nor SELECT_MASKED)
+        testStaticColumnWithDefaultPermissions(maskedRow);
+
+        // test queries with only SELECT_MASKED permission
+        executeNet(format("GRANT SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testStaticColumnWithOnlySelectMasked(maskedRow);
+
+        // test queries with only UNMASK permission (which includes SELECT_MASKED)
+        executeNet(format("REVOKE SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        executeNet(format("GRANT UNMASK ON ALL KEYSPACES TO %s", USER));
+        testStaticColumnWithUnmask();
+
+        // test queries with both UNMASK and SELECT_MASKED permissions
+        executeNet(format("GRANT UNMASK, SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testStaticColumnWithUnmask();
+
+        // test queries again without both UNMASK and SELECT_MASKED permissions
+        executeNet(format("REVOKE UNMASK, SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        testStaticColumnWithDefaultPermissions(maskedRow);
+    }
+
+    private void testStaticColumnWithDefaultPermissions(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", "[s]");
+        });
+    }
+
+    private void testStaticColumnWithOnlySelectMasked(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+        });
+    }
+
+    private void testStaticColumnWithUnmask() throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", CLEAR_ROW);
+        });
+    }
+
+    @Test
+    public void testCollections() throws Throwable
+    {
+        alterTable("ALTER TABLE %s ALTER v MASKED WITH DEFAULT");
+        Object[] maskedRow = row(7, 7, 7, 0);
+
+        // test queries with default permissions (no UNMASK nor SELECT_MASKED)
+        testCollectionsWithDefaultPermissions(maskedRow);
+
+        // test queries with only SELECT_MASKED permission
+        executeNet(format("GRANT SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testCollectionsWithOnlySelectMasked(maskedRow);
+
+        // test queries with only UNMASK permission (which includes SELECT_MASKED)
+        executeNet(format("REVOKE SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        executeNet(format("GRANT UNMASK ON ALL KEYSPACES TO %s", USER));
+        testCollectionsWithUnmask();
+
+        // test queries with both UNMASK and SELECT_MASKED permissions
+        executeNet(format("GRANT UNMASK, SELECT_MASKED ON ALL KEYSPACES TO %s", USER));
+        testCollectionsWithUnmask();
+
+        // test queries again without both UNMASK and SELECT_MASKED permissions
+        executeNet(format("REVOKE UNMASK, SELECT_MASKED ON ALL KEYSPACES FROM %s", USER));
+        testCollectionsWithDefaultPermissions(maskedRow);
+    }
+
+    private void testCollectionsWithDefaultPermissions(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertUnauthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", "[v]");
+        });
+    }
+
+    private void testCollectionsWithOnlySelectMasked(Object[] maskedRow) throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", maskedRow);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", maskedRow);
+        });
+    }
+
+    private void testCollectionsWithUnmask() throws Throwable
+    {
+        assertWithUser(() -> {
+            assertAuthorizedQuery("SELECT * FROM %s", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE token(k) = token(7)", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE k = 7 AND c = 7", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE c = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE s = 7 ALLOW FILTERING", CLEAR_ROW);
+            assertAuthorizedQuery("SELECT * FROM %s WHERE v = 7 ALLOW FILTERING", CLEAR_ROW);
+        });
+    }
+
+    private void assertAuthorizedQuery(String query, Object[]... rows) throws Throwable
+    {
+        assertRowsNet(executeNet(query), rows);
+    }
+
+    private void assertUnauthorizedQuery(String query, String unauthorizedColumns) throws Throwable
+    {
+        assertInvalidMessageNet(format("User %s has no UNMASK nor SELECT_MASKED permission on table %s.%s, " +
+                                       "cannot query masked columns %s",
+                                       USER, KEYSPACE, currentTable(), unauthorizedColumns), query);
+    }
+
+    private void assertWithUser(ThrowingRunnable assertion) throws Throwable
+    {
+        useUser(USER, PASSWORD);
+        assertion.run();
+        useSuperUser();
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/functions/masking/UnmaskPermissionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/functions/masking/UnmaskPermissionTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.functions.masking;
+
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+
+import static java.lang.String.format;
+
+/**
+ * Tests the {@link org.apache.cassandra.auth.Permission#UNMASK} permission.
+ * <p>
+ * The permission is tested for a regular user with the {@code UNMASK} permissions on different resources,
+ * while also verifying the absence of side effects on other ordinary users, superusers and internal queries.
+ */
+public class UnmaskPermissionTest extends CQLTester
+{
+    private static final String CREATE_KEYSPACE = "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = " +
+                                                  "{'class': 'SimpleStrategy', 'replication_factor': '1'}";
+    private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS %s.%s " +
+                                               "(k int, c int, v text MASKED WITH mask_replace('redacted'), " +
+                                               "PRIMARY KEY (k, c))";
+    private static final String INSERT = "INSERT INTO %s.%s (k, c, v) VALUES (?, ?, ?)";
+    private static final String SELECT_WILDCARD = "SELECT * FROM %s.%s";
+    private static final String SELECT_COLUMNS = "SELECT k, c, v FROM %s.%s";
+
+    private static final Object[] CLEAR_ROW = row(0, 0, "sensitive");
+    private static final Object[] MASKED_ROW = row(0, 0, "redacted");
+
+    private static final String KEYSPACE_1 = "mask_keyspace_1";
+    private static final String KEYSPACE_2 = "mask_keyspace_2";
+    private static final String TABLE_1 = "mask_table_1";
+    private static final String TABLE_2 = "mask_table_2";
+
+    private static final String USER = "ddm_user"; // user that will have their permissions changed
+    private static final String OTHER_USER = "ddm_ordinary_user"; // user that won't have their permissions altered
+    private static final String PASSWORD = "ddm_password";
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        DatabaseDescriptor.setPermissionsValidity(0);
+        DatabaseDescriptor.setRolesValidity(0);
+        CQLTester.setUpClass();
+        requireAuthentication();
+        requireNetwork();
+    }
+
+    @Before
+    public void before() throws Throwable
+    {
+        useSuperUser();
+
+        schemaChange(format(CREATE_KEYSPACE, KEYSPACE_1));
+        schemaChange(format(CREATE_KEYSPACE, KEYSPACE_2));
+
+        createTable(format(CREATE_TABLE, KEYSPACE_1, TABLE_1));
+        createTable(format(CREATE_TABLE, KEYSPACE_1, TABLE_2));
+        createTable(format(CREATE_TABLE, KEYSPACE_2, TABLE_1));
+
+        execute(format(INSERT, KEYSPACE_1, TABLE_1), CLEAR_ROW);
+        execute(format(INSERT, KEYSPACE_1, TABLE_2), CLEAR_ROW);
+        execute(format(INSERT, KEYSPACE_2, TABLE_1), CLEAR_ROW);
+
+        for (String user : Arrays.asList(USER, OTHER_USER))
+        {
+            executeNet(format("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", user, PASSWORD));
+            executeNet(format("GRANT SELECT ON ALL KEYSPACES TO %s", user));
+        }
+    }
+
+    @After
+    public void after() throws Throwable
+    {
+        useSuperUser();
+        executeNet("DROP USER IF EXISTS " + USER);
+    }
+
+    @Test
+    public void testUnmaskDefaults() throws Throwable
+    {
+        // ordinary user without changed permissions should see masked data
+        useUser(OTHER_USER, PASSWORD);
+        assertMasked(KEYSPACE_1, TABLE_1);
+        assertMasked(KEYSPACE_1, TABLE_2);
+        assertMasked(KEYSPACE_2, TABLE_1);
+
+        // super user should see unmasked data
+        useSuperUser();
+        assertClear(KEYSPACE_1, TABLE_1);
+        assertClear(KEYSPACE_1, TABLE_2);
+        assertClear(KEYSPACE_2, TABLE_1);
+
+        // internal user should see unmasked data
+        assertClearInternal(KEYSPACE_1, TABLE_1);
+        assertClearInternal(KEYSPACE_1, TABLE_2);
+        assertClearInternal(KEYSPACE_2, TABLE_1);
+    }
+
+    @Test
+    public void testUnmaskOnAllKeyspaces() throws Throwable
+    {
+        assertPermissions(format("GRANT UNMASK ON ALL KEYSPACES TO %s", USER), () -> {
+            assertClear(KEYSPACE_1, TABLE_1);
+            assertClear(KEYSPACE_1, TABLE_2);
+            assertClear(KEYSPACE_2, TABLE_1);
+        });
+
+        assertPermissions(format("REVOKE UNMASK ON ALL KEYSPACES FROM %s", USER), () -> {
+            assertMasked(KEYSPACE_1, TABLE_1);
+            assertMasked(KEYSPACE_1, TABLE_2);
+            assertMasked(KEYSPACE_2, TABLE_1);
+        });
+    }
+
+    @Test
+    public void testUnmaskOnKeyspace() throws Throwable
+    {
+        assertPermissions(format("GRANT UNMASK ON KEYSPACE %s TO %s", KEYSPACE_1, USER), () -> {
+            assertClear(KEYSPACE_1, TABLE_1);
+            assertClear(KEYSPACE_1, TABLE_2);
+            assertMasked(KEYSPACE_2, TABLE_1);
+        });
+
+        assertPermissions(format("REVOKE UNMASK ON KEYSPACE %s FROM %s", KEYSPACE_1, USER), () -> {
+            assertMasked(KEYSPACE_1, TABLE_1);
+            assertMasked(KEYSPACE_1, TABLE_2);
+            assertMasked(KEYSPACE_2, TABLE_1);
+        });
+    }
+
+    @Test
+    public void testUnmaskOnTable() throws Throwable
+    {
+        assertPermissions(format("GRANT UNMASK ON TABLE %s.%s TO %s", KEYSPACE_1, TABLE_1, USER), () -> {
+            assertClear(KEYSPACE_1, TABLE_1);
+            assertMasked(KEYSPACE_1, TABLE_2);
+            assertMasked(KEYSPACE_2, TABLE_1);
+        });
+
+        assertPermissions(format("REVOKE UNMASK ON TABLE %s.%s FROM %s", KEYSPACE_1, TABLE_1, USER), () -> {
+            assertMasked(KEYSPACE_1, TABLE_1);
+            assertMasked(KEYSPACE_1, TABLE_2);
+            assertMasked(KEYSPACE_2, TABLE_1);
+        });
+    }
+
+    private void assertPermissions(String alterPermissionsQuery, ThrowingRunnable assertion) throws Throwable
+    {
+        // alter permissions as superuser
+        useSuperUser();
+        executeNet(alterPermissionsQuery);
+
+        // verify the tested user permissions
+        useUser(USER, PASSWORD);
+        assertion.run();
+
+        // the ordinary user without modified permissions should keep seeing masked data
+        useUser(OTHER_USER, PASSWORD);
+        assertMasked(KEYSPACE_1, TABLE_1);
+        assertMasked(KEYSPACE_1, TABLE_2);
+        assertMasked(KEYSPACE_2, TABLE_1);
+
+        // super user should keep seeing unmasked data
+        useSuperUser();
+        assertClear(KEYSPACE_1, TABLE_1);
+        assertClear(KEYSPACE_1, TABLE_2);
+        assertClear(KEYSPACE_2, TABLE_1);
+
+        // internal user should keep seeing unmasked data
+        assertClearInternal(KEYSPACE_1, TABLE_1);
+        assertClearInternal(KEYSPACE_1, TABLE_2);
+        assertClearInternal(KEYSPACE_2, TABLE_1);
+    }
+
+    private void assertMasked(String keyspace, String table) throws Throwable
+    {
+        assertRowsNet(executeNet(format(SELECT_WILDCARD, keyspace, table)), MASKED_ROW);
+        assertRowsNet(executeNet(format(SELECT_COLUMNS, keyspace, table)), MASKED_ROW);
+    }
+
+    private void assertClear(String keyspace, String table) throws Throwable
+    {
+        assertRowsNet(executeNet(format(SELECT_WILDCARD, keyspace, table)), CLEAR_ROW);
+        assertRowsNet(executeNet(format(SELECT_COLUMNS, keyspace, table)), CLEAR_ROW);
+    }
+
+    private void assertClearInternal(String keyspace, String table) throws Throwable
+    {
+        assertRows(execute(format(SELECT_WILDCARD, keyspace, table)), CLEAR_ROW);
+        assertRows(execute(format(SELECT_COLUMNS, keyspace, table)), CLEAR_ROW);
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable
+    {
+        void run() throws Throwable;
+    }
+}

--- a/test/unit/org/apache/cassandra/db/CellTest.java
+++ b/test/unit/org/apache/cassandra/db/CellTest.java
@@ -76,7 +76,8 @@ public class CellTest
                                   ColumnIdentifier.getInterned(name, false),
                                   type,
                                   ColumnMetadata.NO_POSITION,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/ColumnsTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnsTest.java
@@ -496,7 +496,7 @@ public class ColumnsTest
 
     private static ColumnMetadata def(String name, AbstractType<?> type, ColumnMetadata.Kind kind)
     {
-        return new ColumnMetadata(TABLE_METADATA, bytes(name), type, ColumnMetadata.NO_POSITION, kind);
+        return new ColumnMetadata(TABLE_METADATA, bytes(name), type, ColumnMetadata.NO_POSITION, kind, null);
     }
 
     private static TableMetadata mock(Columns columns)

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -118,7 +118,8 @@ public class NativeCellTest
                                   ColumnIdentifier.getInterned(uuid.toString(), false),
                                     isComplex ? new SetType<>(BytesType.instance, true) : BytesType.instance,
                                   -1,
-                                  ColumnMetadata.Kind.REGULAR);
+                                  ColumnMetadata.Kind.REGULAR,
+                                  null);
     }
 
     private static Cell<?> rndcell(ColumnMetadata col)

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailTester.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailTester.java
@@ -118,7 +118,15 @@ public abstract class GuardrailTester extends CQLTester
         DatabaseDescriptor.setDiagnosticEventsEnabled(true);
 
         systemClientState = ClientState.forInternalCalls();
+
         userClientState = ClientState.forExternalCalls(InetSocketAddress.createUnresolved("127.0.0.1", 123));
+        AuthenticatedUser user = new AuthenticatedUser(USERNAME)
+        {
+            @Override
+            public boolean canLogin() { return true; }
+        };
+        userClientState.login(user);
+
         superClientState = ClientState.forExternalCalls(InetSocketAddress.createUnresolved("127.0.0.1", 321));
         superClientState.login(new AuthenticatedUser(CassandraRoleManager.DEFAULT_SUPERUSER_NAME));
     }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableHeaderFixTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableHeaderFixTest.java
@@ -386,7 +386,7 @@ public class SSTableHeaderFixTest
             ColumnMetadata cd = getColDef(col);
             AbstractType<?> dropType = cd.type.expandUserTypes();
             cols.removeRegularOrStaticColumn(ci)
-                .recordColumnDrop(new ColumnMetadata(cd.ksName, cd.cfName, cd.name, dropType, cd.position(), cd.kind), FBUtilities.timestampMicros());
+                .recordColumnDrop(new ColumnMetadata(cd.ksName, cd.cfName, cd.name, dropType, cd.position(), cd.kind, cd.getMask()), FBUtilities.timestampMicros());
         }
         tableMetadata = cols.build();
 

--- a/test/unit/org/apache/cassandra/utils/CassandraGenerators.java
+++ b/test/unit/org/apache/cassandra/utils/CassandraGenerators.java
@@ -212,7 +212,7 @@ public final class CassandraGenerators
         }
         ColumnIdentifier name = new ColumnIdentifier(str, true);
         int position = !kind.isPrimaryKeyKind() ? -1 : (int) rnd.next(Constraint.between(0, 30));
-        return new ColumnMetadata(ks, table, name, typeGen.generate(rnd), position, kind);
+        return new ColumnMetadata(ks, table, name, typeGen.generate(rnd), position, kind, null);
     }
 
     public static Gen<ByteBuffer> partitionKeyDataGen(TableMetadata metadata)


### PR DESCRIPTION
Add new SELECT_MASKED permission. It allows to run SELECT queries filtering the clear values of masked columns.

Superusers have it by default, whereas regular users don't have it by default.

Users without UNMASK nor SELECT_MASKED permission won't be authorised to use masked columns on the WHERE part of a SELECT query.