### PR TITLE
[17986] Replace hardcoded numbers with StartupException enum for exit…

### DIFF
--- a/src/java/org/apache/cassandra/exceptions/StartupException.java
+++ b/src/java/org/apache/cassandra/exceptions/StartupException.java
@@ -26,7 +26,6 @@ public class StartupException extends Exception
     public final static int ERR_WRONG_MACHINE_STATE = 1;
     public final static int ERR_WRONG_DISK_STATE = 3;
     public final static int ERR_WRONG_CONFIG = 100;
-    public final static int ERR_OUTDATED_SCHEMA = 101;
 
     public final int returnCode;
 

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -182,7 +182,7 @@ public class CassandraDaemon
         }
         catch (IOException e)
         {
-            exitOrFail(1, e.getMessage(), e.getCause());
+            exitOrFail(StartupException.ERR_WRONG_MACHINE_STATE, e.getMessage(), e.getCause());
         }
     }
 
@@ -418,7 +418,7 @@ public class CassandraDaemon
         catch (ConfigurationException e)
         {
             System.err.println(e.getMessage() + "\nFatal configuration error; unable to start server.  See log for stacktrace.");
-            exitOrFail(1, "Fatal configuration error", e);
+            exitOrFail(StartupException.ERR_WRONG_MACHINE_STATE, "Fatal configuration error", e);
         }
 
         // Because we are writing to the system_distributed keyspace, this should happen after that is created, which
@@ -794,7 +794,7 @@ public class CassandraDaemon
                     logger.error("Exception encountered during startup", e);
                 // try to warn user on stdout too, if we haven't already detached
                 e.printStackTrace();
-                exitOrFail(3, "Exception encountered during startup", e);
+                exitOrFail(StartupException.ERR_WRONG_DISK_STATE, "Exception encountered during startup", e);
             }
             else
             {
@@ -802,7 +802,7 @@ public class CassandraDaemon
                     logger.error("Exception encountered during startup: {}", e.getMessage());
                 // try to warn user on stdout too, if we haven't already detached
                 System.err.println(e.getMessage());
-                exitOrFail(3, "Exception encountered during startup: " + e.getMessage());
+                exitOrFail(StartupException.ERR_WRONG_DISK_STATE, "Exception encountered during startup: " + e.getMessage());
             }
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-17986?filter=12352305

Replace hardcoded numbers with enum: ERR_WRONG_MACHINE_STATE and ERR_WRONG_DISK_STATE for exitOrFail functions. 