### PR TITLE
sstabledump for secondary index sstable error fro CASSANDRA-18254

### DIFF
--- a/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
+++ b/src/java/org/apache/cassandra/db/marshal/PartitionerDefinedOrder.java
@@ -84,7 +84,8 @@ public class PartitionerDefinedOrder extends AbstractType<ByteBuffer>
     @Override
     public String toJSONString(ByteBuffer buffer, int protocolVersion)
     {
-        throw new UnsupportedOperationException();
+        // See CASSANDRA-17698 for more details.
+        return "\"0x" + ByteBufferUtil.bytesToHex(buffer) + '"';
     }
 
     public int compareCustom(ByteBuffer o1, ByteBuffer o2)


### PR DESCRIPTION
sstabledump for secondary index sstable error fro CASSANDRA-18254

patch by <maxwellguo>; reviewed by <Reviewers> for CASSANDRA-#####


```

The [Cassandra 18254](https://issues.apache.org/jira/projects/CASSANDRA/18254/)

