### PR TITLE
Fix outdated wiki links

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2596,7 +2596,7 @@ Features
     - Windows Service ("cassandra.bat install" to enable)
     - A dead node may be replaced in a single step by starting a new node
       with -Dcassandra.replace_token=<token>. More details can be found at
-      http://wiki.apache.org/cassandra/Operations#Replacing_a_Dead_Node
+      https://cassandra.apache.org/doc/latest/cassandra/operating/topo_changes.html#replacing-a-dead-node
     - It is now possible to repair only the first range returned by the
       partitioner for a node with `nodetool repair -pr`. It makes it
       easier/possible to repair a full cluster without any work duplication by
@@ -2750,7 +2750,7 @@ Upgrading
     - Thrift unframed mode has been removed.
     - The addition of key_validation_class means the cli will assume keys
       are bytes, instead of strings, in the absence of other information.
-      See http://wiki.apache.org/cassandra/FAQ#cli_keys for more details.
+      See https://web.archive.org/web/20130818025527/http://wiki.apache.org/cassandra/FAQ#cli_keys for more details.
 
 
 Features
@@ -2758,7 +2758,7 @@ Features
     - added CQL client API and JDBC/DBAPI2-compliant drivers for Java and
       Python, respectively (see: drivers/ subdirectory and doc/cql)
     - added distributed Counters feature;
-      see http://wiki.apache.org/cassandra/Counters
+      see https://cwiki.apache.org/confluence/display/CASSANDRA2/Counters
     - optional intranode encryption; see comments around 'encryption_options'
       in cassandra.yaml
     - compaction multithreading and rate-limiting; see
@@ -2923,7 +2923,7 @@ Features
 Upgrading
 ---------
     The Thrift API has changed in incompatible ways; see below, and refer
-    to http://wiki.apache.org/cassandra/ClientOptions for a list of
+    to https://cwiki.apache.org/confluence/display/CASSANDRA2/ClientOptions for a list of
     higher-level clients that have been updated to support the 0.7 API.
 
     The Cassandra inter-node protocol is incompatible with 0.6.x
@@ -3085,7 +3085,7 @@ JMX metrics
     - progress of data streaming during bootstrap, loadbalance, or other
       data migration, is available under
       org.apache.cassandra.streaming.StreamingService.
-      See http://wiki.apache.org/cassandra/Streaming for details.
+      See https://cwiki.apache.org/confluence/display/CASSANDRA2/Streaming for details.
 
 Installation/Upgrade
 --------------------
@@ -3110,7 +3110,7 @@ Installation/Upgrade
    whole cluster at the same time.
 
 1. Bootstrap, move, load balancing, and active repair have been added.
-   See http://wiki.apache.org/cassandra/Operations.  When upgrading
+   See https://cassandra.apache.org/doc/latest/cassandra/operating/index.html.  When upgrading
    from 0.4, leave autobootstrap set to false for the first restart
    of your old nodes.
 
@@ -3158,7 +3158,7 @@ Installation/Upgrade
    collisions with others in the same cluster.
 
 3. Many Thrift API changes and documentation.  See
-   http://wiki.apache.org/cassandra/API
+   https://cwiki.apache.org/confluence/display/CASSANDRA2/API
 
 4. Removed the web interface in favor of JMX and bin/nodeprobe, which
    has significantly enhanced functionality.

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -212,7 +212,7 @@ JVM_ON_OUT_OF_MEMORY_ERROR_OPT="-XX:OnOutOfMemoryError=kill -9 %p"
 #
 # Cassandra ships with JMX accessible *only* from localhost.  
 # To enable remote JMX connections, uncomment lines below
-# with authentication and/or ssl enabled. See https://wiki.apache.org/cassandra/JmxSecurity 
+# with authentication and/or ssl enabled. See https://cwiki.apache.org/confluence/display/CASSANDRA2/JmxSecurity
 #
 if [ "x$LOCAL_JMX" = "x" ]; then
     LOCAL_JMX=yes

--- a/doc/cql3/CQL.textile
+++ b/doc/cql3/CQL.textile
@@ -1061,7 +1061,7 @@ The @BATCH@ statement group multiple modification statements (insertions/updates
 Note that:
 * @BATCH@ statements may only contain @UPDATE@, @INSERT@ and @DELETE@ statements.
 * Batches are _not_ a full analogue for SQL transactions.
-* If a timestamp is not specified for each operation, then all operations will be applied with the same timestamp. Due to Cassandra's conflict resolution procedure in the case of "timestamp ties":http://wiki.apache.org/cassandra/FAQ#clocktie, operations may be applied in an order that is different from the order they are listed in the @BATCH@ statement. To force a particular operation ordering, you must specify per-operation timestamps.
+* If a timestamp is not specified for each operation, then all operations will be applied with the same timestamp. Due to Cassandra's conflict resolution procedure in the case of "timestamp ties":https://cassandra.apache.org/doc/latest/cassandra/faq/index.html#what-on-same-timestamp-update, operations may be applied in an order that is different from the order they are listed in the @BATCH@ statement. To force a particular operation ordering, you must specify per-operation timestamps.
 
 h4(#unloggedBatch). @UNLOGGED@
 
@@ -1918,7 +1918,7 @@ saving.
 
 h3(#counters). Counters
 
-The @counter@ type is used to define _counter columns_. A counter column is a column whose value is a 64-bit signed integer and on which 2 operations are supported: incrementation and decrementation (see "@UPDATE@":#updateStmt for syntax).  Note the value of a counter cannot be set. A counter doesn't exist until first incremented/decremented, and the first incrementation/decrementation is made as if the previous value was 0. Deletion of counter columns is supported but have some limitations (see the "Cassandra Wiki":http://wiki.apache.org/cassandra/Counters for more information).
+The @counter@ type is used to define _counter columns_. A counter column is a column whose value is a 64-bit signed integer and on which 2 operations are supported: incrementation and decrementation (see "@UPDATE@":#updateStmt for syntax).  Note the value of a counter cannot be set. A counter doesn't exist until first incremented/decremented, and the first incrementation/decrementation is made as if the previous value was 0. Deletion of counter columns is supported but have some limitations (see the "Cassandra Wiki":https://cwiki.apache.org/confluence/display/CASSANDRA2/Counters for more information).
 
 The use of the counter type is limited in the following way:
 * It cannot be used for column that is part of the @PRIMARY KEY@ of a table.

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 :description: Starting page for Apache Cassandra documentation.
 :keywords: Apache, Cassandra, NoSQL, database
 :cass-url: http://cassandra.apache.org
-:cass-contrib-url: https://wiki.apache.org/cassandra/HowToContribute
+:cass-contrib-url: https://cwiki.apache.org/confluence/display/CASSANDRA2/HowToContribute
 
 This is the official documentation for {cass-url}[Apache Cassandra].
 If you would like to contribute to this documentation, you are welcome to do so by submitting your contribution like any other patch following {cass-contrib-url}[these instructions].

--- a/doc/modules/cassandra/pages/developing/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/cql_singlefile.adoc
@@ -1612,7 +1612,7 @@ statements.
 * If a timestamp is not specified for each operation, then all
 operations will be applied with the same timestamp. Due to Cassandra’s
 conflict resolution procedure in the case of
-http://wiki.apache.org/cassandra/FAQ#clocktie[timestamp ties],
+https://cassandra.apache.org/doc/latest/cassandra/faq/index.html#what-on-same-timestamp-update[timestamp ties],
 operations may be applied in an order that is different from the order
 they are listed in the `BATCH` statement. To force a particular
 operation ordering, you must specify per-operation timestamps.
@@ -2851,7 +2851,7 @@ cannot be set. A counter doesn’t exist until first
 incremented/decremented, and the first incrementation/decrementation is
 made as if the previous value was 0. Deletion of counter columns is
 supported but have some limitations (see the
-http://wiki.apache.org/cassandra/Counters[Cassandra Wiki] for more
+https://cwiki.apache.org/confluence/display/CASSANDRA2/Counters[Cassandra Wiki] for more
 information).
 
 The use of the counter type is limited in the following way:

--- a/doc/modules/cassandra/pages/developing/cql/dml.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/dml.adoc
@@ -439,7 +439,7 @@ statements (not other batches for instance).
 operations will be applied with the same timestamp (either one generated
 automatically, or the timestamp provided at the batch level). Due to
 Cassandra's conflict resolution procedure in the case of
-http://wiki.apache.org/cassandra/FAQ#clocktie[timestamp ties],
+https://cassandra.apache.org/doc/latest/cassandra/faq/index.html#what-on-same-timestamp-update[timestamp ties],
 operations may be applied in an order that is different from the order
 they are listed in the `BATCH` statement. To force a particular
 operation ordering, you must specify per-operation timestamps.

--- a/test/resources/functions/configure_cassandra.sh
+++ b/test/resources/functions/configure_cassandra.sh
@@ -33,7 +33,7 @@ function configure_cassandra() {
   case $CLOUD_PROVIDER in
     # We want the gossip protocol to use internal (private) addresses, and the
     # client to use public addresses.
-    # See http://wiki.apache.org/cassandra/FAQ#cant_listen_on_ip_any
+    # See https://cassandra.apache.org/doc/latest/cassandra/faq/index.html#why-cant-list-all
     ec2 | aws-ec2 )
       PRIVATE_SELF_HOST=`wget -q -O - http://169.254.169.254/latest/meta-data/local-ipv4`
       # EC2 is NATed


### PR DESCRIPTION
Noticed the `wiki.apache.org/cassandra` links are outdated.

* Replaced them by the newer location `cwiki.apache.org/confluence/display/CASSANDRA2` if possible.
* Some wiki pages are superseded by the [cassandra.apache.org/doc/latest/](https://cassandra.apache.org/doc/latest/), used Cassandra documentation links if possible.
* Replaced unavailable content by `archive.org` links.