### PR TITLE
docs: add link to PHP extension

### DIFF
--- a/doc/modules/cassandra/pages/getting_started/drivers.adoc
+++ b/doc/modules/cassandra/pages/getting_started/drivers.adoc
@@ -33,10 +33,8 @@ functionality supported by a specific driver.
 
 == PHP
 
-* http://code.google.com/a/apache-extras.org/p/cassandra-pdo[CQL | PHP]
 * https://github.com/datastax/php-driver/[Datastax PHP driver]
-* https://github.com/aparkhomenko/php-cassandra[PHP-Cassandra]
-* https://github.com/duoshuo/php-cassandra[PHP Library for Cassandra]
+* https://github.com/nano-interactive/ext-cassandra[PHP extension]
 
 == C++
 


### PR DESCRIPTION
- Outdated drivers for PHP are removed.
- Added a link to actual PHP extension.

polandll: Fix required for trunk as well, I suspect.