### PR TITLE
CASSANDRA-18311 fix BufferPool.memoryInUse counter

### DIFF
--- a/src/java/org/apache/cassandra/utils/memory/BufferPool.java
+++ b/src/java/org/apache/cassandra/utils/memory/BufferPool.java
@@ -874,7 +874,8 @@ public class BufferPool
         public void putUnusedPortion(ByteBuffer buffer)
         {
             Chunk chunk = Chunk.getParentChunk(buffer);
-            int size = buffer.capacity() - buffer.limit();
+            int originalCapacity = buffer.capacity();
+            int size = originalCapacity - buffer.limit();
 
             if (chunk == null)
             {
@@ -883,7 +884,8 @@ public class BufferPool
             }
 
             chunk.freeUnusedPortion(buffer);
-            memoryInUse.add(-size);
+            // Calculate the actual freed bytes which may be different from `size` when pooling is involved
+            memoryInUse.add(buffer.capacity() - originalCapacity);
         }
 
         public ByteBuffer get(int size)

--- a/test/unit/org/apache/cassandra/utils/memory/BufferPoolTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/BufferPoolTest.java
@@ -1018,6 +1018,38 @@ public class BufferPoolTest
         assertEquals(0, bufferPool.usedSizeInBytes());
     }
 
+    @Test
+    public void testPuttingUnusedPortion()
+    {
+        final int expectedCapacity = BufferPool.TINY_ALLOCATION_UNIT * 4;
+        final int quarterUnit = BufferPool.TINY_ALLOCATION_UNIT / 4;
+        final int requestedCapacity = expectedCapacity - 3 * quarterUnit;
+
+        ByteBuffer buffer = bufferPool.getAtLeast(requestedCapacity, BufferType.OFF_HEAP);
+        assertNotNull(buffer);
+        assertEquals(expectedCapacity, buffer.capacity());
+        assertEquals(expectedCapacity, bufferPool.usedSizeInBytes());
+
+        buffer.limit(requestedCapacity); // 3.25 x unit
+        bufferPool.putUnusedPortion(buffer);
+
+        // the unused portion was too small to be returned, the buffer remains unchanged
+        assertEquals(expectedCapacity, buffer.capacity());
+        // used size is didn't change either
+        assertEquals(expectedCapacity, bufferPool.usedSizeInBytes());
+
+        buffer.limit(expectedCapacity - BufferPool.TINY_ALLOCATION_UNIT); // 3.0 x unit
+        bufferPool.putUnusedPortion(buffer);
+
+        // now we should notice a change
+        assertEquals(BufferPool.TINY_ALLOCATION_UNIT * 3, buffer.capacity());
+        assertEquals(BufferPool.TINY_ALLOCATION_UNIT * 3, bufferPool.usedSizeInBytes());
+
+        bufferPool.put(buffer);
+
+        assertEquals(0, bufferPool.usedSizeInBytes());
+    }
+
     private BufferPool.Chunk allocate(int num, int bufferSize, List<ByteBuffer> buffers)
     {
         for (int i = 0; i < num; i++)


### PR DESCRIPTION
The counter was incorrectly decremented by the size of the unused portion of the provided buffer. It is now decremented by the number of bytes actually returned to the pool (that may be different than "size"). The number is calculated as a difference between original and resulting buffer capacity.