### PR TITLE
Improve debuggability and correctness of ref detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,10 @@ jobs:
   j8_jvm_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -110,17 +110,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -140,7 +140,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -302,17 +302,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -330,10 +330,10 @@ jobs:
   j8_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -410,17 +410,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -437,10 +437,10 @@ jobs:
   j8_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -517,17 +517,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -544,10 +544,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -670,17 +670,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -698,7 +698,7 @@ jobs:
   j8_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -754,17 +754,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -784,7 +784,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -870,17 +870,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -941,17 +941,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -971,7 +971,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1133,17 +1133,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1161,10 +1161,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1241,17 +1241,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1272,7 +1272,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1434,17 +1434,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1464,7 +1464,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1550,17 +1550,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1578,10 +1578,10 @@ jobs:
   j8_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1658,17 +1658,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1685,10 +1685,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1765,17 +1765,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1796,7 +1796,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1958,17 +1958,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -1989,7 +1989,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2144,17 +2144,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2172,7 +2172,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2228,17 +2228,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2256,10 +2256,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2360,17 +2360,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2388,10 +2388,10 @@ jobs:
   j8_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2468,17 +2468,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2495,10 +2495,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2575,17 +2575,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2603,7 +2603,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -2659,17 +2659,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2690,7 +2690,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2852,17 +2852,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2880,10 +2880,10 @@ jobs:
   j8_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2960,17 +2960,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -2987,10 +2987,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3067,17 +3067,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3098,7 +3098,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3184,17 +3184,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3255,17 +3255,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3286,7 +3286,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3372,17 +3372,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3399,10 +3399,10 @@ jobs:
   j8_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3503,17 +3503,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3530,10 +3530,10 @@ jobs:
   j8_cqlsh-dtests-py2-offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3610,17 +3610,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3637,10 +3637,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3741,17 +3741,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3769,10 +3769,10 @@ jobs:
   j8_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3873,17 +3873,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -3903,7 +3903,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3989,17 +3989,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4059,17 +4059,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4090,7 +4090,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4252,17 +4252,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4279,7 +4279,7 @@ jobs:
   j8_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -4335,17 +4335,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4362,10 +4362,10 @@ jobs:
   j8_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4442,17 +4442,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4512,17 +4512,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4540,10 +4540,10 @@ jobs:
   j8_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4620,17 +4620,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4647,10 +4647,10 @@ jobs:
   j8_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4751,17 +4751,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4778,10 +4778,10 @@ jobs:
   j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4858,17 +4858,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -4889,7 +4889,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5051,17 +5051,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5079,10 +5079,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5205,17 +5205,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5236,7 +5236,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5398,17 +5398,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5428,7 +5428,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5514,17 +5514,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5542,10 +5542,10 @@ jobs:
   j8_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5622,17 +5622,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5649,10 +5649,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5729,17 +5729,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5757,10 +5757,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5837,17 +5837,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -5868,7 +5868,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6030,17 +6030,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6057,10 +6057,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6161,17 +6161,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6189,10 +6189,10 @@ jobs:
   j8_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6269,17 +6269,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6299,7 +6299,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6461,17 +6461,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6488,10 +6488,10 @@ jobs:
   j8_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6592,17 +6592,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6619,10 +6619,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6699,17 +6699,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6727,10 +6727,10 @@ jobs:
   j8_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6783,17 +6783,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6810,10 +6810,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6888,17 +6888,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -6916,10 +6916,10 @@ jobs:
   j8_jvm_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7081,17 +7081,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7108,10 +7108,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7188,17 +7188,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7219,7 +7219,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7381,17 +7381,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7409,10 +7409,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7489,17 +7489,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7520,7 +7520,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7682,17 +7682,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7709,10 +7709,10 @@ jobs:
   j8_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7765,17 +7765,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7795,7 +7795,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7881,17 +7881,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -7911,7 +7911,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7997,17 +7997,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8103,17 +8103,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8131,10 +8131,10 @@ jobs:
   j8_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8187,17 +8187,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8214,10 +8214,10 @@ jobs:
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8294,17 +8294,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8322,10 +8322,10 @@ jobs:
   j8_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8378,17 +8378,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8439,17 +8439,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8470,7 +8470,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8632,17 +8632,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8659,10 +8659,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8737,17 +8737,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8768,7 +8768,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8923,17 +8923,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -8993,17 +8993,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9023,7 +9023,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9109,17 +9109,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9136,10 +9136,10 @@ jobs:
   j8_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9216,17 +9216,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9243,10 +9243,10 @@ jobs:
   j8_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9347,17 +9347,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9374,10 +9374,10 @@ jobs:
   j8_jvm_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9463,17 +9463,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9568,17 +9568,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9595,10 +9595,10 @@ jobs:
   j8_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9675,17 +9675,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9702,10 +9702,10 @@ jobs:
   j11_cqlsh-dtests-py2-offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9782,17 +9782,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -9813,7 +9813,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9975,17 +9975,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10046,17 +10046,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10107,17 +10107,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10134,10 +10134,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10212,17 +10212,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10243,7 +10243,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10405,17 +10405,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10432,10 +10432,10 @@ jobs:
   j8_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10536,17 +10536,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10566,7 +10566,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10728,17 +10728,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10831,17 +10831,17 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.utils.memory.BufferPoolTest,org.apache.cassandra.utils.UUIDTest,org.apache.cassandra.tools.NodeToolTPStatsTest,org.apache.cassandra.service.DiskFailurePolicyTest,org.apache.cassandra.service.DefaultFSErrorHandlerTest,org.apache.cassandra.net.MessageTest,org.apache.cassandra.io.sstable.SSTableLoaderTest,org.apache.cassandra.io.sstable.DescriptorTest,org.apache.cassandra.dht.SplitterTest,org.apache.cassandra.db.partitions.AtomicBTreePartitionMemtableAccountingTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.commitlog.CommitLogInitWithExceptionTest,org.apache.cassandra.db.ImportTest,org.apache.cassandra.db.ColumnFamilyStoreTest,org.apache.cassandra.db.ColumnFamilyMetricTest,org.apache.cassandra.db.CleanupTest,org.apache.cassandra.cql3.validation.operations.CompactStorageTest,org.apache.cassandra.cql3.validation.operations.AggregationTest,org.apache.cassandra.cql3.validation.entities.UFTest,org.apache.cassandra.cql3.statements.PropertyDefinitionsTest,org.apache.cassandra.cql3.functions.OperationFctsTest,org.apache.cassandra.cql3.KeywordSplit2Test,org.apache.cassandra.cql3.KeywordSplit1Test,org.apache.cassandra.cql3.BatchTest,org.apache.cassandra.auth.FunctionResourceTest
     - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL: org.apache.cassandra.fqltool.commands.DumpTest
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
     - REPEATED_UTESTS_LONG: null
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ring.CleanupFailureTest,org.apache.cassandra.distributed.test.ReprepareOldBehaviourTest,org.apache.cassandra.distributed.test.JVMStabilityInspectorThrowableTest,org.apache.cassandra.distributed.test.ByteBuddyExamplesTest,org.apache.cassandra.distributed.test.AuthTest
     - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS: org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV3XTest,org.apache.cassandra.distributed.upgrade.CompactStoragePagingWithProtocolV30Test
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
     - REPEATED_DTESTS: null
     - REPEATED_DTESTS_COUNT: 500
@@ -10870,11 +10870,23 @@ workflows:
         requires:
         - start_j8_unit_tests
         - j8_build
+    - start_j8_unit_tests_repeat:
+        type: approval
+    - j8_unit_tests_repeat:
+        requires:
+        - start_j8_unit_tests_repeat
+        - j8_build
     - start_j8_jvm_dtests:
         type: approval
     - j8_jvm_dtests:
         requires:
         - start_j8_jvm_dtests
+        - j8_build
+    - start_j8_jvm_dtests_repeat:
+        type: approval
+    - j8_jvm_dtests_repeat:
+        requires:
+        - start_j8_jvm_dtests_repeat
         - j8_build
     - start_j8_cqlshlib_tests:
         type: approval
@@ -10887,6 +10899,12 @@ workflows:
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
+        - j8_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
         - j8_build
     - start_j8_utests_long:
         type: approval
@@ -10912,6 +10930,18 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j8_build
+    - start_j8_utests_cdc_repeat:
+        type: approval
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_j8_utests_cdc_repeat
+        - j8_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j8_build
     - start_j8_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -10923,6 +10953,18 @@ workflows:
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
+        - j8_build
+    - start_j8_utests_compression_repeat:
+        type: approval
+    - j8_utests_compression_repeat:
+        requires:
+        - start_j8_utests_compression_repeat
+        - j8_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
         - j8_build
     - start_j8_utests_stress:
         type: approval
@@ -10948,6 +10990,18 @@ workflows:
         requires:
         - start_j11_utests_fqltool
         - j8_build
+    - start_j8_utests_fqltool_repeat:
+        type: approval
+    - j8_utests_fqltool_repeat:
+        requires:
+        - start_j8_utests_fqltool_repeat
+        - j8_build
+    - start_j11_utests_fqltool_repeat:
+        type: approval
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_j11_utests_fqltool_repeat
+        - j8_build
     - start_j8_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
@@ -10960,6 +11014,18 @@ workflows:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j8_build
+    - start_j8_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j8_utests_system_keyspace_directory_repeat
+        - j8_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j8_build
     - start_j8_dtest_jars_build:
         type: approval
     - j8_dtest_jars_build:
@@ -10971,6 +11037,12 @@ workflows:
     - j8_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
+        - j8_dtest_jars_build
+    - start_jvm_upgrade_dtests_repeat:
+        type: approval
+    - j8_jvm_upgrade_dtests_repeat:
+        requires:
+        - start_jvm_upgrade_dtests_repeat
         - j8_dtest_jars_build
     - start_j8_dtests:
         type: approval
@@ -11152,13 +11224,22 @@ workflows:
     - j8_unit_tests:
         requires:
         - j8_build
+    - j8_unit_tests_repeat:
+        requires:
+        - j8_build
     - j8_jvm_dtests:
+        requires:
+        - j8_build
+    - j8_jvm_dtests_repeat:
         requires:
         - j8_build
     - j8_cqlshlib_tests:
         requires:
         - j8_build
     - j11_unit_tests:
+        requires:
+        - j8_build
+    - j11_unit_tests_repeat:
         requires:
         - j8_build
     - start_utests_long:
@@ -11181,6 +11262,14 @@ workflows:
         requires:
         - start_utests_cdc
         - j8_build
+    - j8_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j8_build
     - start_utests_compression:
         type: approval
     - j8_utests_compression:
@@ -11188,6 +11277,14 @@ workflows:
         - start_utests_compression
         - j8_build
     - j11_utests_compression:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - j8_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j8_build
+    - j11_utests_compression_repeat:
         requires:
         - start_utests_compression
         - j8_build
@@ -11211,12 +11308,27 @@ workflows:
         requires:
         - start_utests_fqltool
         - j8_build
+    - j8_utests_fqltool_repeat:
+        requires:
+        - start_utests_fqltool
+        - j8_build
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_utests_fqltool
+        - j8_build
     - start_utests_system_keyspace_directory:
         type: approval
     - j8_utests_system_keyspace_directory:
         requires:
         - j8_build
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j8_build
+    - j8_utests_system_keyspace_directory_repeat:
+        requires:
+        - j8_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j8_build
@@ -11227,6 +11339,9 @@ workflows:
         - j8_build
         - start_jvm_upgrade_dtests
     - j8_jvm_upgrade_dtests:
+        requires:
+        - j8_dtest_jars_build
+    - j8_jvm_upgrade_dtests_repeat:
         requires:
         - j8_dtest_jars_build
     - j8_dtests:
@@ -11376,11 +11491,23 @@ workflows:
         requires:
         - start_j11_unit_tests
         - j11_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
+        - j11_build
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
         - j11_build
     - start_j11_cqlshlib_tests:
         type: approval
@@ -11482,11 +11609,23 @@ workflows:
         requires:
         - start_j11_utests_cdc
         - j11_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
+        - j11_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
         - j11_build
     - start_j11_utests_stress:
         type: approval
@@ -11500,11 +11639,23 @@ workflows:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+    - start_j11_utests_fqltool_repeat:
+        type: approval
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_j11_utests_fqltool_repeat
+        - j11_build
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
+        - j11_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
         - j11_build
   java11_pre-commit_tests:
     jobs:
@@ -11516,7 +11667,13 @@ workflows:
     - j11_unit_tests:
         requires:
         - j11_build
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
     - j11_jvm_dtests:
+        requires:
+        - j11_build
+    - j11_jvm_dtests_repeat:
         requires:
         - j11_build
     - j11_cqlshlib_tests:
@@ -11604,9 +11761,17 @@ workflows:
         requires:
         - start_utests_cdc
         - j11_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
+        requires:
+        - start_utests_compression
+        - j11_build
+    - j11_utests_compression_repeat:
         requires:
         - start_utests_compression
         - j11_build
@@ -11622,9 +11787,17 @@ workflows:
         requires:
         - start_utests_fqltool
         - j11_build
+    - j11_utests_fqltool_repeat:
+        requires:
+        - start_utests_fqltool
+        - j11_build
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+    - j11_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0.9
+ * Backport CASSANDRA-17205 to 4.0 branch - Remove self-reference in SSTableTidier (CASSANDRA-18332)
  * Fix BufferPool incorrect memoryInUse when putUnusedPortion is used (CASSANDRA-18311)
  * Improve memtable allocator accounting when updating AtomicBTreePartition (CASSANDRA-18125)
  * Update zstd-jni to version 1.5.4-1 (CASSANDRA-18259)

--- a/src/java/org/apache/cassandra/utils/concurrent/Ref.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/Ref.java
@@ -687,7 +687,7 @@ public final class Ref<T> implements RefCounted<T>
                 List<String> names = new ArrayList<>(this.candidates.size());
                 for (Tidy tidy : this.candidates)
                     names.add(tidy.name());
-                logger.warn("Strong reference leak candidates detected: {}", names);
+                logger.error("Strong reference leak candidates detected: {}", names);
             }
             this.candidates = candidates;
         }


### PR DESCRIPTION
|     This patch is a backport of CASSANDRA-17205 and also raises
|     logging level to 'error' from 'warn' in StrongLeakDetector.
|     
|     Patch by jmckenzie; reviewed by TBD for CASSANDRA-18332