### PR TITLE
Update documentation to fix typos & add missing info

### DIFF
--- a/doc/modules/cassandra/pages/faq/index.adoc
+++ b/doc/modules/cassandra/pages/faq/index.adoc
@@ -62,7 +62,7 @@ making sure that each node will generate a random token on the next
 restart.
 
 [[change-replication-factor]]
-== Can I change the replication factor (a a keyspace) on a live cluster?
+== Can I change the replication factor (for a keyspace) on a live cluster?
 
 Yes, but it will require running a full repair (or cleanup) to change
 the replica count of existing data:
@@ -178,16 +178,16 @@ one live seed to contact. Once a node join the ring, it learns about the
 other nodes, so it doesn't need seed on subsequent boot.
 
 You can make a seed a node at any time. There is nothing special about
-seed nodes. If you list the node in seed list it is a seed
+seed nodes. If you list the node in seed list then it is a seed.
 
 Seeds do not auto bootstrap (i.e. if a node has itself in its seed list
-it will not automatically transfer data to itself) If you want a node to
+it will not automatically transfer data to itself). If you want a node to
 do that, bootstrap it first and then add it to seeds later. If you have
 no data (new install) you do not have to worry about bootstrap at all.
 
 Recommended usage of seeds:
 
-* pick two (or more) nodes per data center as seed nodes.
+* pick two (or more) nodes per data center as seed nodes
 * sync the seed list to all your nodes
 
 [[are-seeds-SPOF]]

--- a/doc/modules/cassandra/pages/operating/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/operating/virtualtables.adoc
@@ -67,29 +67,29 @@ The following table describes the virtual tables:
 |caches |Displays the general cache information including cache name, capacity_bytes, entry_count, hit_count, hit_ratio double,
 recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and size_bytes.
 
-|clients |Lists information about all connected clients.
+|clients |Lists information about all connected clients including address, port, connection_stage, driver_name, driver_version, hostname, protocol_version, request_count, ssl_cipher_suite, ssl_enabled, ssl_protocol, username.
 
-|coordinator_read_latency |Records counts, keyspace_name, table_name, max, median, and per_second for coordinator reads.
+|coordinator_read_latency |Records counts, keyspace_name, table_name, max, median, 99th percentile, and per_second for coordinator reads.
 
-|coordinator_scan |Records counts, keyspace_name, table_name, max, median, and per_second for coordinator scans.
+|coordinator_scan_latency |Records counts, keyspace_name, table_name, max, median, 99th percentile, and per_second for coordinator scans.
 
-|coordinator_write_latency |Records counts, keyspace_name, table_name, max, median, and per_second for coordinator writes.
+|coordinator_write_latency |Records counts, keyspace_name, table_name, max, median, 99th percentile, and per_second for coordinator writes.
 
-|disk_usage |Records disk usage including disk_space, keyspace_name, and table_name, sorted by system keyspaces.
+|disk_usage |Records disk usage including disk space used (in mebibytes), keyspace_name, and table_name, sorted by system keyspaces.
 
-|internode_inbound |Lists information about the inbound internode messaging.
+|internode_inbound |Information about the inbound internode messaging including address, port, dc, rack, corrupt_frames_recovered, corrupt_frames_unrecovered, error_bytes, error_count, expired_bytes, expired_count, processed_bytes, processed_count, received_bytes, received_count, scheduled_bytes, scheduled_count, throttled_count, throttled_nanos, using_bytes, and using_reserve_bytes.
 
-|internode_outbound |Information about the outbound internode messaging.
+|internode_outbound |Information about the outbound internode messaging including address, port, dc, rack, active_connections, connection_attempts, error_bytes, error_count, expired_bytes, expired_count, overload_bytes, overload_count, pending_bytes, pending_count, sent_bytes, sent_count, successful_connection_attempts, using_bytes, and using_reserve_bytes.
 
-|local_read_latency |Records counts, keyspace_name, table_name, max, median, and per_second for local reads.
+|local_read_latency |Records counts, keyspace_name, table_name, max, median, 99th percentile, and per_second for local reads.
 
-|local_scan |Records counts, keyspace_name, table_name, max, median, and per_second for local scans.
+|local_scan_latency |Records counts, keyspace_name, table_name, max, median, 99th percentile, and per_second for local scans.
 
-|local_write_latency |Records counts, keyspace_name, table_name, max, median, and per_second for local writes.
+|local_write_latency |Records counts, keyspace_name, table_name, max, median, 99th percentile, and per_second for local writes.
 
-|max_partition_size |A table metric for maximum partition size.
+|max_partition_size |A table metric for maximum partition size in mebibytes.
 
-|rows_per_read |Records counts, keyspace_name, tablek_name, max, and median for rows read.
+|rows_per_read |Records counts, keyspace_name, table_name, max, median, and 99th percentile for rows read.
 
 |settings |Displays configuration settings in cassandra.yaml.
 
@@ -99,9 +99,9 @@ recent_hit_rate_per_second, recent_request_rate_per_second, request_count, and s
 
 |system_properties |Displays environmental system properties set on the node.
 
-|thread_pools |Lists metrics for each thread pool.
+|thread_pools |Lists metrics for each thread pool. These metrics include active_tasks, active_tasks_limit, blocked_tasks, blocked_tasks_all_time, completed_tasks, and pending_tasks.
 
-|tombstones_per_read |Records counts, keyspace_name, tablek_name, max, and median for tombstones.
+|tombstones_per_read |Records counts, keyspace_name, table_name, max, median, and 99th percentile for tombstones.
 |===
 
 For improved usability, from https://issues.apache.org/jira/browse/CASSANDRA-18238[CASSANDRA-18238],

--- a/doc/modules/cassandra/pages/operating/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/operating/virtualtables.adoc
@@ -461,11 +461,6 @@ coordinator_read_latency   local_read_latency   sstable_tasks
 coordinator_scan_latency   local_scan_latency   system_properties
 coordinator_write_latency  local_write_latency  thread_pools 
 disk_usage                 max_partition_size   tombstones_per_read 
-              
-    
-     
-              
-
 ----
 
 [arabic, start=4]
@@ -476,7 +471,8 @@ disk_usage                 max_partition_size   tombstones_per_read
 cqlsh> USE system_views;
 cqlsh> SELECT * FROM clients LIMIT 2;
 ----
- results in:
+
+results in:
 
 [source, cql]
 ----

--- a/doc/modules/cassandra/pages/operating/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/operating/virtualtables.adoc
@@ -447,7 +447,7 @@ results in:
 
 [source, cql]
 ----
-cqlsh> USE system_view;;
+cqlsh> USE system_views;
 cqlsh> DESCRIBE tables;
 ----
 
@@ -468,7 +468,7 @@ local_read_latency  rows_per_read             caches
 
 [source, cql]
 ----
-cqlsh> USE system_view;;
+cqlsh> USE system_views;
 cqlsh> SELECT * FROM clients LIMIT 2;
 ----
  results in:

--- a/doc/modules/cassandra/pages/operating/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/operating/virtualtables.adoc
@@ -455,12 +455,17 @@ results in:
 
 [source, cql]
 ----
-sstable_tasks       clients                   coordinator_write_latency
-disk_usage          local_write_latency       tombstones_per_read
-thread_pools        internode_outbound        settings
-local_scan_latency  coordinator_scan_latency  system_properties
-internode_inbound   coordinator_read_latency  max_partition_size
-local_read_latency  rows_per_read             caches
+caches                     internode_inbound    rows_per_read
+clients                    internode_outbound   settings
+coordinator_read_latency   local_read_latency   sstable_tasks
+coordinator_scan_latency   local_scan_latency   system_properties
+coordinator_write_latency  local_write_latency  thread_pools 
+disk_usage                 max_partition_size   tombstones_per_read 
+              
+    
+     
+              
+
 ----
 
 [arabic, start=4]

--- a/doc/modules/cassandra/pages/operating/virtualtables.adoc
+++ b/doc/modules/cassandra/pages/operating/virtualtables.adoc
@@ -112,9 +112,9 @@ We shall discuss some of the virtual tables in more detail next.
 === Clients Virtual Table
 
 The `clients` virtual table lists all active connections (connected
-clients) including their ip address, port, client_options, connection stage, driver
-name, driver version, hostname, protocol version, request count, ssl
-enabled, ssl protocol and user name:
+clients) including their IP address, port, client options, connection stage, driver
+name, driver version, hostname, protocol version, request count, SSL
+enabled, SSL protocol, and username:
 
 ....
 cqlsh> EXPAND ON ;
@@ -194,7 +194,7 @@ Some examples of how `clients` can be used are:
 upgrading and with `nodetool enableoldprotocolversions` and
 `nodetool disableoldprotocolversions` during upgrades.
 * To identify clients sending too many requests.
-* To find if SSL is enabled during the migration to and from ssl.
+* To find if SSL is enabled during the migration to and from SSL.
 
 The virtual tables may be described with `DESCRIBE` statement. The DDL
 listed however cannot be run to create a virtual table. As an example

--- a/doc/modules/cassandra/pages/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/tools/cqlsh.adoc
@@ -162,7 +162,8 @@ consistency `ALL` is not guaranteed to be enough).
 === `SHOW VERSION`
 
 Prints the `cqlsh`, Cassandra, CQL, and native protocol versions in use.
-Example:
+
+Example usage:
 
 [source,none]
 ----
@@ -173,7 +174,9 @@ cqlsh> SHOW VERSION
 === `SHOW HOST`
 
 Prints the IP address and port of the Cassandra node that `cqlsh` is
-connected to in addition to the cluster name. Example:
+connected to in addition to the cluster name. 
+
+Example usage:
 
 [source,none]
 ----
@@ -470,7 +473,7 @@ See `shared-copy-options` for options that apply to both `COPY TO` and
 `MAXINSERTERRORS`::
   The maximum global number of insert errors to ignore. -1 means
   unlimited. The default is 1000.
-`ERRFILE` =::
+`ERRFILE`::
   A file to store all rows that could not be imported, by default this
   is `import_<ks>_<table>.err` where `<ks>` is your keyspace and
   `<table>` is your table name.
@@ -490,7 +493,7 @@ Options that are common to both `COPY TO` and `COPY FROM`.
   The string placeholder for null values. Defaults to `null`.
 `HEADER`::
   For `COPY TO`, controls whether the first line in the CSV output file
-  will contain the column names. For COPY FROM, specifies whether the
+  will contain the column names. For `COPY FROM`, specifies whether the
   first line in the CSV input file contains column names. Defaults to
   `false`.
 `DECIMALSEP`::
@@ -499,7 +502,7 @@ Options that are common to both `COPY TO` and `COPY FROM`.
 `THOUSANDSSEP`::
   The character that is used to separate thousands. Defaults to the
   empty string.
-`BOOLSTYlE`::
+`BOOLSTYLE`::
   The string literal format for boolean values. Defaults to
   `True,False`.
 `NUMPROCESSES`::


### PR DESCRIPTION
In virtualtables.adoc:
- Fixed incorrect USE statement examples (incorrect keyspace + typo)
- Fixed order of results for DESCRIBE tables command to match the order in cqlsh
- Updated the descriptions of metrics provided in each virtual table to add missing info / add more info
- Fixed typos / punctuation / formatting

In cqlsh.adoc:
- Fixed typos / punctuation / formatting

In faq/index.adoc
- Fixed typos / punctuation
