### PR TITLE
Fixed ISO 8601 format 0 duration parsing. (#CASSANDRA-17919)

### DIFF
--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -299,6 +299,22 @@ fragment EXPONENT
     : E ('+' | '-')? DIGIT+
     ;
 
+fragment DURATION_ISO_8601_PERIOD_DESIGNATORS
+    : '-'? 'P' DIGIT+ 'Y' (DIGIT+ 'M')? (DIGIT+ 'D')?
+    | '-'? 'P' DIGIT+ 'M' (DIGIT+ 'D')?
+    | '-'? 'P' DIGIT+ 'D'
+    ;
+
+fragment DURATION_ISO_8601_TIME_DESIGNATORS
+    : 'T' DIGIT+ 'H' (DIGIT+ 'M')? (DIGIT+ 'S')?
+    | 'T' DIGIT+ 'M' (DIGIT+ 'S')?
+    | 'T' DIGIT+ 'S'
+    ;
+
+fragment DURATION_ISO_8601_WEEK_PERIOD_DESIGNATOR
+    : '-'? 'P' DIGIT+ 'W'
+    ;
+
 fragment DURATION_UNIT
     : Y
     | M O
@@ -344,9 +360,10 @@ BOOLEAN
 
 DURATION
     : '-'? DIGIT+ DURATION_UNIT (DIGIT+ DURATION_UNIT)*
-    | '-'? 'P' (DIGIT+ 'Y')? (DIGIT+ 'M')? (DIGIT+ 'D')? ('T' (DIGIT+ 'H')? (DIGIT+ 'M')? (DIGIT+ 'S')?)? // ISO 8601 "format with designators"
-    | '-'? 'P' DIGIT+ 'W'
     | '-'? 'P' DIGIT DIGIT DIGIT DIGIT '-' DIGIT DIGIT '-' DIGIT DIGIT 'T' DIGIT DIGIT ':' DIGIT DIGIT ':' DIGIT DIGIT // ISO 8601 "alternative format"
+    | '-'? 'P' DURATION_ISO_8601_TIME_DESIGNATORS
+    | DURATION_ISO_8601_WEEK_PERIOD_DESIGNATOR
+    | DURATION_ISO_8601_PERIOD_DESIGNATORS DURATION_ISO_8601_TIME_DESIGNATORS?
     ;
 
 IDENT

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -880,7 +880,12 @@ public abstract class CQLTester
 
     protected String createTable(String keyspace, String query)
     {
-        String currentTable = createTableName();
+        return createTable(keyspace, query, null);
+    }
+
+    protected String createTable(String keyspace, String query, String tableName)
+    {
+        String currentTable = createTableName(tableName);
         String fullQuery = formatQuery(keyspace, query);
         logger.info(fullQuery);
         schemaChange(fullQuery);
@@ -889,7 +894,12 @@ public abstract class CQLTester
 
     protected String createTableName()
     {
-        String currentTable = String.format("table_%02d", seqNumber.getAndIncrement());
+        return createTableName(null);
+    }
+
+    protected String createTableName(String tableName)
+    {
+        String currentTable = tableName == null ? String.format("table_%02d", seqNumber.getAndIncrement()) : tableName;
         tables.add(currentTable);
         return currentTable;
     }

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -55,6 +55,23 @@ import static org.junit.Assert.*;
 public class CreateTest extends CQLTester
 {
     @Test
+    public void testCreateTableWithNameCapitalPAndColumnDuration() throws Throwable
+    {
+        //CASSANDRA-17919
+        createTable(KEYSPACE, "CREATE TABLE %s (a INT PRIMARY KEY, b DURATION);", "P");
+        execute("INSERT INTO %s (a, b) VALUES (1, PT0S)");
+        assertRows(execute("SELECT * FROM %s"), row(1, Duration.newInstance(0, 0, 0)));
+    }
+
+    @Test
+    public void testCreateKeyspaceWithNameCapitalP() throws Throwable
+    {
+        //CASSANDRA-17919
+        executeFormattedQuery("CREATE KEYSPACE IF NOT EXISTS P WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}");
+        executeFormattedQuery("DROP KEYSPACE P");
+    }
+    
+    @Test
     public void testCreateTableWithSmallintColumns() throws Throwable
     {
         createTable("CREATE TABLE %s (a text, b smallint, c smallint, primary key (a, b));");

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/DropTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/DropTest.java
@@ -25,6 +25,15 @@ import org.apache.cassandra.cql3.CQLTester;
 public class DropTest extends CQLTester
 {
     @Test
+    public void testDropTableWithNameCapitalPAndColumnDuration() throws Throwable
+    {
+        //CASSANDRA-17919
+        createTable(KEYSPACE, "CREATE TABLE %s (a INT PRIMARY KEY, b DURATION);", "P");
+        execute("DROP TABLE %s");
+        assertRowsIgnoringOrder(execute(String.format("SELECT * FROM system_schema.dropped_columns WHERE keyspace_name = '%s' AND table_name = 'P'", keyspace())));
+    }
+    
+    @Test
     public void testNonExistingOnes() throws Throwable
     {
         assertInvalidMessage(String.format("Table '%s.table_does_not_exist' doesn't exist", KEYSPACE),  "DROP TABLE " + KEYSPACE + ".table_does_not_exist");

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/InsertTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/InsertTest.java
@@ -25,12 +25,51 @@ import org.junit.Test;
 
 import org.apache.cassandra.cql3.Attributes;
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.Duration;
 import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.UntypedResultSet.Row;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 
 public class InsertTest extends CQLTester
 {
+    @Test
+    public void testInsertZeroDuration() throws Throwable
+    {
+        Duration expectedDuration = Duration.newInstance(0, 0, 0);
+        createTable(KEYSPACE, "CREATE TABLE %s (a INT PRIMARY KEY, b DURATION);");
+        execute("INSERT INTO %s (a, b) VALUES (1, P0Y)");
+        execute("INSERT INTO %s (a, b) VALUES (2, P0M)");
+        execute("INSERT INTO %s (a, b) VALUES (3, P0W)");
+        execute("INSERT INTO %s (a, b) VALUES (4, P0D)");
+        execute("INSERT INTO %s (a, b) VALUES (5, P0Y0M0D)");
+        execute("INSERT INTO %s (a, b) VALUES (6, PT0H)");
+        execute("INSERT INTO %s (a, b) VALUES (7, PT0M)");
+        execute("INSERT INTO %s (a, b) VALUES (8, PT0S)");
+        execute("INSERT INTO %s (a, b) VALUES (9, PT0H0M0S)");
+        execute("INSERT INTO %s (a, b) VALUES (10, P0YT0H)");
+        execute("INSERT INTO %s (a, b) VALUES (11, P0MT0M)");
+        execute("INSERT INTO %s (a, b) VALUES (12, P0DT0S)");
+        execute("INSERT INTO %s (a, b) VALUES (13, P0M0DT0H0S)");
+        execute("INSERT INTO %s (a, b) VALUES (14, P0Y0M0DT0H0M0S)");
+        assertRowsIgnoringOrder(execute("SELECT * FROM %s"),
+                    row(1, expectedDuration),
+                    row(2, expectedDuration),
+                    row(3, expectedDuration),
+                    row(4, expectedDuration),
+                    row(5, expectedDuration),
+                    row(6, expectedDuration),
+                    row(7, expectedDuration),
+                    row(8, expectedDuration),
+                    row(9, expectedDuration),
+                    row(10, expectedDuration),
+                    row(11, expectedDuration),
+                    row(12, expectedDuration),
+                    row(13, expectedDuration),
+                    row(14, expectedDuration)
+        );
+        assertInvalidMessage("no viable alternative at input ')' (... b) VALUES (15, [P]))","INSERT INTO %s (a, b) VALUES (15, P)");
+    }
+    
     @Test
     public void testEmptyTTL() throws Throwable
     {


### PR DESCRIPTION
The change description is available at https://issues.apache.org/jira/browse/CASSANDRA-17919 patch submission, as it involves multiple versions.

In short, I've fixed how Lexer.g recognizes 0 duration token in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) format and updated unit tests to cover the change.

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)