### PR TITLE
Enable single_sstable_uplevel by default for LCS

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -65,7 +65,7 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
         super(cfs, options);
         int configuredMaxSSTableSize = DEFAULT_MAX_SSTABLE_SIZE_MIB;
         int configuredLevelFanoutSize = DEFAULT_LEVEL_FANOUT_SIZE;
-        boolean configuredSingleSSTableUplevel = false;
+        boolean configuredSingleSSTableUplevel = true;
         SizeTieredCompactionStrategyOptions localOptions = new SizeTieredCompactionStrategyOptions(options);
         if (options != null)
         {

--- a/src/java/org/apache/cassandra/db/compaction/SingleSSTableLCSTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/SingleSSTableLCSTask.java
@@ -45,6 +45,11 @@ public class SingleSSTableLCSTask extends AbstractCompactionTask
         this.level = level;
     }
 
+    protected int getLevel()
+    {
+        return level;
+    }
+
     @Override
     protected void executeInternal(ActiveCompactionsTracker activeCompactions)
     {

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsCQLTest.java
@@ -542,10 +542,10 @@ public class CompactionsCQLTest extends CQLTester
         getCurrentColumnFamilyStore().forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
 
         LeveledCompactionStrategy lcs = (LeveledCompactionStrategy) getCurrentColumnFamilyStore().getCompactionStrategyManager().getUnrepairedUnsafe().first();
-        LeveledCompactionTask lcsTask;
+        AbstractCompactionTask lcsTask;
         while (true)
         {
-            lcsTask = (LeveledCompactionTask) Iterables.getOnlyElement(lcs.getNextBackgroundTasks(0), null);
+            lcsTask = Iterables.getOnlyElement(lcs.getNextBackgroundTasks(0), null);
             if (lcsTask != null)
             {
                 lcsTask.execute(CompactionManager.instance.active);
@@ -591,7 +591,7 @@ public class CompactionsCQLTest extends CQLTester
             // ignored
         }
 
-        lcsTask = (LeveledCompactionTask) Iterables.getOnlyElement(lcs.getNextBackgroundTasks(0), null);
+        lcsTask = Iterables.getOnlyElement(lcs.getNextBackgroundTasks(0), null);
         try
         {
             assertNotNull(lcsTask);

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -599,9 +599,20 @@ public class LeveledCompactionStrategyTest
                 {
                     try
                     {
-                        assertTrue(task instanceof LeveledCompactionTask);
-                        LeveledCompactionTask lcsTask = (LeveledCompactionTask) task;
-                        level = Math.max(level, lcsTask.getLevel());
+                        if (task instanceof LeveledCompactionTask)
+                        {
+                            LeveledCompactionTask lcsTask = (LeveledCompactionTask) task;
+                            level = Math.max(level, lcsTask.getLevel());
+                        }
+                        else if (task instanceof SingleSSTableLCSTask)
+                        {
+                            SingleSSTableLCSTask singleSSTableLCSTask = (SingleSSTableLCSTask) task;
+                            level = Math.max(level, singleSSTableLCSTask.getLevel());
+                        }
+                        else
+                        {
+                            Assert.fail("Got unexpected task of type " + task.getClass().getCanonicalName());
+                        }
                     }
                     finally
                     {


### PR DESCRIPTION
single_sstable_uplevel for LCS introduced in 4.0. It is disabled by default. This change will enable it by default.

[CASSANDRA-18509](https://issues.apache.org/jira/browse/CASSANDRA-18509)

