### PR TITLE
CASSANDRA-18467: ant generate-idea-files support for JDK 17

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -188,6 +188,14 @@
       <isset property="arch_x86" />
     </condition>
 
+    <resources id="_jvm8_arg_items">
+        <!-- add necessary args in <string> tags; see _jvm11_arg_items as an example -->
+    </resources>
+    <pathconvert property="_jvm8_args_concat" refid="_jvm8_arg_items" pathsep=" "/>
+    <condition property="java-jvmargs" value="${_jvm8_args_concat}">
+        <equals arg1="${ant.java.version}" arg2="1.8"/>
+    </condition>
+
     <resources id="_jvm11_arg_items">
         <string>-Djdk.attach.allowAttachSelf=true</string>
         <string>-XX:+UseConcMarkSweepGC</string>
@@ -219,8 +227,8 @@
         <string>--add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED</string>
         <string>--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED</string>
     </resources>
-    <pathconvert property="_jvm_args_concat" refid="_jvm11_arg_items" pathsep=" "/>
-    <condition property="java11-jvmargs" value="${_jvm_args_concat}" else="">
+    <pathconvert property="_jvm11_args_concat" refid="_jvm11_arg_items" pathsep=" "/>
+    <condition property="java-jvmargs" value="${_jvm11_args_concat}">
         <equals arg1="${ant.java.version}" arg2="11"/>
     </condition>
 
@@ -264,8 +272,8 @@
         <string>--add-opens java.base/java.lang.reflect=ALL-UNNAMED</string>
         <string>--add-opens java.base/java.net=ALL-UNNAMED</string>
     </resources>
-    <pathconvert property="_jvm_args_concat2" refid="_jvm17_arg_items" pathsep=" "/>
-    <condition property="java17-jvmargs" value="${_jvm_args_concat2}" else="">
+    <pathconvert property="_jvm17_args_concat" refid="_jvm17_arg_items" pathsep=" "/>
+    <condition property="java-jvmargs" value="${_jvm17_args_concat}">
         <equals arg1="${ant.java.version}" arg2="17"/>
     </condition>
 
@@ -299,10 +307,13 @@
         <string>-Dio.netty.tryReflectionSetAccessible=true</string>
     </resources>
     <pathconvert property="_jvm17_test_arg_items_concat" refid="_jvm17_test_arg_items" pathsep=" "/>
-    <condition property="_std-test-jvmargs11" value="${_jvm11_test_arg_items_concat}" else=" ">
+    <condition property="_std-test-jvmargs" value="${_jvm8_test_arg_items_concat}">
+        <equals arg1="${ant.java.version}" arg2="1.8"/>
+    </condition>
+    <condition property="_std-test-jvmargs" value="${_jvm11_test_arg_items_concat}">
             <equals arg1="${ant.java.version}" arg2="11"/>
     </condition>
-    <condition property="_std-test-jvmargs17" value="${_jvm17_test_arg_items_concat}" else=" ">
+    <condition property="_std-test-jvmargs" value="${_jvm17_test_arg_items_concat}">
         <equals arg1="${ant.java.version}" arg2="17"/>
     </condition>
 
@@ -483,8 +494,7 @@
         <jvmarg value="-Dcassandra.reads.thresholds.coordinator.defensive_checks_enabled=true" /> <!-- enable defensive checks -->
         <jvmarg value="-javaagent:${build.lib}/jamm-${jamm.version}.jar" />
         <jvmarg value="-ea"/>
-        <jvmarg line="${java11-jvmargs}"/>
-        <jvmarg line="${java17-jvmargs}"/>
+        <jvmarg line="${java-jvmargs}"/>
       </java>
     </target>
 
@@ -1141,12 +1151,10 @@
         <jvmarg value="-Dcassandra.test.flush_local_schema_changes=${cassandra.test.flush_local_schema_changes}"/>
         <jvmarg value="-Dcassandra.test.messagingService.nonGracefulShutdown=${cassandra.test.messagingService.nonGracefulShutdown}"/>
         <jvmarg value="-Dcassandra.use_nix_recursive_delete=${cassandra.use_nix_recursive_delete}"/>
-        <jvmarg line="${java11-jvmargs}"/>
-        <jvmarg line="${java17-jvmargs}"/>
+        <jvmarg line="${java-jvmargs}"/>
         <!-- disable shrinks in quicktheories CASSANDRA-15554 -->
         <jvmarg value="-DQT_SHRINKS=0"/>
-        <jvmarg line="${_std-test-jvmargs11}" />
-        <jvmarg line="${_std-test-jvmargs17}" />
+        <jvmarg line="${_std-test-jvmargs} " />
         <jvmarg line="${test.jvm.args}" />
         <optjvmargs/>
         <!-- Uncomment to debug unittest, attach debugger to port 1416 -->
@@ -1793,13 +1801,13 @@
       </java>
   </target>
 
-  <target name="_maybe_update_idea_to_java11" depends="init" if="java.version.11">
-    <replace file="${eclipse.project.name}.iml" token="JDK_1_8" value="JDK_11"/>
-    <replace file=".idea/misc.xml" token="JDK_1_8" value="JDK_11"/>
-    <replace file=".idea/misc.xml" token="1.8" value="11"/>
+  <target name="_maybe_update_idea_to_java11plus" depends="init" unless="java.version.8">
+    <replace file="${eclipse.project.name}.iml" token="JDK_1_8" value="JDK_${ant.java.version}"/>
+    <replace file=".idea/misc.xml" token="JDK_1_8" value="JDK_${ant.java.version}"/>
+    <replace file=".idea/misc.xml" token="1.8" value="${ant.java.version}"/>
     <replaceregexp file=".idea/workspace.xml"
                    match="name=&quot;VM_PARAMETERS&quot; value=&quot;(.*)"
-                   replace="name=&quot;VM_PARAMETERS&quot; value=&quot;\1 ${java11-jvmargs}"
+                   replace="name=&quot;VM_PARAMETERS&quot; value=&quot;\1 ${java-jvmargs} ${_std-test-jvmargs}"
                    byline="true"/>
 
       <echo file=".idea/compiler.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
@@ -1808,11 +1816,21 @@
     <option name="ADDITIONAL_OPTIONS_STRING" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED" />
   </component>
 </project>]]></echo>
-      <echo>"IDE configuration updated for use with JDK11"</echo>
+      <echo>"IDE configuration updated for use with JDK${ant.java.version}"</echo>
+      <echo>Please note that `ant realclean` does *NOT* remove IntelliJ-specific files</echo>
+      <echo/>
+      <echo>Warning! If you observer strange behavior in IntelliJ please</echo>
+      <echo>verify that the SDK that is being used is indeed version ${ant.java.version}.</echo>
+      <echo>The used JDK version can be verified in Project Structure/Project Setting/Project</echo>
+      <echo>and Project Structure/Platform Setting/SDKs</echo>
+      <echo>In particular it is worth checking if the used JDK, typically named "${ant.java.version}",</echo>
+      <echo>indeed points to a java ${ant.java.version} installation.</echo>
   </target>
 
   <!-- Generate IDEA project description files -->
   <target name="generate-idea-files" depends="init,resolver-dist-lib,gen-cql3-grammar,generate-jflex-java,createVersionPropFile" description="Generate IDEA files">
+    <delete dir=".idea"/>
+    <delete file="${eclipse.project.name}.iml"/>
     <mkdir dir=".idea"/>
     <mkdir dir=".idea/libraries"/>
     <copy todir=".idea" overwrite="true">
@@ -1830,7 +1848,7 @@
     </modules>
   </component>
 </project>]]></echo>
-      <antcall target="_maybe_update_idea_to_java11"/>
+      <antcall target="_maybe_update_idea_to_java11plus"/>
   </target>
 
   <!-- Generate Eclipse project description files -->


### PR DESCRIPTION
ant generate-idea-files now support JDK 8, JDK 11 and JDK 17. To add support of another JDK the java-jvmargs property must be set for the JDK in question (see how it's done in build.xml for Java 11 and 17)

Other minor, but notable changes are:
- test jvmargs are now added to idea run configurations
- .idea dir and project iml file are first removed and then recreated during ant generate-idea-files

patch by Jakub Żytka ; reviewed by Ekaterina Dimitrova for CASSANDRA-18467
