### PR TITLE
CASSANDRA-18434 Update cassandra.yaml with example for accepted_protocols field

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1382,6 +1382,9 @@ server_encryption_options:
   require_endpoint_verification: false
   # More advanced defaults:
   # protocol: TLS
+  # accepted_protocols: [
+  #   TLSv1.2, TLSv1.1
+  # ]
   # store_type: JKS
   # cipher_suites: [
   #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -1425,6 +1428,9 @@ client_encryption_options:
   # truststore_password: cassandra
   # More advanced defaults:
   # protocol: TLS
+  # accepted_protocols: [
+  #   TLSv1.2, TLSv1.1
+  # ]
   # store_type: JKS
   # cipher_suites: [
   #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
Add example in the yaml for accepted_protocols field of encrypted_options config introduced in CASSANDRA-13325.

Patch by Sudeep Rao; reviewed by TBD for CASSANDRA-#####
