### PR TITLE
CASSANDRA-18525 Adding keyspace column to clients virtual table

### DIFF
--- a/src/java/org/apache/cassandra/db/virtual/ClientsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/ClientsTable.java
@@ -40,6 +40,7 @@ final class ClientsTable extends AbstractVirtualTable
     private static final String SSL_ENABLED = "ssl_enabled";
     private static final String SSL_PROTOCOL = "ssl_protocol";
     private static final String SSL_CIPHER_SUITE = "ssl_cipher_suite";
+    private static final String KEYSPACE_NAME = "keyspace_name";
 
     ClientsTable(String keyspace)
     {
@@ -60,6 +61,7 @@ final class ClientsTable extends AbstractVirtualTable
                            .addRegularColumn(SSL_ENABLED, BooleanType.instance)
                            .addRegularColumn(SSL_PROTOCOL, UTF8Type.instance)
                            .addRegularColumn(SSL_CIPHER_SUITE, UTF8Type.instance)
+                           .addRegularColumn(KEYSPACE_NAME, UTF8Type.instance)
                            .build());
     }
 
@@ -83,7 +85,8 @@ final class ClientsTable extends AbstractVirtualTable
                   .column(REQUEST_COUNT, client.requestCount())
                   .column(SSL_ENABLED, client.sslEnabled())
                   .column(SSL_PROTOCOL, client.sslProtocol().orElse(null))
-                  .column(SSL_CIPHER_SUITE, client.sslCipherSuite().orElse(null));
+                  .column(SSL_CIPHER_SUITE, client.sslCipherSuite().orElse(null))
+                  .column(KEYSPACE_NAME, client.keyspace().orElse(null));
         }
 
         return result;

--- a/test/unit/org/apache/cassandra/db/virtual/ClientsTableKeyspaceColTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/ClientsTableKeyspaceColTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.virtual;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.service.EmbeddedCassandraService;
+
+public class ClientsTableKeyspaceColTest extends CQLTester
+{
+
+    private static Cluster cluster;
+    private static EmbeddedCassandraService cassandra;
+    private static final String KS_NAME = "vts";
+
+    @BeforeClass
+    public static void setupClass() throws IOException
+    {
+        cassandra = ServerTestUtils.startEmbeddedCassandraService();
+
+        cluster = Cluster.builder().addContactPoint("127.0.0.1")
+                         .withPort(DatabaseDescriptor.getNativeTransportPort())
+                         .build();
+
+        ClientsTable table = new ClientsTable(KS_NAME);
+        VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(KS_NAME, ImmutableList.of(table)));
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        if (cluster != null)
+            cluster.close();
+        if (cassandra != null)
+            cassandra.stop();
+    }
+
+    @Test
+    public void testWithoutConnectingToKeyspace()
+    {
+        try (Session session = cluster.connect())
+        {
+            List<Row> rows = session.execute("SELECT * from " + KS_NAME + ".clients").all();
+            Assert.assertTrue("At least one client should be returned.", rows.size() > 0);
+            for (Row r : rows)
+            {
+                // No keyspace is specifed while connecting. 'keyspace' column should be null.
+                Assert.assertNull(r.getString("keyspace_name"));
+            }
+        }
+    }
+
+    @Test
+    public void testChangingKeyspace()
+    {
+        String keyspace1 = "system_distributed";
+        String keyspace2 = "system_auth";
+        try (Session session = cluster.connect(keyspace1))
+        {
+
+            InetAddress poolConnection = null;
+            int port = -1;
+            List<Row> rows = session.execute("SELECT * from " + KS_NAME + ".clients").all();
+            for (Row r : rows)
+            {
+                // Keyspace is used for pool connection only (control connection is not using keyspace).
+                // Using keyspace != null as a hint to identify a pool connection as we can't identify
+                // control connection based on information in this table.
+                String keyspace = r.getString("keyspace_name");
+                if (keyspace1.equals(keyspace))
+                {
+                    poolConnection = r.getInet("address");
+                    port = r.getInt("port");
+                }
+            }
+
+            Assert.assertNotEquals(-1, port);
+            Assert.assertNotNull(poolConnection);
+
+            session.execute("USE " + keyspace2);
+
+            String actualKeyspace = null;
+            for (Row r : session.execute("SELECT * from " + KS_NAME + ".clients").all())
+            {
+                if (poolConnection.equals(r.getInet("address")) && port == r.getInt("port"))
+                {
+                    actualKeyspace = r.getString("keyspace_name");
+                }
+            }
+
+            Assert.assertEquals(keyspace2, actualKeyspace);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/virtual/ClientsTableKeyspaceColTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/ClientsTableKeyspaceColTest.java
@@ -33,10 +33,9 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.service.EmbeddedCassandraService;
 
-public class ClientsTableKeyspaceColTest extends CQLTester
+public class ClientsTableKeyspaceColTest
 {
 
     private static Cluster cluster;


### PR DESCRIPTION
Added new column `keyspace_name` (used by the client) to clients virtual table.

[CASSANDRA-18525](https://issues.apache.org/jira/browse/CASSANDRA-18525)


