### PR TITLE
CASSANDRA-18508: Allow javax.net.ssl properties to be specified in a file

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -245,7 +245,9 @@ else
   # turn on JMX authentication. See below for further options
   JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
 
-  # jmx ssl options
+  # JMX SSL options
+  # Consider using the jmx_encryption_options section of cassandra.yaml instead to prevent sensitive information being
+  #   exposxed
   #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=true"
   #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.need.client.auth=true"
   #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.protocols=<enabled-protocols>"

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1182,6 +1182,29 @@ client_encryption_options:
     #   TLS_RSA_WITH_AES_256_CBC_SHA
     # ]
 
+jmx_encryption_options:
+  - class_name: org.apache.cassandra.auth.jmx.ConfigurationJmxEncryptionOptionsProvider
+    parameters:
+      - enabled: false
+        keystore: conf/.keystore
+        keystore_password: cassandra
+        # require_client_auth: false
+        #
+        # Set trustore and truststore_password if require_client_auth is true:
+        # truststore: conf/.truststore
+        # truststore_password: cassandra
+        #
+        # More advanced defaults below:
+        # keystore_type: JKS
+        # truststore_type: JKS
+        # protocols: [TLSv1.1,TLSv1.2,TLSv1.3]
+        # cipher_suites: [
+        #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        #   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+        #   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256,
+        #   TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA
+        # ]
+
 # internode_compression controls whether traffic between nodes is
 # compressed.
 # Can be:

--- a/src/java/org/apache/cassandra/auth/jmx/ConfigurationJmxEncryptionOptionsProvider.java
+++ b/src/java/org/apache/cassandra/auth/jmx/ConfigurationJmxEncryptionOptionsProvider.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.auth.jmx;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.cassandra.config.EncryptionOptions;
+
+public class ConfigurationJmxEncryptionOptionsProvider implements JmxEncryptionOptionsProvider
+{
+    private static final String encryptionsOptionsClassName = EncryptionOptions.class.getName();
+    private static final String jmxEncryptionOptionsClassName = EncryptionOptions.JmxEncryptionOptions.class.getName();
+
+    public static class JmxEncryptionOptionSetter
+    {
+        public void setValue(EncryptionOptions.JmxEncryptionOptions encryptionOptions, String className, String fieldName, String value)
+        {
+            try
+            {
+                Field field = Class.forName(className).getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(encryptionOptions, value);
+            }
+            catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class JmxEncryptionOptionSetterBooleanPrimative extends JmxEncryptionOptionSetter
+    {
+        public void setValue(EncryptionOptions.JmxEncryptionOptions encryptionOptions, String className, String fieldName, String value)
+        {
+            try
+            {
+                Field field = Class.forName(className).getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(encryptionOptions, Boolean.parseBoolean(value));
+            }
+            catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class JmxEncryptionOptionSetterBooleanObject extends JmxEncryptionOptionSetter
+    {
+        public void setValue(EncryptionOptions.JmxEncryptionOptions encryptionOptions, String className, String fieldName, String value)
+        {
+            try
+            {
+                Field field = Class.forName(className).getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(encryptionOptions, Boolean.valueOf(value));
+            }
+            catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class JmxEncryptionOptionSetterListStrings extends JmxEncryptionOptionSetter
+    {
+        private static final Pattern COMMA_DELIMITED_VALUES_PATTERN = Pattern.compile("\\s*,\\s*");
+
+        public void setValue(EncryptionOptions.JmxEncryptionOptions encryptionOptions, String className, String fieldName, String value)
+        {
+            int value_len = value.length();
+            int start_offset = value.charAt(0) == '[' ? 1 : 0;
+            int end_offset = value.charAt(value_len - 1) == ']' ? value_len - 1 : value_len;
+            try
+            {
+                Field field = Class.forName(className).getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(
+                    encryptionOptions,
+                    Arrays.asList(COMMA_DELIMITED_VALUES_PATTERN.split(value.substring(start_offset, end_offset)))
+                );
+            }
+            catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    enum JmxEncryptionOption
+    {
+        enabled("enabled", encryptionsOptionsClassName, "enabled", new JmxEncryptionOptionSetterBooleanObject()),
+        keystorePath("keystore", encryptionsOptionsClassName, "keystore", new JmxEncryptionOptionSetter()),
+        keystorePassword("keystore_password", encryptionsOptionsClassName, "keystore_password", new JmxEncryptionOptionSetter()),
+        keystoreType("keystore_type", jmxEncryptionOptionsClassName, "keystore_type", new JmxEncryptionOptionSetter()),
+        truststorePath("truststore", encryptionsOptionsClassName, "truststore", new JmxEncryptionOptionSetter()),
+        truststorePassword("truststore_password", encryptionsOptionsClassName, "truststore_password", new JmxEncryptionOptionSetter()),
+        truststoreType("truststore_type", jmxEncryptionOptionsClassName, "truststore_type", new JmxEncryptionOptionSetter()),
+        requireClientAuth("require_client_auth", encryptionsOptionsClassName, "require_client_auth", new JmxEncryptionOptionSetterBooleanPrimative()),
+        cipherSuites("cipher_suites", encryptionsOptionsClassName, "cipher_suites", new JmxEncryptionOptionSetterListStrings()),
+        protocols("protocols", encryptionsOptionsClassName, "accepted_protocols", new JmxEncryptionOptionSetterListStrings());
+
+        public final String optionName;
+        public final String className;
+        public final String fieldName;
+        public final JmxEncryptionOptionSetter setter;
+
+        JmxEncryptionOption(String optionName, String className, String fieldName, JmxEncryptionOptionSetter setter)
+        {
+            this.optionName = optionName;
+            this.className = className;
+            this.fieldName = fieldName;
+            this.setter = setter;
+        }
+    }
+
+    private final EncryptionOptions.JmxEncryptionOptions jmxEncryptionOptions =
+        new EncryptionOptions.JmxEncryptionOptions();
+
+    public ConfigurationJmxEncryptionOptionsProvider(Map<String, String> parameters)
+    {
+        for (JmxEncryptionOption jeo : JmxEncryptionOption.values())
+        {
+            String value = (parameters.get(jeo.optionName) == null) ? null : String.valueOf(parameters.get(jeo.optionName));
+            if (value != null)
+                jeo.setter.setValue(jmxEncryptionOptions, jeo.className, jeo.fieldName, value.trim());
+        }
+        jmxEncryptionOptions.applyConfig();
+    }
+
+    public EncryptionOptions.JmxEncryptionOptions getJmxEncryptionOptions()
+    {
+        return jmxEncryptionOptions;
+    }
+}

--- a/src/java/org/apache/cassandra/auth/jmx/JmxEncryptionOptionsProvider.java
+++ b/src/java/org/apache/cassandra/auth/jmx/JmxEncryptionOptionsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.auth.jmx;
+
+import org.apache.cassandra.config.EncryptionOptions;
+
+public interface JmxEncryptionOptionsProvider
+{
+    EncryptionOptions.JmxEncryptionOptions getJmxEncryptionOptions();
+}

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -285,6 +285,7 @@ public class Config
 
     public EncryptionOptions.ServerEncryptionOptions server_encryption_options = new EncryptionOptions.ServerEncryptionOptions();
     public EncryptionOptions client_encryption_options = new EncryptionOptions();
+    public ParameterizedClass jmx_encryption_options;
 
     public InternodeCompression internode_compression = InternodeCompression.none;
 
@@ -674,6 +675,7 @@ public class Config
     private static final List<String> SENSITIVE_KEYS = new ArrayList<String>() {{
         add("client_encryption_options");
         add("server_encryption_options");
+        add("jmx_encryption_options");
     }};
 
     public static void log(Config config)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
@@ -48,6 +49,8 @@ import org.apache.cassandra.auth.IAuthorizer;
 import org.apache.cassandra.auth.IInternodeAuthenticator;
 import org.apache.cassandra.auth.INetworkAuthorizer;
 import org.apache.cassandra.auth.IRoleManager;
+import org.apache.cassandra.auth.jmx.JmxEncryptionOptionsProvider;
+import org.apache.cassandra.auth.jmx.ConfigurationJmxEncryptionOptionsProvider;
 import org.apache.cassandra.config.Config.CommitLogSync;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.commitlog.AbstractCommitLogSegmentManager;
@@ -136,6 +139,7 @@ public class DatabaseDescriptor
     private static Comparator<Replica> localComparator;
     private static EncryptionContext encryptionContext;
     private static boolean hasLoggedConfig;
+    private static JmxEncryptionOptionsProvider jmxEncryptionOptionsProvider;
 
     private static DiskOptimizationStrategy diskOptimizationStrategy;
 
@@ -799,6 +803,51 @@ public class DatabaseDescriptor
             {
                 throw new ConfigurationException("Encryption must be enabled in client_encryption_options for native_transport_port_ssl", false);
             }
+        }
+
+        try
+        {
+            final ParameterizedClass jmxEncryptionOptions = (conf.jmx_encryption_options == null) ?
+                new ParameterizedClass(
+                    ConfigurationJmxEncryptionOptionsProvider.class.getName(),
+                    ImmutableMap.of("enabled", "false")
+                )
+                :
+                conf.jmx_encryption_options;
+
+            final Class<?> jmxEncryptionOptionsProviderClass = Class.forName(jmxEncryptionOptions.class_name);
+            if (!JmxEncryptionOptionsProvider.class.isAssignableFrom(jmxEncryptionOptionsProviderClass))
+            {
+                throw new ConfigurationException(
+                    jmxEncryptionOptions.class_name
+                    + " is not an instance of "
+                    + JmxEncryptionOptionsProvider.class.getCanonicalName(),
+                    false
+                );
+            }
+
+            jmxEncryptionOptionsProvider =
+                (JmxEncryptionOptionsProvider)jmxEncryptionOptionsProviderClass
+                                              .getConstructor(Map.class)
+                                              .newInstance(jmxEncryptionOptions.parameters);
+        }
+        catch (ClassNotFoundException e)
+        {
+            throw new ConfigurationException(
+            e.getMessage()
+            + "\nUnable to find JMX encryption provider class: "
+            + conf.jmx_encryption_options.class_name,
+            false
+            );
+        }
+        // there are four checked exceptions that could be thrown here;
+        //  InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException
+        catch (Exception e)
+        {
+            throw new ConfigurationException(
+            e.getMessage() + "\nFatal configuration error; unable to start server. See log for stacktrace.",
+            true
+            );
         }
 
         if (conf.snapshot_links_per_second < 0)
@@ -2549,6 +2598,11 @@ public class DatabaseDescriptor
     public static void updateNativeProtocolEncryptionOptions(Function<EncryptionOptions, EncryptionOptions> update)
     {
         conf.client_encryption_options = update.apply(conf.client_encryption_options);
+    }
+
+    public static EncryptionOptions.JmxEncryptionOptions getJmxEncryptionOptions()
+    {
+        return jmxEncryptionOptionsProvider.getJmxEncryptionOptions();
     }
 
     public static int getHintedHandoffThrottleInKB()

--- a/src/java/org/apache/cassandra/config/EncryptionOptions.java
+++ b/src/java/org/apache/cassandra/config/EncryptionOptions.java
@@ -669,4 +669,16 @@ public class EncryptionOptions
         }
 
     }
+
+    public static class JmxEncryptionOptions extends EncryptionOptions
+    {
+        public String keystore_type;
+        public String truststore_type;
+
+        public JmxEncryptionOptions()
+        {
+            keystore_type = "JKS";
+            truststore_type = "JKS";
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes the issue where sensitive JMX SSL configuration options are easily exposed when viewing the Cassandra process. It fixes the issue by adding a Cassandra system property called `cassandra.jmx.remote.ssl.config.file`. This property specifies a path to a file containing the `javax.net.ssl.* properties`. It is an alternative to specifying the properties directly in the _cassandra-env.sh_ file. It can be used as a method to hide security sensitive properties from the process output.

# Reproduce the issue using these steps

This issue exists in all versions of Cassandra.

**1. Generate JKS fomat keystore and truststore files**

This can be done using the following [instructions](https://stackoverflow.com/questions/47434877/how-to-generate-keystore-and-truststore)

Name the generated keystore and truststore keystore.jks and truststore.jks respectively, and place them in _/etc/ssl/_. Ensure their permissions are set to be readable only by the user running the Cassandra process.

**2. Configure Cassandra to allow encrypted remote JMX connections**

Modify the _cassandra-env.sh_ file as per the following snippet.

```
...
JMX_PORT="7199"
JMXREMOTE_PORT="7198"
LOCAL_JMX="no"

if [ "$LOCAL_JMX" = "yes" ]; then
  JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.local.port=$JMX_PORT"
  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
else
  JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.remote.port=$JMX_PORT"
  # if ssl is enabled the same port cannot be used for both jmx and rmi so either
  # pick another value for this property or comment out to use a random port (though see CASSANDRA-7087 for origins)
   JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMXREMOTE_PORT"

  # turn on JMX authentication. See below for further options
  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"

  # jmx ssl options
  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=true"
  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.need.client.auth=true"
  #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.protocols=<enabled-protocols>"
  #JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl.enabled.cipher.suites=<enabled-cipher-suites>"
  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStore=/etc/ssl/keystore.jks"
  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStorePassword=keystorepassword"
  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStore=/etc/ssl/truststore.jks"
  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStorePassword=truststorepassword"
fi
...
```

**3. Start Cassandra and inspect the system process**

This assumes installation via `tar.gz` binary distribution. The output generated by the `ps` command has been modified to highlight the issue this PR fixes. 

```
$ cd /opt/cassandra/bin
$ ./cassandra

$ ps aux | grep "cassandra"

cassand+      ... /opt/java/openjdk/bin/java -ea -da:net.openhft... -XX:+UseThreadPriorities ... -Dcassandra.jmx.remote.port=7199 -Dcom.sun.management.jmxremote.rmi.port=7198 -Dcom.sun.management.jmxremote.authenticate=true -Dcom.sun.management.jmxremote.ssl=true -Dcom.sun.management.jmxremote.ssl.need.client.auth=true -Djavax.net.ssl.keyStore=/etc/ssl/cassandra_keystore.jks -Djavax.net.ssl.keyStorePassword=cassandraprivkeypassword -Djavax.net.ssl.trustStore=/etc/ssl/common_truststore.jks -Djavax.net.ssl.trustStorePassword=truststorepassword -Dcom.sun.management.jmxremote.password.file=/etc/cassandra/jmxremote.password...: org.apache.cassandra.service.CassandraDaemon
```

patch by Anthony Grasso for CASSANDRA-18508