### PR TITLE
CASSANDRA-18346: Add column info during deserialization error

### DIFF
--- a/src/java/org/apache/cassandra/db/filter/ColumnSubselection.java
+++ b/src/java/org/apache/cassandra/db/filter/ColumnSubselection.java
@@ -194,10 +194,14 @@ public abstract class ColumnSubselection implements Comparable<ColumnSubselectio
             {
                 // If we don't find the definition, it could be we have data for a dropped column, and we shouldn't
                 // fail deserialization because of that. So we grab a "fake" ColumnDefinition that ensure proper
-                // deserialization. The column will be ignore later on anyway.
+                // deserialization. The column will be ignored later on anyway.
                 column = metadata.getDroppedColumnDefinition(name);
                 if (column == null)
-                    throw new RuntimeException("Unknown column " + UTF8Type.instance.getString(name) + " during deserialization");
+                {
+                    String errorMsg = String.format("Unknown column %s in table %s.%s during deserialization",
+                                                    UTF8Type.instance.getString(name), metadata.ksName, metadata.cfName);
+                    throw new RuntimeException(errorMsg);
+                }
             }
 
             Kind kind = Kind.values()[in.readUnsignedByte()];


### PR DESCRIPTION
Adding keyspace, table name to error message during column deserialization


The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-18346)

