### PR TITLE
Use WithProperties to improve properties handling (CASSANDRA-18453)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0
+ * Use WithProperties to ensure that system properties are handled (CASSANDRA-18453)
  * Fix sstable formats configuration (CASSANDRA-18441)
  * Add guardrail to bound timestamps (CASSANDRA-18352)
  * Add keyspace_name column to system_views.clients (CASSANDRA-18525)

--- a/checkstyle_test.xml
+++ b/checkstyle_test.xml
@@ -122,7 +122,7 @@
       <property name="id" value="clearValueSystemPropertyUsage"/>
       <property name="format" value="\.clearValue\("/>
       <property name="ignoreComments" value="true"/>
-      <property name="message" value="Please use withProperties approach instead." />
+      <property name="message" value="Please use WithProperties in try-with-resources instead. See CASSANDRA-18453." />
     </module>
 
     <module name="RedundantImport"/>

--- a/checkstyle_test.xml
+++ b/checkstyle_test.xml
@@ -118,6 +118,13 @@
       <property name="message" value="Use the CassandraRelevantProperties or CassandraRelevantEnv instead." />
     </module>
 
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="clearValueSystemPropertyUsage"/>
+      <property name="format" value="\.clearValue\("/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="Please use withProperties approach instead." />
+    </module>
+
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
   </module>

--- a/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
@@ -473,6 +473,7 @@ public class GossipHelper
         withProperty(prop, Boolean.toString(value), r);
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     public static void withProperty(CassandraRelevantProperties prop, String value, Runnable r)
     {
         String prev = prop.setString(value);

--- a/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
@@ -473,7 +473,6 @@ public class GossipHelper
         withProperty(prop, Boolean.toString(value), r);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     public static void withProperty(CassandraRelevantProperties prop, String value, Runnable r)
     {
         String prev = prop.setString(value);
@@ -484,7 +483,7 @@ public class GossipHelper
         finally
         {
             if (prev == null)
-                prop.clearValue();
+                prop.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
             else
                 prop.setString(prev);
         }

--- a/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
@@ -58,12 +58,11 @@ public class BootstrapBinaryDisabledTest extends TestBaseImpl
         originalResetBootstrapProgress = RESET_BOOTSTRAP_PROGRESS.setBoolean(false);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void afterClass()
     {
         if (originalResetBootstrapProgress == null)
-            RESET_BOOTSTRAP_PROGRESS.clearValue();
+            RESET_BOOTSTRAP_PROGRESS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
         else
             RESET_BOOTSTRAP_PROGRESS.setBoolean(originalResetBootstrapProgress);
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
@@ -58,6 +58,7 @@ public class BootstrapBinaryDisabledTest extends TestBaseImpl
         originalResetBootstrapProgress = RESET_BOOTSTRAP_PROGRESS.setBoolean(false);
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void afterClass()
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/BootstrapBinaryDisabledTest.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.distributed.api.SimpleQueryResult;
 import org.apache.cassandra.distributed.api.TokenSupplier;
 import org.apache.cassandra.distributed.shared.Byteman;
 import org.apache.cassandra.distributed.shared.NetworkTopology;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.utils.Shared;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.RESET_BOOTSTRAP_PROGRESS;
@@ -49,22 +50,19 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_WRITE
  */
 public class BootstrapBinaryDisabledTest extends TestBaseImpl
 {
-    static Boolean originalResetBootstrapProgress = null;
+    static WithProperties properties;
 
     @BeforeClass
     public static void beforeClass() throws Throwable
     {
         TestBaseImpl.beforeClass();
-        originalResetBootstrapProgress = RESET_BOOTSTRAP_PROGRESS.setBoolean(false);
+        properties = new WithProperties().set(RESET_BOOTSTRAP_PROGRESS, false);
     }
 
     @AfterClass
     public static void afterClass()
     {
-        if (originalResetBootstrapProgress == null)
-            RESET_BOOTSTRAP_PROGRESS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
-        else
-            RESET_BOOTSTRAP_PROGRESS.setBoolean(originalResetBootstrapProgress);
+        properties.close();
     }
 
     @Test

--- a/test/distributed/org/apache/cassandra/distributed/test/DataResurrectionCheckTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/DataResurrectionCheckTest.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.config.StartupChecksOptions;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.distributed.api.IIsolatedExecutor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.StartupException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.service.DataResurrectionCheck;
@@ -59,11 +60,9 @@ public class DataResurrectionCheckTest extends TestBaseImpl
     @Test
     public void testDataResurrectionCheck() throws Exception
     {
-        try
+        // set it to 1 hour so check will be not updated after it is written, for test purposes
+        try (WithProperties properties = new WithProperties().set(CHECK_DATA_RESURRECTION_HEARTBEAT_PERIOD, 3600000))
         {
-            // set it to 1 hour so check will be not updated after it is written, for test purposes
-            CHECK_DATA_RESURRECTION_HEARTBEAT_PERIOD.setInt(3600000);
-
             // start the node with the check enabled, it will just pass fine as there are not any user tables yet
             // and system tables are young enough
             try (Cluster cluster = build().withNodes(1)
@@ -128,10 +127,6 @@ public class DataResurrectionCheckTest extends TestBaseImpl
                                                    EXCLUDED_TABLES_CONFIG_PROPERTY, "ks1.tb1,ks2.tb1",
                                                    EXCLUDED_KEYSPACES_CONFIG_PROPERTY, "ks3"));
             }
-        }
-        finally
-        {
-            CHECK_DATA_RESURRECTION_HEARTBEAT_PERIOD.clearValue();
         }
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/FailingResponseDoesNotLogTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/FailingResponseDoesNotLogTest.java
@@ -71,13 +71,16 @@ public class FailingResponseDoesNotLogTest extends TestBaseImpl
     @Test
     public void dispatcherErrorDoesNotLock() throws IOException
     {
-        try (WithProperties properties = new WithProperties().set(CUSTOM_QUERY_HANDLER_CLASS, AlwaysRejectErrorQueryHandler.class.getName()))
-        {
+        try (
+            WithProperties properties = new WithProperties().set(CUSTOM_QUERY_HANDLER_CLASS, AlwaysRejectErrorQueryHandler.class.getName());
             Cluster cluster = Cluster.build(1)
                                      .withConfig(c -> c.with(Feature.NATIVE_PROTOCOL, Feature.GOSSIP)
-                                                       .set("client_error_reporting_exclusions", ImmutableMap.of("subnets", Collections.singletonList("127.0.0.1")))
-                                     )
+                                                       .set("client_error_reporting_exclusions", ImmutableMap.of("subnets", Collections.singletonList("127.0.0.1"))))
                                      .start();
+
+        )
+        {
+
             try (SimpleClient client = SimpleClient.builder("127.0.0.1", 9042).build().connect(false))
             {
                 client.execute("SELECT * FROM system.peers", ConsistencyLevel.ONE);

--- a/test/distributed/org/apache/cassandra/distributed/test/FailingResponseDoesNotLogTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/FailingResponseDoesNotLogTest.java
@@ -71,12 +71,11 @@ public class FailingResponseDoesNotLogTest extends TestBaseImpl
     @Test
     public void dispatcherErrorDoesNotLock() throws IOException
     {
-        try (
-            WithProperties properties = new WithProperties().set(CUSTOM_QUERY_HANDLER_CLASS, AlwaysRejectErrorQueryHandler.class.getName());
-            Cluster cluster = Cluster.build(1)
-                                     .withConfig(c -> c.with(Feature.NATIVE_PROTOCOL, Feature.GOSSIP)
-                                                       .set("client_error_reporting_exclusions", ImmutableMap.of("subnets", Collections.singletonList("127.0.0.1"))))
-                                     .start();
+        try (WithProperties properties = new WithProperties().set(CUSTOM_QUERY_HANDLER_CLASS, AlwaysRejectErrorQueryHandler.class.getName());
+             Cluster cluster = Cluster.build(1)
+                                      .withConfig(c -> c.with(Feature.NATIVE_PROTOCOL, Feature.GOSSIP)
+                                                        .set("client_error_reporting_exclusions", ImmutableMap.of("subnets", Collections.singletonList("127.0.0.1"))))
+                                      .start();
 
         )
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/MessageForwardingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MessageForwardingTest.java
@@ -122,8 +122,7 @@ public class MessageForwardingTest extends TestBaseImpl
         finally
         {
             if (originalTraceTimeout == null)
-                // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-                WAIT_FOR_TRACING_EVENTS_TIMEOUT_SECS.clearValue();
+                WAIT_FOR_TRACING_EVENTS_TIMEOUT_SECS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
             else
                 WAIT_FOR_TRACING_EVENTS_TIMEOUT_SECS.setInt(originalTraceTimeout);
         }

--- a/test/distributed/org/apache/cassandra/distributed/test/MessageForwardingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MessageForwardingTest.java
@@ -122,6 +122,7 @@ public class MessageForwardingTest extends TestBaseImpl
         finally
         {
             if (originalTraceTimeout == null)
+                // checkstyle: suppress below 'clearValueSystemPropertyUsage'
                 WAIT_FOR_TRACING_EVENTS_TIMEOUT_SECS.clearValue();
             else
                 WAIT_FOR_TRACING_EVENTS_TIMEOUT_SECS.setInt(originalTraceTimeout);

--- a/test/distributed/org/apache/cassandra/distributed/test/MigrationCoordinatorTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MigrationCoordinatorTest.java
@@ -40,13 +40,12 @@ import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 public class MigrationCoordinatorTest extends TestBaseImpl
 {
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @Before
     public void setUp()
     {
-        REPLACE_ADDRESS.clearValue();
-        CONSISTENT_RANGE_MOVEMENT.clearValue();
-        IGNORED_SCHEMA_CHECK_VERSIONS.clearValue();
+        REPLACE_ADDRESS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        CONSISTENT_RANGE_MOVEMENT.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        IGNORED_SCHEMA_CHECK_VERSIONS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
     /**
      * We shouldn't wait on versions only available from a node being replaced

--- a/test/distributed/org/apache/cassandra/distributed/test/MigrationCoordinatorTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MigrationCoordinatorTest.java
@@ -40,6 +40,7 @@ import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 public class MigrationCoordinatorTest extends TestBaseImpl
 {
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @Before
     public void setUp()
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/NativeMixedVersionTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NativeMixedVersionTest.java
@@ -30,6 +30,7 @@ import com.datastax.driver.core.Session;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.IO_NETTY_EVENTLOOP_THREADS;
@@ -41,15 +42,15 @@ public class NativeMixedVersionTest extends TestBaseImpl
     {
         // make sure to limit the netty thread pool to size 1, this will make the test determanistic as all work
         // will happen on the single thread.
-        IO_NETTY_EVENTLOOP_THREADS.setInt(1);
-        try (Cluster cluster = Cluster.build(1)
-                                      .withConfig(c ->
-                                                  c.with(Feature.values())
-                                                   .set("read_thresholds_enabled", true)
-                                                   .set("local_read_size_warn_threshold", "1KiB")
-                                      )
-                                      .start())
+        try (WithProperties properties = new WithProperties().set(IO_NETTY_EVENTLOOP_THREADS, 1))
         {
+            Cluster cluster = Cluster.build(1)
+                                     .withConfig(c ->
+                                                 c.with(Feature.values())
+                                                  .set("read_thresholds_enabled", true)
+                                                  .set("local_read_size_warn_threshold", "1KiB")
+                                     )
+                                     .start();
             init(cluster);
             cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int, ck1 int, value blob, PRIMARY KEY (pk, ck1))"));
             IInvokableInstance node = cluster.get(1);
@@ -79,10 +80,6 @@ public class NativeMixedVersionTest extends TestBaseImpl
             // this should not happen; so make sure no logs are found
             List<String> result = node.logs().grep("Warnings present in message with version less than").getResult();
             Assertions.assertThat(result).isEmpty();
-        }
-        finally
-        {
-            IO_NETTY_EVENTLOOP_THREADS.clearValue();
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/PaxosRepair2Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/PaxosRepair2Test.java
@@ -335,12 +335,13 @@ public class PaxosRepair2Test extends TestBaseImpl
     @Test
     public void paxosAutoRepair() throws Throwable
     {
-        try (WithProperties properties = new WithProperties().set(AUTO_REPAIR_FREQUENCY_SECONDS, 1).set(DISABLE_PAXOS_AUTO_REPAIRS, true))
+        try (WithProperties properties = new WithProperties().set(AUTO_REPAIR_FREQUENCY_SECONDS, 1).set(DISABLE_PAXOS_AUTO_REPAIRS, true);
+             Cluster cluster = init(Cluster.create(3, cfg -> cfg
+                                                             .set("paxos_variant", "v2")
+                                                             .set("paxos_repair_enabled", true)
+                                                             .set("truncate_request_timeout_in_ms", 1000L)));
+             )
         {
-            Cluster cluster = init(Cluster.create(3, cfg -> cfg
-                                                            .set("paxos_variant", "v2")
-                                                            .set("paxos_repair_enabled", true)
-                                                            .set("truncate_request_timeout_in_ms", 1000L)));
             cluster.forEach(i -> {
                 Assert.assertFalse(CassandraRelevantProperties.CLOCK_GLOBAL.isPresent());
                 Assert.assertEquals(1, CassandraRelevantProperties.AUTO_REPAIR_FREQUENCY_SECONDS.getInt());

--- a/test/distributed/org/apache/cassandra/distributed/test/VirtualTableLogsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/VirtualTableLogsTest.java
@@ -51,11 +51,12 @@ public class VirtualTableLogsTest extends TestBaseImpl
     @Test
     public void testVTableOutput() throws Throwable
     {
-        try (WithProperties properties = new WithProperties().set(LOGBACK_CONFIGURATION_FILE, "test/conf/logback-dtest_with_vtable_appender.xml"))
+        try (WithProperties properties = new WithProperties().set(LOGBACK_CONFIGURATION_FILE, "test/conf/logback-dtest_with_vtable_appender.xml");
+             Cluster cluster = Cluster.build(1)
+                                      .withConfig(c -> c.with(Feature.values()))
+                                      .start();
+             )
         {
-            Cluster cluster = Cluster.build(1)
-                                     .withConfig(c -> c.with(Feature.values()))
-                                     .start();
             List<TestingLogMessage> rows = getRows(cluster);
             assertFalse(rows.isEmpty());
 
@@ -67,11 +68,12 @@ public class VirtualTableLogsTest extends TestBaseImpl
     public void testMultipleAppendersFailToStartNode() throws Throwable
     {
         LOGBACK_CONFIGURATION_FILE.setString("test/conf/logback-dtest_with_vtable_appender_invalid.xml");
-        try (WithProperties properties = new WithProperties().set(LOGBACK_CONFIGURATION_FILE, "test/conf/logback-dtest_with_vtable_appender_invalid.xml"))
+        try (WithProperties properties = new WithProperties().set(LOGBACK_CONFIGURATION_FILE, "test/conf/logback-dtest_with_vtable_appender_invalid.xml");
+             Cluster ignored = Cluster.build(1)
+                                      .withConfig(c -> c.with(Feature.values()))
+                                      .start();
+             )
         {
-            Cluster ignored = Cluster.build(1)
-                                     .withConfig(c -> c.with(Feature.values()))
-                                     .start();
             fail("Node should not start as there is supposed to be invalid logback configuration file.");
         }
         catch (IllegalStateException ex)

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
@@ -84,6 +84,7 @@ public class BootstrapTest extends TestBaseImpl
     {
         CassandraRelevantProperties.MIGRATION_DELAY.setLong(savedMigrationDelay);
         if (originalResetBootstrapProgress == null)
+            // checkstyle: suppress below 'clearValueSystemPropertyUsage'
             RESET_BOOTSTRAP_PROGRESS.clearValue();
         else
             RESET_BOOTSTRAP_PROGRESS.setBoolean(originalResetBootstrapProgress);
@@ -110,6 +111,7 @@ public class BootstrapTest extends TestBaseImpl
     @Test
     public void bootstrapUnspecifiedResumeTest() throws Throwable
     {
+        // checkstyle: suppress below 'clearValueSystemPropertyUsage'
         RESET_BOOTSTRAP_PROGRESS.clearValue();
         bootstrapTest();
     }
@@ -126,6 +128,7 @@ public class BootstrapTest extends TestBaseImpl
     @Test
     public void bootstrapUnspecifiedFailsOnResumeTest() throws Throwable
     {
+        // checkstyle: suppress below 'clearValueSystemPropertyUsage'
         RESET_BOOTSTRAP_PROGRESS.clearValue();
 
         // Need our partitioner active for rangeToBytes conversion below

--- a/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/BootstrapTest.java
@@ -84,8 +84,7 @@ public class BootstrapTest extends TestBaseImpl
     {
         CassandraRelevantProperties.MIGRATION_DELAY.setLong(savedMigrationDelay);
         if (originalResetBootstrapProgress == null)
-            // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-            RESET_BOOTSTRAP_PROGRESS.clearValue();
+            RESET_BOOTSTRAP_PROGRESS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
         else
             RESET_BOOTSTRAP_PROGRESS.setBoolean(originalResetBootstrapProgress);
     }
@@ -111,8 +110,7 @@ public class BootstrapTest extends TestBaseImpl
     @Test
     public void bootstrapUnspecifiedResumeTest() throws Throwable
     {
-        // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-        RESET_BOOTSTRAP_PROGRESS.clearValue();
+        RESET_BOOTSTRAP_PROGRESS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
         bootstrapTest();
     }
 
@@ -128,8 +126,7 @@ public class BootstrapTest extends TestBaseImpl
     @Test
     public void bootstrapUnspecifiedFailsOnResumeTest() throws Throwable
     {
-        // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-        RESET_BOOTSTRAP_PROGRESS.clearValue();
+        RESET_BOOTSTRAP_PROGRESS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
 
         // Need our partitioner active for rangeToBytes conversion below
         Config c = DatabaseDescriptor.loadConfig();

--- a/test/unit/org/apache/cassandra/auth/PasswordAuthenticatorTest.java
+++ b/test/unit/org/apache/cassandra/auth/PasswordAuthenticatorTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.mindrot.jbcrypt.BCrypt;
 
 import com.datastax.driver.core.Authenticator;
@@ -118,19 +119,10 @@ public class PasswordAuthenticatorTest extends CQLTester
 
     private void executeSaltRoundsPropertyTest(Integer rounds)
     {
-        Integer oldProperty = AUTH_BCRYPT_GENSALT_LOG2_ROUNDS.setInt(rounds);
-        try
+        try (WithProperties properties = new WithProperties().set(AUTH_BCRYPT_GENSALT_LOG2_ROUNDS, rounds))
         {
             getGensaltLogRounds();
             Assert.fail("Property " + AUTH_BCRYPT_GENSALT_LOG2_ROUNDS.getKey() + " must be in interval [4,30]");
-        }
-        finally
-        {
-            if (oldProperty != null)
-                AUTH_BCRYPT_GENSALT_LOG2_ROUNDS.setInt(oldProperty);
-            else
-                // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-                AUTH_BCRYPT_GENSALT_LOG2_ROUNDS.clearValue();
         }
     }
 

--- a/test/unit/org/apache/cassandra/auth/PasswordAuthenticatorTest.java
+++ b/test/unit/org/apache/cassandra/auth/PasswordAuthenticatorTest.java
@@ -129,6 +129,7 @@ public class PasswordAuthenticatorTest extends CQLTester
             if (oldProperty != null)
                 AUTH_BCRYPT_GENSALT_LOG2_ROUNDS.setInt(oldProperty);
             else
+                // checkstyle: suppress below 'clearValueSystemPropertyUsage'
                 AUTH_BCRYPT_GENSALT_LOG2_ROUNDS.clearValue();
         }
     }

--- a/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
+++ b/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
@@ -26,7 +26,6 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_CASSANDRA_RELEVANT_PROPERTIES;
-import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 

--- a/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
+++ b/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
@@ -21,10 +21,12 @@ package org.apache.cassandra.config;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_CASSANDRA_RELEVANT_PROPERTIES;
+import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -40,14 +42,9 @@ public class CassandraRelevantPropertiesTest
 
     @Test
     public void testSystemPropertyisSet() {
-        try
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, "test"))
         {
-            TEST_CASSANDRA_RELEVANT_PROPERTIES.setString("test");
             Assertions.assertThat(System.getProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey())).isEqualTo("test"); // checkstyle: suppress nearby 'blockSystemPropertyUsage'
-        }
-        finally
-        {
-            TEST_CASSANDRA_RELEVANT_PROPERTIES.clearValue();
         }
     }
 

--- a/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
+++ b/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
@@ -50,14 +50,9 @@ public class CassandraRelevantPropertiesTest
     @Test
     public void testString()
     {
-        try
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, "some-string"))
         {
-            System.setProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey(), "some-string");
             Assertions.assertThat(TEST_CASSANDRA_RELEVANT_PROPERTIES.getString()).isEqualTo("some-string");
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 
@@ -84,82 +79,54 @@ public class CassandraRelevantPropertiesTest
     @Test
     public void testBoolean_null()
     {
-        try
+        try (WithProperties properties = new WithProperties())
         {
             TEST_CASSANDRA_RELEVANT_PROPERTIES.getBoolean();
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 
     @Test
     public void testDecimal()
     {
-        try
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, "123456789"))
         {
-            System.setProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey(), "123456789");
             Assertions.assertThat(TEST_CASSANDRA_RELEVANT_PROPERTIES.getInt()).isEqualTo(123456789);
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 
     @Test
     public void testHexadecimal()
     {
-        try
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, "0x1234567a"))
         {
-            System.setProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey(), "0x1234567a");
             Assertions.assertThat(TEST_CASSANDRA_RELEVANT_PROPERTIES.getInt()).isEqualTo(305419898);
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 
     @Test
     public void testOctal()
     {
-        try
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, "01234567"))
         {
-            System.setProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey(), "01234567");
             Assertions.assertThat(TEST_CASSANDRA_RELEVANT_PROPERTIES.getInt()).isEqualTo(342391);
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 
     @Test(expected = ConfigurationException.class)
     public void testInteger_empty()
     {
-        try
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, ""))
         {
-            System.setProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey(), "");
             Assertions.assertThat(TEST_CASSANDRA_RELEVANT_PROPERTIES.getInt()).isEqualTo(342391);
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 
     @Test(expected = ConfigurationException.class)
     public void testInteger_null()
     {
-        try
+        try (WithProperties properties = new WithProperties())
         {
             TEST_CASSANDRA_RELEVANT_PROPERTIES.getInt();
-        }
-        finally
-        {
-            System.clearProperty(TEST_CASSANDRA_RELEVANT_PROPERTIES.getKey());
         }
     }
 

--- a/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
+++ b/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
@@ -134,9 +134,10 @@ public class CassandraRelevantPropertiesTest
     public void testClearProperty()
     {
         assertNull(TEST_CASSANDRA_RELEVANT_PROPERTIES.getString());
-        TEST_CASSANDRA_RELEVANT_PROPERTIES.setString("test");
-        assertEquals("test", TEST_CASSANDRA_RELEVANT_PROPERTIES.getString());
-        TEST_CASSANDRA_RELEVANT_PROPERTIES.clearValue();
+        try (WithProperties properties = new WithProperties().set(TEST_CASSANDRA_RELEVANT_PROPERTIES, "test"))
+        {
+            assertEquals("test", TEST_CASSANDRA_RELEVANT_PROPERTIES.getString());
+        }
         assertNull(TEST_CASSANDRA_RELEVANT_PROPERTIES.getString());
     }
 }

--- a/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
+++ b/test/unit/org/apache/cassandra/config/CassandraRelevantPropertiesTest.java
@@ -82,6 +82,7 @@ public class CassandraRelevantPropertiesTest
         try (WithProperties properties = new WithProperties())
         {
             TEST_CASSANDRA_RELEVANT_PROPERTIES.getBoolean();
+            Assertions.assertThat(TEST_CASSANDRA_RELEVANT_PROPERTIES.getBoolean()).isFalse();
         }
     }
 

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -259,6 +259,7 @@ public class DatabaseDescriptorTest
         }
         finally
         {
+            // checkstyle: suppress below 'clearValueSystemPropertyUsage'
             if (previous == null)
                 PARTITIONER.clearValue();
             else

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -34,6 +34,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.assertj.core.api.Assertions;
 
@@ -236,8 +237,7 @@ public class DatabaseDescriptorTest
     @Test
     public void testInvalidPartitionPropertyOverride() throws Exception
     {
-        String previous = PARTITIONER.setString("ThisDoesNotExist");
-        try
+        try (WithProperties properties = new WithProperties().set(PARTITIONER, "ThisDoesNotExist"))
         {
             Config testConfig = DatabaseDescriptor.loadConfig();
             testConfig.partitioner = "Murmur3Partitioner";
@@ -256,14 +256,6 @@ public class DatabaseDescriptorTest
                 Assert.assertEquals(ClassNotFoundException.class, cause.getClass());
                 Assert.assertEquals("org.apache.cassandra.dht.ThisDoesNotExist", cause.getMessage());
             }
-        }
-        finally
-        {
-            // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-            if (previous == null)
-                PARTITIONER.clearValue();
-            else
-                PARTITIONER.setString(previous);
         }
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/TTLTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/TTLTest.java
@@ -34,7 +34,9 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ExpirationDateOverflowHandling;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.rows.AbstractCell;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.io.sstable.IScrubber;
 import org.apache.cassandra.io.util.File;
@@ -45,6 +47,7 @@ import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 import org.assertj.core.api.Assertions;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_IGNORE_REPLAY_ERRORS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -404,8 +407,7 @@ public class TTLTest extends CQLTester
         }
         if (runSStableScrub)
         {
-            TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
-            try
+            try (WithProperties properties = new WithProperties().set(TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST, true))
             {
                 ToolResult tool;
                 if (reinsertOverflowedTTL)
@@ -419,10 +421,6 @@ public class TTLTest extends CQLTester
                     Assertions.assertThat(tool.getStdout()).contains("Fixed 2 rows with overflowed local deletion time.");
                 else
                     Assertions.assertThat(tool.getStdout()).contains("No valid partitions found while scrubbing");
-            }
-            finally
-            {
-                TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue();
             }
         }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/TTLTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/TTLTest.java
@@ -34,7 +34,6 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ExpirationDateOverflowHandling;
 import org.apache.cassandra.db.Keyspace;
-import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.rows.AbstractCell;
 import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -47,7 +46,6 @@ import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 import org.assertj.core.api.Assertions;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_IGNORE_REPLAY_ERRORS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -891,7 +891,6 @@ public abstract class CommitLogTest
         }
     }
 
-    // private void assertReplay(int expectedReplayedMutations, Runnable systemPropertySetter) throws Throwable
     private void assertReplay(int expectedReplayedMutations, CassandraRelevantProperties property, String propertyValue) throws Throwable
     {
         try (WithProperties properties = new WithProperties().set(property, propertyValue))

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -214,12 +214,11 @@ public abstract class CommitLogTest
         CommitLog.instance.resetUnsafe(true);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @After
     public void afterTest()
     {
         CommitLogSegmentReader.setAllowSkipSyncMarkerCrc(false);
-        COMMIT_LOG_REPLAY_LIST.clearValue();
+        COMMIT_LOG_REPLAY_LIST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
         testKiller.reset();
     }
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cassandra.db.commitlog;
 
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.util.File;
 
 import java.io.ByteArrayOutputStream;
@@ -337,14 +338,9 @@ public abstract class CommitLogTest
     @Test
     public void testRecoveryWithGarbageLog_ignoredByProperty() throws Exception
     {
-        try
+        try (WithProperties properties = new WithProperties().set(COMMITLOG_IGNORE_REPLAY_ERRORS, "true"))
         {
-            COMMITLOG_IGNORE_REPLAY_ERRORS.setBoolean(true);
             testRecoveryWithGarbageLog();
-        }
-        finally
-        {
-            COMMITLOG_IGNORE_REPLAY_ERRORS.clearValue();
         }
     }
 
@@ -1239,16 +1235,11 @@ public abstract class CommitLogTest
 
         int replayed = 0;
 
-        try
+        try (WithProperties properties = new WithProperties().set(COMMITLOG_IGNORE_REPLAY_ERRORS, true))
         {
-            COMMITLOG_IGNORE_REPLAY_ERRORS.setBoolean(true);
             replayed = CommitLog.instance.resetUnsafe(false);
         }
-        finally
-        {
-            COMMITLOG_IGNORE_REPLAY_ERRORS.clearValue();
-        }
-
+        
         assertEquals(replayed, 1);
     }
 }

--- a/test/unit/org/apache/cassandra/db/virtual/SystemPropertiesTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SystemPropertiesTableTest.java
@@ -32,15 +32,10 @@ import org.junit.Test;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
-import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.distributed.shared.WithProperties;
-import org.assertj.core.api.Assertions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-
-import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_CASSANDRA_RELEVANT_PROPERTIES;
 
 // checkstyle: suppress below 'blockSystemPropertyUsage'
 

--- a/test/unit/org/apache/cassandra/db/virtual/SystemPropertiesTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SystemPropertiesTableTest.java
@@ -32,10 +32,15 @@ import org.junit.Test;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.assertj.core.api.Assertions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_CASSANDRA_RELEVANT_PROPERTIES;
 
 // checkstyle: suppress below 'blockSystemPropertyUsage'
 

--- a/test/unit/org/apache/cassandra/gms/ShadowRoundTest.java
+++ b/test/unit/org/apache/cassandra/gms/ShadowRoundTest.java
@@ -51,7 +51,6 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.AUTO_BOOTSTRAP;
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
-import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
 import static org.apache.cassandra.net.MockMessagingService.verb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;

--- a/test/unit/org/apache/cassandra/gms/ShadowRoundTest.java
+++ b/test/unit/org/apache/cassandra/gms/ShadowRoundTest.java
@@ -173,18 +173,13 @@ public class ShadowRoundTest
                 }, 1);
 
 
-        AUTO_BOOTSTRAP.setBoolean(false);
-        try
+        try (WithProperties properties = new WithProperties().set(AUTO_BOOTSTRAP, false))
         {
             StorageService.instance.checkForEndpointCollision(SystemKeyspace.getOrInitializeLocalHostId(), SystemKeyspace.loadHostIds().keySet());
         }
         catch (Exception e)
         {
             assertEquals("Unable to gossip with any peers", e.getMessage());
-        }
-        finally
-        {
-            AUTO_BOOTSTRAP.clearValue();
         }
     }
 

--- a/test/unit/org/apache/cassandra/gms/ShadowRoundTest.java
+++ b/test/unit/org/apache/cassandra/gms/ShadowRoundTest.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.IEndpointSnitch;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -50,6 +51,7 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.AUTO_BOOTSTRAP;
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
+import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST;
 import static org.apache.cassandra.net.MockMessagingService.verb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -213,14 +215,9 @@ public class ShadowRoundTest
                 }, 1);
 
 
-        AUTO_BOOTSTRAP.setBoolean(false);
-        try
+        try (WithProperties properties = new WithProperties().set(AUTO_BOOTSTRAP, false))
         {
             StorageService.instance.checkForEndpointCollision(SystemKeyspace.getOrInitializeLocalHostId(), SystemKeyspace.loadHostIds().keySet());
-        }
-        finally
-        {
-            AUTO_BOOTSTRAP.clearValue();
         }
     }
 

--- a/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
@@ -79,6 +79,7 @@ import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.WriteTimeoutException;
@@ -132,6 +133,8 @@ public class ScrubTest
 
     private static final AtomicInteger seq = new AtomicInteger();
 
+    static WithProperties properties;
+
     String ksName;
     Keyspace keyspace;
 
@@ -160,13 +163,13 @@ public class ScrubTest
         keyspace = Keyspace.open(ksName);
 
         CompactionManager.instance.disableAutoCompaction();
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
+        properties = new WithProperties().set(TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST, true);
     }
 
     @AfterClass
     public static void clearClassEnv()
     {
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
@@ -163,6 +163,7 @@ public class ScrubTest
         TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void clearClassEnv()
     {

--- a/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
@@ -163,11 +163,10 @@ public class ScrubTest
         TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void clearClassEnv()
     {
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue();
+        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -651,6 +651,7 @@ public class ConnectionTest
         {
             MessagingService.instance().versions.set(FBUtilities.getBroadcastAddressAndPort(),
                                                      current_version);
+            // checkstyle: suppress below 'clearValueSystemPropertyUsage'
             if (originalStoragePort != null)
                 SSL_STORAGE_PORT.setInt(originalStoragePort);
             else

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -58,6 +58,7 @@ import io.netty.channel.ChannelPromise;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.UnknownColumnException;
 import org.apache.cassandra.io.IVersionedAsymmetricSerializer;
@@ -573,8 +574,7 @@ public class ConnectionTest
     @Test
     public void testPendingOutboundConnectionUpdatesMessageVersionOnReconnectAttempt() throws Throwable
     {
-        final Integer originalStoragePort = SSL_STORAGE_PORT.setInt(7011);
-        try
+        try (WithProperties properties = new WithProperties().set(SSL_STORAGE_PORT, 7011))
         {
             // Set up an inbound connection listening *only* on the SSL storage port to
             // replicate a 3.x node.  Force the messaging version to be incorrectly set to 4.0
@@ -651,11 +651,6 @@ public class ConnectionTest
         {
             MessagingService.instance().versions.set(FBUtilities.getBroadcastAddressAndPort(),
                                                      current_version);
-            // checkstyle: suppress below 'clearValueSystemPropertyUsage'
-            if (originalStoragePort != null)
-                SSL_STORAGE_PORT.setInt(originalStoragePort);
-            else
-                SSL_STORAGE_PORT.clearValue();
         }
     }
 

--- a/test/unit/org/apache/cassandra/security/CustomSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/CustomSslContextFactoryConfigTest.java
@@ -37,10 +37,9 @@ public class CustomSslContextFactoryConfigTest
         CASSANDRA_CONFIG.setString("cassandra-sslcontextfactory.yaml");
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/CustomSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/CustomSslContextFactoryConfigTest.java
@@ -37,6 +37,7 @@ public class CustomSslContextFactoryConfigTest
         CASSANDRA_CONFIG.setString("cassandra-sslcontextfactory.yaml");
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
         CASSANDRA_CONFIG.clearValue();

--- a/test/unit/org/apache/cassandra/security/CustomSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/CustomSslContextFactoryConfigTest.java
@@ -25,21 +25,24 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
 public class CustomSslContextFactoryConfigTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-sslcontextfactory.yaml");
+        properties = new WithProperties().set(CASSANDRA_CONFIG, "cassandra-sslcontextfactory.yaml");
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/CustomSslContextFactoryInvalidConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/CustomSslContextFactoryInvalidConfigTest.java
@@ -35,10 +35,9 @@ public class CustomSslContextFactoryInvalidConfigTest
         CASSANDRA_CONFIG.setString("cassandra-sslcontextfactory-invalidconfiguration.yaml");
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/test/unit/org/apache/cassandra/security/CustomSslContextFactoryInvalidConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/CustomSslContextFactoryInvalidConfigTest.java
@@ -24,20 +24,22 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
 public class CustomSslContextFactoryInvalidConfigTest
 {
+    static WithProperties properties;
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-sslcontextfactory-invalidconfiguration.yaml");
+        properties = new WithProperties().set(CASSANDRA_CONFIG, "cassandra-sslcontextfactory-invalidconfiguration.yaml");
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/test/unit/org/apache/cassandra/security/CustomSslContextFactoryInvalidConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/CustomSslContextFactoryInvalidConfigTest.java
@@ -35,6 +35,7 @@ public class CustomSslContextFactoryInvalidConfigTest
         CASSANDRA_CONFIG.setString("cassandra-sslcontextfactory-invalidconfiguration.yaml");
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
         CASSANDRA_CONFIG.clearValue();

--- a/test/unit/org/apache/cassandra/security/DefaultSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/DefaultSslContextFactoryTest.java
@@ -33,6 +33,7 @@ import io.netty.handler.ssl.OpenSslContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslProvider;
 import org.apache.cassandra.config.EncryptionOptions;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
 
@@ -220,12 +221,13 @@ public class DefaultSslContextFactoryTest
     public void testDisableOpenSslForInJvmDtests() {
         // The configuration name below is hard-coded intentionally to make sure we don't break the contract without
         // changing the documentation appropriately
-        DISABLE_TCACTIVE_OPENSSL.setBoolean(true);
-        Map<String,Object> config = new HashMap<>();
-        config.putAll(commonConfig);
+        try (WithProperties properties = new WithProperties().set(DISABLE_TCACTIVE_OPENSSL, true))
+        {
+            Map<String,Object> config = new HashMap<>();
+            config.putAll(commonConfig);
 
-        DefaultSslContextFactory defaultSslContextFactoryImpl = new DefaultSslContextFactory(config);
-        Assert.assertEquals(SslProvider.JDK, defaultSslContextFactoryImpl.getSslProvider());
-        DISABLE_TCACTIVE_OPENSSL.clearValue();
+            DefaultSslContextFactory defaultSslContextFactoryImpl = new DefaultSslContextFactory(config);
+            Assert.assertEquals(SslProvider.JDK, defaultSslContextFactoryImpl.getSslProvider());
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
@@ -47,6 +47,7 @@ public class FileBasedSslContextFactoryTest
         CASSANDRA_CONFIG.reset();
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {

--- a/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.config.ParameterizedClass;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
@@ -41,16 +42,19 @@ public class FileBasedSslContextFactoryTest
 
     private EncryptionOptions.ServerEncryptionOptions encryptionOptions;
 
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
         CASSANDRA_CONFIG.reset();
+        properties = new WithProperties();
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
@@ -47,11 +47,10 @@ public class FileBasedSslContextFactoryTest
         CASSANDRA_CONFIG.reset();
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigTest.java
@@ -27,21 +27,24 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
 public class PEMBasedSslContextFactoryConfigTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory.yaml");
+        properties = new WithProperties().set(CASSANDRA_CONFIG, "cassandra-pem-sslcontextfactory.yaml");
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigTest.java
@@ -38,6 +38,7 @@ public class PEMBasedSslContextFactoryConfigTest
         CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory.yaml");
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigTest.java
@@ -38,11 +38,10 @@ public class PEMBasedSslContextFactoryConfigTest
         CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory.yaml");
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest.java
@@ -39,6 +39,7 @@ public class PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest
         CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-mismatching-passwords.yaml");
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest.java
@@ -27,22 +27,25 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
 public class PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-mismatching-passwords.yaml");
+        properties = new WithProperties().set(CASSANDRA_CONFIG, "cassandra-pem-sslcontextfactory-mismatching-passwords.yaml");
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test(expected = ConfigurationException.class)

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest.java
@@ -39,11 +39,10 @@ public class PEMBasedSslContextFactoryConfigWithMismatchingPasswordsTest
         CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-mismatching-passwords.yaml");
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test(expected = ConfigurationException.class)

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest.java
@@ -40,12 +40,11 @@ public class PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest
         DISABLE_TCACTIVE_OPENSSL.setBoolean(true);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue();
-        DISABLE_TCACTIVE_OPENSSL.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        DISABLE_TCACTIVE_OPENSSL.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest.java
@@ -40,6 +40,7 @@ public class PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest
         DISABLE_TCACTIVE_OPENSSL.setBoolean(true);
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest.java
@@ -27,24 +27,27 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
 
 public class PEMBasedSslContextFactoryConfigWithUnencryptedKeysTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-unencryptedkeys.yaml");
-        DISABLE_TCACTIVE_OPENSSL.setBoolean(true);
+        properties = new WithProperties()
+                     .set(CASSANDRA_CONFIG, "cassandra-pem-sslcontextfactory-unencryptedkeys.yaml")
+                     .set(DISABLE_TCACTIVE_OPENSSL, true);
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
-        DISABLE_TCACTIVE_OPENSSL.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryInvalidConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryInvalidConfigTest.java
@@ -39,6 +39,7 @@ public class PEMBasedSslContextFactoryInvalidConfigTest
         CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-invalidconfiguration.yaml");
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryInvalidConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryInvalidConfigTest.java
@@ -27,22 +27,25 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
 public class PEMBasedSslContextFactoryInvalidConfigTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-invalidconfiguration.yaml");
+        properties = new WithProperties().set(CASSANDRA_CONFIG, "cassandra-pem-sslcontextfactory-invalidconfiguration.yaml");
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test(expected = ConfigurationException.class)

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryInvalidConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryInvalidConfigTest.java
@@ -39,11 +39,10 @@ public class PEMBasedSslContextFactoryInvalidConfigTest
         CASSANDRA_CONFIG.setString("cassandra-pem-sslcontextfactory-invalidconfiguration.yaml");
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test(expected = ConfigurationException.class)

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryTest.java
@@ -35,6 +35,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslProvider;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.config.ParameterizedClass;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
 import static org.apache.cassandra.security.PEMBasedSslContextFactory.ConfigKey.ENCODED_CERTIFICATES;
@@ -414,13 +415,14 @@ public class PEMBasedSslContextFactoryTest
     {
         // The configuration name below is hard-coded intentionally to make sure we don't break the contract without
         // changing the documentation appropriately
-        DISABLE_TCACTIVE_OPENSSL.setBoolean(true);
-        Map<String, Object> config = new HashMap<>();
-        config.putAll(commonConfig);
+        try (WithProperties properties = new WithProperties().set(DISABLE_TCACTIVE_OPENSSL, true))
+        {
+            Map<String, Object> config = new HashMap<>();
+            config.putAll(commonConfig);
 
-        PEMBasedSslContextFactory sslContextFactory = new PEMBasedSslContextFactory(config);
-        Assert.assertEquals(SslProvider.JDK, sslContextFactory.getSslProvider());
-        DISABLE_TCACTIVE_OPENSSL.clearValue();
+            PEMBasedSslContextFactory sslContextFactory = new PEMBasedSslContextFactory(config);
+            Assert.assertEquals(SslProvider.JDK, sslContextFactory.getSslProvider());
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/test/unit/org/apache/cassandra/security/PEMJKSSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMJKSSslContextFactoryConfigTest.java
@@ -38,6 +38,7 @@ public class PEMJKSSslContextFactoryConfigTest
         CASSANDRA_CONFIG.setString("cassandra-pem-jks-sslcontextfactory.yaml");
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
         CASSANDRA_CONFIG.clearValue();

--- a/test/unit/org/apache/cassandra/security/PEMJKSSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMJKSSslContextFactoryConfigTest.java
@@ -38,10 +38,9 @@ public class PEMJKSSslContextFactoryConfigTest
         CASSANDRA_CONFIG.setString("cassandra-pem-jks-sslcontextfactory.yaml");
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
-        CASSANDRA_CONFIG.clearValue();
+        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/security/PEMJKSSslContextFactoryConfigTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMJKSSslContextFactoryConfigTest.java
@@ -27,20 +27,23 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
 public class PEMJKSSslContextFactoryConfigTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setupDatabaseDescriptor()
     {
-        CASSANDRA_CONFIG.setString("cassandra-pem-jks-sslcontextfactory.yaml");
+        properties = new WithProperties().set(CASSANDRA_CONFIG, "cassandra-pem-jks-sslcontextfactory.yaml");
     }
 
     @AfterClass
     public static void tearDownDatabaseDescriptor() {
-        CASSANDRA_CONFIG.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/AbstractFilesystemOwnershipCheckTest.java
+++ b/test/unit/org/apache/cassandra/service/AbstractFilesystemOwnershipCheckTest.java
@@ -216,12 +216,11 @@ public abstract class AbstractFilesystemOwnershipCheckTest
         AbstractFilesystemOwnershipCheckTest.executeAndFail(AbstractFilesystemOwnershipCheckTest.checker(tempDir), options, MISSING_PROPERTY, CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.getKey());
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @Test
     public void checkEnabledButClusterPropertyIsUnset()
     {
         Assume.assumeFalse(options.getConfig(check_filesystem_ownership).containsKey("ownership_token"));
-        CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.clearValue();
+        CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
         AbstractFilesystemOwnershipCheckTest.executeAndFail(AbstractFilesystemOwnershipCheckTest.checker(tempDir), options, MISSING_PROPERTY, CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.getKey());
     }
 

--- a/test/unit/org/apache/cassandra/service/AbstractFilesystemOwnershipCheckTest.java
+++ b/test/unit/org/apache/cassandra/service/AbstractFilesystemOwnershipCheckTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.StartupChecksOptions;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.StartupException;
 import org.apache.cassandra.io.util.File;
 
@@ -66,11 +67,14 @@ public abstract class AbstractFilesystemOwnershipCheckTest
 
     protected StartupChecksOptions options = new StartupChecksOptions();
 
+    static WithProperties properties;
+
     protected void setup()
     {
         cleanTempDir();
         tempDir = new File(com.google.common.io.Files.createTempDir());
         token = makeRandomString(10);
+        properties = new WithProperties();
         System.clearProperty(CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_FILENAME.getKey());
         System.clearProperty(CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.getKey());
         System.clearProperty(CassandraRelevantProperties.FILE_SYSTEM_CHECK_ENABLE.getKey());
@@ -188,6 +192,7 @@ public abstract class AbstractFilesystemOwnershipCheckTest
     public void teardown() throws IOException
     {
         cleanTempDir();
+        properties.close();
     }
 
     // tests for enabling/disabling/configuring the check

--- a/test/unit/org/apache/cassandra/service/AbstractFilesystemOwnershipCheckTest.java
+++ b/test/unit/org/apache/cassandra/service/AbstractFilesystemOwnershipCheckTest.java
@@ -216,6 +216,7 @@ public abstract class AbstractFilesystemOwnershipCheckTest
         AbstractFilesystemOwnershipCheckTest.executeAndFail(AbstractFilesystemOwnershipCheckTest.checker(tempDir), options, MISSING_PROPERTY, CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.getKey());
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @Test
     public void checkEnabledButClusterPropertyIsUnset()
     {

--- a/test/unit/org/apache/cassandra/service/ClientStateTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientStateTest.java
@@ -60,11 +60,10 @@ public class ClientStateTest
         AuthCacheService.initializeAndRegisterCaches();
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void afterClass()
     {
-        ORG_APACHE_CASSANDRA_DISABLE_MBEAN_REGISTRATION.clearValue();
+        ORG_APACHE_CASSANDRA_DISABLE_MBEAN_REGISTRATION.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/ClientStateTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientStateTest.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.auth.Roles;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
@@ -46,10 +47,12 @@ import static org.junit.Assert.fail;
 
 public class ClientStateTest
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void beforeClass()
     {
-        ORG_APACHE_CASSANDRA_DISABLE_MBEAN_REGISTRATION.setBoolean(true);
+        properties = new WithProperties().set(ORG_APACHE_CASSANDRA_DISABLE_MBEAN_REGISTRATION, true);
         SchemaLoader.prepareServer();
         DatabaseDescriptor.setAuthFromRoot(true);
         // create the system_auth keyspace so the IRoleManager can function as normal
@@ -63,7 +66,7 @@ public class ClientStateTest
     @AfterClass
     public static void afterClass()
     {
-        ORG_APACHE_CASSANDRA_DISABLE_MBEAN_REGISTRATION.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/ClientStateTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientStateTest.java
@@ -60,6 +60,7 @@ public class ClientStateTest
         AuthCacheService.initializeAndRegisterCaches();
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void afterClass()
     {

--- a/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceServerTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.dht.Murmur3Partitioner.LongToken;
 import org.apache.cassandra.dht.OrderPreservingPartitioner.StringToken;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.Gossiper;
@@ -635,7 +636,7 @@ public class StorageServiceServerTest
     @Test
     public void isReplacingSameHostAddressAndHostIdTest() throws UnknownHostException
     {
-        try
+        try (WithProperties properties = new WithProperties())
         {
             UUID differentHostId = UUID.randomUUID();
             Assert.assertFalse(StorageService.instance.isReplacingSameHostAddressAndHostId(differentHostId));
@@ -655,10 +656,6 @@ public class StorageServiceServerTest
             // Check tolerates the DNS entry going away for the replace_address
             REPLACE_ADDRESS.setString("unresolvable.host.local.");
             Assert.assertFalse(StorageService.instance.isReplacingSameHostAddressAndHostId(differentHostId));
-        }
-        finally
-        {
-            REPLACE_ADDRESS.clearValue();
         }
     }
 }

--- a/test/unit/org/apache/cassandra/service/SystemPropertiesBasedFileSystemOwnershipCheckTest.java
+++ b/test/unit/org/apache/cassandra/service/SystemPropertiesBasedFileSystemOwnershipCheckTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.service;
 import org.junit.Before;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.distributed.shared.WithProperties;
 
 public class SystemPropertiesBasedFileSystemOwnershipCheckTest extends AbstractFilesystemOwnershipCheckTest
 {
@@ -28,7 +29,7 @@ public class SystemPropertiesBasedFileSystemOwnershipCheckTest extends AbstractF
     public void setup()
     {
         super.setup();
-        CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN.setString(token);
-        CassandraRelevantProperties.FILE_SYSTEM_CHECK_ENABLE.setBoolean(true);
+        properties = new WithProperties().set(CassandraRelevantProperties.FILE_SYSTEM_CHECK_OWNERSHIP_TOKEN, token)
+                                         .set(CassandraRelevantProperties.FILE_SYSTEM_CHECK_ENABLE, true);
     }
 }

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionRangeReadCommand;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.partitions.CachedPartition;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.index.StubIndex;
 import org.apache.cassandra.schema.IndexMetadata;
@@ -48,18 +49,20 @@ import static org.junit.Assert.assertEquals;
  */
 public class RangeCommandsTest extends CQLTester
 {
+
+    static WithProperties properties;
     private static final int MAX_CONCURRENCY_FACTOR = 4;
 
     @BeforeClass
     public static void defineSchema() throws ConfigurationException
     {
-        MAX_CONCURRENT_RANGE_REQUESTS.setInt(MAX_CONCURRENCY_FACTOR);
+        properties = new WithProperties().set(MAX_CONCURRENT_RANGE_REQUESTS, MAX_CONCURRENCY_FACTOR);
     }
 
     @AfterClass
     public static void cleanup()
     {
-        MAX_CONCURRENT_RANGE_REQUESTS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
@@ -56,11 +56,10 @@ public class RangeCommandsTest extends CQLTester
         MAX_CONCURRENT_RANGE_REQUESTS.setInt(MAX_CONCURRENCY_FACTOR);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void cleanup()
     {
-        MAX_CONCURRENT_RANGE_REQUESTS.clearValue();
+        MAX_CONCURRENT_RANGE_REQUESTS.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
+++ b/test/unit/org/apache/cassandra/service/reads/range/RangeCommandsTest.java
@@ -56,6 +56,7 @@ public class RangeCommandsTest extends CQLTester
         MAX_CONCURRENT_RANGE_REQUESTS.setInt(MAX_CONCURRENCY_FACTOR);
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void cleanup()
     {

--- a/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSStablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSStablesTest.java
@@ -57,11 +57,10 @@ public class StandaloneUpgraderOnSStablesTest
         TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void clearClassEnv()
     {
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue();
+        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSStablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSStablesTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.StartupException;
 import org.apache.cassandra.io.sstable.LegacySSTableTest;
@@ -48,19 +49,21 @@ import static org.junit.Assert.assertEquals;
  */
 public class StandaloneUpgraderOnSStablesTest
 {
+    static WithProperties properties;
+
     String legacyId = LegacySSTableTest.legacyVersions[LegacySSTableTest.legacyVersions.length - 1];
 
     @BeforeClass
     public static void defineSchema() throws ConfigurationException
     {
         LegacySSTableTest.defineSchema();
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
+        properties = new WithProperties().set(TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST, true);
     }
 
     @AfterClass
     public static void clearClassEnv()
     {
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSStablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneUpgraderOnSStablesTest.java
@@ -57,6 +57,7 @@ public class StandaloneUpgraderOnSStablesTest
         TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void clearClassEnv()
     {

--- a/test/unit/org/apache/cassandra/tools/StandaloneVerifierOnSSTablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneVerifierOnSSTablesTest.java
@@ -72,6 +72,7 @@ public class StandaloneVerifierOnSSTablesTest extends OfflineToolUtils
         StorageService.instance.initServer();
     }
 
+    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void teardown() throws Exception
     {

--- a/test/unit/org/apache/cassandra/tools/StandaloneVerifierOnSSTablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneVerifierOnSSTablesTest.java
@@ -72,12 +72,11 @@ public class StandaloneVerifierOnSSTablesTest extends OfflineToolUtils
         StorageService.instance.initServer();
     }
 
-    // checkstyle: suppress below 'clearValueSystemPropertyUsage'
     @AfterClass
     public static void teardown() throws Exception
     {
         SchemaLoader.cleanupAndLeaveDirs();
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue();
+        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/StandaloneVerifierOnSSTablesTest.java
+++ b/test/unit/org/apache/cassandra/tools/StandaloneVerifierOnSSTablesTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.sstable.VerifyTest;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -61,13 +62,15 @@ import static org.junit.Assert.assertEquals;
  */
 public class StandaloneVerifierOnSSTablesTest extends OfflineToolUtils
 {
+    static WithProperties properties;
+
     @BeforeClass
     public static void setup()
     {
         // since legacy tables test data uses ByteOrderedPartitioner that's what we need
         // for the check version to work
         CassandraRelevantProperties.PARTITIONER.setString("org.apache.cassandra.dht.ByteOrderedPartitioner");
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.setBoolean(true);
+        properties = new WithProperties().set(TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST, true);
         SchemaLoader.loadSchema();
         StorageService.instance.initServer();
     }
@@ -76,7 +79,7 @@ public class StandaloneVerifierOnSSTablesTest extends OfflineToolUtils
     public static void teardown() throws Exception
     {
         SchemaLoader.cleanupAndLeaveDirs();
-        TEST_UTIL_ALLOW_TOOL_REINIT_FOR_TEST.clearValue(); // checkstyle: suppress nearby 'clearValueSystemPropertyUsage'
+        properties.close();
     }
 
     @Test


### PR DESCRIPTION
Using WithProperties to improve handling of property set and cleanups.

To find the actual try catches, I've used IntelliJ structural search with this pattern:

```
try ($ResourceType$ $resource$ = $init$; $expression$) {
  $TryStatement$;
} finally {
    $property$.clearValue();
}
```

patch by Bernardo Botella

