### PR TITLE
CASSANDRA-18239: Incorporate CheckerFramework for static analysis

### DIFF
--- a/.build/build-checkerframework.xml
+++ b/.build/build-checkerframework.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project basedir="." name="apache-cassandra-checkerframework"
+         xmlns:if="ant:if"
+         xmlns:unless="ant:unless">
+
+    <property name="checkerframework.version" value="3.35.0"/>
+    <property name="checkerframework.jars.dir" value="${build.dir}/checkerframework-jars"/>
+    <property name="checkerframework.output.dir" value="${build.dir}/checkerframework-output"/>
+
+    <property name="cf.check.only" value="" description="Specify a glob pattern of source files for CheckerFramework to verify"/>
+    <property name="cf.skip" value="false" description="When set to true, CheckerFramework execution is silently skipped"/>
+    <property name="cf.verbose" value="false" description="Enable verbose output from the CheckerFramework"/>
+
+    <!-- Options to be added for the processor when running with verbose output -->
+    <resources id="_cf_verbose_output_args">
+        <string>-Afilenames</string>
+        <string>-Ashowchecks</string>
+        <string>-AshowInferenceSteps</string>
+        <string>-AshowWpiFailedInferences</string>
+    </resources>
+    <pathconvert property="_cf_verbose_output_args_line" refid="_cf_verbose_output_args" pathsep=" "/>
+
+    <!-- Project-wide suppressed warnings -->
+    <resources id="_cf_suppressed_warnings">
+    </resources>
+    <pathconvert property="_cf_suppressed_warnings_line" refid="_cf_suppressed_warnings" pathsep=","/>
+
+    <resources id="_cf_args_j11plus">
+        <string>--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED</string>
+        <string>--add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</string>
+        <string>--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</string>
+    </resources>
+    <pathconvert property="_cf_args_line_j11plus" refid="_cf_args_j11plus" pathsep=" "/>
+
+    <macrodef name="run-cf">
+        <attribute name="includes" default="**"/>
+        <attribute name="listfiles" default="false"/>
+        <attribute name="src" default="src/java"/>
+        <attribute name="outputDir" default="${build.dir}/checkerframework"/>
+
+        <sequential>
+            <delete includeemptydirs="true" quiet="true">
+                <fileset dir="@{outputDir}">
+                    <include name="**/*"/>
+                </fileset>
+            </delete>
+
+            <mkdir dir="@{outputDir}"/>
+
+            <path id="processor.classpath">
+                <fileset dir="${checkerframework.jars.dir}">
+                    <include name="*.jar"/>
+                </fileset>
+            </path>
+
+            <condition property="_cf.skip" value="true" else="false">
+                <or>
+                    <equals arg1="@{includes}" arg2=""/>
+                    <istrue value="${cf.skip}"/>
+                </or>
+            </condition>
+
+            <condition property="_cf_verbose_output_args_line_cond" value="${_cf_verbose_output_args_line}" else="">
+                <istrue value="${cf.verbose}"/>
+            </condition>
+
+            <javac debug="false" encoding="utf-8" fork="true" memoryinitialsize="4g" memorymaximumsize="4g"
+                   includeantruntime="false" includes="@{includes}"
+                   destdir="@{outputDir}" source="${ant.java.version}" target="${ant.java.version}"
+                   listfiles="@{listfiles}" unless:true="${_cf.skip}">
+
+                <src path="@{src}"/>
+
+                <!-- Bug filed to Checker Framework https://github.com/typetools/checker-framework/issues/6030 -->
+                <exclude name="org/apache/cassandra/service/reads/DataResolver.java"/>
+                <exclude name="org/apache/cassandra/io/sstable/format/SSTableScanner.java"/>
+
+                <!-- Generated sources are deliberately excluded from analysis because we cannot do anything with problems
+                     found there (also because they crash CheckerFramework). Therefore, the regular compilation must be run
+                     before the analysis so the checker-compiler can access already compiled generated classes.  -->
+
+                <compilerarg value="-XDignore.symbol.file"/>
+                <compilerarg line="-Xmaxwarns 10000"/>
+                <compilerarg line="-Xmaxerrs 10000"/>
+
+                <compilerarg line="${_cf_args_line_j11plus}"/>
+
+                <compilerarg value="-processorpath"/>
+                <compilerarg pathref="processor.classpath"/>
+
+                <compilerarg value="-processor"/>
+                <compilerarg value="org.checkerframework.checker.resourceleak.ResourceLeakChecker"/>  <!-- add more checkers if needed -->
+
+                <compilerarg value="-proc:only"/> <!-- do not compile, only run annotation processors -->
+
+                <compilerarg value="-ApermitInitializationLeak"/>
+                <compilerarg value="-ApermitStaticOwning"/>
+                <compilerarg value="-AprintAllQualifiers"/>
+                <compilerarg value="-AprintVerboseGenerics"/>
+                <compilerarg value="-AshowPrefixInWarningMessages"/>
+                <compilerarg value="-AsuppressWarnings=${_cf_suppressed_warnings_line}"/>
+
+                <compilerarg line="${_cf_verbose_output_args_line_cond}"/>
+
+                <classpath>
+                    <path refid="cassandra.classpath"/>
+                </classpath>
+            </javac>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="run-cf-changed">
+        <attribute name="src"/>
+        <attribute name="outputDir"/>
+        <sequential>
+            <check-changed-files outputProperty="modified-files" paths="@{src}"/>
+            <filelist id="modified-files-list" files="${modified-files}"/>
+            <pathconvert property="modified-paths" refid="modified-files-list" pathsep=",">
+                <map from="@{src}/" to=""/>
+            </pathconvert>
+            <run-cf includes="${modified-paths}" listfiles="true" src="@{src}" outputDir="@{outputDir}"/>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="run-cf-dirty">
+        <attribute name="src"/>
+        <attribute name="outputDir"/>
+        <sequential>
+            <check-dirty-files outputProperty="modified-files" paths="@{src}"/>
+            <filelist id="modified-files-list" files="${modified-files}"/>
+            <pathconvert property="modified-paths" refid="modified-files-list" pathsep=",">
+                <map from="@{src}/" to=""/>
+            </pathconvert>
+            <run-cf includes="${modified-paths}" listfiles="true" src="@{src}" outputDir="@{outputDir}"/>
+        </sequential>
+    </macrodef>
+
+</project>

--- a/.build/build-checkerframework.xml
+++ b/.build/build-checkerframework.xml
@@ -73,12 +73,6 @@
         <attribute name="outputDir" default="${build.dir}/checkerframework"/>
 
         <sequential>
-            <delete includeemptydirs="true" quiet="true">
-                <fileset dir="@{outputDir}">
-                    <include name="**/*"/>
-                </fileset>
-            </delete>
-
             <mkdir dir="@{outputDir}"/>
 
             <path id="processor.classpath">
@@ -124,8 +118,6 @@
 
                 <compilerarg value="-processor"/>
                 <compilerarg value="org.checkerframework.checker.resourceleak.ResourceLeakChecker"/>  <!-- add more checkers if needed -->
-
-                <compilerarg value="-proc:only"/> <!-- do not compile, only run annotation processors -->
 
                 <compilerarg value="-ApermitInitializationLeak"/>
                 <compilerarg value="-ApermitStaticOwning"/>

--- a/.build/build-checkerframework.xml
+++ b/.build/build-checkerframework.xml
@@ -39,6 +39,15 @@
 
     <!-- Project-wide suppressed warnings -->
     <resources id="_cf_suppressed_warnings">
+        <string>argument</string>
+        <string>assignment</string>
+        <string>cast.unsafe</string>
+        <string>contracts.postcondition</string>
+        <string>destructor.exceptional.postcondition</string>
+        <string>methodref.receiver.bound</string>
+        <string>methodref.receiver</string>
+        <string>return</string>
+        <string>type.argument</string>
     </resources>
     <pathconvert property="_cf_suppressed_warnings_line" refid="_cf_suppressed_warnings" pathsep=","/>
 

--- a/.build/build-git.xml
+++ b/.build/build-git.xml
@@ -17,9 +17,10 @@
   limitations under the License.
 -->
 <project basedir="." name="apache-cassandra-git-tasks"
-         xmlns:if="ant:if">
+         xmlns:if="ant:if"
+         xmlns:unless="ant:unless">
 
-    <target name="_get-git-sha">
+    <target name="-git-init">
         <exec executable="git" osfamily="unix" dir="${basedir}" logError="false" failonerror="false" failifexecutionfails="false" resultproperty="git.is-available.exit-code">
             <arg value="rev-parse"/>
             <arg value="--is-inside-work-tree"/>
@@ -30,6 +31,25 @@
         </condition>
         <echo message="git.is-available=${git.is-available}"/>
 
+        <exec if:true="${git.is-available}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+            <arg value="diff"/>
+            <arg value="--help"/>
+            <redirector outputproperty="git.output.diffHelp--merge-base-arg">
+                <outputfilterchain>
+                    <linecontains matchany="--merge-base"/>
+                </outputfilterchain>
+            </redirector>
+        </exec>
+        <condition property="git.is-merge-base-supported" value="true">
+            <not>
+                <equals arg1="${git.output.diffHelp--merge-base-arg}" arg2=""/>
+            </not>
+        </condition>
+        <echo level="info" if:true="${git.is-merge-base-supported}" message="Git supports --merge-base argument"/>
+        <echo level="warning" unless:true="${git.is-merge-base-supported}" message="Git does not support --merge-base argument - please update Git to 2.30+"/>
+    </target>
+
+    <target name="_get-git-sha" depends="-git-init">
         <exec if:true="${git.is-available}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
             <arg value="describe"/>
             <arg value="--match=''"/>
@@ -52,4 +72,72 @@
         <echo level="warning" if:true="${is-dirty}">Repository state is dirty</echo>
         <echo level="warning" if:true="${is-dirty}">${git.diffstat}</echo>
     </target>
+
+    <macrodef name="check-dirty-files">
+        <attribute name="outputProperty" default="dirtyFiles"/> <!-- property to store the list of dirty files -->
+        <attribute name="paths" default="."/> <!-- space separated paths to be checked -->
+
+        <sequential>
+            <exec if:true="${git.is-available}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+                <arg value="diff"/>
+                <arg value="--name-only"/>
+                <arg value="--no-renames"/>
+                <arg value="--ignore-all-space"/>
+                <arg value="--staged"/>
+                <arg line="@{paths}"/>
+                <redirector outputproperty="git.output.staged"/>
+            </exec>
+            <exec if:true="${git.is-available}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+                <arg value="diff"/>
+                <arg value="--name-only"/>
+                <arg value="--no-renames"/>
+                <arg value="--ignore-all-space"/>
+                <arg line="@{paths}"/>
+                <redirector outputproperty="git.output.unstaged"/>
+            </exec>
+
+            <property name="@{outputProperty}" value="${git.output.staged}${line.separator}${git.output.unstaged}"/>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="check-changed-files">
+        <attribute name="outputProperty" default="changedFiles"/> <!-- property to store the list of changed files -->
+        <attribute name="paths" default="."/> <!-- space separated paths to be checked -->
+
+        <sequential>
+            <fail unless:true="${git.is-merge-base-supported}" message="Git does not support --merge-base argument - please update Git to 2.30+"/>
+
+            <check-dirty-files outputProperty="git.output.dirtyFiles" paths="@{paths}"/>
+
+            <!--
+            Retrieves the configured name of the Apache Cassandra repository in Git, unless it is provided by user in the apache.repo.name property.
+            This is needed to find the diff between the HEAD and the upstream base branch.
+            -->
+            <exec if:true="${git.is-merge-base-supported}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+                <arg value="remote"/>
+                <arg value="-v"/>
+                <redirector outputproperty="apache.repo.name">
+                    <outputfilterchain>
+                        <linecontainsregexp regexp=".*apache\/cassandra\.git.*\(fetch\).*"/>
+                        <replaceregex pattern="(\S+)\s.*apache\/cassandra\.git.*\(fetch\).*" replace="\1"/>
+                    </outputfilterchain>
+                </redirector>
+            </exec>
+            <echo if:true="${git.is-merge-base-supported}" message="apache.repo.name=${apache.repo.name}"/>
+
+            <exec if:true="${git.is-merge-base-supported}" executable="git" osfamily="unix" dir="${basedir}" logError="true" failonerror="false" failifexecutionfails="false">
+                <arg value="diff"/>
+                <arg value="--name-only"/>
+                <arg value="--no-renames"/>
+                <arg value="--ignore-all-space"/>
+                <arg value="--merge-base"/>
+                <arg value="${apache.repo.name}/trunk"/>
+                <arg line="@{paths}"/>
+                <redirector outputproperty="git.output.changedFiles"/>
+            </exec>
+
+            <property name="@{outputProperty}" value="${git.output.changedFiles}${line.separator}${git.output.dirtyFiles}"/>
+        </sequential>
+    </macrodef>
+
 </project>

--- a/.build/build-resolver.xml
+++ b/.build/build-resolver.xml
@@ -95,6 +95,8 @@
             </sequential>
         </macrodef>
 
+        <delete dir="${checkerframework.jars.dir}" quiet="true"/>
+
         <resolve>
             <dependencies>
                 <dependency groupId="com.datastax.wikitext" artifactId="wikitext-core-ant" version="1.3"/>
@@ -133,6 +135,14 @@
                 <dependency groupId="com.puppycrawl.tools" artifactId="checkstyle" version="${checkstyle.version}" />
             </dependencies>
             <path refid="checkstyle.classpath" classpath="runtime"/>
+        </resolve>
+        <resolve>
+            <dependencies>
+                <dependency groupId="org.checkerframework" artifactId="checker" version="${checkerframework.version}" classifier="all"/>
+                <dependency groupId="org.checkerframework" artifactId="checker-qual" version="${checkerframework.version}"/>
+                <dependency groupId="org.checkerframework" artifactId="checker-util" version="${checkerframework.version}"/>
+            </dependencies>
+            <files refid="checkerframework.jars" dir="${checkerframework.jars.dir}" layout="{artifactId}-{classifier}.{extension}"/>
         </resolve>
 
         <macrodef name="install">

--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -58,6 +58,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>

--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -246,6 +246,12 @@
     -->
     <dependencies>
       <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>${checkerframework.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
         <version>1.1.10.1</version>

--- a/build.xml
+++ b/build.xml
@@ -547,11 +547,37 @@
         <copy todir="${basedir}/conf" file="${build.classes.main}/META-INF/hotspot_compiler"/>
     </target>
 
-    <target name="check" depends="_main-jar,build-test" description="Verifies the source code and dependencies. This task is intended to run on pre-commit and locally. It should verify mostly modified files compared to the upstream base branch." unless="check.skip">
+    <target name="cf-all" depends="build,fqltool-build,stress-build" description="Run CheckerFramework against all production source files. This goal is intended to be run on CI.">
+        <run-cf includes="**" listfiles="false" src="${build.src.java}" outputDir="${checkerframework.output.dir}/main"/>
+        <run-cf includes="**" listfiles="false" src="${fqltool.build.src}" outputDir="${checkerframework.output.dir}/fqltool"/>
+        <run-cf includes="**" listfiles="false" src="${stress.build.src}" outputDir="${checkerframework.output.dir}/stress"/>
+    </target>
+
+    <target name="cf" depends="-git-init,build,fqltool-build,stress-build" description="Run CheckerFramework against all changed production source files compared to the latest common ancestor between HEAD and trunk. This goal is intended to be run locally before starting CI.">
+        <run-cf-changed src="${build.src.java}" outputDir="${checkerframework.output.dir}/main"/>
+        <run-cf-changed src="${fqltool.build.src}" outputDir="${checkerframework.output.dir}/fqltool"/>
+        <run-cf-changed src="${stress.build.src}" outputDir="${checkerframework.output.dir}/stress"/>
+    </target>
+
+    <target name="cf-dirty" depends="-git-init,build,fqltool-build,stress-build" description="Run CheckerFramework against changed production source files (staged for commit). This is the default goal an engineer should execute before committing changes.">
+        <run-cf-dirty src="${build.src.java}" outputDir="${checkerframework.output.dir}/main"/>
+        <run-cf-dirty src="${fqltool.build.src}" outputDir="${checkerframework.output.dir}/fqltool"/>
+        <run-cf-dirty src="${stress.build.src}" outputDir="${checkerframework.output.dir}/stress"/>
+    </target>
+
+    <target name="cf-only" depends="build,fqltool-build,stress-build" description="Run CheckerFramework against production source files specified in cf.check.only property (comma separated file paths under src/java or glob patterns, for example -Dcf.check.only=org/apache/cassandra/utils/**)">
+        <fail if:blank="${cf.check.only}" message="cf.check.only property is not set"/>
+        <run-cf includes="${cf.check.only}" listfiles="true" src="${build.src.java}" outputDir="${checkerframework.output.dir}/main"/>
+        <run-cf includes="${cf.check.only}" listfiles="true" src="${fqltool.build.src}" outputDir="${checkerframework.output.dir}/fqltool"/>
+        <run-cf includes="${cf.check.only}" listfiles="true" src="${stress.build.src}" outputDir="${checkerframework.output.dir}/stress"/>
+    </target>
+
+    <target name="check" depends="-git-init,build,build-test" description="Verifies the source code and dependencies. This task is intended to run on pre-commit and locally. It should verify mostly modified files compared to the upstream base branch." unless="check.skip">
         <antcall target="rat-check" inheritrefs="true"/>
         <antcall target="checkstyle" inheritrefs="true"/>
         <antcall target="checkstyle-test" inheritrefs="true"/>
-        <antcall target="eclipse-warnings" inheritrefs="true"/>
+        <antcall if:true="${git.is-merge-base-supported}" target="cf" inheritrefs="true"/>
+        <antcall unless:true="${git.is-merge-base-supported}" target="cf-all" inheritrefs="true"/>
     </target>
 
     <!-- Stress build file -->
@@ -2107,4 +2133,5 @@
   <import file="${build.helpers.dir}/build-owasp.xml"/>
   <import file="${build.helpers.dir}/build-git.xml"/>
   <import file="${build.helpers.dir}/build-checkstyle.xml"/>
+  <import file="${build.helpers.dir}/build-checkerframework.xml"/>
 </project>

--- a/src/java/org/apache/cassandra/audit/BinAuditLogger.java
+++ b/src/java/org/apache/cassandra/audit/BinAuditLogger.java
@@ -30,7 +30,11 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.binlog.BinLog;
 import org.apache.cassandra.utils.concurrent.WeightedQueue;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
+@InheritableMustCall("stop")
 public class BinAuditLogger implements IAuditLogger
 {
     public static final long CURRENT_VERSION = 0;
@@ -38,7 +42,7 @@ public class BinAuditLogger implements IAuditLogger
     public static final String AUDITLOG_MESSAGE = "message";
     private static final Logger logger = LoggerFactory.getLogger(BinAuditLogger.class);
 
-    private volatile BinLog binLog;
+    private volatile @Owning BinLog binLog;
 
     public BinAuditLogger(AuditLogOptions auditLoggingOptions)
     {
@@ -60,6 +64,7 @@ public class BinAuditLogger implements IAuditLogger
     /**
      * Stop the audit log leaving behind any generated files.
      */
+    @EnsuresCalledMethods(value = "this.binLog", methods = "stop")
     public synchronized void stop()
     {
         try

--- a/src/java/org/apache/cassandra/cache/AutoSavingCache.java
+++ b/src/java/org/apache/cassandra/cache/AutoSavingCache.java
@@ -196,7 +196,6 @@ public class AutoSavingCache<K extends CacheKey, V> extends InstrumentingCache<K
         return cacheLoad;
     }
 
-    @SuppressWarnings("resource")
     public int loadSaved()
     {
         int count = 0;

--- a/src/java/org/apache/cassandra/cache/OHCProvider.java
+++ b/src/java/org/apache/cassandra/cache/OHCProvider.java
@@ -31,6 +31,9 @@ import org.apache.cassandra.io.util.RebufferingInputStream;
 import org.apache.cassandra.schema.TableId;
 import org.caffinitas.ohc.OHCache;
 import org.caffinitas.ohc.OHCacheBuilder;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 public class OHCProvider implements CacheProvider<RowCacheKey, IRowCacheEntry>
 {
@@ -47,9 +50,10 @@ public class OHCProvider implements CacheProvider<RowCacheKey, IRowCacheEntry>
 
     private static class OHCacheAdapter implements ICache<RowCacheKey, IRowCacheEntry>
     {
-        private final OHCache<RowCacheKey, IRowCacheEntry> ohCache;
+        @SuppressWarnings(RESOURCE) // this is bad, this class does not even have a close method
+        private final @Owning OHCache<RowCacheKey, IRowCacheEntry> ohCache;
 
-        public OHCacheAdapter(OHCache<RowCacheKey, IRowCacheEntry> ohCache)
+        public OHCacheAdapter(@Owning OHCache<RowCacheKey, IRowCacheEntry> ohCache)
         {
             this.ohCache = ohCache;
         }

--- a/src/java/org/apache/cassandra/cache/OHCProvider.java
+++ b/src/java/org/apache/cassandra/cache/OHCProvider.java
@@ -192,7 +192,6 @@ public class OHCProvider implements CacheProvider<RowCacheKey, IRowCacheEntry>
             }
         }
 
-        @SuppressWarnings("resource")
         public IRowCacheEntry deserialize(ByteBuffer buf)
         {
             try

--- a/src/java/org/apache/cassandra/cache/SerializingCache.java
+++ b/src/java/org/apache/cassandra/cache/SerializingCache.java
@@ -17,21 +17,22 @@
  */
 package org.apache.cassandra.cache;
 
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
-
 import org.apache.cassandra.concurrent.ImmediateExecutor;
 import org.apache.cassandra.io.ISerializer;
+import org.apache.cassandra.io.util.DataOutputStreamPlus;
 import org.apache.cassandra.io.util.MemoryInputStream;
 import org.apache.cassandra.io.util.MemoryOutputStream;
 import org.apache.cassandra.io.util.WrappedDataOutputStreamPlus;
 import org.apache.cassandra.utils.FBUtilities;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Iterator;
 
 /**
  * Serializes cache values off-heap.
@@ -106,9 +107,9 @@ public class SerializingCache<K, V> implements ICache<K, V>
             return null;
         }
 
-        try
+        try (DataOutputStreamPlus out = new WrappedDataOutputStreamPlus(new MemoryOutputStream(freeableMemory)))
         {
-            serializer.serialize(value, new WrappedDataOutputStreamPlus(new MemoryOutputStream(freeableMemory)));
+            serializer.serialize(value, out);
         }
         catch (IOException e)
         {

--- a/src/java/org/apache/cassandra/cache/SerializingCache.java
+++ b/src/java/org/apache/cassandra/cache/SerializingCache.java
@@ -76,7 +76,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
         }, serializer);
     }
 
-    @SuppressWarnings("resource")
     private V deserialize(RefCountedMemory mem)
     {
         try
@@ -90,7 +89,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
         }
     }
 
-    @SuppressWarnings("resource")
     private RefCountedMemory serialize(V value)
     {
         long serializedSize = serializer.serializedSize(value);
@@ -149,7 +147,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
         cache.invalidateAll();
     }
 
-    @SuppressWarnings("resource")
     public V get(K key)
     {
         RefCountedMemory mem = cache.getIfPresent(key);
@@ -167,7 +164,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
         }
     }
 
-    @SuppressWarnings("resource")
     public void put(K key, V value)
     {
         RefCountedMemory mem = serialize(value);
@@ -189,7 +185,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
             old.unreference();
     }
 
-    @SuppressWarnings("resource")
     public boolean putIfAbsent(K key, V value)
     {
         RefCountedMemory mem = serialize(value);
@@ -213,7 +208,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
         return old == null;
     }
 
-    @SuppressWarnings("resource")
     public boolean replace(K key, V oldToReplace, V value)
     {
         // if there is no old value in our cache, we fail
@@ -257,7 +251,6 @@ public class SerializingCache<K, V> implements ICache<K, V>
 
     public void remove(K key)
     {
-        @SuppressWarnings("resource")
         RefCountedMemory mem = cache.asMap().remove(key);
         if (mem != null)
             mem.unreference();

--- a/src/java/org/apache/cassandra/concurrent/ExecutorLocals.java
+++ b/src/java/org/apache/cassandra/concurrent/ExecutorLocals.java
@@ -48,7 +48,7 @@ public class ExecutorLocals implements WithResources, Closeable // TODO if Execu
 
     public static class Impl
     {
-        @SuppressWarnings({"resource", RESOURCE})
+        @SuppressWarnings(RESOURCE)
         protected static void set(TraceState traceState, ClientWarn.State clientWarnState)
         {
             if (traceState == null && clientWarnState == null) locals.set(none);
@@ -83,7 +83,6 @@ public class ExecutorLocals implements WithResources, Closeable // TODO if Execu
         return locals == none ? WithResources.none() : locals;
     }
 
-    @SuppressWarnings("resource")
     public static ExecutorLocals create(TraceState traceState)
     {
         ExecutorLocals current = current();

--- a/src/java/org/apache/cassandra/cql3/functions/JavaBasedUDFunction.java
+++ b/src/java/org/apache/cassandra/cql3/functions/JavaBasedUDFunction.java
@@ -590,7 +590,6 @@ public final class JavaBasedUDFunction extends UDFunction
             return findType(result.toString());
         }
 
-        @SuppressWarnings("resource")
         private NameEnvironmentAnswer findType(String className)
         {
             if (className.equals(this.className))

--- a/src/java/org/apache/cassandra/db/CassandraKeyspaceWriteHandler.java
+++ b/src/java/org/apache/cassandra/db/CassandraKeyspaceWriteHandler.java
@@ -39,7 +39,6 @@ public class CassandraKeyspaceWriteHandler implements KeyspaceWriteHandler
     }
 
     @Override
-    @SuppressWarnings("resource") // group is closed when CassandraWriteContext is closed
     public WriteContext beginWrite(Mutation mutation, boolean makeDurable) throws RequestExecutionException
     {
         OpOrder.Group group = null;
@@ -100,7 +99,6 @@ public class CassandraKeyspaceWriteHandler implements KeyspaceWriteHandler
         return CommitLog.instance.add(mutation);
     }
 
-    @SuppressWarnings("resource") // group is closed when CassandraWriteContext is closed
     private WriteContext createEmptyContext()
     {
         OpOrder.Group group = null;

--- a/src/java/org/apache/cassandra/db/CassandraTableWriteHandler.java
+++ b/src/java/org/apache/cassandra/db/CassandraTableWriteHandler.java
@@ -32,7 +32,6 @@ public class CassandraTableWriteHandler implements TableWriteHandler
     }
 
     @Override
-    @SuppressWarnings("resource")
     public void write(PartitionUpdate update, WriteContext context, UpdateTransaction updateTransaction)
     {
         CassandraWriteContext ctx = CassandraWriteContext.fromContext(context);

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -1294,7 +1294,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                     Iterator<SSTableMultiWriter> writerIterator = flushResults.iterator();
                     while (writerIterator.hasNext())
                     {
-                        @SuppressWarnings("resource")
                         SSTableMultiWriter writer = writerIterator.next();
                         if (writer.getBytesWritten() > 0)
                         {
@@ -1926,7 +1925,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return nowInSec - metadata().params.gcGraceSeconds;
     }
 
-    @SuppressWarnings("resource")
     public RefViewFragment selectAndReference(Function<View, Iterable<SSTableReader>> filter)
     {
         long failingSince = -1L;
@@ -2535,7 +2533,6 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
                                           Supplier<Collection<Range<PartitionPosition>>> rangesSupplier,
                                           Refs<SSTableReader> placeIntoRefs)
     {
-        @SuppressWarnings("resource") // closed by finish or on exception
         SSTableMultiWriter memtableContent = writeMemtableRanges(rangesSupplier, repairSessionID);
         if (memtableContent != null)
         {

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -176,6 +176,7 @@ import org.apache.cassandra.utils.concurrent.Future;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.concurrent.Refs;
 import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
 import static org.apache.cassandra.config.DatabaseDescriptor.getFlushWriters;
@@ -183,6 +184,7 @@ import static org.apache.cassandra.db.commitlog.CommitLogPosition.NONE;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.apache.cassandra.utils.FBUtilities.now;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
 import static org.apache.cassandra.utils.concurrent.CountDownLatch.newCountDownLatch;
@@ -320,7 +322,9 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     private final CassandraStreamManager streamManager;
 
     private final TableRepairManager repairManager;
-    public final TopPartitionTracker topPartitions;
+
+    @SuppressWarnings(RESOURCE) // acceptable - topPartitions are closed on table invalidation
+    public final @Owning TopPartitionTracker topPartitions;
 
     private final SSTableImporter sstableImporter;
 

--- a/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
+++ b/src/java/org/apache/cassandra/db/PartitionRangeReadCommand.java
@@ -316,7 +316,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
     }
 
     @VisibleForTesting
-    @SuppressWarnings("resource")
     public UnfilteredPartitionIterator queryStorage(final ColumnFamilyStore cfs, ReadExecutionController controller)
     {
         ColumnFamilyStore.ViewFragment view = cfs.select(View.selectLive(dataRange().keyRange()));
@@ -329,7 +328,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
             SSTableReadsListener readCountUpdater = newReadCountUpdater();
             for (Memtable memtable : view.memtables)
             {
-                @SuppressWarnings("resource") // We close on exception and on closing the result returned by this method
                 UnfilteredPartitionIterator iter = memtable.partitionIterator(columnFilter(), dataRange(), readCountUpdater);
                 controller.updateMinOldestUnrepairedTombstone(memtable.getMinLocalDeletionTime());
                 inputCollector.addMemtableIterator(RTBoundValidator.validate(iter, RTBoundValidator.Stage.MEMTABLE, false));
@@ -345,7 +343,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
                 if (!intersects && !hasPartitionLevelDeletions && !hasRequiredStatics)
                     continue;
 
-                @SuppressWarnings("resource") // We close on exception and on closing the result returned by this method
                 UnfilteredPartitionIterator iter = sstable.partitionIterator(columnFilter(), dataRange(), readCountUpdater);
                 inputCollector.addSSTableIterator(sstable, RTBoundValidator.validate(iter, RTBoundValidator.Stage.SSTABLE, false));
 
@@ -560,7 +557,6 @@ public class PartitionRangeReadCommand extends ReadCommand implements PartitionR
         }
 
         @Override
-        @SuppressWarnings("resource")
         public UnfilteredPartitionIterator executeLocally(ReadExecutionController executionController)
         {
             VirtualTable view = VirtualKeyspaceRegistry.instance.getTableNullable(metadata().id);

--- a/src/java/org/apache/cassandra/db/RangeTombstoneList.java
+++ b/src/java/org/apache/cassandra/db/RangeTombstoneList.java
@@ -353,7 +353,6 @@ public class RangeTombstoneList implements Iterable<RangeTombstone>, IMeasurable
         return iterator(false);
     }
 
-    @SuppressWarnings("resource")
     public Iterator<RangeTombstone> iterator(boolean reversed)
     {
         return reversed

--- a/src/java/org/apache/cassandra/db/ReadCommand.java
+++ b/src/java/org/apache/cassandra/db/ReadCommand.java
@@ -329,7 +329,6 @@ public abstract class ReadCommand extends AbstractReadQuery
      */
     public abstract boolean isReversed();
 
-    @SuppressWarnings("resource")
     public ReadResponse createResponse(UnfilteredPartitionIterator iterator, RepairedDataInfo rdi)
     {
         // validate that the sequence of RT markers is correct: open is followed by close, deletion times for both
@@ -341,7 +340,6 @@ public abstract class ReadCommand extends AbstractReadQuery
                : ReadResponse.createDataResponse(iterator, this, rdi);
     }
 
-    @SuppressWarnings("resource") // We don't need to close an empty iterator.
     public ReadResponse createEmptyResponse()
     {
         UnfilteredPartitionIterator iterator = EmptyIterators.unfilteredPartition(metadata());
@@ -398,7 +396,6 @@ public abstract class ReadCommand extends AbstractReadQuery
      *
      * @return an iterator over the result of executing this command locally.
      */
-    @SuppressWarnings("resource") // The result iterator is closed upon exceptions (we know it's fine to potentially not close the intermediary
                                   // iterators created inside the try as long as we do close the original resultIterator), or by closing the result.
     public UnfilteredPartitionIterator executeLocally(ReadExecutionController executionController)
     {
@@ -843,7 +840,6 @@ public abstract class ReadCommand extends AbstractReadQuery
         return toCQLString();
     }
 
-    @SuppressWarnings("resource") // resultant iterators are closed by their callers
     InputCollector<UnfilteredRowIterator> iteratorsForPartition(ColumnFamilyStore.ViewFragment view, ReadExecutionController controller)
     {
         final BiFunction<List<UnfilteredRowIterator>, RepairedDataInfo, UnfilteredRowIterator> merge =
@@ -860,7 +856,6 @@ public abstract class ReadCommand extends AbstractReadQuery
         return new InputCollector<>(view, controller, merge, postLimitPartitions);
     }
 
-    @SuppressWarnings("resource") // resultant iterators are closed by their callers
     InputCollector<UnfilteredPartitionIterator> iteratorsForRange(ColumnFamilyStore.ViewFragment view, ReadExecutionController controller)
     {
         final BiFunction<List<UnfilteredPartitionIterator>, RepairedDataInfo, UnfilteredPartitionIterator> merge =
@@ -944,7 +939,6 @@ public abstract class ReadCommand extends AbstractReadQuery
                 unrepairedIters.add(iter);
         }
 
-        @SuppressWarnings("resource") // the returned iterators are closed by the caller
         List<T> finalizeIterators(ColumnFamilyStore cfs, long nowInSec, long oldestUnrepairedTombstone)
         {
             if (repairedIters.isEmpty())

--- a/src/java/org/apache/cassandra/db/ReadExecutionController.java
+++ b/src/java/org/apache/cassandra/db/ReadExecutionController.java
@@ -120,7 +120,6 @@ public class ReadExecutionController implements AutoCloseable
      * @param command the command for which to create a controller.
      * @return the created execution controller, which must always be closed.
      */
-    @SuppressWarnings("resource") // ops closed during controller close
     static ReadExecutionController forCommand(ReadCommand command, boolean trackRepairedStatus)
     {
         ColumnFamilyStore baseCfs = Keyspace.openAndGetStore(command.metadata());

--- a/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
+++ b/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
@@ -116,7 +116,6 @@ public class SizeEstimatesRecorder implements SchemaChangeListener, Runnable
         }
     }
 
-    @SuppressWarnings("resource")
     private static Map<Range<Token>, Pair<Long, Long>> computeSizeEstimates(ColumnFamilyStore table, Collection<Range<Token>> ranges)
     {
         // for each local primary range, estimate (crudely) mean partition size and partitions count.

--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
@@ -51,6 +51,7 @@ import static org.apache.cassandra.concurrent.InfiniteLoopExecutor.Daemon.NON_DA
 import static org.apache.cassandra.concurrent.InfiniteLoopExecutor.Interrupts.SYNCHRONIZED;
 import static org.apache.cassandra.concurrent.InfiniteLoopExecutor.SimulatorSafe.SAFE;
 import static org.apache.cassandra.db.commitlog.CommitLogSegment.Allocation;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 import static org.apache.cassandra.utils.concurrent.WaitQueue.newWaitQueue;
 
 /**
@@ -301,6 +302,7 @@ public abstract class AbstractCommitLogSegmentManager
     {
         do
         {
+            @SuppressWarnings(RESOURCE) // only for the timer context - it does not register any resources
             WaitQueue.Signal prepared = segmentPrepared.register(commitLog.metrics.waitingOnSegmentAllocation.time(), Context::stop);
             if (availableSegment == null && allocatingFrom == currentAllocatingFrom)
                 prepared.awaitUninterruptibly();

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -21,7 +21,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,27 +35,29 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.zip.CRC32;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.cassandra.io.util.File;
-import org.apache.cassandra.io.util.FileWriter;
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 
 import com.codahale.metrics.Timer;
-import org.apache.cassandra.config.*;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.commitlog.CommitLog.Configuration;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.FileWriter;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.utils.NativeLibrary;
 import org.apache.cassandra.utils.IntegerInterval;
+import org.apache.cassandra.utils.NativeLibrary;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.concurrent.WaitQueue;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 import static org.apache.cassandra.utils.concurrent.WaitQueue.newWaitQueue;
 
 /*
@@ -123,7 +131,8 @@ public abstract class CommitLogSegment
     public final long id;
 
     final File logFile;
-    final FileChannel channel;
+    @SuppressWarnings(RESOURCE)
+    final @Owning FileChannel channel;
     final int fd;
 
     protected final AbstractCommitLogSegmentManager manager;

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -222,7 +222,6 @@ public abstract class CommitLogSegment
      * Allocate space in this buffer for the provided mutation, and return the allocated Allocation object.
      * Returns null if there is not enough space in this segment, and a new segment is needed.
      */
-    @SuppressWarnings("resource") //we pass the op order around
     Allocation allocate(Mutation mutation, int size)
     {
         final OpOrder.Group opGroup = appendOrder.start();

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
@@ -25,20 +25,20 @@ import javax.crypto.Cipher;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.AbstractIterator;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.db.commitlog.CommitLogReadHandler.CommitLogReadErrorReason;
+import org.apache.cassandra.db.commitlog.CommitLogReadHandler.CommitLogReadException;
 import org.apache.cassandra.db.commitlog.EncryptedFileSegmentInputStream.ChunkProvider;
-import org.apache.cassandra.db.commitlog.CommitLogReadHandler.*;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileSegmentInputStream;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.schema.CompressionParams;
-import org.apache.cassandra.security.EncryptionUtils;
 import org.apache.cassandra.security.EncryptionContext;
+import org.apache.cassandra.security.EncryptionUtils;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_ALLOW_IGNORE_SYNC_CRC;

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
@@ -301,7 +301,6 @@ public class CommitLogSegmentReader implements Iterable<CommitLogSegmentReader.S
             nextLogicalStart = reader.getFilePointer();
         }
 
-        @SuppressWarnings("resource")
         public SyncSegment nextSegment(final int startPosition, final int nextSectionStartPosition) throws IOException
         {
             reader.seek(startPosition);
@@ -381,7 +380,6 @@ public class CommitLogSegmentReader implements Iterable<CommitLogSegmentReader.S
             };
         }
 
-        @SuppressWarnings("resource")
         public SyncSegment nextSegment(int startPosition, int nextSectionStartPosition) throws IOException
         {
             int totalPlainTextLength = reader.readInt();

--- a/src/java/org/apache/cassandra/db/commitlog/EncryptedFileSegmentInputStream.java
+++ b/src/java/org/apache/cassandra/db/commitlog/EncryptedFileSegmentInputStream.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import org.apache.cassandra.io.util.DataPosition;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileSegmentInputStream;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 /**
  * Each segment of an encrypted file may contain many encrypted chunks, and each chunk needs to be individually decrypted
@@ -42,7 +43,7 @@ public class EncryptedFileSegmentInputStream extends FileSegmentInputStream impl
      */
     private int totalChunkOffset;
 
-    public EncryptedFileSegmentInputStream(String filePath, long segmentOffset, int position, int expectedLength, ChunkProvider chunkProvider)
+    public @MustCallAlias EncryptedFileSegmentInputStream(String filePath, long segmentOffset, int position, int expectedLength, ChunkProvider chunkProvider)
     {
         super(chunkProvider.nextChunk(), filePath, position);
         this.segmentOffset = segmentOffset;

--- a/src/java/org/apache/cassandra/db/commitlog/PeriodicCommitLogService.java
+++ b/src/java/org/apache/cassandra/db/commitlog/PeriodicCommitLogService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.cassandra.config.DatabaseDescriptor;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 class PeriodicCommitLogService extends AbstractCommitLogService
 {
@@ -33,6 +34,7 @@ class PeriodicCommitLogService extends AbstractCommitLogService
               !(commitLog.configuration.useCompression() || commitLog.configuration.useEncryption()));
     }
 
+    @SuppressWarnings(RESOURCE) // just because of the time context which does not neet to be closed
     protected void maybeWaitForSync(CommitLogSegment.Allocation alloc)
     {
         long expectedSyncTime = nanoTime() - blockWhenSyncLagsNanos;

--- a/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractCompactionStrategy.java
@@ -254,7 +254,6 @@ public abstract class AbstractCompactionStrategy
      * allow for a more memory efficient solution if we know the sstable don't overlap (see
      * LeveledCompactionStrategy for instance).
      */
-    @SuppressWarnings("resource")
     public ScannerList getScanners(Collection<SSTableReader> sstables, Collection<Range<Token>> ranges)
     {
         ArrayList<ISSTableScanner> scanners = new ArrayList<ISSTableScanner>();
@@ -368,7 +367,6 @@ public abstract class AbstractCompactionStrategy
 
             for (int i=0, isize=scanners.size(); i<isize; i++)
             {
-                @SuppressWarnings("resource")
                 ISSTableScanner scanner = scanners.get(i);
                 compressed += scanner.getCompressedLengthInBytes();
                 uncompressed += scanner.getLengthInBytes();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -318,7 +318,6 @@ public class CompactionController extends AbstractCompactionController
                                 Predicates.notNull());
     }
 
-    @SuppressWarnings("resource") // caller to close
     private UnfilteredRowIterator getShadowIterator(SSTableReader reader, DecoratedKey key, boolean tombstoneOnly)
     {
         if (reader.isMarkedSuspect() ||

--- a/src/java/org/apache/cassandra/db/compaction/CompactionIterator.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionIterator.java
@@ -118,7 +118,6 @@ public class CompactionIterator extends CompactionInfo.Holder implements Unfilte
         this(type, scanners, controller, nowInSec, compactionId, ActiveCompactionsTracker.NOOP, null);
     }
 
-    @SuppressWarnings("resource") // We make sure to close mergedIterator in close() and CompactionIterator is itself an AutoCloseable
     public CompactionIterator(OperationType type,
                               List<ISSTableScanner> scanners,
                               AbstractCompactionController controller,
@@ -210,7 +209,6 @@ public class CompactionIterator extends CompactionInfo.Holder implements Unfilte
                 int merged = 0;
                 for (int i=0, isize=versions.size(); i<isize; i++)
                 {
-                    @SuppressWarnings("resource")
                     UnfilteredRowIterator iter = versions.get(i);
                     if (iter != null)
                         merged++;
@@ -230,7 +228,6 @@ public class CompactionIterator extends CompactionInfo.Holder implements Unfilte
                 Columns regulars = Columns.NONE;
                 for (int i=0, isize=versions.size(); i<isize; i++)
                 {
-                    @SuppressWarnings("resource")
                     UnfilteredRowIterator iter = versions.get(i);
                     if (iter != null)
                     {
@@ -660,7 +657,6 @@ public class CompactionIterator extends CompactionInfo.Holder implements Unfilte
         }
 
         @Override
-        @SuppressWarnings("resource")
         protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
         {
             currentToken = partition.partitionKey().getToken();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionLogger.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionLogger.java
@@ -54,6 +54,7 @@ import org.apache.cassandra.utils.NoSpamLogger;
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
 import static org.apache.cassandra.config.CassandraRelevantProperties.LOG_DIR;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 public class CompactionLogger
 {
@@ -327,6 +328,7 @@ public class CompactionLogger
             return new OutputStreamWriter(Files.newOutputStream(compactionLog, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
         }
 
+        @SuppressWarnings(RESOURCE) // TODO this seems to be an actual bug that we never close the 'stream'
         private void writeLocal(String toWrite)
         {
             try

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -419,7 +419,6 @@ public class CompactionManager implements CompactionManagerMBean
      * @param jobs the number of threads to use - 0 means use all available. It never uses more than concurrent_compactors threads
      * @return status of the operation
      */
-    @SuppressWarnings("resource")
     private AllSSTableOpStatus parallelAllSSTableOperation(final ColumnFamilyStore cfs,
                                                            final OneSSTableOperation operation,
                                                            int jobs,
@@ -981,13 +980,11 @@ public class CompactionManager implements CompactionManagerMBean
         FBUtilities.waitOnFutures(submitMaximal(cfStore, getDefaultGcBefore(cfStore, FBUtilities.nowInSeconds()), splitOutput));
     }
 
-    @SuppressWarnings("resource") // the tasks are executed in parallel on the executor, making sure that they get closed
     public List<Future<?>> submitMaximal(final ColumnFamilyStore cfStore, final long gcBefore, boolean splitOutput)
     {
             return submitMaximal(cfStore, gcBefore, splitOutput, OperationType.MAJOR_COMPACTION);
     }
 
-    @SuppressWarnings("resource")
     public List<Future<?>> submitMaximal(final ColumnFamilyStore cfStore, final long gcBefore, boolean splitOutput, OperationType operationType)
     {
         // here we compute the task off the compaction executor, so having that present doesn't

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyHolder.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyHolder.java
@@ -183,7 +183,6 @@ public class CompactionStrategyHolder extends AbstractStrategyHolder
     }
 
     @Override
-    @SuppressWarnings("resource")
     public List<ISSTableScanner> getScanners(GroupedSSTableContainer sstables, Collection<Range<Token>> ranges)
     {
         List<ISSTableScanner> scanners = new ArrayList<>(strategies.size());

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -243,7 +243,6 @@ public class CompactionStrategyManager implements INotificationConsumer
      * @return
      */
     @VisibleForTesting
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     AbstractCompactionTask findUpgradeSSTableTask()
     {
         if (!isEnabled() || !DatabaseDescriptor.automaticSSTableUpgrade())
@@ -951,7 +950,6 @@ public class CompactionStrategyManager implements INotificationConsumer
      * @param ranges
      * @return
      */
-    @SuppressWarnings("resource")
     public AbstractCompactionStrategy.ScannerList maybeGetScanners(Collection<SSTableReader> sstables,  Collection<Range<Token>> ranges)
     {
         maybeReloadDiskBoundaries();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionTasks.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTasks.java
@@ -28,7 +28,6 @@ import org.apache.cassandra.utils.FBUtilities;
 
 public class CompactionTasks extends AbstractCollection<AbstractCompactionTask> implements AutoCloseable
 {
-    @SuppressWarnings("resource")
     private static final CompactionTasks EMPTY = new CompactionTasks(Collections.emptyList());
 
     private final Collection<AbstractCompactionTask> tasks;

--- a/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/LeveledCompactionStrategy.java
@@ -126,7 +126,6 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
      * the only difference between background and maximal in LCS is that maximal is still allowed
      * (by explicit user request) even when compaction is disabled.
      */
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     public AbstractCompactionTask getNextBackgroundTask(long gcBefore)
     {
         Collection<SSTableReader> previousCandidate = null;
@@ -179,7 +178,6 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
         }
     }
 
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     public synchronized Collection<AbstractCompactionTask> getMaximalTask(long gcBefore, boolean splitOutput)
     {
         Iterable<SSTableReader> sstables = manifest.getSSTables();
@@ -195,7 +193,6 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
     }
 
     @Override
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     public AbstractCompactionTask getUserDefinedTask(Collection<SSTableReader> sstables, long gcBefore)
     {
 
@@ -337,7 +334,6 @@ public class LeveledCompactionStrategy extends AbstractCompactionStrategy
                     Collection<SSTableReader> intersecting = LeveledScanner.intersecting(byLevel.get(level), ranges);
                     if (!intersecting.isEmpty())
                     {
-                        @SuppressWarnings("resource") // The ScannerList will be in charge of closing (and we close properly on errors)
                         ISSTableScanner scanner = new LeveledScanner(cfs.metadata(), intersecting, ranges);
                         scanners.add(scanner);
                     }

--- a/src/java/org/apache/cassandra/db/compaction/PendingRepairManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/PendingRepairManager.java
@@ -264,7 +264,6 @@ class PendingRepairManager
         return tasks;
     }
 
-    @SuppressWarnings("resource")
     private RepairFinishedCompactionTask getRepairFinishedCompactionTask(TimeUUID sessionID)
     {
         Preconditions.checkState(canCleanup(sessionID));
@@ -429,7 +428,6 @@ class PendingRepairManager
         return !ActiveRepairService.instance.consistent.local.isSessionInProgress(sessionID);
     }
 
-    @SuppressWarnings("resource")
     synchronized Set<ISSTableScanner> getScanners(Collection<SSTableReader> sstables, Collection<Range<Token>> ranges)
     {
         if (sstables.isEmpty())

--- a/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/SizeTieredCompactionStrategy.java
@@ -175,7 +175,6 @@ public class SizeTieredCompactionStrategy extends AbstractCompactionStrategy
         return sstr.getReadMeter() == null ? 0.0 : sstr.getReadMeter().twoHourRate() / sstr.estimatedKeys();
     }
 
-    @SuppressWarnings("resource")
     public AbstractCompactionTask getNextBackgroundTask(long gcBefore)
     {
         List<SSTableReader> previousCandidate = null;
@@ -203,7 +202,6 @@ public class SizeTieredCompactionStrategy extends AbstractCompactionStrategy
         }
     }
 
-    @SuppressWarnings("resource")
     public synchronized Collection<AbstractCompactionTask> getMaximalTask(final long gcBefore, boolean splitOutput)
     {
         Iterable<SSTableReader> filteredSSTables = filterSuspectSSTables(sstables);
@@ -217,7 +215,6 @@ public class SizeTieredCompactionStrategy extends AbstractCompactionStrategy
         return Arrays.<AbstractCompactionTask>asList(new CompactionTask(cfs, txn, gcBefore));
     }
 
-    @SuppressWarnings("resource")
     public AbstractCompactionTask getUserDefinedTask(Collection<SSTableReader> sstables, final long gcBefore)
     {
         assert !sstables.isEmpty(); // checked for by CM.submitUserDefined

--- a/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategy.java
@@ -80,7 +80,6 @@ public class TimeWindowCompactionStrategy extends AbstractCompactionStrategy
     }
 
     @Override
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     public AbstractCompactionTask getNextBackgroundTask(long gcBefore)
     {
         List<SSTableReader> previousCandidate = null;
@@ -380,7 +379,6 @@ public class TimeWindowCompactionStrategy extends AbstractCompactionStrategy
     }
 
     @Override
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     public synchronized Collection<AbstractCompactionTask> getMaximalTask(long gcBefore, boolean splitOutput)
     {
         Iterable<SSTableReader> filteredSSTables = filterSuspectSSTables(sstables);
@@ -407,7 +405,6 @@ public class TimeWindowCompactionStrategy extends AbstractCompactionStrategy
     }
 
     @Override
-    @SuppressWarnings("resource") // transaction is closed by AbstractCompactionTask::execute
     public synchronized AbstractCompactionTask getUserDefinedTask(Collection<SSTableReader> sstables, long gcBefore)
     {
         assert !sstables.isEmpty(); // checked for by CM.submitUserDefined

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -157,7 +157,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         List<Set<SSTableReader>> nonOverlapping = splitInNonOverlappingSets(filterSuspectSSTables(getSSTables()));
         for (Set<SSTableReader> set : nonOverlapping)
         {
-            @SuppressWarnings("resource")   // closed by the returned task
             LifecycleTransaction txn = cfs.getTracker().tryModify(set, OperationType.COMPACTION);
             if (txn != null)
                 tasks.add(createCompactionTask(txn, gcBefore));
@@ -194,7 +193,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     }
 
     @Override
-    @SuppressWarnings("resource")   // transaction closed by the returned task
     public AbstractCompactionTask getUserDefinedTask(Collection<SSTableReader> sstables, final long gcBefore)
     {
         assert !sstables.isEmpty(); // checked for by CM.submitUserDefined
@@ -231,7 +229,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         }
     }
 
-    @SuppressWarnings("resource")   // transaction closed by the returned task
     private UnifiedCompactionTask createCompactionTask(CompactionPick pick, long gcBefore)
     {
         Preconditions.checkNotNull(pick);

--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedCompactionWriter.java
@@ -82,7 +82,6 @@ public class ShardedCompactionWriter extends CompactionAwareWriter
     }
 
     @Override
-    @SuppressWarnings("resource")
     protected SSTableWriter sstableWriter(Directories.DataDirectory directory, DecoratedKey nextKey)
     {
         if (nextKey != null)

--- a/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
@@ -223,7 +223,6 @@ public abstract class CompactionAwareWriter extends Transactional.AbstractTransa
         sstableWriter.switchWriter(sstableWriter(directory, nextKey));
     }
 
-    @SuppressWarnings("resource")
     protected SSTableWriter sstableWriter(Directories.DataDirectory directory, DecoratedKey nextKey)
     {
         Descriptor descriptor = cfs.newSSTableDescriptor(getDirectories().getLocationForDisk(directory));

--- a/src/java/org/apache/cassandra/db/compaction/writers/DefaultCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/DefaultCompactionWriter.java
@@ -48,7 +48,6 @@ public class DefaultCompactionWriter extends CompactionAwareWriter
         this(cfs, directories, txn, nonExpiredSSTables, keepOriginals, sstableLevel);
     }
 
-    @SuppressWarnings("resource")
     public DefaultCompactionWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, boolean keepOriginals, int sstableLevel)
     {
         super(cfs, directories, txn, nonExpiredSSTables, keepOriginals);

--- a/src/java/org/apache/cassandra/db/compaction/writers/MajorLeveledCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/MajorLeveledCompactionWriter.java
@@ -47,7 +47,6 @@ public class MajorLeveledCompactionWriter extends CompactionAwareWriter
         this(cfs, directories, txn, nonExpiredSSTables, maxSSTableSize, false);
     }
 
-    @SuppressWarnings("resource")
     public MajorLeveledCompactionWriter(ColumnFamilyStore cfs,
                                         Directories directories,
                                         LifecycleTransaction txn,

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -327,7 +327,6 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             {
                 DecoratedKey pk;
 
-                @SuppressWarnings("resource")
                 protected BaseRowIterator<?> applyToPartition(BaseRowIterator<?> partition)
                 {
                     pk = partition.partitionKey();

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -173,14 +173,12 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
     /**
      * construct an empty Transaction with no existing readers
      */
-    @SuppressWarnings("resource") // log closed during postCleanup
     public static LifecycleTransaction offline(OperationType operationType)
     {
         Tracker dummy = Tracker.newDummyTracker();
         return new LifecycleTransaction(dummy, new LogTransaction(operationType, dummy), Collections.emptyList());
     }
 
-    @SuppressWarnings("resource") // log closed during postCleanup
     LifecycleTransaction(Tracker tracker, OperationType operationType, Iterable<? extends SSTableReader> readers)
     {
         this(tracker, new LogTransaction(operationType, tracker), readers);

--- a/src/java/org/apache/cassandra/db/lifecycle/LogAwareFileLister.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LogAwareFileLister.java
@@ -24,20 +24,26 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import org.apache.cassandra.io.util.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.Directories;
+import org.apache.cassandra.io.util.File;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
-import static org.apache.cassandra.db.Directories.*;
+import static org.apache.cassandra.db.Directories.FileType;
+import static org.apache.cassandra.db.Directories.OnTxnErr;
 
 /**
  * A class for listing files in a folder.
@@ -101,7 +107,7 @@ final class LogAwareFileLister
                     .collect(Collectors.toList());
     }
 
-    static List<File> list(DirectoryStream<Path> stream) throws IOException
+    static List<File> list(@Owning DirectoryStream<Path> stream) throws IOException
     {
         try
         {

--- a/src/java/org/apache/cassandra/db/lifecycle/LogReplicaSet.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LogReplicaSet.java
@@ -83,7 +83,6 @@ public class LogReplicaSet implements AutoCloseable
 
         try
         {
-            @SuppressWarnings("resource")  // LogReplicas are closed in LogReplicaSet::close
             final LogReplica replica = LogReplica.create(directory, fileName);
             records.forEach(replica::append);
             replicasByFile.put(directory, replica);

--- a/src/java/org/apache/cassandra/db/memtable/Flushing.java
+++ b/src/java/org/apache/cassandra/db/memtable/Flushing.java
@@ -88,7 +88,6 @@ public class Flushing
         }
     }
 
-    @SuppressWarnings("resource")   // writer owned by runnable, to be closed or aborted by its caller
     static FlushRunnable flushRunnable(ColumnFamilyStore cfs,
                                        Memtable memtable,
                                        PartitionPosition from,

--- a/src/java/org/apache/cassandra/db/partitions/PartitionIterators.java
+++ b/src/java/org/apache/cassandra/db/partitions/PartitionIterators.java
@@ -31,7 +31,6 @@ public abstract class PartitionIterators
 {
     private PartitionIterators() {}
 
-    @SuppressWarnings("resource") // The created resources are returned right away
     public static RowIterator getOnlyElement(final PartitionIterator iter, SinglePartitionReadQuery query)
     {
         // If the query has no results, we'll get an empty iterator, but we still
@@ -58,7 +57,6 @@ public abstract class PartitionIterators
         return Transformation.apply(toReturn, new Close());
     }
 
-    @SuppressWarnings("resource") // The created resources are returned right away
     public static PartitionIterator concat(final List<PartitionIterator> iterators)
     {
         if (iterators.size() == 1)
@@ -116,7 +114,6 @@ public abstract class PartitionIterators
      * Note that this is only meant for debugging as this can log a very large amount of
      * logging at INFO.
      */
-    @SuppressWarnings("resource") // The created resources are returned right away
     public static PartitionIterator loggingIterator(PartitionIterator iterator, final String id)
     {
         class Logger extends Transformation<RowIterator>

--- a/src/java/org/apache/cassandra/db/partitions/PartitionUpdate.java
+++ b/src/java/org/apache/cassandra/db/partitions/PartitionUpdate.java
@@ -186,7 +186,6 @@ public class PartitionUpdate extends AbstractBTreePartition
      * Warning: this method does not close the provided iterator, it is up to
      * the caller to close it.
      */
-    @SuppressWarnings("resource")
     public static PartitionUpdate fromIterator(UnfilteredRowIterator iterator, ColumnFilter filter)
     {
         iterator = UnfilteredRowIterators.withOnlyQueriedData(iterator, filter);
@@ -206,7 +205,6 @@ public class PartitionUpdate extends AbstractBTreePartition
      * Warning: this method does not close the provided iterator, it is up to
      * the caller to close it.
      */
-    @SuppressWarnings("resource")
     public static PartitionUpdate fromIterator(RowIterator iterator, ColumnFilter filter)
     {
         iterator = RowIterators.withOnlyQueriedData(iterator, filter);
@@ -242,7 +240,6 @@ public class PartitionUpdate extends AbstractBTreePartition
      *
      * @return the deserialized update or {@code null} if {@code bytes == null}.
      */
-    @SuppressWarnings("resource")
     public static PartitionUpdate fromBytes(ByteBuffer bytes, int version)
     {
         if (bytes == null)

--- a/src/java/org/apache/cassandra/db/partitions/PurgeFunction.java
+++ b/src/java/org/apache/cassandra/db/partitions/PurgeFunction.java
@@ -74,7 +74,6 @@ public abstract class PurgeFunction extends Transformation<UnfilteredRowIterator
     }
 
     @Override
-    @SuppressWarnings("resource")
     protected UnfilteredRowIterator applyToPartition(UnfilteredRowIterator partition)
     {
         onNewPartition(partition.partitionKey());

--- a/src/java/org/apache/cassandra/db/partitions/UnfilteredPartitionIterators.java
+++ b/src/java/org/apache/cassandra/db/partitions/UnfilteredPartitionIterators.java
@@ -51,7 +51,6 @@ public abstract class UnfilteredPartitionIterators
         public static MergeListener NOOP = (partitionKey, versions) -> UnfilteredRowIterators.MergeListener.NOOP;
     }
 
-    @SuppressWarnings("resource") // The created resources are returned right away
     public static UnfilteredRowIterator getOnlyElement(final UnfilteredPartitionIterator iter, SinglePartitionReadCommand command)
     {
         // If the query has no results, we'll get an empty iterator, but we still
@@ -101,7 +100,6 @@ public abstract class UnfilteredPartitionIterators
         return FilteredPartitions.filter(iterator, nowInSec);
     }
 
-    @SuppressWarnings("resource")
     public static UnfilteredPartitionIterator merge(final List<? extends UnfilteredPartitionIterator> iterators, final MergeListener listener)
     {
         assert !iterators.isEmpty();
@@ -125,7 +123,6 @@ public abstract class UnfilteredPartitionIterators
                 toMerge.set(idx, current);
             }
 
-            @SuppressWarnings("resource")
             protected UnfilteredRowIterator getReduced()
             {
                 UnfilteredRowIterators.MergeListener rowListener = listener == null
@@ -185,7 +182,6 @@ public abstract class UnfilteredPartitionIterators
         };
     }
 
-    @SuppressWarnings("resource")
     public static UnfilteredPartitionIterator mergeLazily(final List<? extends UnfilteredPartitionIterator> iterators)
     {
         assert !iterators.isEmpty();

--- a/src/java/org/apache/cassandra/db/repair/PendingAntiCompaction.java
+++ b/src/java/org/apache/cassandra/db/repair/PendingAntiCompaction.java
@@ -189,7 +189,6 @@ public class PendingAntiCompaction
             this.acquireSleepMillis = acquireSleepMillis;
         }
 
-        @SuppressWarnings("resource")
         private AcquireResult acquireTuple()
         {
             // this method runs with compactions stopped & disabled

--- a/src/java/org/apache/cassandra/db/rows/Row.java
+++ b/src/java/org/apache/cassandra/db/rows/Row.java
@@ -726,7 +726,6 @@ public interface Row extends Unfiltered, Iterable<ColumnData>, IMeasurableMemory
             lastRowSet = i;
         }
 
-        @SuppressWarnings("resource")
         public Row merge(DeletionTime activeDeletion)
         {
             // If for this clustering we have only one row version and have no activeDeletion (i.e. nothing to filter out),
@@ -835,7 +834,6 @@ public interface Row extends Unfiltered, Iterable<ColumnData>, IMeasurableMemory
                 return ColumnMetadataVersionComparator.INSTANCE.compare(column, dataColumn) < 0;
             }
 
-            @SuppressWarnings("resource")
             protected ColumnData getReduced()
             {
                 if (column.isSimple())

--- a/src/java/org/apache/cassandra/db/rows/Rows.java
+++ b/src/java/org/apache/cassandra/db/rows/Rows.java
@@ -123,7 +123,6 @@ public abstract class Rows
      * @param merged the result of merging {@code inputs}.
      * @param inputs the inputs whose merge yielded {@code merged}.
      */
-    @SuppressWarnings("resource")
     public static void diff(RowDiffListener diffListener, Row merged, Row...inputs)
     {
         Clustering<?> clustering = merged.clustering();

--- a/src/java/org/apache/cassandra/db/rows/UnfilteredRowIteratorWithLowerBound.java
+++ b/src/java/org/apache/cassandra/db/rows/UnfilteredRowIteratorWithLowerBound.java
@@ -118,7 +118,6 @@ public class UnfilteredRowIteratorWithLowerBound extends LazilyInitializedUnfilt
     @Override
     protected UnfilteredRowIterator initializeIterator()
     {
-        @SuppressWarnings("resource") // 'iter' is added to iterators which is closed on exception, or through the closing of the final merged iterator
         UnfilteredRowIterator iter = RTBoundValidator.validate(sstable.rowIterator(partitionKey(), slices, selectedColumns, isReverseOrder, listener),
                                                                RTBoundValidator.Stage.SSTABLE, false);
         return iter;

--- a/src/java/org/apache/cassandra/db/rows/UnfilteredRowIterators.java
+++ b/src/java/org/apache/cassandra/db/rows/UnfilteredRowIterators.java
@@ -451,7 +451,6 @@ public abstract class UnfilteredRowIterators
             }
         }
 
-        @SuppressWarnings("resource") // We're not really creating any resource here
         private static void checkForInvalidInput(List<UnfilteredRowIterator> iterators)
         {
             if (iterators.isEmpty())
@@ -467,7 +466,6 @@ public abstract class UnfilteredRowIterators
             }
         }
 
-        @SuppressWarnings("resource") // We're not really creating any resource here
         private static DeletionTime collectPartitionLevelDeletion(List<UnfilteredRowIterator> iterators, MergeListener listener)
         {
             DeletionTime[] versions = listener == null ? null : new DeletionTime[iterators.size()];

--- a/src/java/org/apache/cassandra/db/streaming/CassandraCompressedStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraCompressedStreamReader.java
@@ -53,7 +53,6 @@ public class CassandraCompressedStreamReader extends CassandraStreamReader
      * @throws java.io.IOException if reading the remote sstable fails. Will throw an RTE if local write fails.
      */
     @Override
-    @SuppressWarnings("resource") // input needs to remain open, streams on top of it can't be closed
     public SSTableMultiWriter read(DataInputPlus inputPlus) throws Throwable
     {
         long totalSize = totalSize();

--- a/src/java/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamReader.java
@@ -82,7 +82,6 @@ public class CassandraEntireSSTableStreamReader implements IStreamReader
      * @return SSTable transferred
      * @throws IOException if reading the remote sstable fails. Will throw an RTE if local write fails.
      */
-    @SuppressWarnings("resource") // input needs to remain open, streams on top of it can't be closed
     @Override
     public SSTableMultiWriter read(DataInputPlus in) throws IOException
     {
@@ -168,7 +167,6 @@ public class CassandraEntireSSTableStreamReader implements IStreamReader
         return dir;
     }
 
-    @SuppressWarnings("resource")
     protected SSTableZeroCopyWriter createWriter(ColumnFamilyStore cfs, long totalSize, Collection<Component> components) throws IOException
     {
         File dataDir = getDataDir(cfs, totalSize);

--- a/src/java/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamWriter.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamWriter.java
@@ -88,7 +88,6 @@ public class CassandraEntireSSTableStreamWriter
                          component,
                          prettyPrintMemory(length));
 
-            @SuppressWarnings("resource") // this is closed after the file is transferred by AsyncChannelOutputPlus
             FileChannel channel = context.channel(sstable.descriptor, component, length);
             long bytesWritten = out.writeFileToChannel(channel, limiter);
             progress += bytesWritten;

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamManager.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamManager.java
@@ -82,7 +82,6 @@ public class CassandraStreamManager implements TableStreamManager
         return new CassandraStreamReceiver(cfs, session, totalStreams);
     }
 
-    @SuppressWarnings("resource")   // references placed onto returned collection or closed on error
     @Override
     public Collection<OutgoingStream> createOutgoingStreams(StreamSession session, RangesAtEndpoint replicas, TimeUUID pendingRepair, PreviewKind previewKind)
     {

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReader.java
@@ -102,7 +102,6 @@ public class CassandraStreamReader implements IStreamReader
      * @return SSTable transferred
      * @throws IOException if reading the remote sstable fails. Will throw an RTE if local write fails.
      */
-    @SuppressWarnings("resource") // input needs to remain open, streams on top of it can't be closed
     @Override
     public SSTableMultiWriter read(DataInputPlus inputPlus) throws Throwable
     {
@@ -154,7 +153,6 @@ public class CassandraStreamReader implements IStreamReader
     {
         return header != null? header.toHeader(metadata) : null; //pre-3.0 sstable have no SerializationHeader
     }
-    @SuppressWarnings("resource")
     protected SSTableMultiWriter createWriter(ColumnFamilyStore cfs, long totalSize, long repairedAt, TimeUUID pendingRepair, SSTableFormat<?, ?> format) throws IOException
     {
         Directories.DataDirectory localDir = cfs.getDirectories().getWriteableLocation(totalSize);

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
@@ -97,7 +97,6 @@ public class CassandraStreamReceiver implements StreamReceiver
     }
 
     @Override
-    @SuppressWarnings("resource")
     public synchronized void received(IncomingStream stream)
     {
         CassandraIncomingFile file = getFile(stream);

--- a/src/java/org/apache/cassandra/db/streaming/ComponentContext.java
+++ b/src/java/org/apache/cassandra/db/streaming/ComponentContext.java
@@ -76,8 +76,19 @@ public class ComponentContext implements AutoCloseable
         @SuppressWarnings("resource") // file channel will be closed by Caller
         FileChannel channel = toTransfer.newReadChannel();
 
-        assert size == channel.size() : String.format("Entire sstable streaming expects %s file size to be %s but got %s.",
-                                                      component, size, channel.size());
+        try
+        {
+            if (size != channel.size())
+            {
+                throw new AssertionError(String.format("Entire sstable streaming expects %s file size to be %s but got %s.",
+                                                       component, size, channel.size()));
+            }
+        }
+        catch (Throwable t)
+        {
+            FileUtils.closeQuietly(channel);
+        }
+
         return channel;
     }
 

--- a/src/java/org/apache/cassandra/db/streaming/ComponentContext.java
+++ b/src/java/org/apache/cassandra/db/streaming/ComponentContext.java
@@ -73,7 +73,6 @@ public class ComponentContext implements AutoCloseable
     public FileChannel channel(Descriptor descriptor, Component component, long size) throws IOException
     {
         File toTransfer = hardLinks.containsKey(component) ? hardLinks.get(component) : descriptor.fileFor(component);
-        @SuppressWarnings("resource") // file channel will be closed by Caller
         FileChannel channel = toTransfer.newReadChannel();
 
         try

--- a/src/java/org/apache/cassandra/db/transform/BasePartitions.java
+++ b/src/java/org/apache/cassandra/db/transform/BasePartitions.java
@@ -75,7 +75,6 @@ implements BasePartitionIterator<R>
         return fail;
     }
 
-    @SuppressWarnings("resource")
     public final boolean hasNext()
     {
         BaseRowIterator<?> next = null;

--- a/src/java/org/apache/cassandra/db/transform/Filter.java
+++ b/src/java/org/apache/cassandra/db/transform/Filter.java
@@ -35,7 +35,6 @@ public final class Filter extends Transformation
     }
 
     @Override
-    @SuppressWarnings("resource")
     protected RowIterator applyToPartition(BaseRowIterator iterator)
     {
         return iterator instanceof UnfilteredRows

--- a/src/java/org/apache/cassandra/db/transform/FilteredPartitions.java
+++ b/src/java/org/apache/cassandra/db/transform/FilteredPartitions.java
@@ -50,14 +50,12 @@ public final class FilteredPartitions extends BasePartitions<RowIterator, BasePa
     /**
      * Filter any RangeTombstoneMarker from the iterator's iterators, transforming it into a PartitionIterator.
      */
-    @SuppressWarnings("resource")
     public static FilteredPartitions filter(UnfilteredPartitionIterator iterator, long nowInSecs)
     {
         FilteredPartitions filtered = filter(iterator, new Filter(nowInSecs, iterator.metadata().enforceStrictLiveness()));
         return (FilteredPartitions) Transformation.apply(filtered, new EmptyPartitionsDiscarder());
     }
 
-    @SuppressWarnings("resource")
     public static FilteredPartitions filter(UnfilteredPartitionIterator iterator, Filter filter)
     {
         return iterator instanceof UnfilteredPartitions

--- a/src/java/org/apache/cassandra/db/view/ViewBuilderTask.java
+++ b/src/java/org/apache/cassandra/db/view/ViewBuilderTask.java
@@ -89,7 +89,6 @@ public class ViewBuilderTask extends CompactionInfo.Holder implements Callable<L
         this.keysBuilt = keysBuilt;
     }
 
-    @SuppressWarnings("resource")
     private void buildKey(DecoratedKey key)
     {
         ReadQuery selectQuery = view.getReadQuery();

--- a/src/java/org/apache/cassandra/db/virtual/AbstractVirtualTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/AbstractVirtualTable.java
@@ -75,7 +75,6 @@ public abstract class AbstractVirtualTable implements VirtualTable
     }
 
     @Override
-    @SuppressWarnings("resource")
     public final UnfilteredPartitionIterator select(DecoratedKey partitionKey, ClusteringIndexFilter clusteringIndexFilter, ColumnFilter columnFilter)
     {
         Partition partition = data(partitionKey).getPartition(partitionKey);

--- a/src/java/org/apache/cassandra/hints/ChecksummedDataInput.java
+++ b/src/java/org/apache/cassandra/hints/ChecksummedDataInput.java
@@ -76,7 +76,6 @@ public class ChecksummedDataInput extends RebufferingInputStream
         this(channel, BufferType.OFF_HEAP);
     }
 
-    @SuppressWarnings("resource")
     public static ChecksummedDataInput open(File file)
     {
         ChannelProxy channel = new ChannelProxy(file);

--- a/src/java/org/apache/cassandra/hints/ChecksummedDataInput.java
+++ b/src/java/org/apache/cassandra/hints/ChecksummedDataInput.java
@@ -24,9 +24,15 @@ import java.util.zip.CRC32;
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.io.compress.BufferType;
-import org.apache.cassandra.io.util.*;
-import org.apache.cassandra.utils.Throwables;
+import org.apache.cassandra.io.util.ChannelProxy;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.io.util.RebufferingInputStream;
 import org.apache.cassandra.utils.NativeLibrary;
+import org.apache.cassandra.utils.Throwables;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  * A {@link RandomAccessReader} wrapper that calculates the CRC in place.
@@ -49,9 +55,9 @@ public class ChecksummedDataInput extends RebufferingInputStream
     private long limitMark;
 
     protected long bufferOffset;
-    protected final ChannelProxy channel;
+    protected final @Owning ChannelProxy channel;
 
-    ChecksummedDataInput(ChannelProxy channel, BufferType bufferType)
+    ChecksummedDataInput(@Owning ChannelProxy channel, BufferType bufferType)
     {
         super(bufferType.allocate(RandomAccessReader.DEFAULT_BUFFER_SIZE));
 
@@ -240,6 +246,7 @@ public class ChecksummedDataInput extends RebufferingInputStream
     }
 
     @Override
+    @EnsuresCalledMethods(value = "this.channel", methods = "close")
     public void close()
     {
         FileUtils.clean(buffer);

--- a/src/java/org/apache/cassandra/hints/CompressedChecksummedDataInput.java
+++ b/src/java/org/apache/cassandra/hints/CompressedChecksummedDataInput.java
@@ -161,7 +161,6 @@ public final class CompressedChecksummedDataInput extends ChecksummedDataInput
         super.close();
     }
 
-    @SuppressWarnings("resource") // Closing the ChecksummedDataInput will close the underlying channel.
     public static ChecksummedDataInput upgradeInput(@Owning ChecksummedDataInput input, ICompressor compressor)
     {
         long position = input.getPosition();

--- a/src/java/org/apache/cassandra/hints/CompressedHintsWriter.java
+++ b/src/java/org/apache/cassandra/hints/CompressedHintsWriter.java
@@ -26,8 +26,8 @@ import java.util.zip.CRC32;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.io.compress.ICompressor;
-
 import org.apache.cassandra.io.util.File;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class CompressedHintsWriter extends HintsWriter
 {
@@ -38,7 +38,7 @@ public class CompressedHintsWriter extends HintsWriter
 
     private volatile ByteBuffer compressionBuffer = null;
 
-    public CompressedHintsWriter(File directory, HintsDescriptor descriptor, File file, FileChannel channel, int fd, CRC32 globalCRC)
+    public CompressedHintsWriter(File directory, HintsDescriptor descriptor, File file, @Owning FileChannel channel, int fd, CRC32 globalCRC)
     {
         super(directory, descriptor, file, channel, fd, globalCRC);
         compressor = descriptor.createCompressor();

--- a/src/java/org/apache/cassandra/hints/EncryptedHintsWriter.java
+++ b/src/java/org/apache/cassandra/hints/EncryptedHintsWriter.java
@@ -25,9 +25,10 @@ import javax.crypto.Cipher;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.security.EncryptionUtils;
-import org.apache.cassandra.io.compress.ICompressor;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.utils.FBUtilities.updateChecksum;
 
@@ -37,7 +38,7 @@ public class EncryptedHintsWriter extends HintsWriter
     private final ICompressor compressor;
     private volatile ByteBuffer byteBuffer;
 
-    protected EncryptedHintsWriter(File directory, HintsDescriptor descriptor, File file, FileChannel channel, int fd, CRC32 globalCRC)
+    protected EncryptedHintsWriter(File directory, HintsDescriptor descriptor, File file, @Owning FileChannel channel, int fd, CRC32 globalCRC)
     {
         super(directory, descriptor, file, channel, fd, globalCRC);
         cipher = descriptor.getCipher();

--- a/src/java/org/apache/cassandra/hints/HintsBuffer.java
+++ b/src/java/org/apache/cassandra/hints/HintsBuffer.java
@@ -160,7 +160,6 @@ final class HintsBuffer
         earliestHintByHost.remove(hostId);
     }
 
-    @SuppressWarnings("resource")
     Allocation allocate(int hintSize)
     {
         int totalSize = hintSize + ENTRY_OVERHEAD_SIZE;

--- a/src/java/org/apache/cassandra/hints/HintsDescriptor.java
+++ b/src/java/org/apache/cassandra/hints/HintsDescriptor.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.hints;
 
 import java.io.DataInput;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -33,9 +34,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
-
-import org.apache.cassandra.io.util.File;
-import org.apache.cassandra.io.util.FileInputStreamPlus;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
 import org.slf4j.Logger;
@@ -47,6 +45,8 @@ import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.security.EncryptionContext;
@@ -394,7 +394,8 @@ final class HintsDescriptor
 
         // Let's avoid allocation of serialized output, use counting output stream
         int serializedParamsLength;
-        try (CountingOutputStream out = new CountingOutputStream(ByteStreams.nullOutputStream()))
+        try (OutputStream nullOut = ByteStreams.nullOutputStream();
+             CountingOutputStream out = new CountingOutputStream(nullOut))
         {
             JsonUtils.JSON_OBJECT_MAPPER.writeValue(out, parameters);
             serializedParamsLength = (int) out.getCount();

--- a/src/java/org/apache/cassandra/hints/HintsReader.java
+++ b/src/java/org/apache/cassandra/hints/HintsReader.java
@@ -74,7 +74,6 @@ class HintsReader implements AutoCloseable, Iterable<HintsReader.Page>
         this.rateLimiter = rateLimiter;
     }
 
-    @SuppressWarnings("resource") // HintsReader owns input
     static HintsReader open(File file, RateLimiter rateLimiter)
     {
         ChecksummedDataInput reader = ChecksummedDataInput.open(file);
@@ -151,7 +150,6 @@ class HintsReader implements AutoCloseable, Iterable<HintsReader.Page>
 
     final class PagesIterator extends AbstractIterator<Page>
     {
-        @SuppressWarnings("resource")
         protected Page computeNext()
         {
             input.tryUncacheRead();

--- a/src/java/org/apache/cassandra/hints/HintsWriteExecutor.java
+++ b/src/java/org/apache/cassandra/hints/HintsWriteExecutor.java
@@ -255,7 +255,6 @@ final class HintsWriteExecutor
         }
     }
 
-    @SuppressWarnings("resource")   // writer not closed here
     private void flushInternal(Iterator<ByteBuffer> iterator, HintsStore store)
     {
         long maxHintsFileSize = DatabaseDescriptor.getMaxHintsFileSize();

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -180,7 +180,6 @@ public interface Index
      */
     public static class CollatedViewIndexBuildingSupport implements IndexBuildingSupport
     {
-        @SuppressWarnings("resource")
         public SecondaryIndexBuilder getIndexBuildTask(ColumnFamilyStore cfs, Set<Index> indexes, Collection<SSTableReader> sstables)
         {
             return new CollatedViewIndexBuilder(cfs, indexes, new ReducingKeyIterator(sstables), sstables);

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -510,7 +510,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
                            {
                                SecondaryIndexBuilder builder = buildingSupport.getIndexBuildTask(baseCfs, groupedIndexes, sstables);
                                final AsyncPromise<Object> build = new AsyncPromise<>();
-                               CompactionManager.instance.submitIndexBuild(builder).addCallback(new FutureCallback()
+                               CompactionManager.instance.submitIndexBuild(builder).addCallback(new FutureCallback<Object>()
                                {
                                    @Override
                                    public void onFailure(Throwable t)
@@ -552,7 +552,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
                 }
 
                 // Flush all built indexes with an aynchronous callback to log the success or failure of the flush
-                flushIndexesBlocking(builtIndexes, new FutureCallback()
+                flushIndexesBlocking(builtIndexes, new FutureCallback<Object>()
                 {
                     String indexNames = StringUtils.join(builtIndexes.stream()
                                                                      .map(i -> i.getIndexMetadata().name)

--- a/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndex.java
@@ -683,7 +683,6 @@ public abstract class CassandraIndex implements Index
         };
     }
 
-    @SuppressWarnings("resource")
     private void buildBlocking()
     {
         baseCfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.INDEX_BUILD_STARTED);

--- a/src/java/org/apache/cassandra/index/internal/CassandraIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/internal/CassandraIndexSearcher.java
@@ -54,7 +54,6 @@ public abstract class CassandraIndexSearcher implements Index.Searcher
         this.index = index;
     }
 
-    @SuppressWarnings("resource") // Both the OpOrder and 'indexIter' are closed on exception, or through the closing of the result
     // of this method.
     public UnfilteredPartitionIterator search(ReadExecutionController executionController)
     {

--- a/src/java/org/apache/cassandra/index/internal/composites/CompositesSearcher.java
+++ b/src/java/org/apache/cassandra/index/internal/composites/CompositesSearcher.java
@@ -162,7 +162,6 @@ public class CompositesSearcher extends CassandraIndexSearcher
                                                                     null);
                     }
 
-                    @SuppressWarnings("resource") // We close right away if empty, and if it's assign to next it will be called either
                     // by the next caller of next, or through closing this iterator is this come before.
                     UnfilteredRowIterator dataIter =
                         filterStaleEntries(dataCmd.queryMemtableAndDisk(index.baseCfs, executionController),
@@ -206,7 +205,6 @@ public class CompositesSearcher extends CassandraIndexSearcher
     }
 
     // We assume all rows in dataIter belong to the same partition.
-    @SuppressWarnings("resource")
     private UnfilteredRowIterator filterStaleEntries(UnfilteredRowIterator dataIter,
                                                      final ByteBuffer indexValue,
                                                      final List<IndexEntry> entries,

--- a/src/java/org/apache/cassandra/index/internal/keys/KeysSearcher.java
+++ b/src/java/org/apache/cassandra/index/internal/keys/KeysSearcher.java
@@ -93,7 +93,6 @@ public class KeysSearcher extends CassandraIndexSearcher
                                                                                            command.clusteringIndexFilter(key),
                                                                                            null);
 
-                    @SuppressWarnings("resource") // filterIfStale closes it's iterator if either it materialize it or if it returns null.
                                                   // Otherwise, we close right away if empty, and if it's assigned to next it will be called either
                                                   // by the next caller of next, or through closing this iterator is this come before.
                     UnfilteredRowIterator dataIter = filterIfStale(dataCmd.queryMemtableAndDisk(index.baseCfs, executionController),

--- a/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
@@ -38,13 +38,17 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.concurrent.Ref;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
+@InheritableMustCall("release")
 public class SSTableIndex
 {
     private final ColumnIndex columnIndex;
     private final Ref<SSTableReader> sstableRef;
     private final SSTableReader sstable;
-    private final OnDiskIndex index;
+    private final @Owning OnDiskIndex index;
     private final AtomicInteger references = new AtomicInteger(1);
     private final AtomicBoolean obsolete = new AtomicBoolean(false);
 
@@ -124,6 +128,7 @@ public class SSTableIndex
         }
     }
 
+    @EnsuresCalledMethods(value = "index", methods = "close")
     public void release()
     {
         int n = references.decrementAndGet();

--- a/src/java/org/apache/cassandra/index/sasi/TermIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/TermIterator.java
@@ -79,7 +79,7 @@ public class TermIterator extends RangeIterator<Long, Token>
         this.referencedIndexes = referencedIndexes;
     }
 
-    @SuppressWarnings({"resource", RESOURCE})
+    @SuppressWarnings(RESOURCE)
     public static TermIterator build(final Expression e, Set<SSTableIndex> perSSTableIndexes)
     {
         final List<RangeIterator<Long, Token>> tokens = new CopyOnWriteArrayList<>();

--- a/src/java/org/apache/cassandra/index/sasi/TermIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/TermIterator.java
@@ -19,26 +19,29 @@ package org.apache.cassandra.index.sasi;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.concurrent.ImmediateExecutor;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.index.sasi.disk.Token;
 import org.apache.cassandra.index.sasi.plan.Expression;
-import org.apache.cassandra.index.sasi.utils.RangeUnionIterator;
 import org.apache.cassandra.index.sasi.utils.RangeIterator;
+import org.apache.cassandra.index.sasi.utils.RangeUnionIterator;
 import org.apache.cassandra.io.util.FileUtils;
-
 import org.apache.cassandra.utils.concurrent.CountDownLatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
 import static org.apache.cassandra.index.sasi.disk.OnDiskIndexBuilder.Mode.CONTAINS;
 import static org.apache.cassandra.index.sasi.plan.Expression.Op.PREFIX;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 import static org.apache.cassandra.utils.concurrent.CountDownLatch.newCountDownLatch;
 
 public class TermIterator extends RangeIterator<Long, Token>
@@ -76,7 +79,7 @@ public class TermIterator extends RangeIterator<Long, Token>
         this.referencedIndexes = referencedIndexes;
     }
 
-    @SuppressWarnings("resource")
+    @SuppressWarnings({"resource", RESOURCE})
     public static TermIterator build(final Expression e, Set<SSTableIndex> perSSTableIndexes)
     {
         final List<RangeIterator<Long, Token>> tokens = new CopyOnWriteArrayList<>();
@@ -187,6 +190,7 @@ public class TermIterator extends RangeIterator<Long, Token>
         }
     }
 
+    @Override
     public void close()
     {
         FileUtils.closeQuietly(union);

--- a/src/java/org/apache/cassandra/index/sasi/analyzer/StandardAnalyzer.java
+++ b/src/java/org/apache/cassandra/index/sasi/analyzer/StandardAnalyzer.java
@@ -27,17 +27,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.cassandra.index.sasi.analyzer.filter.*;
+import com.google.common.annotations.VisibleForTesting;
+
+import com.carrotsearch.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntObjectMap;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sasi.analyzer.filter.*;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.utils.ByteBufferUtil;
-
-import com.google.common.annotations.VisibleForTesting;
-
-import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntObjectHashMap;
 
 public class StandardAnalyzer extends AbstractAnalyzer
 {
@@ -159,7 +158,7 @@ public class StandardAnalyzer extends AbstractAnalyzer
         init(options, UTF8Type.instance);
     }
 
-    public void init(StandardTokenizerOptions tokenizerOptions, AbstractType<?> validator)
+    private void init(StandardTokenizerOptions tokenizerOptions, AbstractType<?> validator)
     {
         this.validator = validator;
         this.options = tokenizerOptions;
@@ -170,6 +169,7 @@ public class StandardAnalyzer extends AbstractAnalyzer
         this.inputReader = reader;
     }
 
+    @Override
     public boolean hasNext()
     {
         try
@@ -189,6 +189,7 @@ public class StandardAnalyzer extends AbstractAnalyzer
         return false;
     }
 
+    @Override
     public void reset(ByteBuffer input)
     {
         this.next = null;

--- a/src/java/org/apache/cassandra/index/sasi/conf/DataTracker.java
+++ b/src/java/org/apache/cassandra/index/sasi/conf/DataTracker.java
@@ -34,6 +34,8 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.utils.Pair;
 
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
 /** a pared-down version of DataTracker and DT.View. need one for each index of each column family */
 public class DataTracker
 {
@@ -88,7 +90,7 @@ public class DataTracker
     public boolean hasSSTable(SSTableReader sstable)
     {
         View currentView = view.get();
-        for (SSTableIndex index : currentView)
+        for (SSTableIndex index : currentView.getIndexes())
         {
             if (index.getSSTable().equals(sstable))
                 return true;
@@ -104,7 +106,7 @@ public class DataTracker
             return;
 
         Set<SSTableReader> toRemove = new HashSet<>(sstablesToRebuild);
-        for (SSTableIndex index : currentView)
+        for (SSTableIndex index : currentView.getIndexes())
         {
             SSTableReader sstable = index.getSSTable();
             if (!sstablesToRebuild.contains(sstable))
@@ -123,7 +125,7 @@ public class DataTracker
             return;
 
         Set<SSTableReader> toRemove = new HashSet<>();
-        for (SSTableIndex index : currentView)
+        for (SSTableIndex index : currentView.getIndexes())
         {
             SSTableReader sstable = index.getSSTable();
             if (sstable.getMaxTimestamp() > truncateUntil)
@@ -136,6 +138,7 @@ public class DataTracker
         update(toRemove, Collections.<SSTableReader>emptyList());
     }
 
+    @SuppressWarnings(RESOURCE)
     private Pair<Set<SSTableIndex>, Set<SSTableReader>> getBuiltIndexes(Collection<SSTableReader> sstables)
     {
         Set<SSTableIndex> indexes = new HashSet<>(sstables.size());

--- a/src/java/org/apache/cassandra/index/sasi/conf/view/View.java
+++ b/src/java/org/apache/cassandra/index/sasi/conf/view/View.java
@@ -21,18 +21,21 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.index.sasi.SSTableIndex;
-import org.apache.cassandra.index.sasi.conf.ColumnIndex;
-import org.apache.cassandra.index.sasi.plan.Expression;
+import com.google.common.collect.Iterables;
+
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.index.sasi.SSTableIndex;
+import org.apache.cassandra.index.sasi.conf.ColumnIndex;
+import org.apache.cassandra.index.sasi.plan.Expression;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.IntervalTree;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
-import com.google.common.collect.Iterables;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 public class View implements Iterable<SSTableIndex>
 {
@@ -47,6 +50,7 @@ public class View implements Iterable<SSTableIndex>
         this(index, Collections.<SSTableIndex>emptyList(), Collections.<SSTableReader>emptyList(), indexes);
     }
 
+    @SuppressWarnings(RESOURCE)
     public View(ColumnIndex index,
                 Collection<SSTableIndex> currentView,
                 Collection<SSTableReader> oldSSTables,
@@ -91,22 +95,26 @@ public class View implements Iterable<SSTableIndex>
             throw new IllegalStateException(String.format("mismatched sizes for intervals tree for keys vs terms: %d != %d", keyIntervalTree.intervalCount(), termTree.intervalCount()));
     }
 
-    public Set<SSTableIndex> match(Expression expression)
+    @SuppressWarnings("annotations.on.use")
+    public Set<@MustCallAlias SSTableIndex> match(Expression expression)
     {
         return termTree.search(expression);
     }
 
-    public List<SSTableIndex> match(ByteBuffer minKey, ByteBuffer maxKey)
+    @SuppressWarnings("annotations.on.use")
+    public List<@MustCallAlias SSTableIndex> match(ByteBuffer minKey, ByteBuffer maxKey)
     {
         return keyIntervalTree.search(Interval.create(new Key(minKey, keyValidator), new Key(maxKey, keyValidator), (SSTableIndex) null));
     }
 
-    public Iterator<SSTableIndex> iterator()
+    @SuppressWarnings("annotations.on.use")
+    public Iterator<@MustCallAlias SSTableIndex> iterator()
     {
         return view.values().iterator();
     }
 
-    public Collection<SSTableIndex> getIndexes()
+    @SuppressWarnings("annotations.on.use")
+    public Collection<@MustCallAlias SSTableIndex> getIndexes()
     {
         return view.values();
     }

--- a/src/java/org/apache/cassandra/index/sasi/disk/OnDiskBlock.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/OnDiskBlock.java
@@ -81,7 +81,6 @@ public abstract class OnDiskBlock<T extends Term>
         return new SearchResult<>(element, cmp, middle);
     }
 
-    @SuppressWarnings("resource")
     protected T getTerm(int index)
     {
         MappedBuffer dup = blockIndex.duplicate();

--- a/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndex.java
@@ -51,6 +51,8 @@ import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.index.sasi.disk.OnDiskBlock.SearchResult;
 
@@ -112,7 +114,7 @@ public class OnDiskIndex implements Iterable<OnDiskIndex.DataTerm>, Closeable
     protected final OnDiskIndexBuilder.TermSize termSize;
 
     protected final AbstractType<?> comparator;
-    protected final MappedBuffer indexFile;
+    protected final @Owning MappedBuffer indexFile;
     protected final long indexSize;
     protected final boolean hasMarkedPartials;
 
@@ -150,7 +152,15 @@ public class OnDiskIndex implements Iterable<OnDiskIndex.DataTerm>, Closeable
             hasMarkedPartials = backingFile.readBoolean();
 
             FileChannel channel = index.newReadChannel();
-            indexSize = channel.size();
+            try
+            {
+                indexSize = channel.size();
+            }
+            catch (IOException e)
+            {
+                channel.close();
+                throw e;
+            }
             indexFile = new MappedBuffer(new ChannelProxy(index, channel));
         }
         catch (IOException e)
@@ -279,8 +289,7 @@ public class OnDiskIndex implements Iterable<OnDiskIndex.DataTerm>, Closeable
         {
             @SuppressWarnings("resource")
             RangeIterator<Long, Token> range = searchRange(e);
-            if (range != null)
-                builder.add(range);
+            builder.add(range);
         }
 
         return builder.build();
@@ -441,6 +450,7 @@ public class OnDiskIndex implements Iterable<OnDiskIndex.DataTerm>, Closeable
         return new TermIterator(0, new Expression("", comparator), IteratorOrder.DESC);
     }
 
+    @EnsuresCalledMethods(value = { "indexFile" }, methods = "close")
     public void close() throws IOException
     {
         FileUtils.closeQuietly(indexFile);

--- a/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndex.java
@@ -127,7 +127,6 @@ public class OnDiskIndex implements Iterable<OnDiskIndex.DataTerm>, Closeable
 
     protected final ByteBuffer minTerm, maxTerm, minKey, maxKey;
 
-    @SuppressWarnings("resource")
     public OnDiskIndex(File index, AbstractType<?> cmp, Function<Long, DecoratedKey> keyReader)
     {
         keyFetcher = keyReader;
@@ -287,7 +286,6 @@ public class OnDiskIndex implements Iterable<OnDiskIndex.DataTerm>, Closeable
         RangeUnionIterator.Builder<Long, Token> builder = RangeUnionIterator.builder();
         for (Expression e : ranges)
         {
-            @SuppressWarnings("resource")
             RangeIterator<Long, Token> range = searchRange(e);
             builder.add(range);
         }

--- a/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndexBuilder.java
@@ -282,7 +282,6 @@ public class OnDiskIndexBuilder
         return true;
     }
 
-    @SuppressWarnings("resource")
     protected void finish(Descriptor descriptor, Pair<ByteBuffer, ByteBuffer> range, File file, TermIterator terms)
     {
         SequentialWriter out = null;

--- a/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndexBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/OnDiskIndexBuilder.java
@@ -19,29 +19,50 @@ package org.apache.cassandra.index.sasi.disk;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import org.apache.cassandra.db.DecoratedKey;
-import org.apache.cassandra.index.sasi.plan.Expression.Op;
-import org.apache.cassandra.index.sasi.sa.IndexedTerm;
-import org.apache.cassandra.index.sasi.sa.IntegralSA;
-import org.apache.cassandra.index.sasi.sa.SA;
-import org.apache.cassandra.index.sasi.sa.TermIterator;
-import org.apache.cassandra.index.sasi.sa.SuffixSA;
-import org.apache.cassandra.db.marshal.*;
-import org.apache.cassandra.io.FSWriteError;
-import org.apache.cassandra.io.util.*;
-import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.Pair;
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.LongSet;
 import com.carrotsearch.hppc.ShortArrayList;
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.DateType;
+import org.apache.cassandra.db.marshal.DoubleType;
+import org.apache.cassandra.db.marshal.FloatType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.LongType;
+import org.apache.cassandra.db.marshal.TimeUUIDType;
+import org.apache.cassandra.db.marshal.TimestampType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.index.sasi.plan.Expression.Op;
+import org.apache.cassandra.index.sasi.sa.IndexedTerm;
+import org.apache.cassandra.index.sasi.sa.IntegralSA;
+import org.apache.cassandra.index.sasi.sa.SA;
+import org.apache.cassandra.index.sasi.sa.SuffixSA;
+import org.apache.cassandra.index.sasi.sa.TermIterator;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.util.DataOutputBufferFixed;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.io.util.SequentialWriter;
+import org.apache.cassandra.io.util.SequentialWriterOption;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Pair;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 public class OnDiskIndexBuilder
 {
@@ -526,7 +547,9 @@ public class OnDiskIndexBuilder
 
         public MutableBlock()
         {
-            buffer = new DataOutputBufferFixed(BLOCK_SIZE);
+            @SuppressWarnings(RESOURCE) // TODO refactor everything so that DOBs which do not have to be closed are not closeable or are closeable and are closed
+            DataOutputBufferFixed buf = new DataOutputBufferFixed(BLOCK_SIZE);
+            this.buffer = buf;
             offsets = new ShortArrayList();
         }
 

--- a/src/java/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/PerSSTableIndexWriter.java
@@ -302,7 +302,7 @@ public class PerSSTableIndexWriter implements SSTableFlushObserver
                     // parts are present but there is something still in memory, let's flush that inline
                     if (!currentBuilder.isEmpty())
                     {
-                        @SuppressWarnings({ "resource", RESOURCE })
+                        @SuppressWarnings(RESOURCE)
                         OnDiskIndex last = scheduleSegmentFlush(false).call();
                         segments.add(ImmediateFuture.success(last));
                     }
@@ -312,7 +312,7 @@ public class PerSSTableIndexWriter implements SSTableFlushObserver
 
                     for (Future<OnDiskIndex> f : segments)
                     {
-                        @SuppressWarnings({ "resource", RESOURCE })
+                        @SuppressWarnings(RESOURCE)
                         OnDiskIndex part = f.get();
                         if (part == null)
                             continue;
@@ -338,7 +338,6 @@ public class PerSSTableIndexWriter implements SSTableFlushObserver
 
                     for (int segment = 0; segment < segmentNumber; segment++)
                     {
-                        @SuppressWarnings("resource")
                         OnDiskIndex part = parts[segment];
 
                         if (part != null)

--- a/src/java/org/apache/cassandra/index/sasi/disk/StaticTokenTreeBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/StaticTokenTreeBuilder.java
@@ -55,7 +55,6 @@ import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
  *
  * See https://issues.apache.org/jira/browse/CASSANDRA-11383 for more details.
  */
-@SuppressWarnings("resource")
 public class StaticTokenTreeBuilder extends AbstractTokenTreeBuilder
 {
     private final CombinedTerm combinedTerm;

--- a/src/java/org/apache/cassandra/index/sasi/disk/StaticTokenTreeBuilder.java
+++ b/src/java/org/apache/cassandra/index/sasi/disk/StaticTokenTreeBuilder.java
@@ -22,14 +22,16 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.SortedMap;
 
+import com.google.common.collect.Iterators;
+
+import com.carrotsearch.hppc.LongSet;
 import org.apache.cassandra.index.sasi.utils.CombinedTerm;
 import org.apache.cassandra.index.sasi.utils.RangeIterator;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.Pair;
 
-import com.carrotsearch.hppc.LongSet;
-import com.google.common.collect.Iterators;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 /**
  * Intended usage of this class is to be used in place of {@link DynamicTokenTreeBuilder}
@@ -83,10 +85,11 @@ public class StaticTokenTreeBuilder extends AbstractTokenTreeBuilder
         return tokenCount == 0;
     }
 
-    public Iterator<Pair<Long, LongSet>> iterator()
+    public AbstractIterator<Pair<Long, LongSet>> iterator()
     {
+        @SuppressWarnings(RESOURCE)
         Iterator<Token> iterator = combinedTerm.getTokenIterator();
-        return new AbstractIterator<Pair<Long, LongSet>>()
+        return new AbstractIterator<>()
         {
             protected Pair<Long, LongSet> computeNext()
             {
@@ -114,6 +117,7 @@ public class StaticTokenTreeBuilder extends AbstractTokenTreeBuilder
         if (root.isLeaf())
             return;
 
+        @SuppressWarnings(RESOURCE)
         RangeIterator<Long, Token> tokens = combinedTerm.getTokenIterator();
         ByteBuffer blockBuffer = ByteBuffer.allocate(BLOCK_BYTES);
         Iterator<Node> leafIterator = leftmostLeaf.levelIterator();
@@ -129,6 +133,7 @@ public class StaticTokenTreeBuilder extends AbstractTokenTreeBuilder
 
     protected void constructTree()
     {
+        @SuppressWarnings(RESOURCE)
         RangeIterator<Long, Token> tokens = combinedTerm.getTokenIterator();
 
         tokenCount = 0;
@@ -174,7 +179,9 @@ public class StaticTokenTreeBuilder extends AbstractTokenTreeBuilder
         if (root.tokenCount() == 0)
         {
             numBlocks = 1;
-            root = new StaticLeaf(combinedTerm.getTokenIterator(), treeMinToken, treeMaxToken, tokenCount, true);
+            @SuppressWarnings(RESOURCE)
+            RangeIterator<Long, Token> tokenIterator = combinedTerm.getTokenIterator();
+            root = new StaticLeaf(tokenIterator, treeMinToken, treeMaxToken, tokenCount, true);
         }
     }
 

--- a/src/java/org/apache/cassandra/index/sasi/memory/SkipListMemIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/memory/SkipListMemIndex.java
@@ -63,7 +63,6 @@ public class SkipListMemIndex extends MemIndex
         return overhead;
     }
 
-    @SuppressWarnings("resource")
     public RangeIterator<Long, Token> search(Expression expression)
     {
         ByteBuffer min = expression.lower == null ? null : expression.lower.value;

--- a/src/java/org/apache/cassandra/index/sasi/memory/TrieMemIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/memory/TrieMemIndex.java
@@ -137,7 +137,6 @@ public class TrieMemIndex extends MemIndex
             return overhead;
         }
 
-        @SuppressWarnings("resource")
         public RangeIterator<Long, Token> search(Expression expression)
         {
             ByteBuffer prefix = expression.lower == null ? null : expression.lower.value;

--- a/src/java/org/apache/cassandra/index/sasi/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/Operation.java
@@ -45,7 +45,6 @@ import org.apache.cassandra.schema.ColumnMetadata.Kind;
 import org.apache.cassandra.utils.FBUtilities;
 import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
-@SuppressWarnings("resource")
 public class Operation extends RangeIterator<Long, Token>
 {
     public enum OperationType

--- a/src/java/org/apache/cassandra/index/sasi/plan/Operation.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/Operation.java
@@ -19,26 +19,31 @@ package org.apache.cassandra.index.sasi.plan;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
-import org.apache.cassandra.schema.ColumnMetadata;
-import org.apache.cassandra.schema.ColumnMetadata.Kind;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
+
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.filter.RowFilter;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Unfiltered;
-import org.apache.cassandra.index.sasi.conf.ColumnIndex;
 import org.apache.cassandra.index.sasi.analyzer.AbstractAnalyzer;
+import org.apache.cassandra.index.sasi.conf.ColumnIndex;
 import org.apache.cassandra.index.sasi.disk.Token;
 import org.apache.cassandra.index.sasi.plan.Expression.Op;
 import org.apache.cassandra.index.sasi.utils.RangeIntersectionIterator;
 import org.apache.cassandra.index.sasi.utils.RangeIterator;
 import org.apache.cassandra.index.sasi.utils.RangeUnionIterator;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.*;
-
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.schema.ColumnMetadata.Kind;
 import org.apache.cassandra.utils.FBUtilities;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 @SuppressWarnings("resource")
 public class Operation extends RangeIterator<Long, Token>
@@ -71,7 +76,7 @@ public class Operation extends RangeIterator<Long, Token>
 
     protected Operation left, right;
 
-    private Operation(OperationType operation,
+    private @MustCallAlias Operation(OperationType operation,
                       QueryController controller,
                       ListMultimap<ColumnMetadata, Expression> expressions,
                       RangeIterator<Long, Token> range,
@@ -381,6 +386,7 @@ public class Operation extends RangeIterator<Long, Token>
             range.skipTo(nextToken);
     }
 
+    @Override
     public void close() throws IOException
     {
         controller.releaseIndexes(this);
@@ -426,7 +432,7 @@ public class Operation extends RangeIterator<Long, Token>
                 expressions.addAll(newExpressions);
         }
 
-        public Operation complete()
+        public @MustCallAlias Operation complete()
         {
             if (!expressions.isEmpty())
             {
@@ -440,7 +446,8 @@ public class Operation extends RangeIterator<Long, Token>
                     range.add(rightOp);
                 }
 
-                return new Operation(op, controller, analyzedExpressions, range.build(), null, rightOp);
+                @MustCallAlias RangeIterator<Long, Token> it = range.build();
+                return new Operation(op, controller, analyzedExpressions, it, null, rightOp);
             }
             else
             {

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
@@ -152,7 +152,6 @@ public class QueryController
 
         for (Map.Entry<Expression, Set<SSTableIndex>> e : view)
         {
-            @SuppressWarnings("resource") // RangeIterators are closed by releaseIndexes
             RangeIterator<Long, Token> index = TermIterator.build(e.getKey(), e.getValue());
 
             builder.add(index);

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryController.java
@@ -17,7 +17,15 @@
  */
 package org.apache.cassandra.index.sasi.plan;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Sets;
@@ -48,6 +56,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.Pair;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 
@@ -184,10 +193,11 @@ public class QueryController
         resources.values().forEach(this::releaseIndexes);
     }
 
+    @SuppressWarnings("annotations.on.use")
     private Map<Expression, Set<SSTableIndex>> getView(OperationType op, Collection<Expression> expressions)
     {
         // first let's determine the primary expression if op is AND
-        Pair<Expression, Set<SSTableIndex>> primary = (op == OperationType.AND) ? calculatePrimary(expressions) : null;
+        Pair<Expression, Set<@MustCallAlias SSTableIndex>> primary = (op == OperationType.AND) ? calculatePrimary(expressions) : null;
 
         Map<Expression, Set<SSTableIndex>> indexes = new HashMap<>();
         for (Expression e : expressions)

--- a/src/java/org/apache/cassandra/index/sasi/plan/QueryPlan.java
+++ b/src/java/org/apache/cassandra/index/sasi/plan/QueryPlan.java
@@ -17,18 +17,30 @@
  */
 package org.apache.cassandra.index.sasi.plan;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 
-import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.db.PartitionRangeReadCommand;
+import org.apache.cassandra.db.ReadCommand;
+import org.apache.cassandra.db.ReadExecutionController;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
-import org.apache.cassandra.db.rows.*;
+import org.apache.cassandra.db.rows.AbstractUnfilteredRowIterator;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
+import org.apache.cassandra.exceptions.RequestTimeoutException;
 import org.apache.cassandra.index.sasi.disk.Token;
 import org.apache.cassandra.index.sasi.plan.Operation.OperationType;
-import org.apache.cassandra.exceptions.RequestTimeoutException;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.AbstractIterator;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 public class QueryPlan
 {
@@ -48,7 +60,7 @@ public class QueryPlan
      *
      * @return root of the operations tree.
      */
-    private Operation analyze()
+    private @MustCallAlias Operation analyze()
     {
         try
         {

--- a/src/java/org/apache/cassandra/index/sasi/utils/CombinedTerm.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/CombinedTerm.java
@@ -18,11 +18,15 @@
 package org.apache.cassandra.index.sasi.utils;
 
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.cassandra.index.sasi.disk.*;
-import org.apache.cassandra.index.sasi.disk.OnDiskIndex.DataTerm;
 import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.index.sasi.disk.OnDiskIndex;
+import org.apache.cassandra.index.sasi.disk.OnDiskIndex.DataTerm;
+import org.apache.cassandra.index.sasi.disk.StaticTokenTreeBuilder;
+import org.apache.cassandra.index.sasi.disk.Token;
+import org.apache.cassandra.index.sasi.disk.TokenTreeBuilder;
 
 public class CombinedTerm implements CombinedValue<DataTerm>
 {

--- a/src/java/org/apache/cassandra/index/sasi/utils/CombinedTermIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/CombinedTermIterator.java
@@ -27,7 +27,6 @@ import org.apache.cassandra.index.sasi.sa.TermIterator;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.utils.Pair;
 
-@SuppressWarnings("resource")
 public class CombinedTermIterator extends TermIterator
 {
     final Descriptor descriptor;

--- a/src/java/org/apache/cassandra/index/sasi/utils/MappedBuffer.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/MappedBuffer.java
@@ -22,12 +22,14 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel.MapMode;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
-
-import com.google.common.annotations.VisibleForTesting;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class MappedBuffer implements Closeable
 {
@@ -52,13 +54,13 @@ public class MappedBuffer implements Closeable
         this(file.getChannel(), 30);
     }
 
-    public MappedBuffer(ChannelProxy file)
+    public MappedBuffer(@Owning ChannelProxy file)
     {
         this(file, 30);
     }
 
     @VisibleForTesting
-    protected MappedBuffer(ChannelProxy file, int numPageBits)
+    protected MappedBuffer(@Owning ChannelProxy file, int numPageBits)
     {
         if (numPageBits > Integer.SIZE - 1)
             throw new IllegalArgumentException("page size can't be bigger than 1G");
@@ -100,7 +102,7 @@ public class MappedBuffer implements Closeable
         return position;
     }
 
-    public MappedBuffer position(long newPosition)
+    public @MustCallAlias MappedBuffer position(long newPosition)
     {
         if (newPosition < 0 || newPosition > limit)
             throw new IllegalArgumentException("position: " + newPosition + ", limit: " + limit);
@@ -114,7 +116,7 @@ public class MappedBuffer implements Closeable
         return limit;
     }
 
-    public MappedBuffer limit(long newLimit)
+    public @MustCallAlias MappedBuffer limit(long newLimit)
     {
         if (newLimit < position || newLimit > capacity)
             throw new IllegalArgumentException();
@@ -210,7 +212,7 @@ public class MappedBuffer implements Closeable
         return slice;
     }
 
-    public MappedBuffer duplicate()
+    public @MustCallAlias MappedBuffer duplicate()
     {
         return new MappedBuffer(this);
     }

--- a/src/java/org/apache/cassandra/index/sasi/utils/OnDiskIndexIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/OnDiskIndexIterator.java
@@ -20,16 +20,17 @@ package org.apache.cassandra.index.sasi.utils;
 import java.io.IOException;
 import java.util.Iterator;
 
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.index.sasi.disk.OnDiskIndex;
 import org.apache.cassandra.index.sasi.disk.OnDiskIndex.DataTerm;
-import org.apache.cassandra.db.marshal.AbstractType;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 public class OnDiskIndexIterator extends RangeIterator<DataTerm, CombinedTerm>
 {
     private final AbstractType<?> comparator;
     private final Iterator<DataTerm> terms;
 
-    public OnDiskIndexIterator(OnDiskIndex index)
+    public @MustCallAlias OnDiskIndexIterator(OnDiskIndex index)
     {
         super(index.min(), index.max(), Long.MAX_VALUE);
 
@@ -37,7 +38,7 @@ public class OnDiskIndexIterator extends RangeIterator<DataTerm, CombinedTerm>
         this.terms = index.iterator();
     }
 
-    public static RangeIterator<DataTerm, CombinedTerm> union(OnDiskIndex... union)
+    public static @MustCallAlias RangeIterator<DataTerm, CombinedTerm> union(OnDiskIndex... union)
     {
         RangeUnionIterator.Builder<DataTerm, CombinedTerm> builder = RangeUnionIterator.builder();
         for (OnDiskIndex e : union)

--- a/src/java/org/apache/cassandra/index/sasi/utils/RangeIntersectionIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/RangeIntersectionIterator.java
@@ -30,7 +30,6 @@ import org.apache.cassandra.io.util.FileUtils;
 
 import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
-@SuppressWarnings("resource")
 public class RangeIntersectionIterator
 {
     protected enum Strategy

--- a/src/java/org/apache/cassandra/index/sasi/utils/RangeIntersectionIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/RangeIntersectionIterator.java
@@ -23,10 +23,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.PriorityQueue;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
+
 import org.apache.cassandra.io.util.FileUtils;
 
-import com.google.common.annotations.VisibleForTesting;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 @SuppressWarnings("resource")
 public class RangeIntersectionIterator
@@ -125,6 +127,7 @@ public class RangeIntersectionIterator
             super(statistics, ranges);
         }
 
+        @SuppressWarnings(RESOURCE)
         protected D computeNext()
         {
             List<RangeIterator<K, D>> processed = null;
@@ -199,6 +202,7 @@ public class RangeIntersectionIterator
             return endOfData();
         }
 
+        @SuppressWarnings(RESOURCE)
         protected void performSkipTo(K nextToken)
         {
             List<RangeIterator<K, D>> skipped = new ArrayList<>();
@@ -240,6 +244,7 @@ public class RangeIntersectionIterator
                 smallestIterator.skipTo(getMinimum());
         }
 
+        @SuppressWarnings(RESOURCE)
         protected D computeNext()
         {
             while (smallestIterator.hasNext())

--- a/src/java/org/apache/cassandra/index/sasi/utils/RangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/RangeIterator.java
@@ -24,6 +24,12 @@ import java.util.PriorityQueue;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
+// TODO this iterator has #close method which is not used in many places - this is a bug because some implemnetations may require cleanup
 public abstract class RangeIterator<K extends Comparable<K>, T extends CombinedValue<K>> extends AbstractIterator<T> implements Closeable
 {
     private final K min, max;
@@ -149,7 +155,8 @@ public abstract class RangeIterator<K extends Comparable<K>, T extends CombinedV
             return ranges.size();
         }
 
-        public Builder<K, D> add(RangeIterator<K, D> range)
+        @SuppressWarnings(RESOURCE)
+        public @Owning Builder<K, D> add(@Owning RangeIterator<K, D> range)
         {
             if (range == null)
                 return this;
@@ -170,7 +177,7 @@ public abstract class RangeIterator<K extends Comparable<K>, T extends CombinedV
             return this;
         }
 
-        public final RangeIterator<K, D> build()
+        public final @MustCallAlias RangeIterator<K, D> build()
         {
             if (rangeCount() == 0)
                 return new EmptyRangeIterator<>();
@@ -247,12 +254,12 @@ public abstract class RangeIterator<K extends Comparable<K>, T extends CombinedV
                 tokenCount += range.getCount();
             }
 
-            private RangeIterator<K, D> min(RangeIterator<K, D> a, RangeIterator<K, D> b)
+            private @MustCallAlias RangeIterator<K, D> min(RangeIterator<K, D> a, RangeIterator<K, D> b)
             {
                 return a.getCount() > b.getCount() ? b : a;
             }
 
-            private RangeIterator<K, D> max(RangeIterator<K, D> a, RangeIterator<K, D> b)
+            private @MustCallAlias RangeIterator<K, D> max(RangeIterator<K, D> a, RangeIterator<K, D> b)
             {
                 return a.getCount() > b.getCount() ? a : b;
             }

--- a/src/java/org/apache/cassandra/index/sasi/utils/RangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/RangeUnionIterator.java
@@ -18,10 +18,15 @@
 package org.apache.cassandra.index.sasi.utils;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 
 import org.apache.cassandra.io.util.FileUtils;
+
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 /**
  * Range Union Iterator is used to return sorted stream of elements from multiple RangeIterator instances.
@@ -47,6 +52,7 @@ public class RangeUnionIterator<K extends Comparable<K>, D extends CombinedValue
         this.ranges = ranges;
     }
 
+    @SuppressWarnings(RESOURCE)
     public D computeNext()
     {
         RangeIterator<K, D> head = null;
@@ -105,6 +111,7 @@ public class RangeUnionIterator<K extends Comparable<K>, D extends CombinedValue
         return candidate;
     }
 
+    @SuppressWarnings(RESOURCE)
     protected void performSkipTo(K nextToken)
     {
         List<RangeIterator<K, D>> changedRanges = new ArrayList<>();

--- a/src/java/org/apache/cassandra/index/sasi/utils/RangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sasi/utils/RangeUnionIterator.java
@@ -41,7 +41,6 @@ import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
  * @param <K> The type used to sort ranges.
  * @param <D> The container type which is going to be returned by {@link Iterator#next()}.
  */
-@SuppressWarnings("resource")
 public class RangeUnionIterator<K extends Comparable<K>, D extends CombinedValue<K>> extends RangeIterator<K, D>
 {
     private final PriorityQueue<RangeIterator<K, D>> ranges;

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -67,7 +67,6 @@ public class CompressionMetadata extends WrappedSharedCloseable
     public final CompressionParams parameters;
 
     @VisibleForTesting
-    @SuppressWarnings("resource")
     public static CompressionMetadata open(File chunksIndexFile, long compressedLength, boolean hasMaxCompressedSize)
     {
         CompressionParams parameters;
@@ -200,7 +199,6 @@ public class CompressionMetadata extends WrappedSharedCloseable
             throw new FSReadError(e, input.file);
         }
 
-        @SuppressWarnings("resource")
         Memory offsets = Memory.allocate(chunkCount * 8L);
         int i = 0;
         try
@@ -441,7 +439,6 @@ public class CompressionMetadata extends WrappedSharedCloseable
             }
         }
 
-        @SuppressWarnings("resource")
         public CompressionMetadata open(long dataLength, long compressedLength)
         {
             SafeMemory tOffsets = this.offsets.sharedCopy();

--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableIterator.java
@@ -77,7 +77,7 @@ public abstract class AbstractSSTableIterator<RIE extends AbstractRowIndexEntry>
 
     protected final Slices slices;
 
-    @SuppressWarnings({"resource", RESOURCE}) // We need this because the analysis is not able to determine that we do close
+    @SuppressWarnings(RESOURCE) // We need this because the analysis is not able to determine that we do close
     // file on every path where we created it.
     protected AbstractSSTableIterator(SSTableReader sstable,
                                       @Owning FileDataInput file,

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -68,6 +68,8 @@ import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JavaDriverUtils;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 
@@ -122,12 +124,12 @@ public class CQLSSTableWriter implements Closeable
             DatabaseDescriptor.setPartitionerUnsafe(Murmur3Partitioner.instance);
     }
 
-    private final AbstractSSTableSimpleWriter writer;
+    private final @Owning AbstractSSTableSimpleWriter writer;
     private final ModificationStatement modificationStatement;
     private final List<ColumnSpecification> boundNames;
     private final List<TypeCodec> typeCodecs;
 
-    private CQLSSTableWriter(AbstractSSTableSimpleWriter writer, ModificationStatement modificationStatement, List<ColumnSpecification> boundNames)
+    private CQLSSTableWriter(@Owning AbstractSSTableSimpleWriter writer, ModificationStatement modificationStatement, List<ColumnSpecification> boundNames)
     {
         this.writer = writer;
         this.modificationStatement = modificationStatement;
@@ -348,6 +350,8 @@ public class CQLSSTableWriter implements Closeable
      * This method should be called, otherwise the produced sstables are not
      * guaranteed to be complete (and won't be in practice).
      */
+    @Override
+    @EnsuresCalledMethods(value = "writer", methods = "close")
     public void close() throws IOException
     {
         writer.close();

--- a/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/CQLSSTableWriter.java
@@ -558,7 +558,6 @@ public class CQLSSTableWriter implements Closeable
             return this;
         }
 
-        @SuppressWarnings("resource")
         public CQLSSTableWriter build()
         {
             if (directory == null)

--- a/src/java/org/apache/cassandra/io/sstable/KeyIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/KeyIterator.java
@@ -24,17 +24,21 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.CloseableIterator;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
+@InheritableMustCall("close")
 public class KeyIterator extends AbstractIterator<DecoratedKey> implements CloseableIterator<DecoratedKey>
 {
     private final IPartitioner partitioner;
-    private final KeyReader it;
+    private final @Owning KeyReader it;
     private final ReadWriteLock fileAccessLock;
     private final long totalBytes;
 
     private boolean initialized = false;
 
-    public KeyIterator(KeyReader it, IPartitioner partitioner, long totalBytes, ReadWriteLock fileAccessLock)
+    public KeyIterator(@Owning KeyReader it, IPartitioner partitioner, long totalBytes, ReadWriteLock fileAccessLock)
     {
         this.it = it;
         this.partitioner = partitioner;
@@ -73,6 +77,8 @@ public class KeyIterator extends AbstractIterator<DecoratedKey> implements Close
         }
     }
 
+    @EnsuresCalledMethods(value = "this.it", methods = "close")
+    @Override
     public void close()
     {
         if (fileAccessLock != null)

--- a/src/java/org/apache/cassandra/io/sstable/ReducingKeyIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/ReducingKeyIterator.java
@@ -30,6 +30,8 @@ import org.apache.cassandra.utils.IMergeIterator;
 import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Throwables;
 
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
 /**
  * Caller must acquire and release references to the sstables used here.
  */
@@ -38,6 +40,7 @@ public class ReducingKeyIterator implements CloseableIterator<DecoratedKey>
     private final ArrayList<KeyIterator> iters;
     private volatile IMergeIterator<DecoratedKey, DecoratedKey> mi;
 
+    @SuppressWarnings(RESOURCE)
     public ReducingKeyIterator(Collection<SSTableReader> sstables)
     {
         iters = new ArrayList<>(sstables.size());

--- a/src/java/org/apache/cassandra/io/sstable/SSTableIdentityIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableIdentityIterator.java
@@ -59,7 +59,6 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
         this.staticRow = iterator.readStaticRow();
     }
 
-    @SuppressWarnings("resource")
     public static SSTableIdentityIterator create(SSTableReader sstable, RandomAccessReader file, DecoratedKey key)
     {
         try
@@ -78,7 +77,6 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
         }
     }
 
-    @SuppressWarnings("resource")
     public static SSTableIdentityIterator create(SSTableReader sstable, FileDataInput dfile, long dataPosition, DecoratedKey key, boolean tombstoneOnly)
     {
         try

--- a/src/java/org/apache/cassandra/io/sstable/SSTableLoader.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableLoader.java
@@ -94,7 +94,6 @@ public class SSTableLoader implements StreamEventHandler
         this.connectionsPerHost = connectionsPerHost;
     }
 
-    @SuppressWarnings("resource")
     private Multimap<InetAddressAndPort, CassandraOutgoingFile> openSSTables(final Map<InetAddressAndPort, Collection<Range<Token>>> ranges)
     {
         outputHandler.output("Opening sstables and calculating sections to stream");

--- a/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableTxnWriter.java
@@ -96,7 +96,6 @@ public class SSTableTxnWriter extends Transactional.AbstractTransactional implem
         return writer.finished();
     }
 
-    @SuppressWarnings("resource") // log and writer closed during doPostCleanup
     public static SSTableTxnWriter create(ColumnFamilyStore cfs, Descriptor descriptor, long keyCount, long repairedAt, TimeUUID pendingRepair, boolean isTransient, SerializationHeader header)
     {
         LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.WRITE);
@@ -105,7 +104,6 @@ public class SSTableTxnWriter extends Transactional.AbstractTransactional implem
     }
 
 
-    @SuppressWarnings("resource") // log and writer closed during doPostCleanup
     public static SSTableTxnWriter createRangeAware(TableMetadataRef metadata,
                                                     long keyCount,
                                                     long repairedAt,
@@ -132,7 +130,6 @@ public class SSTableTxnWriter extends Transactional.AbstractTransactional implem
         return new SSTableTxnWriter(txn, writer);
     }
 
-    @SuppressWarnings("resource") // log and writer closed during doPostCleanup
     public static SSTableTxnWriter create(TableMetadataRef metadata,
                                           Descriptor descriptor,
                                           long keyCount,

--- a/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableZeroCopyWriter.java
@@ -44,7 +44,9 @@ import org.apache.cassandra.schema.TableId;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
+@SuppressWarnings(RESOURCE)
 public class SSTableZeroCopyWriter extends SSTable implements SSTableMultiWriter
 {
     private static final Logger logger = LoggerFactory.getLogger(SSTableZeroCopyWriter.class);

--- a/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
@@ -106,7 +106,6 @@ public class SimpleSSTableMultiWriter implements SSTableMultiWriter
         writer.close();
     }
 
-    @SuppressWarnings("resource") // SimpleSSTableMultiWriter closes writer
     public static SSTableMultiWriter create(Descriptor descriptor,
                                             long keyCount,
                                             long repairedAt,

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1545,7 +1545,6 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
         }
 
         // get a new reference to the shared GlobalTidy for this sstable
-        @SuppressWarnings("resource")
         public static Ref<GlobalTidy> get(SSTableReader sstable)
         {
             Descriptor descriptor = sstable.descriptor;

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableWriter.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.io.util.MmappedRegionsCache;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Transactional;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -483,7 +484,7 @@ public abstract class SSTableWriter extends SSTable implements Transactional
             return flushObservers;
         }
 
-        public abstract MmappedRegionsCache getMmappedRegionsCache();
+        public abstract @MustCallAlias MmappedRegionsCache getMmappedRegionsCache();
 
         public Builder(Descriptor descriptor)
         {

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
@@ -76,6 +76,8 @@ import org.apache.cassandra.utils.OutputHandler;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Refs;
 import org.apache.cassandra.utils.memory.HeapCloner;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 
@@ -93,7 +95,7 @@ public abstract class SortedTableScrubber<R extends SSTableReaderWithFilter> imp
     protected final boolean isCommutative;
     protected final long expectedBloomFilterSize;
     protected final ReadWriteLock fileAccessLock = new ReentrantReadWriteLock();
-    protected final RandomAccessReader dataFile;
+    protected final @Owning RandomAccessReader dataFile;
     protected final ScrubInfo scrubInfo;
 
     protected final NegativeLocalDeletionInfoMetrics negativeLocalDeletionInfoMetrics = new NegativeLocalDeletionInfoMetrics();
@@ -357,6 +359,9 @@ public abstract class SortedTableScrubber<R extends SSTableReaderWithFilter> imp
         }
     }
 
+    @Override
+    @EnsuresCalledMethods(value = "this.dataFile", methods = "close")
+    public abstract void close();
 
     public static class ScrubInfo extends CompactionInfo.Holder
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableVerifier.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableVerifier.java
@@ -63,6 +63,8 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.OutputHandler;
 import org.apache.cassandra.utils.TimeUUID;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public abstract class SortedTableVerifier<R extends SSTableReaderWithFilter> implements IVerifier
 {
@@ -72,7 +74,7 @@ public abstract class SortedTableVerifier<R extends SSTableReaderWithFilter> imp
     protected final R sstable;
 
     protected final ReadWriteLock fileAccessLock;
-    protected final RandomAccessReader dataFile;
+    protected final @Owning RandomAccessReader dataFile;
     protected final VerifyInfo verifyInfo;
     protected final Options options;
     protected final boolean isOffline;
@@ -394,6 +396,7 @@ public abstract class SortedTableVerifier<R extends SSTableReaderWithFilter> imp
     }
 
     @Override
+    @EnsuresCalledMethods(value = "this.dataFile", methods = "close")
     public void close()
     {
         fileAccessLock.writeLock().lock();

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -63,6 +63,8 @@ import org.apache.cassandra.utils.FilterFactory;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.concurrent.Transactional;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -375,6 +377,7 @@ public abstract class SortedTableWriter<P extends SortedTablePartitionWriter> ex
         }
     }
 
+    @InheritableMustCall({ "doCommit", "doAbort"})
     protected static abstract class AbstractIndexWriter extends AbstractTransactional implements Transactional
     {
         protected final Descriptor descriptor;
@@ -448,8 +451,8 @@ public abstract class SortedTableWriter<P extends SortedTablePartitionWriter> ex
             return (B) this;
         }
 
-        public abstract SequentialWriter getDataWriter();
+        public abstract @MustCallAlias SequentialWriter getDataWriter();
 
-        public abstract P getPartitionWriter();
+        public abstract @MustCallAlias P getPartitionWriter();
     }
 }

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.io.sstable.format.SortedTablePartitionWriter;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.SequentialWriter;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 /**
  * Column index builder used by {@link org.apache.cassandra.io.sstable.format.big.BigTableWriter}.
@@ -190,7 +191,7 @@ public class BigFormatPartitionWriter extends SortedTablePartitionWriter
         firstClustering = null;
     }
 
-    private DataOutputBuffer reuseOrAllocateBuffer()
+    private @MustCallAlias DataOutputBuffer reuseOrAllocateBuffer()
     {
         // Check whether a reusable DataOutputBuffer already exists for this
         // ColumnIndex instance and return it.

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigSSTableReaderLoadingBuilder.java
@@ -182,7 +182,6 @@ public class BigSSTableReaderLoadingBuilder extends SortedTableReaderLoadingBuil
      * @param rebuildSummary true if index summary, first and last keys should be rebuilt
      * @return a pair of created filter and index summary component (or nulls if some of them were not created)
      */
-    @SuppressWarnings("resource")
     private Pair<IFilter, IndexSummaryComponent> buildSummaryAndBloomFilter(FileHandle indexFile,
                                                                             SerializationHeader serializationHeader,
                                                                             boolean rebuildFilter,

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableKeyReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableKeyReader.java
@@ -68,7 +68,6 @@ public class BigTableKeyReader implements KeyReader
         }
     }
 
-    @SuppressWarnings({ "resource" })
     public static BigTableKeyReader create(FileHandle indexFile, IndexSerializer serializer) throws IOException
     {
         FileHandle iFile = null;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableKeyReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableKeyReader.java
@@ -28,12 +28,14 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Throwables;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 @NotThreadSafe
 public class BigTableKeyReader implements KeyReader
 {
-    private final FileHandle indexFile;
-    private final RandomAccessReader indexFileReader;
+    private final @Owning FileHandle indexFile;
+    private final @Owning RandomAccessReader indexFileReader;
     private final IndexSerializer rowIndexEntrySerializer;
     private final long initialPosition;
 
@@ -41,8 +43,8 @@ public class BigTableKeyReader implements KeyReader
     private long dataPosition;
     private long keyPosition;
 
-    private BigTableKeyReader(FileHandle indexFile,
-                              RandomAccessReader indexFileReader,
+    private BigTableKeyReader(@Owning FileHandle indexFile,
+                              @Owning RandomAccessReader indexFileReader,
                               IndexSerializer rowIndexEntrySerializer)
     {
         this.indexFile = indexFile;
@@ -95,6 +97,7 @@ public class BigTableKeyReader implements KeyReader
     }
 
     @Override
+    @EnsuresCalledMethods(value = {"this.indexFileReader", "this.indexFile"}, methods = "close")
     public void close()
     {
         key = null;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -621,7 +621,6 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
      * @param samplingLevel the desired sampling level for the index summary on the new SSTableReader
      * @return a new SSTableReader
      */
-    @SuppressWarnings("resource")
     public BigTableReader cloneWithNewSummarySamplingLevel(ColumnFamilyStore parent, int samplingLevel) throws IOException
     {
         assert openReason != OpenReason.EARLY;

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java
@@ -41,10 +41,14 @@ import org.apache.cassandra.io.sstable.format.SSTableScanner;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.io.util.RandomAccessReader;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
+@InheritableMustCall("doClose")
 public class BigTableScanner extends SSTableScanner<BigTableReader, RowIndexEntry, BigTableScanner.BigScanningIterator>
 {
-    protected final RandomAccessReader ifile;
+    protected final @Owning RandomAccessReader ifile;
 
     private AbstractBounds<PartitionPosition> currentRange;
 
@@ -117,6 +121,7 @@ public class BigTableScanner extends SSTableScanner<BigTableReader, RowIndexEntr
         }
     }
 
+    @EnsuresCalledMethods(value = {"this.dfile", "this.ifile"}, methods = "close")
     protected void doClose() throws IOException
     {
         FileUtils.close(dfile, ifile);

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScrubber.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScrubber.java
@@ -37,12 +37,14 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.OutputHandler;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class BigTableScrubber extends SortedTableScrubber<BigTableReader> implements IScrubber
 {
     private final boolean isIndex;
 
-    private final RandomAccessReader indexFile;
+    private final @Owning RandomAccessReader indexFile;
     private final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
 
     private ByteBuffer currentIndexKey;
@@ -275,6 +277,7 @@ public class BigTableScrubber extends SortedTableScrubber<BigTableReader> implem
     }
 
     @Override
+    @EnsuresCalledMethods(value = {"indexFile", "dataFile"}, methods = "close")
     public void close()
     {
         fileAccessLock.writeLock().lock();

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -146,7 +146,6 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         return entry;
     }
 
-    @SuppressWarnings("resource")
     private BigTableReader openInternal(IndexSummaryBuilder.ReadableBoundary boundary, SSTableReader.OpenReason openReason)
     {
         assert boundary == null || (boundary.indexLength > 0 && boundary.dataLength > 0);
@@ -281,7 +280,6 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
             summary = new IndexSummaryBuilder(b.getKeyCount(), b.getTableMetadataRef().getLocal().params.minIndexInterval, Downsampling.BASE_SAMPLING_LEVEL);
             // register listeners to be alerted when the data files are flushed
             writer.setPostFlushListener(() -> summary.markIndexSynced(writer.getLastFlushOffset()));
-            @SuppressWarnings("resource")
             @MustCallAlias SequentialWriter dataWriter = b.getDataWriter();
             dataWriter.setPostFlushListener(() -> summary.markDataSynced(dataWriter.getLastFlushOffset()));
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/big/IndexSummaryComponent.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/IndexSummaryComponent.java
@@ -69,7 +69,6 @@ public class IndexSummaryComponent
      * if loaded index summary has different index interval from current value stored in schema,
      * then Summary.db file will be deleted and need to be rebuilt.
      */
-    @SuppressWarnings("resource")
     public static IndexSummaryComponent load(File summaryFile, TableMetadata metadata) throws IOException
     {
         if (!summaryFile.exists())

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
@@ -31,6 +31,8 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  *  A Cell Iterator over SSTable
@@ -54,7 +56,7 @@ public class SSTableIterator extends AbstractSSTableIterator<RowIndexEntry>
     }
 
     @SuppressWarnings("resource") // caller to close
-    protected Reader createReaderInternal(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile, Version version)
+    protected Reader createReaderInternal(RowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
     {
         return indexEntry.isIndexed()
              ? new ForwardIndexedReader(indexEntry, file, shouldCloseFile)
@@ -84,7 +86,7 @@ public class SSTableIterator extends AbstractSSTableIterator<RowIndexEntry>
 
         private int lastBlockIdx; // the last index block that has data for the current query
 
-        private ForwardIndexedReader(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+        private ForwardIndexedReader(RowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
             this.indexState = new IndexState(this, metadata.comparator, indexEntry, false, ifile);
@@ -92,6 +94,7 @@ public class SSTableIterator extends AbstractSSTableIterator<RowIndexEntry>
         }
 
         @Override
+        @EnsuresCalledMethods(value = {"file", "this.indexState"}, methods = "close")
         public void close() throws IOException
         {
             super.close();

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableIterator.java
@@ -55,7 +55,6 @@ public class SSTableIterator extends AbstractSSTableIterator<RowIndexEntry>
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
-    @SuppressWarnings("resource") // caller to close
     protected Reader createReaderInternal(RowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
     {
         return indexEntry.isIndexed()

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
@@ -70,7 +70,6 @@ public class SSTableReversedIterator extends AbstractSSTableIterator<RowIndexEnt
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
-    @SuppressWarnings("resource") // caller to close
     protected Reader createReaderInternal(RowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
     {
         return indexEntry.isIndexed()

--- a/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/SSTableReversedIterator.java
@@ -46,6 +46,8 @@ import org.apache.cassandra.io.util.FileHandle;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.AbstractIterator;
 import org.apache.cassandra.utils.btree.BTree;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  *  A Cell Iterator in reversed clustering order over SSTable
@@ -69,7 +71,7 @@ public class SSTableReversedIterator extends AbstractSSTableIterator<RowIndexEnt
     }
 
     @SuppressWarnings("resource") // caller to close
-    protected Reader createReaderInternal(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile, Version version)
+    protected Reader createReaderInternal(RowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
     {
         return indexEntry.isIndexed()
              ? new ReverseIndexedReader(indexEntry, file, shouldCloseFile)
@@ -103,7 +105,7 @@ public class SSTableReversedIterator extends AbstractSSTableIterator<RowIndexEnt
         protected boolean skipFirstIteratedItem;
         protected boolean skipLastIteratedItem;
 
-        private ReverseReader(FileDataInput file, boolean shouldCloseFile)
+        private ReverseReader(@Owning FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
         }
@@ -279,13 +281,14 @@ public class SSTableReversedIterator extends AbstractSSTableIterator<RowIndexEnt
         // The last index block to consider for the slice
         private int lastBlockIdx;
 
-        private ReverseIndexedReader(RowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+        private ReverseIndexedReader(RowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
             this.indexState = new IndexState(this, metadata.comparator, indexEntry, true, ifile);
         }
 
         @Override
+        @EnsuresCalledMethods(value = { "file", "this.indexState"}, methods = "close")
         public void close() throws IOException
         {
             super.close();

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReaderLoadingBuilder.java
@@ -101,7 +101,7 @@ public class BtiTableReaderLoadingBuilder extends SortedTableReaderLoadingBuilde
 
             if (builder.getComponents().contains(Components.PARTITION_INDEX) && builder.getComponents().contains(Components.ROW_INDEX) && rebuildFilter)
             {
-                @SuppressWarnings({ "resource", "RedundantSuppression" })
+
                 IFilter filter = buildBloomFilter(statsComponent.statsMetadata());
                 builder.setFilter(filter);
                 FilterComponent.save(filter, descriptor, false);

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableScanner.java
@@ -36,7 +36,12 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
 import org.apache.cassandra.io.sstable.format.SSTableScanner;
 import org.apache.cassandra.io.util.FileUtils;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
+@InheritableMustCall("doClose")
 public class BtiTableScanner extends SSTableScanner<BtiTableReader, TrieIndexEntry, BtiTableScanner.BtiScanningIterator>
 {
     // Full scan of the sstables
@@ -72,6 +77,7 @@ public class BtiTableScanner extends SSTableScanner<BtiTableReader, TrieIndexEnt
         super(sstable, columns, dataRange, rangeIterator, listener);
     }
 
+    @EnsuresCalledMethods(value = {"this.dfile", "this.iterator"}, methods = "close")
     protected void doClose() throws IOException
     {
         FileUtils.close(dfile, iterator);
@@ -88,6 +94,7 @@ public class BtiTableScanner extends SSTableScanner<BtiTableReader, TrieIndexEnt
         private PartitionIterator iterator;
 
         @Override
+        @SuppressWarnings(RESOURCE)
         protected boolean prepareToIterateRow() throws IOException
         {
             while (true)

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableScrubber.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableScrubber.java
@@ -38,12 +38,14 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.OutputHandler;
 import org.apache.cassandra.utils.Throwables;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class BtiTableScrubber extends SortedTableScrubber<BtiTableReader> implements IScrubber
 {
     private final boolean isIndex;
     private final AbstractType<?> partitionKeyType;
-    private ScrubPartitionIterator indexIterator;
+    private @Owning ScrubPartitionIterator indexIterator;
 
     public BtiTableScrubber(ColumnFamilyStore cfs,
                             LifecycleTransaction transaction,
@@ -299,6 +301,7 @@ public class BtiTableScrubber extends SortedTableScrubber<BtiTableReader> implem
     }
 
     @Override
+    @EnsuresCalledMethods(value = { "indexIterator", "dataFile"}, methods = "close")
     public void close()
     {
         fileAccessLock.writeLock().lock();

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -103,7 +103,6 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
         return entry;
     }
 
-    @SuppressWarnings({"resource", "RedundantSuppression"})
     private BtiTableReader openInternal(OpenReason openReason, boolean isFinal, Supplier<PartitionIndex> partitionIndexSupplier)
     {
         IFilter filter = null;
@@ -167,7 +166,6 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
     }
 
     @Override
-    @SuppressWarnings({"resource", "RedundantSuppression"})
     protected SSTableReader openFinal(OpenReason openReason)
     {
 
@@ -224,7 +222,6 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
             // register listeners to be alerted when the data files are flushed
             partitionIndexWriter.setPostFlushListener(() -> partitionIndex.markPartitionIndexSynced(partitionIndexWriter.getLastFlushOffset()));
             rowIndexWriter.setPostFlushListener(() -> partitionIndex.markRowIndexSynced(rowIndexWriter.getLastFlushOffset()));
-            @SuppressWarnings({"resource", "RedundantSuppression"})
             SequentialWriter dataWriter = b.getDataWriter();
             dataWriter.setPostFlushListener(() -> partitionIndex.markDataSynced(dataWriter.getLastFlushOffset()));
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndex.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.bytecomparable.ByteSource;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.SharedCloseable;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  * This class holds the partition index as an on-disk trie mapping unique prefixes of decorated keys to:
@@ -402,7 +403,7 @@ public class PartitionIndex implements SharedCloseable
             super(index.instantiateRebufferer(), index.root);
         }
 
-        IndexPosIterator(PartitionIndex index, PartitionPosition start, PartitionPosition end)
+        IndexPosIterator(@Owning PartitionIndex index, PartitionPosition start, PartitionPosition end)
         {
             super(index.instantiateRebufferer(), index.root, start, end, true);
         }

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIndexBuilder.java
@@ -110,7 +110,7 @@ class PartitionIndexBuilder implements AutoCloseable
 
         try (FileHandle fh = fhBuilder.withLengthOverride(writer.getLastFlushOffset()).complete())
         {
-            @SuppressWarnings({ "resource", "RedundantSuppression" })
+
             PartitionIndex pi = new PartitionIndexEarly(fh, partialIndexTail.root(), partialIndexTail.count(), firstKey, partialIndexLastKey, partialIndexTail.cutoff(), partialIndexTail.tail());
             partialIndexConsumer.accept(pi);
             partialIndexConsumer = null;

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/PartitionIterator.java
@@ -62,7 +62,7 @@ class PartitionIterator extends PartitionIndex.IndexPosIterator implements KeyRe
     private DecoratedKey nextKey;
     private TrieIndexEntry nextEntry;
 
-    @SuppressWarnings({ "resource", "RedundantSuppression" })
+
     static PartitionIterator create(PartitionIndex partitionIndex, IPartitioner partitioner, FileHandle rowIndexFile, FileHandle dataFile,
                                     PartitionPosition left, int inclusiveLeft, PartitionPosition right, int exclusiveRight, Version version) throws IOException
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/SSTableIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/SSTableIterator.java
@@ -29,6 +29,8 @@ import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.sstable.format.bti.RowIndexReader.IndexInfo;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  *  Unfiltered row iterator over a BTI SSTable.
@@ -51,7 +53,7 @@ class SSTableIterator extends AbstractSSTableIterator<AbstractRowIndexEntry>
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
-    protected Reader createReaderInternal(AbstractRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile, Version version)
+    protected Reader createReaderInternal(AbstractRowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
     {
         if (indexEntry.isIndexed())
             return new ForwardIndexedReader(indexEntry, file, shouldCloseFile, version);
@@ -82,7 +84,7 @@ class SSTableIterator extends AbstractSSTableIterator<AbstractRowIndexEntry>
         private final long basePosition;
         private final Version version;
 
-        private ForwardIndexedReader(AbstractRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile, Version version)
+        private ForwardIndexedReader(AbstractRowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
         {
             super(file, shouldCloseFile);
             basePosition = indexEntry.position;
@@ -91,6 +93,7 @@ class SSTableIterator extends AbstractSSTableIterator<AbstractRowIndexEntry>
         }
 
         @Override
+        @EnsuresCalledMethods(value = { "file", "this.indexReader"}, methods = "close")
         public void close() throws IOException
         {
             indexReader.close();

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/SSTableReversedIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/SSTableReversedIterator.java
@@ -37,6 +37,8 @@ import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.sstable.format.bti.RowIndexReader.IndexInfo;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.io.util.FileHandle;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  * Unfiltered row iterator over a BTI SSTable that returns rows in reverse order.
@@ -59,7 +61,7 @@ class SSTableReversedIterator extends AbstractSSTableIterator<TrieIndexEntry>
         super(sstable, file, key, indexEntry, slices, columns, ifile);
     }
 
-    protected Reader createReaderInternal(TrieIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile, Version version)
+    protected Reader createReaderInternal(TrieIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile, Version version)
     {
         if (indexEntry.isIndexed())
             return new ReverseIndexedReader(indexEntry, file, shouldCloseFile);
@@ -103,7 +105,7 @@ class SSTableReversedIterator extends AbstractSSTableIterator<TrieIndexEntry>
         private boolean foundLessThan;
         private long startPos = -1;
 
-        private ReverseReader(FileDataInput file, boolean shouldCloseFile)
+        private ReverseReader(@Owning FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
         }
@@ -244,7 +246,7 @@ class SSTableReversedIterator extends AbstractSSTableIterator<TrieIndexEntry>
         private Slice currentSlice;
         private long currentBlockStart;
 
-        public ReverseIndexedReader(AbstractRowIndexEntry indexEntry, FileDataInput file, boolean shouldCloseFile)
+        public ReverseIndexedReader(AbstractRowIndexEntry indexEntry, @Owning FileDataInput file, boolean shouldCloseFile)
         {
             super(file, shouldCloseFile);
             basePosition = indexEntry.position;
@@ -252,6 +254,7 @@ class SSTableReversedIterator extends AbstractSSTableIterator<TrieIndexEntry>
         }
 
         @Override
+        @EnsuresCalledMethods(value = {"file", "indexReader"}, methods = "close")
         public void close() throws IOException
         {
             if (indexReader != null)

--- a/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java
+++ b/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummary.java
@@ -421,7 +421,6 @@ public class IndexSummary extends WrappedSharedCloseable
             out.write(t.entries, 0, t.entriesLength);
         }
 
-        @SuppressWarnings("resource")
         public <T extends InputStream & DataInputPlus> IndexSummary deserialize(T in, IPartitioner partitioner, int expectedMinIndexInterval, int maxIndexInterval) throws IOException
         {
             int minIndexInterval = in.readInt();

--- a/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java
+++ b/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryBuilder.java
@@ -327,7 +327,6 @@ public class IndexSummaryBuilder implements AutoCloseable
      * @param partitioner the partitioner used for the index summary
      * @return a new IndexSummary
      */
-    @SuppressWarnings("resource")
     public static IndexSummary downsample(IndexSummary existing, int newSamplingLevel, int minIndexInterval, IPartitioner partitioner)
     {
         // To downsample the old index summary, we'll go through (potentially) several rounds of downsampling.

--- a/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryManager.java
+++ b/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryManager.java
@@ -171,7 +171,7 @@ public class IndexSummaryManager<T extends SSTableReader & IndexSummarySupport<T
     {
         List<T> summaryProviders = indexSummariesProvider.get();
         double total = 0.0;
-        for (IndexSummarySupport summaryProvider : summaryProviders)
+        for (T summaryProvider : summaryProviders)
             total += summaryProvider.getIndexSummary().getEffectiveIndexInterval();
         return total / summaryProviders.size();
     }
@@ -188,7 +188,7 @@ public class IndexSummaryManager<T extends SSTableReader & IndexSummarySupport<T
     public double getMemoryPoolSizeInMB()
     {
         long total = 0;
-        for (IndexSummarySupport summaryProvider : indexSummariesProvider.get())
+        for (T summaryProvider : indexSummariesProvider.get())
             total += summaryProvider.getIndexSummary().getOffHeapSize();
         return total / 1024.0 / 1024.0;
     }

--- a/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryManager.java
+++ b/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryManager.java
@@ -200,7 +200,6 @@ public class IndexSummaryManager<T extends SSTableReader & IndexSummarySupport<T
      *          left: total size of the off heap index summaries for the sstables we were unable to mark compacting (they were involved in other compactions)
      *          right: the transactions, keyed by table id.
      */
-    @SuppressWarnings("resource")
     private Pair<Long, Map<TableId, LifecycleTransaction>> getRestributionTransactions()
     {
         List<SSTableReader> allCompacting = new ArrayList<>();

--- a/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryRedistribution.java
+++ b/src/java/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryRedistribution.java
@@ -297,7 +297,6 @@ public class IndexSummaryRedistribution extends CompactionInfo.Holder
     /**
      * Add hooks to correctly update the storage load metrics once the transaction is closed/aborted
      */
-    @SuppressWarnings("resource") // Transactions are closed in finally outside of this method
     private void addHooks(ColumnFamilyStore cfs, Map<TableId, LifecycleTransaction> transactions, long oldSize, long newSize, long oldSizeUncompressed, long newSizeUncompressed)
     {
         LifecycleTransaction txn = transactions.get(cfs.metadata.id);

--- a/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/BufferManagingRebufferer.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.apache.cassandra.utils.memory.BufferPools;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  * Buffer manager used for reading from a ChunkReader when cache is not in use. Instances of this class are
@@ -33,13 +35,13 @@ import org.apache.cassandra.utils.memory.BufferPools;
  */
 public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer.BufferHolder
 {
-    protected final ChunkReader source;
+    protected final @Owning ChunkReader source;
     protected final ByteBuffer buffer;
     protected long offset = 0;
 
     abstract long alignedPosition(long position);
 
-    protected BufferManagingRebufferer(ChunkReader wrapped)
+    protected BufferManagingRebufferer(@Owning ChunkReader wrapped)
     {
         this.source = wrapped;
         buffer = BufferPools.forChunkCache().get(wrapped.chunkSize(), wrapped.preferredBufferType()).order(ByteOrder.BIG_ENDIAN);
@@ -53,6 +55,7 @@ public abstract class BufferManagingRebufferer implements Rebufferer, Rebufferer
         offset = -1;
     }
 
+    @EnsuresCalledMethods(value = "this.source", methods = "close")
     @Override
     public void close()
     {

--- a/src/java/org/apache/cassandra/io/util/ChecksummedRandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksummedRandomAccessReader.java
@@ -23,7 +23,6 @@ import org.apache.cassandra.utils.ChecksumType;
 
 public final class ChecksummedRandomAccessReader
 {
-    @SuppressWarnings("resource") // The Rebufferer owns both the channel and the validator and handles closing both.
     public static RandomAccessReader open(File file, File crcFile) throws IOException
     {
         ChannelProxy channel = new ChannelProxy(file);

--- a/src/java/org/apache/cassandra/io/util/ChecksummedRebufferer.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksummedRebufferer.java
@@ -22,13 +22,15 @@ import java.io.IOException;
 
 import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Closeable;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
-class ChecksummedRebufferer extends BufferManagingRebufferer
+class ChecksummedRebufferer extends BufferManagingRebufferer implements Closeable
 {
-    private final DataIntegrityMetadata.ChecksumValidator validator;
+    private final @Owning DataIntegrityMetadata.ChecksumValidator validator;
 
-    @SuppressWarnings("resource") // chunk reader is closed by super::close()
-    ChecksummedRebufferer(ChannelProxy channel, DataIntegrityMetadata.ChecksumValidator validator)
+    ChecksummedRebufferer(@Owning  ChannelProxy channel, @Owning DataIntegrityMetadata.ChecksumValidator validator)
     {
         super(new SimpleChunkReader(channel, channel.size(), BufferType.ON_HEAP, validator.chunkSize));
         this.validator = validator;
@@ -56,6 +58,7 @@ class ChecksummedRebufferer extends BufferManagingRebufferer
         return this;
     }
 
+    @EnsuresCalledMethods(value = {"this.validator", "this.source"}, methods = "close")
     @Override
     public void close()
     {

--- a/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/ChecksummedSequentialWriter.java
@@ -20,6 +20,10 @@ package org.apache.cassandra.io.util;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
 public class ChecksummedSequentialWriter extends SequentialWriter
 {
     private static final SequentialWriterOption CRC_WRITER_OPTION = SequentialWriterOption.newBuilder()
@@ -30,7 +34,8 @@ public class ChecksummedSequentialWriter extends SequentialWriter
     private final ChecksumWriter crcMetadata;
     private final Optional<File> digestFile;
 
-    public ChecksummedSequentialWriter(File file, File crcPath, File digestFile, SequentialWriterOption option)
+    @SuppressWarnings(RESOURCE) // don't know how to annotate that crcWriter is closed in the txn proxy
+    public ChecksummedSequentialWriter(File file, File crcPath, File digestFile, @Owning SequentialWriterOption option)
     {
         super(file, option);
         crcWriter = new SequentialWriter(crcPath, CRC_WRITER_OPTION);

--- a/src/java/org/apache/cassandra/io/util/DataInputBuffer.java
+++ b/src/java/org/apache/cassandra/io/util/DataInputBuffer.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+
 /**
  * Input stream around a single ByteBuffer.
  */
@@ -40,7 +42,7 @@ public class DataInputBuffer extends RebufferingInputStream
      * @param buffer
      * @param duplicate Whether or not to duplicate the buffer to ensure thread safety
      */
-    public DataInputBuffer(ByteBuffer buffer, boolean duplicate)
+    public @MustCallAlias DataInputBuffer(ByteBuffer buffer, boolean duplicate)
     {
         super(duplicate ? buffer.duplicate() : buffer);
     }

--- a/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java
+++ b/src/java/org/apache/cassandra/io/util/DataIntegrityMetadata.java
@@ -24,13 +24,15 @@ import java.util.zip.CheckedInputStream;
 import java.util.zip.Checksum;
 
 import org.apache.cassandra.utils.ChecksumType;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class DataIntegrityMetadata
 {
     public static class ChecksumValidator implements Closeable
     {
         private final ChecksumType checksumType;
-        private final RandomAccessReader reader;
+        private final @Owning RandomAccessReader reader;
         public final int chunkSize;
 
         public ChecksumValidator(File dataFile, File crcFile) throws IOException
@@ -40,7 +42,7 @@ public class DataIntegrityMetadata
                  dataFile.absolutePath());
         }
 
-        public ChecksumValidator(ChecksumType checksumType, RandomAccessReader reader, String dataFilename) throws IOException
+        public ChecksumValidator(ChecksumType checksumType, @Owning RandomAccessReader reader, String dataFilename) throws IOException
         {
             this.checksumType = checksumType;
             this.reader = reader;
@@ -81,6 +83,8 @@ public class DataIntegrityMetadata
                 throw new IOException(String.format("Corrupted file: integrity check (%s) failed for %s: %d != %d", checksumType.name(), reader.getPath(), storedValue, calculatedValue));
         }
 
+        @EnsuresCalledMethods(value = "this.reader", methods = "close")
+        @Override
         public void close()
         {
             reader.close();

--- a/src/java/org/apache/cassandra/io/util/DataOutputBufferFixed.java
+++ b/src/java/org/apache/cassandra/io/util/DataOutputBufferFixed.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+
 
 /**
  * An implementation of the DataOutputStream interface using a FastByteArrayOutputStream and exposing
@@ -31,17 +33,17 @@ import java.nio.ByteBuffer;
  */
 public class DataOutputBufferFixed extends DataOutputBuffer
 {
-    public DataOutputBufferFixed()
+    public @MustCallAlias DataOutputBufferFixed()
     {
         this(128);
     }
 
-    public DataOutputBufferFixed(int size)
+    public @MustCallAlias DataOutputBufferFixed(int size)
     {
         super(size);
     }
 
-    public DataOutputBufferFixed(ByteBuffer buffer)
+    public @MustCallAlias DataOutputBufferFixed(ByteBuffer buffer)
     {
         super(buffer);
     }

--- a/src/java/org/apache/cassandra/io/util/DataOutputStreamPlus.java
+++ b/src/java/org/apache/cassandra/io/util/DataOutputStreamPlus.java
@@ -24,6 +24,8 @@ import java.nio.channels.WritableByteChannel;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DATA_OUTPUT_STREAM_PLUS_TEMP_BUFFER_SIZE;
 
@@ -36,14 +38,14 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.DATA_OUTPU
 public abstract class DataOutputStreamPlus extends OutputStream implements DataOutputPlus
 {
     //Dummy wrapper channel for derived implementations that don't have a channel
-    protected final WritableByteChannel channel;
+    protected final @Owning WritableByteChannel channel;
 
     protected DataOutputStreamPlus()
     {
         this.channel = newDefaultChannel();
     }
 
-    protected DataOutputStreamPlus(WritableByteChannel channel)
+    protected DataOutputStreamPlus(@Owning WritableByteChannel channel)
     {
         this.channel = channel;
     }
@@ -133,4 +135,10 @@ public abstract class DataOutputStreamPlus extends OutputStream implements DataO
         };
     }
 
+    @EnsuresCalledMethods(value = "this.channel", methods = "close")
+    @Override
+    public void close() throws IOException
+    {
+        channel.close();
+    }
 }

--- a/src/java/org/apache/cassandra/io/util/FileHandle.java
+++ b/src/java/org/apache/cassandra/io/util/FileHandle.java
@@ -361,7 +361,6 @@ public class FileHandle extends SharedCloseableImpl
         }
 
         @VisibleForTesting
-        @SuppressWarnings("resource")
         public FileHandle complete(Function<File, ChannelProxy> channelProxyFactory)
         {
             ChannelProxy channel = null;

--- a/src/java/org/apache/cassandra/io/util/FileInputStreamPlus.java
+++ b/src/java/org/apache/cassandra/io/util/FileInputStreamPlus.java
@@ -24,9 +24,13 @@ import java.nio.channels.FileChannel;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
 public class FileInputStreamPlus extends RebufferingInputStream
 {
-    final FileChannel channel;
+    final @Owning FileChannel channel;
     public final File file;
 
     public FileInputStreamPlus(String file) throws NoSuchFileException
@@ -60,11 +64,12 @@ public class FileInputStreamPlus extends RebufferingInputStream
         buffer.flip();
     }
 
-    public FileChannel getChannel()
+    public @MustCallAlias FileChannel getChannel()
     {
         return channel;
     }
 
+    @EnsuresCalledMethods(value = "this.channel", methods = "close")
     @Override
     public void close() throws IOException
     {

--- a/src/java/org/apache/cassandra/io/util/FileOutputStreamPlus.java
+++ b/src/java/org/apache/cassandra/io/util/FileOutputStreamPlus.java
@@ -23,6 +23,8 @@ import java.nio.channels.FileChannel;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+
 import static org.apache.cassandra.io.util.File.WriteMode.OVERWRITE;
 
 public class FileOutputStreamPlus extends BufferedDataOutputStreamPlus
@@ -62,7 +64,7 @@ public class FileOutputStreamPlus extends BufferedDataOutputStreamPlus
         ((FileChannel)channel).force(true);
     }
 
-    public FileChannel getChannel()
+    public @MustCallAlias FileChannel getChannel()
     {
         return (FileChannel) channel;
     }

--- a/src/java/org/apache/cassandra/io/util/FileReader.java
+++ b/src/java/org/apache/cassandra/io/util/FileReader.java
@@ -23,13 +23,11 @@ import java.io.InputStreamReader;
 
 public class FileReader extends InputStreamReader
 {
-    @SuppressWarnings("resource") // FISP is closed by ISR::close
     public FileReader(String file) throws IOException
     {
         super(new FileInputStreamPlus(file));
     }
 
-    @SuppressWarnings("resource") // FISP is closed by ISR::close
     public FileReader(File file) throws IOException
     {
         super(new FileInputStreamPlus(file));

--- a/src/java/org/apache/cassandra/io/util/FileSegmentInputStream.java
+++ b/src/java/org/apache/cassandra/io/util/FileSegmentInputStream.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.io.util;
 
 import java.nio.ByteBuffer;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+
 /**
  * This is the same as DataInputBuffer, i.e. a stream for a fixed byte buffer,
  * except that we also implement FileDataInput by using an offset and a file path.
@@ -29,7 +31,7 @@ public class FileSegmentInputStream extends DataInputBuffer implements FileDataI
     private final String filePath;
     private final long offset;
 
-    public FileSegmentInputStream(ByteBuffer buffer, String filePath, long offset)
+    public @MustCallAlias FileSegmentInputStream(ByteBuffer buffer, String filePath, long offset)
     {
         super(buffer, false);
         this.filePath = filePath;

--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -62,6 +62,8 @@ import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.SyncUtil;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsVarArgs;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.JAVA_IO_TMPDIR;
 import static org.apache.cassandra.utils.Throwables.maybeFail;
@@ -276,6 +278,7 @@ public final class FileUtils
         }
     }
 
+    @EnsuresCalledMethods(value = "#1", methods = "close")
     public static void closeQuietly(Closeable c)
     {
         try
@@ -289,6 +292,7 @@ public final class FileUtils
         }
     }
 
+    @EnsuresCalledMethods(value = "#1", methods = "close")
     public static void closeQuietly(AutoCloseable c)
     {
         try
@@ -302,6 +306,8 @@ public final class FileUtils
         }
     }
 
+    @EnsuresCalledMethodsVarArgs("close")
+    @SuppressWarnings("ensuresvarargs.unverified")
     public static void close(Closeable... cs) throws IOException
     {
         close(Arrays.asList(cs));

--- a/src/java/org/apache/cassandra/io/util/FileWriter.java
+++ b/src/java/org/apache/cassandra/io/util/FileWriter.java
@@ -25,13 +25,11 @@ import org.apache.cassandra.io.util.File.WriteMode;
 
 public class FileWriter extends OutputStreamWriter
 {
-    @SuppressWarnings("resource") // FOSP is closed by OSW::close
     public FileWriter(File file) throws IOException
     {
         super(new FileOutputStreamPlus(file));
     }
 
-    @SuppressWarnings("resource") // FOSP is closed by OSW::close
     public FileWriter(File file, WriteMode mode) throws IOException
     {
         super(new FileOutputStreamPlus(file, mode));

--- a/src/java/org/apache/cassandra/io/util/MemoryInputStream.java
+++ b/src/java/org/apache/cassandra/io/util/MemoryInputStream.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.utils.memory.MemoryUtil;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 public class MemoryInputStream extends RebufferingInputStream implements DataInput
 {
@@ -34,7 +35,7 @@ public class MemoryInputStream extends RebufferingInputStream implements DataInp
     private long offset;
 
 
-    public MemoryInputStream(Memory mem)
+    public @MustCallAlias MemoryInputStream(Memory mem)
     {
         this(mem, Ints.saturatedCast(mem.size));
     }

--- a/src/java/org/apache/cassandra/io/util/MmappedRegionsCache.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegionsCache.java
@@ -26,12 +26,14 @@ import javax.annotation.concurrent.NotThreadSafe;
 import com.google.common.base.Preconditions;
 
 import org.apache.cassandra.io.compress.CompressionMetadata;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 
 /**
  * It is a utility class for caching {@link MmappedRegions} primarily used by a {@link FileHandle.Builder} when a handle
  * to the same file is created multiple times (as when an sstable is opened early).
  */
 @NotThreadSafe
+@InheritableMustCall("close")
 public class MmappedRegionsCache implements AutoCloseable
 {
     private final Map<File, MmappedRegions> cache = new HashMap<>();

--- a/src/java/org/apache/cassandra/io/util/MmappedRegionsCache.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegionsCache.java
@@ -47,7 +47,6 @@ public class MmappedRegionsCache implements AutoCloseable
      * @param length  length of the file
      * @return a shared copy of the cached mmapped regions
      */
-    @SuppressWarnings("resource")
     public MmappedRegions getOrCreate(ChannelProxy channel, long length)
     {
         Preconditions.checkState(!closed);
@@ -65,7 +64,6 @@ public class MmappedRegionsCache implements AutoCloseable
      * @param metadata compression metadata of the file
      * @return a shared copy of the cached mmapped regions
      */
-    @SuppressWarnings("resource")
     public MmappedRegions getOrCreate(ChannelProxy channel, CompressionMetadata metadata)
     {
         Preconditions.checkState(!closed);
@@ -76,7 +74,6 @@ public class MmappedRegionsCache implements AutoCloseable
     }
 
     @Override
-    @SuppressWarnings("resource")
     public void close()
     {
         closed = true;

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -19,13 +19,13 @@ package org.apache.cassandra.io.util;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.google.common.primitives.Ints;
 
 import org.apache.cassandra.io.compress.BufferType;
 import org.apache.cassandra.io.util.Rebufferer.BufferHolder;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 @NotThreadSafe
 public class RandomAccessReader extends RebufferingInputStream implements FileDataInput
@@ -44,7 +44,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
      *
      * @param rebufferer Rebufferer to use
      */
-    RandomAccessReader(Rebufferer rebufferer)
+    RandomAccessReader(@Owning Rebufferer rebufferer)
     {
         super(Rebufferer.EMPTY.buffer());
         this.rebufferer = rebufferer;
@@ -293,7 +293,7 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
     // not have a shared channel.
     static class RandomAccessReaderWithOwnChannel extends RandomAccessReader
     {
-        RandomAccessReaderWithOwnChannel(Rebufferer rebufferer)
+        RandomAccessReaderWithOwnChannel(@Owning Rebufferer rebufferer)
         {
             super(rebufferer);
         }

--- a/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
+++ b/src/java/org/apache/cassandra/io/util/RandomAccessReader.java
@@ -325,7 +325,6 @@ public class RandomAccessReader extends RebufferingInputStream implements FileDa
      * @param file File to open for reading
      * @return new RandomAccessReader that owns the channel opened in this method.
      */
-    @SuppressWarnings("resource")
     public static RandomAccessReader open(File file)
     {
         ChannelProxy channel = new ChannelProxy(file);

--- a/src/java/org/apache/cassandra/io/util/SafeMemoryWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SafeMemoryWriter.java
@@ -31,7 +31,6 @@ public class SafeMemoryWriter extends DataOutputBuffer
 {
     private @Owning SafeMemory memory;
 
-    @SuppressWarnings("resource")
     public SafeMemoryWriter(long initialCapacity)
     {
         this(new SafeMemory(initialCapacity));

--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.utils.SyncUtil;
 import org.apache.cassandra.utils.concurrent.Transactional;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 
 import static org.apache.cassandra.utils.Throwables.merge;
 
@@ -427,6 +428,7 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
         return txnProxy.abort(accumulate);
     }
 
+    @EnsuresCalledMethods(value = "this.channel", methods = "close")
     @Override
     public final void close()
     {

--- a/src/java/org/apache/cassandra/io/util/WrappedDataOutputStreamPlus.java
+++ b/src/java/org/apache/cassandra/io/util/WrappedDataOutputStreamPlus.java
@@ -19,7 +19,9 @@ package org.apache.cassandra.io.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.channels.WritableByteChannel;
+
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  * When possible use {@link WrappedDataOutputStreamPlus} instead of this class, as it will
@@ -29,16 +31,11 @@ import java.nio.channels.WritableByteChannel;
  */
 public class WrappedDataOutputStreamPlus extends UnbufferedDataOutputStreamPlus
 {
-    protected final OutputStream out;
-    public WrappedDataOutputStreamPlus(OutputStream out)
+    protected final @Owning OutputStream out;
+
+    public WrappedDataOutputStreamPlus(@Owning OutputStream out)
     {
         super();
-        this.out = out;
-    }
-
-    public WrappedDataOutputStreamPlus(OutputStream out, WritableByteChannel channel)
-    {
-        super(channel);
         this.out = out;
     }
 
@@ -54,9 +51,11 @@ public class WrappedDataOutputStreamPlus extends UnbufferedDataOutputStreamPlus
         out.write(oneByte);
     }
 
+    @EnsuresCalledMethods(value = {"this.channel", "this.out"}, methods = "close")
     @Override
     public void close() throws IOException
     {
+        FileUtils.closeQuietly(channel);
         out.close();
     }
 

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -1039,7 +1039,6 @@ public class TableMetrics
                 // using SSTableSet.CANONICAL.
                 assert sstable.openReason != SSTableReader.OpenReason.EARLY;
 
-                @SuppressWarnings("resource")
                 CompressionMetadata compressionMetadata = sstable.getCompressionMetadata();
                 compressedLengthSum += compressionMetadata.compressedFileLength;
                 dataLengthSum += compressionMetadata.dataLength;

--- a/src/java/org/apache/cassandra/net/HandshakeProtocol.java
+++ b/src/java/org/apache/cassandra/net/HandshakeProtocol.java
@@ -362,7 +362,6 @@ public class HandshakeProtocol
             }
         }
 
-        @SuppressWarnings("resource")
         static ConfirmOutboundPre40 maybeDecode(ByteBuf in)
         {
             ByteBuffer nio = in.nioBuffer();

--- a/src/java/org/apache/cassandra/net/InboundMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandler.java
@@ -33,9 +33,9 @@ import org.apache.cassandra.concurrent.Stage;
 import org.apache.cassandra.exceptions.IncompatibleSchemaException;
 import org.apache.cassandra.io.util.DataInputBuffer;
 import org.apache.cassandra.locator.InetAddressAndPort;
-import org.apache.cassandra.net.Message.Header;
-import org.apache.cassandra.net.FrameDecoder.IntactFrame;
 import org.apache.cassandra.net.FrameDecoder.CorruptFrame;
+import org.apache.cassandra.net.FrameDecoder.IntactFrame;
+import org.apache.cassandra.net.Message.Header;
 import org.apache.cassandra.net.ResourceLimits.Limit;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.tracing.Tracing;
@@ -44,6 +44,7 @@ import org.apache.cassandra.utils.NoSpamLogger;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.cassandra.utils.MonotonicClock.Global.approxTime;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 /**
  * Implementation of {@link AbstractMessageHandler} for processing internode messages from peers.
@@ -388,6 +389,7 @@ public class InboundMessageHandler extends AbstractMessageHandler
     /**
      * Submit a {@link ProcessMessage} task to the appropriate {@link Stage} for the {@link Verb}.
      */
+    @SuppressWarnings(RESOURCE) // TODO ExecutorLocals are Closeable but they are not closed here
     private void dispatch(ProcessMessage task)
     {
         Header header = task.header();

--- a/src/java/org/apache/cassandra/net/OutboundConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnection.java
@@ -760,7 +760,6 @@ public class OutboundConnection
          *
          * If there is more work to be done, we submit ourselves for execution once the eventLoop has time.
          */
-        @SuppressWarnings("resource")
         boolean doRun(Established established)
         {
             if (!isWritable)
@@ -974,7 +973,7 @@ public class OutboundConnection
             }
         }
 
-        @SuppressWarnings({ "resource", "RedundantSuppression" }) // make eclipse warnings go away
+
         boolean doRun(Established established)
         {
             Message<?> send = queue.tryPoll(approxTime.now(), this::execute);

--- a/src/java/org/apache/cassandra/net/OutboundConnection.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnection.java
@@ -29,13 +29,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import org.apache.cassandra.utils.concurrent.AsyncPromise;
-import org.apache.cassandra.utils.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,11 +47,14 @@ import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.concurrent.SucceededFuture;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.io.util.DataOutputBufferFixed;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.net.OutboundConnectionInitiator.Result.MessagingSuccess;
 import org.apache.cassandra.tracing.Tracing;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.NoSpamLogger;
+import org.apache.cassandra.utils.concurrent.AsyncPromise;
+import org.apache.cassandra.utils.concurrent.CountDownLatch;
 import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static java.lang.Math.max;
@@ -63,11 +62,18 @@ import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.cassandra.net.InternodeConnectionUtils.isSSLError;
 import static org.apache.cassandra.net.MessagingService.current_version;
-import static org.apache.cassandra.net.OutboundConnectionInitiator.*;
+import static org.apache.cassandra.net.OutboundConnectionInitiator.Result;
+import static org.apache.cassandra.net.OutboundConnectionInitiator.SslFallbackConnectionType;
+import static org.apache.cassandra.net.OutboundConnectionInitiator.initiateMessaging;
 import static org.apache.cassandra.net.OutboundConnections.LARGE_MESSAGE_THRESHOLD;
-import static org.apache.cassandra.net.ResourceLimits.*;
-import static org.apache.cassandra.net.ResourceLimits.Outcome.*;
-import static org.apache.cassandra.net.SocketFactory.*;
+import static org.apache.cassandra.net.ResourceLimits.EndpointAndGlobal;
+import static org.apache.cassandra.net.ResourceLimits.Limit;
+import static org.apache.cassandra.net.ResourceLimits.Outcome;
+import static org.apache.cassandra.net.ResourceLimits.Outcome.INSUFFICIENT_ENDPOINT;
+import static org.apache.cassandra.net.ResourceLimits.Outcome.SUCCESS;
+import static org.apache.cassandra.net.SocketFactory.encryptionConnectionSummary;
+import static org.apache.cassandra.net.SocketFactory.isCausedByConnectionReset;
+import static org.apache.cassandra.net.SocketFactory.isConnectionReset;
 import static org.apache.cassandra.utils.FBUtilities.prettyPrintMemory;
 import static org.apache.cassandra.utils.MonotonicClock.Global.approxTime;
 import static org.apache.cassandra.utils.Throwables.isCausedBy;
@@ -775,13 +781,14 @@ public class OutboundConnection
             int canonicalSize = 0; // number of bytes we must use for our resource accounting
             int sendingBytes = 0;
             int sendingCount = 0;
+            DataOutputBufferFixed out = null;
             try (OutboundMessageQueue.WithLock withLock = queue.lockOrCallback(approxTime.now(), this::execute))
             {
                 if (withLock == null)
                     return false; // we failed to acquire the queue lock, so return; we will be scheduled again when the lock is available
 
                 sending = established.payloadAllocator.allocate(true, maxSendBytes);
-                DataOutputBufferFixed out = new DataOutputBufferFixed(sending.buffer);
+                out = new DataOutputBufferFixed(sending.buffer);
 
                 Message<?> next;
                 while ( null != (next = withLock.peek()) )
@@ -809,7 +816,7 @@ public class OutboundConnection
                             sending.release();
                             sending = null; // set to null to prevent double-release if we fail to allocate our new buffer
                             sending = established.payloadAllocator.allocate(true, messageSize);
-                            //noinspection IOResourceOpenedButNotSafelyClosed
+                            out.close();
                             out = new DataOutputBufferFixed(sending.buffer);
                         }
 
@@ -900,6 +907,8 @@ public class OutboundConnection
             }
             finally
             {
+                FileUtils.closeQuietly(out);
+
                 if (canonicalSize > 0)
                     releaseCapacity(sendingCount, canonicalSize);
 
@@ -1023,6 +1032,10 @@ public class OutboundConnection
 
                 onFailedSerialize(send, established.messagingVersion, out == null ? 0 : (int) out.flushedToNetwork(), t);
                 return tryAgain;
+            }
+            finally
+            {
+                FileUtils.closeQuietly(out);
             }
         }
 

--- a/src/java/org/apache/cassandra/net/SharedDefaultFileRegion.java
+++ b/src/java/org/apache/cassandra/net/SharedDefaultFileRegion.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.netty.channel.DefaultFileRegion;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.RefCounted;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 /**
  * Netty's DefaultFileRegion closes the underlying FileChannel as soon as
@@ -32,6 +34,7 @@ import org.apache.cassandra.utils.concurrent.RefCounted;
  *
  * See {@link AsyncChannelOutputPlus} for its usage.
  */
+@InheritableMustCall("deallocate")
 public class SharedDefaultFileRegion extends DefaultFileRegion
 {
     public static class SharedFileChannel
@@ -41,7 +44,7 @@ public class SharedDefaultFileRegion extends DefaultFileRegion
         final Ref<FileChannel> ref;
         final AtomicInteger refCount = new AtomicInteger(1);
 
-        SharedFileChannel(FileChannel fileChannel)
+        SharedFileChannel(@Owning FileChannel fileChannel)
         {
             this.ref = new Ref<>(fileChannel, new RefCounted.Tidy()
             {
@@ -86,7 +89,7 @@ public class SharedDefaultFileRegion extends DefaultFileRegion
         shared.release();
     }
 
-    public static SharedFileChannel share(FileChannel fileChannel)
+    public static SharedFileChannel share(@Owning FileChannel fileChannel)
     {
         return new SharedFileChannel(fileChannel);
     }

--- a/src/java/org/apache/cassandra/repair/ValidationManager.java
+++ b/src/java/org/apache/cassandra/repair/ValidationManager.java
@@ -98,7 +98,6 @@ public class ValidationManager
      * Performs a readonly "compaction" of all sstables in order to validate complete rows,
      * but without writing the merge result
      */
-    @SuppressWarnings("resource")
     private void doValidation(ColumnFamilyStore cfs, Validator validator) throws IOException, NoSuchRepairSessionException
     {
         // this isn't meant to be race-proof, because it's not -- it won't cause bugs for a CFS to be dropped

--- a/src/java/org/apache/cassandra/security/EncryptionUtils.java
+++ b/src/java/org/apache/cassandra/security/EncryptionUtils.java
@@ -118,7 +118,6 @@ public class EncryptionUtils
         return outputBuffer;
     }
 
-    @SuppressWarnings("resource")
     public static ByteBuffer encrypt(ByteBuffer inputBuffer, ByteBuffer outputBuffer, boolean allowBufferResize, Cipher cipher) throws IOException
     {
         Preconditions.checkNotNull(outputBuffer, "output buffer may not be null");
@@ -173,7 +172,6 @@ public class EncryptionUtils
     }
 
     // path used when decrypting commit log files
-    @SuppressWarnings("resource")
     public static ByteBuffer decrypt(FileDataInput fileDataInput, ByteBuffer outputBuffer, boolean allowBufferResize, Cipher cipher) throws IOException
     {
         try (ReadableByteChannel channel = new DataInputReadChannel(fileDataInput))

--- a/src/java/org/apache/cassandra/security/EncryptionUtils.java
+++ b/src/java/org/apache/cassandra/security/EncryptionUtils.java
@@ -34,6 +34,9 @@ import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.util.ChannelProxy;
 import org.apache.cassandra.io.util.FileDataInput;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.checkerframework.checker.mustcall.qual.NotOwning;
+
+import static org.apache.cassandra.utils.SuppressionConstants.CONTRACTS_CONDITIONAL_POSTCONDITION;
 
 /**
  * Encryption and decryption functions specific to the commit log.
@@ -119,7 +122,10 @@ public class EncryptionUtils
     public static ByteBuffer encrypt(ByteBuffer inputBuffer, ByteBuffer outputBuffer, boolean allowBufferResize, Cipher cipher) throws IOException
     {
         Preconditions.checkNotNull(outputBuffer, "output buffer may not be null");
-        return encryptAndWrite(inputBuffer, new ChannelAdapter(outputBuffer), allowBufferResize, cipher);
+        try (WritableByteChannel channel = new ChannelAdapter(outputBuffer))
+        {
+            return encryptAndWrite(inputBuffer, channel, allowBufferResize, cipher);
+        }
     }
 
     /**
@@ -170,7 +176,10 @@ public class EncryptionUtils
     @SuppressWarnings("resource")
     public static ByteBuffer decrypt(FileDataInput fileDataInput, ByteBuffer outputBuffer, boolean allowBufferResize, Cipher cipher) throws IOException
     {
-        return decrypt(new DataInputReadChannel(fileDataInput), outputBuffer, allowBufferResize, cipher);
+        try (ReadableByteChannel channel = new DataInputReadChannel(fileDataInput))
+        {
+            return decrypt(channel, outputBuffer, allowBufferResize, cipher);
+        }
     }
 
     /**
@@ -261,11 +270,12 @@ public class EncryptionUtils
             return readLength;
         }
 
+        @SuppressWarnings(CONTRACTS_CONDITIONAL_POSTCONDITION)
         public boolean isOpen()
         {
             try
             {
-                return fileDataInput.isEOF();
+                return fileDataInput.isEOF(); // TODO is it really opened when it is EOF?
             }
             catch (IOException e)
             {
@@ -284,7 +294,7 @@ public class EncryptionUtils
         private final ChannelProxy channelProxy;
         private volatile long currentPosition;
 
-        public ChannelProxyReadChannel(ChannelProxy channelProxy, long currentPosition)
+        public ChannelProxyReadChannel(@NotOwning ChannelProxy channelProxy, long currentPosition)
         {
             this.channelProxy = channelProxy;
             this.currentPosition = currentPosition;
@@ -303,9 +313,10 @@ public class EncryptionUtils
             return currentPosition;
         }
 
+        @SuppressWarnings(CONTRACTS_CONDITIONAL_POSTCONDITION)
         public boolean isOpen()
         {
-            return channelProxy.isCleanedUp();
+            return channelProxy.isCleanedUp(); // TODO how can it be opened when it is cleaned up?
         }
 
         public void close()

--- a/src/java/org/apache/cassandra/service/ClientWarn.java
+++ b/src/java/org/apache/cassandra/service/ClientWarn.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.apache.cassandra.concurrent.ExecutorLocals;
 import org.apache.cassandra.utils.FBUtilities;
 
-@SuppressWarnings("resource")
 public class ClientWarn extends ExecutorLocals.Impl
 {
     private static final String TRUNCATED = " [truncated]";

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1985,7 +1985,6 @@ public class StorageProxy implements StorageProxyMBean
         return result;
     }
 
-    @SuppressWarnings("resource")
     private static PartitionIterator readRegular(SinglePartitionReadCommand.Group group, ConsistencyLevel consistencyLevel, long queryStartNanoTime)
     throws UnavailableException, ReadFailureException, ReadTimeoutException
     {

--- a/src/java/org/apache/cassandra/service/pager/MultiPartitionPager.java
+++ b/src/java/org/apache/cassandra/service/pager/MultiPartitionPager.java
@@ -149,14 +149,12 @@ public class MultiPartitionPager<T extends SinglePartitionReadQuery> implements 
         throw new AssertionError("Shouldn't be called on an exhausted pager");
     }
 
-    @SuppressWarnings("resource") // iter closed via countingIter
     public PartitionIterator fetchPage(int pageSize, ConsistencyLevel consistency, ClientState clientState, long queryStartNanoTime) throws RequestValidationException, RequestExecutionException
     {
         int toQuery = Math.min(remaining, pageSize);
         return new PagersIterator(toQuery, consistency, clientState, null, queryStartNanoTime);
     }
 
-    @SuppressWarnings("resource") // iter closed via countingIter
     public PartitionIterator fetchPageInternal(int pageSize, ReadExecutionController executionController) throws RequestValidationException, RequestExecutionException
     {
         int toQuery = Math.min(remaining, pageSize);

--- a/src/java/org/apache/cassandra/service/pager/PagingState.java
+++ b/src/java/org/apache/cassandra/service/pager/PagingState.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.transport.ProtocolVersion;
 import static org.apache.cassandra.db.TypeSizes.sizeof;
 import static org.apache.cassandra.db.TypeSizes.sizeofUnsignedVInt;
 import static org.apache.cassandra.utils.ByteBufferUtil.*;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 import static org.apache.cassandra.utils.vint.VIntCoding.computeUnsignedVIntSize;
 import static org.apache.cassandra.utils.vint.VIntCoding.getUnsignedVInt;
 

--- a/src/java/org/apache/cassandra/service/pager/PagingState.java
+++ b/src/java/org/apache/cassandra/service/pager/PagingState.java
@@ -41,7 +41,6 @@ import org.apache.cassandra.transport.ProtocolVersion;
 import static org.apache.cassandra.db.TypeSizes.sizeof;
 import static org.apache.cassandra.db.TypeSizes.sizeofUnsignedVInt;
 import static org.apache.cassandra.utils.ByteBufferUtil.*;
-import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 import static org.apache.cassandra.utils.vint.VIntCoding.computeUnsignedVIntSize;
 import static org.apache.cassandra.utils.vint.VIntCoding.getUnsignedVInt;
 
@@ -124,7 +123,7 @@ public class PagingState
      * Modern serde (> VERSION_3)
      */
 
-    @SuppressWarnings({ "resource", "RedundantSuppression" })
+
     private ByteBuffer modernSerialize() throws IOException
     {
         DataOutputBuffer out = new DataOutputBufferFixed(modernSerializedSize());
@@ -197,7 +196,7 @@ public class PagingState
         return (int)value;
     }
 
-    @SuppressWarnings({ "resource", "RedundantSuppression" })
+
     private static PagingState modernDeserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) throws IOException
     {
         if (protocolVersion.isSmallerThan(ProtocolVersion.V4))
@@ -232,7 +231,7 @@ public class PagingState
      */
 
     @VisibleForTesting
-    @SuppressWarnings({ "resource", "RedundantSuppression" })
+
     ByteBuffer legacySerialize(boolean withRemainingInPartition) throws IOException
     {
         DataOutputBuffer out = new DataOutputBufferFixed(legacySerializedSize(withRemainingInPartition));
@@ -283,7 +282,7 @@ public class PagingState
         return false;
     }
 
-    @SuppressWarnings({ "resource", "RedundantSuppression" })
+
     private static PagingState legacyDeserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) throws IOException
     {
         if (protocolVersion.isGreaterThan(ProtocolVersion.V3))

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -951,7 +951,6 @@ public class Paxos
      * @return the Paxos ballot promised by the replicas if no in-progress requests were seen and a quorum of
      * nodes have seen the mostRecentCommit.  Otherwise, return null.
      */
-    @SuppressWarnings("resource")
     private static BeginResult begin(long deadline,
                                      SinglePartitionReadCommand query,
                                      ConsistencyLevel consistencyForConsensus,

--- a/src/java/org/apache/cassandra/service/paxos/PaxosState.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosState.java
@@ -59,7 +59,6 @@ import static org.apache.cassandra.service.paxos.Commit.*;
 import static org.apache.cassandra.service.paxos.PaxosState.MaybePromise.Outcome.*;
 import static org.apache.cassandra.service.paxos.Commit.Accepted.latestAccepted;
 import static org.apache.cassandra.service.paxos.Commit.Committed.latestCommitted;
-import static org.apache.cassandra.service.paxos.Commit.isAfter;
 
 /**
  * We save to memory the result of each operation before persisting to disk, however each operation that performs
@@ -812,7 +811,6 @@ public class PaxosState implements PaxosOperationLock
         ballotTracker().truncate();
     }
 
-    @SuppressWarnings("resource")
     public static Snapshot unsafeGetIfPresent(DecoratedKey partitionKey, TableMetadata metadata)
     {
         Key key = new Key(partitionKey, metadata);

--- a/src/java/org/apache/cassandra/service/paxos/cleanup/PaxosCleanupLocalCoordinator.java
+++ b/src/java/org/apache/cassandra/service/paxos/cleanup/PaxosCleanupLocalCoordinator.java
@@ -91,14 +91,12 @@ public class PaxosCleanupLocalCoordinator extends AsyncFuture<PaxosCleanupRespon
         scheduleKeyRepairsOrFinish();
     }
 
-    @SuppressWarnings("resource")
     public static PaxosCleanupLocalCoordinator create(PaxosCleanupRequest request)
     {
         CloseableIterator<UncommittedPaxosKey> iterator = PaxosState.uncommittedTracker().uncommittedKeyIterator(request.tableId, request.ranges);
         return new PaxosCleanupLocalCoordinator(request.session, request.tableId, request.ranges, iterator);
     }
 
-    @SuppressWarnings("resource")
     public static PaxosCleanupLocalCoordinator createForAutoRepair(TableId tableId, Collection<Range<Token>> ranges)
     {
         CloseableIterator<UncommittedPaxosKey> iterator = PaxosState.uncommittedTracker().uncommittedKeyIterator(tableId, ranges);

--- a/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosStateTracker.java
+++ b/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosStateTracker.java
@@ -160,7 +160,6 @@ public class PaxosStateTracker
         return create(dataDirectories.getAllDirectories().stream().map(d -> d.location).toArray(File[]::new));
     }
 
-    @SuppressWarnings("resource")
     private void rebuildUncommittedData() throws IOException
     {
         logger.info("Beginning uncommitted paxos data rebuild. Set -D{}=true and restart to skip", SKIP_PAXOS_STATE_REBUILD.getKey());

--- a/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosUncommittedTracker.java
+++ b/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosUncommittedTracker.java
@@ -21,9 +21,7 @@ package org.apache.cassandra.service.paxos.uncommitted;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -31,7 +29,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +38,14 @@ import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableId;
-import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.service.paxos.cleanup.PaxosTableRepairs;
 import org.apache.cassandra.utils.CloseableIterator;
+import org.apache.cassandra.utils.ResourcesMap;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.AUTO_REPAIR_FREQUENCY_SECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_PAXOS_AUTO_REPAIRS;
@@ -157,7 +155,7 @@ public class PaxosUncommittedTracker
         if (!stateFlushEnabled || !started)
             return;
 
-        Map<TableId, UncommittedTableData.FlushWriter> flushWriters = new HashMap<>();
+        ResourcesMap<TableId, UncommittedTableData.FlushWriter> flushWriters = new ResourcesMap<>();
         try (CloseableIterator<PaxosKeyState> iterator = updateSupplier.flushIterator(paxos))
         {
             while (iterator.hasNext())
@@ -171,16 +169,17 @@ public class PaxosUncommittedTracker
                 }
                 writer.append(next);
             }
+            flushWriters.removeAll(null, (acc, flushWriter) -> {
+                flushWriter.finish();
+                return null;
+            });
         }
         catch (Throwable t)
         {
-            for (UncommittedTableData.FlushWriter writer : flushWriters.values())
-                t = writer.abort(t);
+            flushWriters.removeAll(t, (acc, flushWriter) -> flushWriter.abort(acc));
             throw new IOException(t);
         }
 
-        for (UncommittedTableData.FlushWriter writer : flushWriters.values())
-            writer.finish();
     }
 
     @VisibleForTesting
@@ -242,7 +241,7 @@ public class PaxosUncommittedTracker
         Preconditions.checkState(!started);
         truncate();
 
-        Map<TableId, UncommittedTableData.FlushWriter> flushWriters = new HashMap<>();
+        ResourcesMap<TableId, UncommittedTableData.FlushWriter> flushWriters = new ResourcesMap<>();
         try
         {
             while (iterator.hasNext())
@@ -256,13 +255,14 @@ public class PaxosUncommittedTracker
                 }
                 writer.append(next);
             }
-            for (UncommittedTableData.FlushWriter writer : flushWriters.values())
-                writer.finish();
+            flushWriters.removeAll(null, (acc, flushWriter) -> {
+                flushWriter.finish();
+                return null;
+            });
         }
         catch (Throwable t)
         {
-            for (UncommittedTableData.FlushWriter writer : flushWriters.values())
-                t = writer.abort(t);
+            flushWriters.removeAll(t, (acc, flushWriter) -> flushWriter.abort(acc));
             throw new IOException(t);
         }
 

--- a/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosUncommittedTracker.java
+++ b/src/java/org/apache/cassandra/service/paxos/uncommitted/PaxosUncommittedTracker.java
@@ -188,7 +188,6 @@ public class PaxosUncommittedTracker
         return tableStates.get(tableId);
     }
 
-    @SuppressWarnings("resource")
     public CloseableIterator<UncommittedPaxosKey> uncommittedKeyIterator(TableId tableId, Collection<Range<Token>> ranges)
     {
         ranges = (ranges == null || ranges.isEmpty()) ? Collections.singleton(FULL_RANGE) : Range.normalize(ranges);

--- a/src/java/org/apache/cassandra/service/paxos/uncommitted/UncommittedTableData.java
+++ b/src/java/org/apache/cassandra/service/paxos/uncommitted/UncommittedTableData.java
@@ -249,7 +249,6 @@ public class UncommittedTableData
         }
     }
 
-    @SuppressWarnings("resource")
     private static CloseableIterator<PaxosKeyState> merge(Collection<UncommittedDataFile> files, Collection<Range<Token>> ranges)
     {
         List<CloseableIterator<PaxosKeyState>> iterators = new ArrayList<>(files.size());

--- a/src/java/org/apache/cassandra/service/reads/DataResolver.java
+++ b/src/java/org/apache/cassandra/service/reads/DataResolver.java
@@ -220,7 +220,6 @@ public class DataResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<
         return resolveInternal(context, listener, responseProvider, preCountFilter);
     }
 
-    @SuppressWarnings("resource")
     private PartitionIterator resolveWithReplicaFilteringProtection(E replicas, RepairedDataTracker repairedDataTracker)
     {
         // Protecting against inconsistent replica filtering (some replica returning a row that is outdated but that
@@ -265,7 +264,6 @@ public class DataResolver<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<
         return PartitionIterators.doOnClose(completedPartitions, firstPhasePartitions::close);
     }
 
-    @SuppressWarnings("resource")
     private PartitionIterator resolveInternal(ResolveContext context,
                                               UnfilteredPartitionIterators.MergeListener mergeListener,
                                               ResponseProvider responseProvider,

--- a/src/java/org/apache/cassandra/service/reads/ShortReadProtection.java
+++ b/src/java/org/apache/cassandra/service/reads/ShortReadProtection.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.locator.Replica;
  */
 public class ShortReadProtection
 {
-    @SuppressWarnings("resource")
     public static UnfilteredPartitionIterator extend(Replica source,
                                                      Runnable preFetchCallback,
                                                      UnfilteredPartitionIterator partitions,

--- a/src/java/org/apache/cassandra/service/reads/range/RangeCommandIterator.java
+++ b/src/java/org/apache/cassandra/service/reads/range/RangeCommandIterator.java
@@ -231,7 +231,6 @@ public class RangeCommandIterator extends AbstractIterator<RowIterator> implemen
             {
                 ReplicaPlan.ForRangeRead replicaPlan = replicaPlans.next();
 
-                @SuppressWarnings("resource") // response will be closed by concatAndBlockOnRepair, or in the catch block below
                 SingleRangeResponse response = query(replicaPlan, i == 0);
                 concurrentQueries.add(response);
                 readRepairs.add(response.getReadRepair());

--- a/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
+++ b/src/java/org/apache/cassandra/service/reads/range/RangeCommands.java
@@ -52,7 +52,6 @@ public class RangeCommands
      */
     private static final int MAX_CONCURRENT_RANGE_REQUESTS = Math.max(1, CassandraRelevantProperties.MAX_CONCURRENT_RANGE_REQUESTS.getInt(FBUtilities.getAvailableProcessors() * 10));
 
-    @SuppressWarnings("resource") // created iterators will be closed in CQL layer through the chain of transformations
     public static PartitionIterator partitions(PartitionRangeReadCommand command,
                                                ConsistencyLevel consistencyLevel,
                                                long queryStartNanoTime)
@@ -66,7 +65,6 @@ public class RangeCommands
     }
 
     @VisibleForTesting
-    @SuppressWarnings("resource") // created iterators will be closed in CQL layer through the chain of transformations
     static RangeCommandIterator rangeCommandIterator(PartitionRangeReadCommand command,
                                                      ConsistencyLevel consistencyLevel,
                                                      long queryStartNanoTime)

--- a/src/java/org/apache/cassandra/streaming/StreamDeserializingTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamDeserializingTask.java
@@ -54,7 +54,6 @@ public class StreamDeserializingTask implements Runnable
     @Override
     public void run()
     {
-        @SuppressWarnings("resource") // closed in finally
         StreamingDataInputPlus input = channel.in();
         try
         {

--- a/src/java/org/apache/cassandra/streaming/StreamDeserializingTask.java
+++ b/src/java/org/apache/cassandra/streaming/StreamDeserializingTask.java
@@ -26,8 +26,10 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.streaming.messages.KeepAliveMessage;
 import org.apache.cassandra.streaming.messages.StreamMessage;
 import org.apache.cassandra.utils.JVMStabilityInspector;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.streaming.StreamSession.createLogTag;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 /**
  * The task that performs the actual deserialization.
@@ -36,12 +38,13 @@ public class StreamDeserializingTask implements Runnable
 {
     private static final Logger logger = LoggerFactory.getLogger(StreamDeserializingTask.class);
 
-    private final StreamingChannel channel;
+    @SuppressWarnings(RESOURCE) // channel is closed in run method
+    private final @Owning StreamingChannel channel;
     private final int messagingVersion;
     @VisibleForTesting
     protected StreamSession session;
 
-    public StreamDeserializingTask(StreamSession session, StreamingChannel channel, int messagingVersion)
+    public StreamDeserializingTask(StreamSession session, @Owning StreamingChannel channel, int messagingVersion)
     {
         this.session = session;
         this.channel = channel;

--- a/src/java/org/apache/cassandra/streaming/StreamingDataOutputPlus.java
+++ b/src/java/org/apache/cassandra/streaming/StreamingDataOutputPlus.java
@@ -26,6 +26,7 @@ import java.nio.channels.FileChannel;
 import io.netty.channel.FileRegion;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.utils.Shared;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.utils.Shared.Recursive.INTERFACES;
 import static org.apache.cassandra.utils.Shared.Scope.SIMULATION;
@@ -81,7 +82,7 @@ public interface StreamingDataOutputPlus extends DataOutputPlus, Closeable
      * WARNING: this method blocks only for permission to write to the netty channel; it exits before
      * the {@link FileRegion}(zero-copy) or {@link ByteBuffer}(ssl) is flushed to the network.
      */
-    long writeFileToChannel(FileChannel file, RateLimiter limiter) throws IOException;
+    long writeFileToChannel(@Owning FileChannel file, RateLimiter limiter) throws IOException;
 
     default void flush() throws IOException {}
 }

--- a/src/java/org/apache/cassandra/streaming/StreamingDataOutputPlusFixed.java
+++ b/src/java/org/apache/cassandra/streaming/StreamingDataOutputPlusFixed.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
 import org.apache.cassandra.io.util.DataOutputBufferFixed;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class StreamingDataOutputPlusFixed extends DataOutputBufferFixed implements StreamingDataOutputPlus
 {
@@ -40,11 +41,18 @@ public class StreamingDataOutputPlusFixed extends DataOutputBufferFixed implemen
     }
 
     @Override
-    public long writeFileToChannel(FileChannel file, RateLimiter limiter) throws IOException
+    public long writeFileToChannel(@Owning FileChannel file, RateLimiter limiter) throws IOException
     {
-        long count = 0;
-        long tmp;
-        while (0 <= (tmp = file.read(buffer))) count += tmp;
-        return count;
+        try
+        {
+            long count = 0;
+            long tmp;
+            while (0 <= (tmp = file.read(buffer))) count += tmp;
+            return count;
+        }
+        finally
+        {
+            file.close();
+        }
     }
 }

--- a/src/java/org/apache/cassandra/streaming/async/NettyStreamingChannel.java
+++ b/src/java/org/apache/cassandra/streaming/async/NettyStreamingChannel.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntFunction;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +46,14 @@ import org.apache.cassandra.streaming.StreamingDataOutputPlus;
 import org.apache.cassandra.streaming.StreamingDataOutputPlusFixed;
 import org.apache.cassandra.utils.concurrent.Future;
 import org.apache.cassandra.utils.concurrent.ImmediateFuture;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static io.netty.util.AttributeKey.valueOf;
 import static java.lang.Boolean.FALSE;
 
+@InheritableMustCall("close")
 public class NettyStreamingChannel extends ChannelInboundHandlerAdapter implements StreamingChannel
 {
     private static final Logger logger = LoggerFactory.getLogger(NettyStreamingChannel.class);
@@ -71,7 +74,7 @@ public class NettyStreamingChannel extends ChannelInboundHandlerAdapter implemen
      * but the producing side calls {@link AsyncStreamingInputPlus#requestClosure()} to notify the input that it should close.
      */
     @VisibleForTesting
-    final AsyncStreamingInputPlus in;
+    final @Owning AsyncStreamingInputPlus in;
 
     private volatile boolean closed;
 
@@ -191,6 +194,7 @@ public class NettyStreamingChannel extends ChannelInboundHandlerAdapter implemen
     }
 
     @Override
+    @EnsuresCalledMethods(value = "this.in", methods = "close")
     public synchronized io.netty.util.concurrent.Future<?> close()
     {
         if (closed)

--- a/src/java/org/apache/cassandra/streaming/messages/ReceivedMessage.java
+++ b/src/java/org/apache/cassandra/streaming/messages/ReceivedMessage.java
@@ -28,7 +28,6 @@ public class ReceivedMessage extends StreamMessage
 {
     public static Serializer<ReceivedMessage> serializer = new Serializer<ReceivedMessage>()
     {
-        @SuppressWarnings("resource") // Not closing constructed DataInputPlus's as the channel needs to remain open.
         public ReceivedMessage deserialize(DataInputPlus input, int version) throws IOException
         {
             return new ReceivedMessage(TableId.deserialize(input), input.readInt());

--- a/src/java/org/apache/cassandra/tools/AuditLogViewer.java
+++ b/src/java/org/apache/cassandra/tools/AuditLogViewer.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.io.util.File;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
@@ -32,15 +31,18 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import net.openhft.chronicle.core.io.IORuntimeException;
-import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.RollCycles;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
+import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 import net.openhft.chronicle.threads.Pauser;
 import net.openhft.chronicle.wire.ReadMarshallable;
 import net.openhft.chronicle.wire.WireIn;
 import org.apache.cassandra.audit.BinAuditLogger;
+import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.utils.binlog.BinLog;
+
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 /**
  * Tool to view the contenst of AuditLog files in human readable format. Default implementation for AuditLog files
@@ -70,6 +72,7 @@ public class AuditLogViewer
         }
     }
 
+    @SuppressWarnings(RESOURCE) // TODO chronicle queue is not closed
     static void dump(List<String> pathList, String rollCycle, boolean follow, boolean ignoreUnsupported, Consumer<String> displayFun)
     {
         //Backoff strategy for spinning on the queue, not aggressive at all as this doesn't need to be low latency

--- a/src/java/org/apache/cassandra/tools/JMXTool.java
+++ b/src/java/org/apache/cassandra/tools/JMXTool.java
@@ -133,7 +133,6 @@ public class JMXTool
             {
                 void dump(OutputStream output, Map<String, Info> map)
                 {
-                    @SuppressWarnings("resource")
                     // output should be released by caller
                     PrintStream out = toPrintStream(output);
                     for (Map.Entry<String, Info> e : map.entrySet())

--- a/src/java/org/apache/cassandra/tools/JMXTool.java
+++ b/src/java/org/apache/cassandra/tools/JMXTool.java
@@ -71,6 +71,7 @@ import io.airlift.airline.Option;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.utils.JsonUtils;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -171,7 +172,7 @@ public class JMXTool
                 }
             };
 
-            private static PrintStream toPrintStream(OutputStream output)
+            private static @MustCallAlias PrintStream toPrintStream(OutputStream output)
             {
                 try
                 {

--- a/src/java/org/apache/cassandra/tools/JsonTransformer.java
+++ b/src/java/org/apache/cassandra/tools/JsonTransformer.java
@@ -63,6 +63,7 @@ import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.ByteBufferUtil;
 
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 public final class JsonTransformer
 {
@@ -85,6 +86,7 @@ public final class JsonTransformer
 
     private long currentPosition = 0;
 
+    @SuppressWarnings(RESOURCE) // setPrettyPrinter returns a JsonGenerator (alias)
     private JsonTransformer(JsonGenerator json, ISSTableScanner currentScanner, boolean rawTime, TableMetadata metadata, boolean isJsonLines)
     {
         this.json = json;

--- a/src/java/org/apache/cassandra/tools/SSTableExport.java
+++ b/src/java/org/apache/cassandra/tools/SSTableExport.java
@@ -107,7 +107,6 @@ public class SSTableExport
      * @throws ConfigurationException
      *             on configuration failure (wrong params given)
      */
-    @SuppressWarnings("resource")
     public static void main(String[] args) throws ConfigurationException
     {
         CommandLineParser parser = new PosixParser();

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -232,7 +232,6 @@ public abstract class Tracing extends ExecutorLocals.Impl
 
     public void set(TraceState tls)
     {
-        @SuppressWarnings("resource")
         ExecutorLocals current = ExecutorLocals.current();
         ExecutorLocals.Impl.set(tls, current.clientWarnState);
     }

--- a/src/java/org/apache/cassandra/tracing/Tracing.java
+++ b/src/java/org/apache/cassandra/tracing/Tracing.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.net.ParamType;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.TimeUUID;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CUSTOM_TRACING_CLASS;
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
@@ -106,7 +107,7 @@ public abstract class Tracing extends ExecutorLocals.Impl
 
     protected final ConcurrentMap<TimeUUID, TraceState> sessions = new ConcurrentHashMap<>();
 
-    public static final Tracing instance;
+    public static final @Owning Tracing instance;
 
     static
     {
@@ -126,7 +127,9 @@ public abstract class Tracing extends ExecutorLocals.Impl
                 logger.error(String.format("Cannot use class %s for tracing, ignoring by defaulting to normal tracing", customTracingClass), e);
             }
         }
-        instance = null != tracing ? tracing : new TracingImpl();
+        if (tracing == null)
+            tracing = new TracingImpl();
+        instance = tracing;
     }
 
     public TimeUUID getSessionId()

--- a/src/java/org/apache/cassandra/transport/Client.java
+++ b/src/java/org/apache/cassandra/transport/Client.java
@@ -22,7 +22,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import com.google.common.base.Splitter;
 
@@ -33,7 +38,13 @@ import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
-import org.apache.cassandra.transport.messages.*;
+import org.apache.cassandra.transport.messages.AuthResponse;
+import org.apache.cassandra.transport.messages.ExecuteMessage;
+import org.apache.cassandra.transport.messages.OptionsMessage;
+import org.apache.cassandra.transport.messages.PrepareMessage;
+import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.transport.messages.RegisterMessage;
+import org.apache.cassandra.transport.messages.StartupMessage;
 import org.apache.cassandra.utils.Hex;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MD5Digest;
@@ -260,7 +271,10 @@ public class Client extends SimpleClient
         EncryptionOptions encryptionOptions = new EncryptionOptions().applyConfig();
         System.out.println("CQL binary protocol console " + host + "@" + port + " using native protocol version " + version);
 
-        new Client(host, port, version, encryptionOptions).run();
+        try (Client client = new Client(host, port, version, encryptionOptions))
+        {
+            client.run();
+        }
         System.exit(0);
     }
 }

--- a/src/java/org/apache/cassandra/triggers/TriggerExecutor.java
+++ b/src/java/org/apache/cassandra/triggers/TriggerExecutor.java
@@ -23,8 +23,8 @@ import java.util.*;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.cassandra.cql3.QueryProcessor;
@@ -38,6 +38,8 @@ import org.apache.cassandra.schema.TriggerMetadata;
 import org.apache.cassandra.schema.Triggers;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
+
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 public class TriggerExecutor
 {
@@ -56,6 +58,7 @@ public class TriggerExecutor
      * Reload the triggers which is already loaded, Invoking this will update
      * the class loader so new jars can be loaded.
      */
+    @SuppressWarnings(RESOURCE) // TODO should we close customClassLoader?
     public void reloadClasses()
     {
         File triggerDirectory = FBUtilities.cassandraTriggerDir();

--- a/src/java/org/apache/cassandra/utils/BloomFilter.java
+++ b/src/java/org/apache/cassandra/utils/BloomFilter.java
@@ -27,6 +27,7 @@ import org.apache.cassandra.io.util.DataOutputStreamPlus;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.WrappedSharedCloseable;
 import org.apache.cassandra.utils.obs.IBitSet;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class BloomFilter extends WrappedSharedCloseable implements IFilter
 {
@@ -42,7 +43,7 @@ public class BloomFilter extends WrappedSharedCloseable implements IFilter
     public final IBitSet bitset;
     public final int hashCount;
 
-    BloomFilter(int hashCount, IBitSet bitset)
+    BloomFilter(int hashCount, @Owning IBitSet bitset)
     {
         super(bitset);
         this.hashCount = hashCount;

--- a/src/java/org/apache/cassandra/utils/BloomFilterSerializer.java
+++ b/src/java/org/apache/cassandra/utils/BloomFilterSerializer.java
@@ -71,7 +71,6 @@ public final class BloomFilterSerializer implements IGenericSerializer<BloomFilt
     }
 
     @Override
-    @SuppressWarnings("resource")
     public @Owning BloomFilter deserialize(DataInputStreamPlus in) throws IOException
     {
         int hashes = in.readInt();

--- a/src/java/org/apache/cassandra/utils/BloomFilterSerializer.java
+++ b/src/java/org/apache/cassandra/utils/BloomFilterSerializer.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.io.util.DataInputPlus.DataInputStreamPlus;
 import org.apache.cassandra.io.util.DataOutputStreamPlus;
 import org.apache.cassandra.utils.obs.IBitSet;
 import org.apache.cassandra.utils.obs.OffHeapBitSet;
+import org.checkerframework.checker.mustcall.qual.Owning;
 
 public final class BloomFilterSerializer implements IGenericSerializer<BloomFilter, DataInputStreamPlus, DataOutputStreamPlus>
 {
@@ -71,7 +72,7 @@ public final class BloomFilterSerializer implements IGenericSerializer<BloomFilt
 
     @Override
     @SuppressWarnings("resource")
-    public BloomFilter deserialize(DataInputStreamPlus in) throws IOException
+    public @Owning BloomFilter deserialize(DataInputStreamPlus in) throws IOException
     {
         int hashes = in.readInt();
         IBitSet bs = OffHeapBitSet.deserialize(in, oldFormat);

--- a/src/java/org/apache/cassandra/utils/FilterFactory.java
+++ b/src/java/org/apache/cassandra/utils/FilterFactory.java
@@ -67,7 +67,6 @@ public class FilterFactory
         return createFilter(spec.K, numElements, spec.bucketsPerElement);
     }
 
-    @SuppressWarnings("resource")
     private static IFilter createFilter(int hash, long numElements, int bucketsPer)
     {
         long numBits = (numElements * bucketsPer) + BITSET_EXCESS;

--- a/src/java/org/apache/cassandra/utils/JMXServerUtils.java
+++ b/src/java/org/apache/cassandra/utils/JMXServerUtils.java
@@ -84,7 +84,6 @@ public class JMXServerUtils
      * Creates a server programmatically. This allows us to set parameters which normally are
      * inaccessable.
      */
-    @SuppressWarnings("resource")
     @VisibleForTesting
     public static JMXConnectorServer createJMXServer(int port, String hostname, boolean local)
     throws IOException
@@ -171,7 +170,6 @@ public class JMXServerUtils
         return new RMIConnectorServer(serviceURL, env, server, ManagementFactory.getPlatformMBeanServer());
     }
 
-    @SuppressWarnings("resource")
     public static JMXConnectorServer createJMXServer(int port, boolean local) throws IOException
     {
         return createJMXServer(port, null, local);

--- a/src/java/org/apache/cassandra/utils/MergeIterator.java
+++ b/src/java/org/apache/cassandra/utils/MergeIterator.java
@@ -31,7 +31,6 @@ public abstract class MergeIterator<In,Out> extends AbstractIterator<Out> implem
         this.reducer = reducer;
     }
 
-    @SuppressWarnings("resource")
     public static <In, Out> MergeIterator<In, Out> get(List<? extends Iterator<In>> sources,
                                                        Comparator<? super In> comparator,
                                                        Reducer<In, Out> reducer)

--- a/src/java/org/apache/cassandra/utils/NativeLibraryDarwin.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryDarwin.java
@@ -27,6 +27,8 @@ import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
 /**
  * A {@code NativeLibraryWrapper} implementation for Darwin/Mac.
  * <p>
@@ -43,6 +45,7 @@ import com.sun.jna.Pointer;
  * @see NativeLibrary
  */
 @Shared
+@SuppressWarnings(RESOURCE)
 public class NativeLibraryDarwin implements NativeLibraryWrapper
 {
     private static final Logger logger = LoggerFactory.getLogger(NativeLibraryDarwin.class);

--- a/src/java/org/apache/cassandra/utils/NativeLibraryLinux.java
+++ b/src/java/org/apache/cassandra/utils/NativeLibraryLinux.java
@@ -27,6 +27,8 @@ import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
+
 /**
  * A {@code NativeLibraryWrapper} implementation for Linux.
  * <p>
@@ -43,6 +45,7 @@ import com.sun.jna.Pointer;
  * @see NativeLibrary
  */
 @Shared
+@SuppressWarnings(RESOURCE)
 public class NativeLibraryLinux implements NativeLibraryWrapper
 {
     private static boolean available;

--- a/src/java/org/apache/cassandra/utils/ResourcesMap.java
+++ b/src/java/org/apache/cassandra/utils/ResourcesMap.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import org.checkerframework.checker.mustcall.qual.CreatesMustCallFor;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.NotOwning;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+@InheritableMustCall({ "removeAll" })
+public class ResourcesMap<K, V>
+{
+    private final Map<K, V> map;
+
+    public ResourcesMap()
+    {
+        this.map = new HashMap<>();
+    }
+
+    public @NotOwning V get(K key)
+    {
+        return map.get(key);
+    }
+
+    public @Owning V remove(K key)
+    {
+        return map.remove(key);
+    }
+
+    @CreatesMustCallFor
+    public @NotOwning V put(K key, @Owning V value)
+    {
+        return map.put(key, value);
+    }
+
+    public void forEach(Consumer<@MustCallAlias V> consumer)
+    {
+        map.values().forEach(consumer);
+    }
+
+    public <T> void removeAll(T initial, OwningBiFunction<T, V> consumer)
+    {
+        Iterator<V> iterator = map.values().iterator();
+        T acc = initial;
+        while (iterator.hasNext())
+        {
+            V value = iterator.next();
+            try
+            {
+                iterator.remove();
+            }
+            finally
+            {
+                acc = consumer.apply(acc, value);
+            }
+        }
+    }
+
+    public <T> void removeAll(OwningConsumer<V> consumer)
+    {
+        Iterator<V> iterator = map.values().iterator();
+        while (iterator.hasNext())
+        {
+            V value = iterator.next();
+            try
+            {
+                iterator.remove();
+            }
+            finally
+            {
+                consumer.accept(value);
+            }
+        }
+    }
+
+    public interface OwningConsumer<V> extends Consumer<V>
+    {
+        @Override
+        void accept(@Owning V v);
+    }
+
+    public interface OwningBiFunction<T, V> extends BiFunction<T, V, T>
+    {
+        @Override
+        T apply(T t, @Owning V v);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/SuppressionConstants.java
+++ b/src/java/org/apache/cassandra/utils/SuppressionConstants.java
@@ -15,37 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.cassandra.io.util;
 
-import java.io.IOException;
-import java.io.OutputStream;
+package org.apache.cassandra.utils;
 
-import org.checkerframework.checker.mustcall.qual.MustCallAlias;
-import org.checkerframework.checker.mustcall.qual.NotOwning;
-
-/**
- * This class provides a way to stream the writes into the {@link Memory}
- */
-public class MemoryOutputStream extends OutputStream
+public class SuppressionConstants
 {
-
-    private final Memory mem;
-    private long position = 0;
-
-    public @MustCallAlias MemoryOutputStream(@NotOwning Memory mem)
-    {
-        this.mem = mem;
-    }
-
-    public void write(int b)
-    {
-        mem.setByte(position++, (byte) b);
-    }
-
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException
-    {
-        mem.setBytes(position, b, off, len);
-        position += len;
-    }
+    public static final String RESOURCE = "required.method.not.called";
+    public static final String CONTRACTS_CONDITIONAL_POSTCONDITION = "contracts.conditional.postcondition";
+    public static final String ENSUREVARARGS_UNVERIFIED = "ensuresvarargs.unverified";
+    public static final String MISSING_CREATES_MUSTCALL_FOR = "missing.creates.mustcall.for";
 }

--- a/src/java/org/apache/cassandra/utils/Throwables.java
+++ b/src/java/org/apache/cassandra/utils/Throwables.java
@@ -38,6 +38,9 @@ import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsVarArgs;
+
+import static org.apache.cassandra.utils.SuppressionConstants.ENSUREVARARGS_UNVERIFIED;
 
 public final class Throwables
 {
@@ -158,6 +161,8 @@ public final class Throwables
     }
 
     @SafeVarargs
+    @EnsuresCalledMethodsVarArgs("perform")
+    @SuppressWarnings(ENSUREVARARGS_UNVERIFIED)
     public static void perform(File against, FileOpType opType, DiscreteAction<? extends IOException> ... actions)
     {
         perform(against.path(), opType, actions);
@@ -193,6 +198,8 @@ public final class Throwables
     /**
      * @see {@link #closeAndAddSuppressed(Throwable, Iterable)}
      */
+    @EnsuresCalledMethodsVarArgs("close")
+    @SuppressWarnings("ensuresvarargs.unverified")
     public static void closeAndAddSuppressed(@Nonnull Throwable t, AutoCloseable... closeables)
     {
         closeAndAddSuppressed(t, Arrays.asList(closeables));
@@ -201,6 +208,8 @@ public final class Throwables
     /**
      * Do what {@link #closeAndAddSuppressed(Throwable, Iterable)} does, additionally filtering out all null closables.
      */
+    @EnsuresCalledMethodsVarArgs("close")
+    @SuppressWarnings("ensuresvarargs.unverified")
     public static void closeNonNullAndAddSuppressed(@Nonnull Throwable t, AutoCloseable... closeables)
     {
         closeAndAddSuppressed(t, Iterables.filter(Arrays.asList(closeables), Objects::nonNull));
@@ -231,6 +240,8 @@ public final class Throwables
     /**
      * See {@link #close(Throwable, Iterable)}
      */
+    @EnsuresCalledMethodsVarArgs("close")
+    @SuppressWarnings("ensuresvarargs.unverified")
     public static Throwable close(Throwable accumulate, AutoCloseable ... closeables)
     {
         return close(accumulate, Arrays.asList(closeables));

--- a/src/java/org/apache/cassandra/utils/WithResources.java
+++ b/src/java/org/apache/cassandra/utils/WithResources.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.utils;
 import org.apache.cassandra.concurrent.ExecutorPlus;
 
 import static org.apache.cassandra.utils.Shared.Scope.SIMULATION;
+import static org.apache.cassandra.utils.SuppressionConstants.RESOURCE;
 
 /**
  * A generic interface for encapsulating a Runnable task with related work before and after execution,
@@ -66,7 +67,7 @@ public interface WithResources
     }
     static WithResources none() { return None.INSTANCE; }
 
-    @SuppressWarnings("resource")
+    @SuppressWarnings({ "resource", RESOURCE })
     public static WithResources and(WithResources first, WithResources second)
     {
         if (second.isNoOp()) return first;

--- a/src/java/org/apache/cassandra/utils/WithResources.java
+++ b/src/java/org/apache/cassandra/utils/WithResources.java
@@ -67,7 +67,7 @@ public interface WithResources
     }
     static WithResources none() { return None.INSTANCE; }
 
-    @SuppressWarnings({ "resource", RESOURCE })
+    @SuppressWarnings(RESOURCE)
     public static WithResources and(WithResources first, WithResources second)
     {
         if (second.isNoOp()) return first;

--- a/src/java/org/apache/cassandra/utils/concurrent/SharedCloseableImpl.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/SharedCloseableImpl.java
@@ -18,6 +18,8 @@
 */
 package org.apache.cassandra.utils.concurrent;
 
+import org.checkerframework.checker.mustcall.qual.Owning;
+
 /**
  * A simple abstract implementation of SharedCloseable
  */
@@ -25,7 +27,7 @@ public abstract class SharedCloseableImpl implements SharedCloseable
 {
     final Ref<?> ref;
 
-    public SharedCloseableImpl(RefCounted.Tidy tidy)
+    public SharedCloseableImpl(@Owning RefCounted.Tidy tidy)
     {
         ref = new Ref<Object>(null, tidy);
     }

--- a/src/java/org/apache/cassandra/utils/concurrent/WrappedSharedCloseable.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WrappedSharedCloseable.java
@@ -20,6 +20,9 @@ package org.apache.cassandra.utils.concurrent;
 
 import java.util.Arrays;
 
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
 import static org.apache.cassandra.utils.Throwables.maybeFail;
 import static org.apache.cassandra.utils.Throwables.merge;
 
@@ -31,12 +34,12 @@ public abstract class WrappedSharedCloseable extends SharedCloseableImpl
 {
     final AutoCloseable[] wrapped;
 
-    public WrappedSharedCloseable(final AutoCloseable closeable)
+    public WrappedSharedCloseable(final @Owning AutoCloseable closeable)
     {
         this(new AutoCloseable[] {closeable});
     }
 
-    public WrappedSharedCloseable(final AutoCloseable[] closeable)
+    public WrappedSharedCloseable(final @Owning AutoCloseable[] closeable)
     {
         super(new Tidy(closeable));
         wrapped = closeable;
@@ -45,6 +48,8 @@ public abstract class WrappedSharedCloseable extends SharedCloseableImpl
     static final class Tidy implements RefCounted.Tidy
     {
         final AutoCloseable[] closeable;
+
+        @EnsuresCalledMethods(value = "#1", methods = "close")
         Tidy(AutoCloseable[] closeable)
         {
             this.closeable = closeable;

--- a/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtablePool.java
@@ -29,8 +29,9 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Timer;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
-import org.apache.cassandra.utils.concurrent.WaitQueue;
 import org.apache.cassandra.utils.ExecutorUtils;
+import org.apache.cassandra.utils.concurrent.WaitQueue;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 
 import static org.apache.cassandra.utils.concurrent.WaitQueue.newWaitQueue;
 
@@ -249,7 +250,7 @@ public abstract class MemtablePool
             return hasRoom;
         }
 
-        public Timer.Context blockedTimerContext()
+        public @MustCallAlias Timer.Context blockedTimerContext()
         {
             return blockedOnAllocating.time();
         }

--- a/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
+++ b/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
@@ -17,7 +17,9 @@
  */
 package org.apache.cassandra.utils.obs;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.IOException;
+import java.io.InputStream;
 
 import com.google.common.annotations.VisibleForTesting;
 

--- a/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
+++ b/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
@@ -143,7 +143,6 @@ public class OffHeapBitSet implements IBitSet
         return TypeSizes.sizeof((int) bytes.size()) + bytes.size();
     }
 
-    @SuppressWarnings("resource")
     public static <I extends InputStream & DataInput> OffHeapBitSet deserialize(I in, boolean oldBfFormat) throws IOException
     {
         long byteCount = in.readInt() * 8L;

--- a/test/unit/org/apache/cassandra/io/util/DataOutputTest.java
+++ b/test/unit/org/apache/cassandra/io/util/DataOutputTest.java
@@ -218,7 +218,7 @@ public class DataOutputTest
 
     //Can't test it for real without tons of heap so test as much validation as possible
     @Test
-    public void testDataOutputBufferBigReallocation()
+    public void testDataOutputBufferBigReallocation() throws IOException
     {
         //Check saturating cast behavior
         Assert.assertEquals(DataOutputBuffer.MAX_ARRAY_SIZE, DataOutputBuffer.saturatedArraySizeCast(DataOutputBuffer.MAX_ARRAY_SIZE + 1L));

--- a/test/unit/org/apache/cassandra/io/util/SizedIntsTest.java
+++ b/test/unit/org/apache/cassandra/io/util/SizedIntsTest.java
@@ -78,7 +78,7 @@ public class SizedIntsTest
 
 
     @Test
-    public void readWrite()
+    public void readWrite() throws IOException
     {
         try (DataOutputBuffer out = new DataOutputBuffer(8))
         {
@@ -100,7 +100,7 @@ public class SizedIntsTest
     }
 
     @Test
-    public void readWriteUnsigned()
+    public void readWriteUnsigned() throws IOException
     {
         try (DataOutputBuffer out = new DataOutputBuffer(8))
         {

--- a/test/unit/org/apache/cassandra/net/MessageSerializationPropertyTest.java
+++ b/test/unit/org/apache/cassandra/net/MessageSerializationPropertyTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.net;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -65,7 +66,7 @@ public class MessageSerializationPropertyTest implements Serializable
      * Validates that {@link Message#serializedSize(int)} == {@link Message.Serializer#serialize(Message, DataOutputPlus, int)} size.
      */
     @Test
-    public void serializeSizeProperty()
+    public void serializeSizeProperty() throws IOException
     {
         try (DataOutputBuffer out = new DataOutputBuffer(1024))
         {

--- a/tools/stress/src/org/apache/cassandra/io/sstable/StressCQLSSTableWriter.java
+++ b/tools/stress/src/org/apache/cassandra/io/sstable/StressCQLSSTableWriter.java
@@ -567,7 +567,6 @@ public class StressCQLSSTableWriter implements Closeable
             return this;
         }
 
-        @SuppressWarnings("resource")
         public StressCQLSSTableWriter build()
         {
             if (directoryList.isEmpty() && cfs == null)

--- a/tools/stress/src/org/apache/cassandra/stress/StressAction.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressAction.java
@@ -102,7 +102,6 @@ public class StressAction implements Runnable
     }
 
     // type provided separately to support recursive call for mixed command with each command type it is performing
-    @SuppressWarnings("resource") // warmupOutput doesn't need closing
     private void warmup(OpDistributionFactory operations)
     {
         // do 25% of iterations as warmup but no more than 50k (by default hotspot compiles methods after 10k invocations)


### PR DESCRIPTION
This introduced CheckerFramework for static code analysis, intended to replace Eclipse-Warnings. 

Although there is no perfect tool that we can use, CF provides better accuracy and fewer false positives. Additionally, it lets the developer add special annotations to inform about a resource ownership transfer from one object to another, which helps determine who is responsible for closing the resource. 