### PR TITLE
A new nodetool/JMX command that tells whether node's decommission fai…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0
+ * A new nodetool/JMX command that tells whether node's decommission failed or not (CASSANDRA-18555)
  * Make cassandra-stress able to read all credentials from a file (CASSANDRA-18544)
  * Add guardrail for partition size and deprecate compaction_large_partition_warning_threshold (CASSANDRA-18500)
  * Add HISTORY command for CQLSH (CASSANDRA-15046)

--- a/src/java/org/apache/cassandra/metrics/StorageMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/StorageMetrics.java
@@ -45,6 +45,7 @@ public class StorageMetrics
     public static final Counter totalHintsInProgress  = Metrics.counter(factory.createMetricName("TotalHintsInProgress"));
     public static final Counter totalHints = Metrics.counter(factory.createMetricName("TotalHints"));
     public static final Counter repairExceptions = Metrics.counter(factory.createMetricName("RepairExceptions"));
+    public static final Counter errorDecommissiong = Metrics.counter(factory.createMetricName("ErrorDecommissioning"));
 
     private static Gauge<Long> createSummingGauge(String name, ToLongFunction<KeyspaceMetrics> extractor)
     {

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1185,4 +1185,7 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     public void setSkipStreamDiskSpaceCheck(boolean value);
     public boolean getSkipStreamDiskSpaceCheck();
+
+    /** Indicates whether this node's decommission failed. */
+    public boolean isDecommissionFailed();
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2211,6 +2211,11 @@ public class NodeProbe implements AutoCloseable
     {
         return ssProxy.getDefaultKeyspaceReplicationFactor();
     }
+
+    public boolean isDecommissionFailed()
+    {
+        return ssProxy.isDecommissionFailed();
+    }
 }
 
 class ColumnFamilyStoreMBeanIterator implements Iterator<Map.Entry<String, ColumnFamilyStoreMBean>>

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -163,6 +163,7 @@ public class NodeTool
                 InvalidatePermissionsCache.class,
                 InvalidateRolesCache.class,
                 InvalidateRowCache.class,
+                IsDecommissionFailed.class,
                 Join.class,
                 ListPendingHints.class,
                 ListSnapshots.class,


### PR DESCRIPTION

```
A new nodetool/JMX command that tells whether node's decommission failed or not

Currently, when a node is being decommissioned and if any failure happens, then an exception is thrown back to the caller.

But Cassandra's decommission takes considerable time ranging from minutes to hours to days. There are various scenarios in that the caller may need to probe the status again:

The caller times out
It is not possible to keep the caller hanging for such a long time
And If the caller does not know what happened internally, then it cannot retry, etc., leading to other issues.

So, in this ticket, I am going to add a new nodetool/JMX command that can be invoked by the caller anytime, and it will return the correct status.

It might look like a smaller change, but when we need to operate Cassandra at scale in a large-scale fleet, then this becomes a bottleneck and require constant operator intervention.


patch by Jaydeepkumar Chovatia <chovatia.jaydeep@gmail.com>; reviewed by <Reviewers> for CASSANDRA-18555

Co-authored-by: Jaydeepkumar Chovatia <chovatia.jaydeep@gmail.com>

```

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-18555)

