### PR TITLE
CEP-29 CASSANDRA-18584: Not operator

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -1761,6 +1761,7 @@ relation[WhereClause.Builder clauses]
 
 containsOperator returns [Operator o]
     : K_CONTAINS { o = Operator.CONTAINS; } (K_KEY { o = Operator.CONTAINS_KEY; })?
+    | K_NOT K_CONTAINS { o = Operator.NOT_CONTAINS; } (K_KEY { o = Operator.NOT_CONTAINS_KEY; })?
     ;
 
 inMarker returns [AbstractMarker.INRaw marker]

--- a/src/java/org/apache/cassandra/cql3/MarkerOrList.java
+++ b/src/java/org/apache/cassandra/cql3/MarkerOrList.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.cql3.functions.Function;
+
+import static org.apache.cassandra.cql3.statements.RequestValidations.checkBindValueSet;
+import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
+
+/**
+ * Represents either a single marker for IN values, or a list of IN values, like:
+ * "SELECT ... WHERE x IN ?"
+ * "SELECT ... WHERE x IN (?, ?, ?)"
+ * "SELECT ... WHERE x IN (a, b, c)"
+ */
+public class MarkerOrList
+{
+    final AbstractMarker marker;
+    final List<Term> values;
+
+    private MarkerOrList(AbstractMarker marker, List<Term> values)
+    {
+        assert ((marker != null) ^ (values != null));
+        this.marker = marker;
+        this.values = values;
+    }
+
+    public static MarkerOrList marker(AbstractMarker marker)
+    {
+        return new MarkerOrList(marker, null);
+    }
+
+    public static MarkerOrList list(List<Term> values)
+    {
+        return new MarkerOrList(null, values);
+    }
+
+    public void addFunctionsTo(List<Function> functions)
+    {
+        if (values != null)
+        {
+            for (Term term : values)
+            {
+                if (term != null)
+                    term.addFunctionsTo(functions);
+            }
+        }
+    }
+
+    public List<ByteBuffer> bindAndGet(QueryOptions options, ColumnIdentifier column)
+    {
+        // (NOT IN | IN) ?,  where ? bound to a list of values
+        if (marker != null)
+        {
+            Term.Terminal term = marker.bind(options);
+            checkNotNull(term, "Invalid null value for column %s", column);
+            checkBindValueSet(term.get(options.getProtocolVersion()), "Invalid unset value for column %s", column);
+            Term.MultiItemTerminal lval = (Term.MultiItemTerminal) term;
+            return lval.getElements();
+        }
+        else
+        // (NOT IN | IN) (value1, value2, ...)
+        {
+            assert values != null;
+            List<ByteBuffer> result = new ArrayList<>(values.size());
+            for (Term term : values)
+            {
+                ByteBuffer value = term.bindAndGet(options);
+                result.add(value);
+            }
+            return result;
+        }
+    }
+
+    public List<List<ByteBuffer>> bindAndGetTuples(QueryOptions options, Collection<ColumnIdentifier> columns)
+    {
+        if (columns.isEmpty())
+            throw new IllegalArgumentException("Columns must not be empty");
+
+        // (NOT IN | IN) ?,  where ? bound to a list of tuples
+        if (marker != null && marker instanceof Tuples.InMarker)
+        {
+            Tuples.InMarker inMarker = (Tuples.InMarker) marker;
+            Tuples.InValue inValue = inMarker.bind(options);
+            checkNotNull(inValue, "Invalid null value for columns %s", columns);
+            return inValue.getSplitValues();
+        }
+        // (NOT IN | IN) ?,  where ? bound to a list of scalar values, we need to convert the elements to singleton lists
+        else if (marker != null)
+        {
+            ColumnIdentifier firstColumn = columns.iterator().next();
+            List<ByteBuffer> values = bindAndGet(options, firstColumn);
+            return values.stream().map(Collections::singletonList).collect(Collectors.toList());
+        }
+        // (NOT IN | IN) (value1, value2, ...)
+        else
+        {
+            assert values != null;
+            return values.stream()
+                         .map(v -> getTuple(v, options))
+                         .collect(Collectors.toList());
+        }
+    }
+
+    private List<ByteBuffer> getTuple(Term value, QueryOptions options)
+    {
+        Term.Terminal terminal = value.bind(options);
+        return (terminal instanceof Term.MultiItemTerminal)
+            ? ((Term.MultiItemTerminal) terminal).getElements()
+            : Collections.singletonList(terminal.get(options.getProtocolVersion()));
+    }
+
+    public String toString()
+    {
+        return (marker != null) ? marker.toString(): values.toString();
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
@@ -141,6 +141,11 @@ public class MultiColumnRelation extends Relation
         return new MultiColumnRestriction.EQRestriction(receivers, term);
     }
 
+    protected Restriction newNEQRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        throw invalidRequest("%s cannot be used for multi-column relations", operator());
+    }
+
     @Override
     protected Restriction newINRestriction(TableMetadata table, VariableSpecifications boundNames)
     {
@@ -167,7 +172,7 @@ public class MultiColumnRelation extends Relation
     }
 
     @Override
-    protected Restriction newContainsRestriction(TableMetadata table, VariableSpecifications boundNames, boolean isKey)
+    protected Restriction newContainsRestriction(TableMetadata table, VariableSpecifications boundNames, boolean isKey, boolean isNot)
     {
         throw invalidRequest("%s cannot be used for multi-column relations", operator());
     }

--- a/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
@@ -95,6 +95,11 @@ public class MultiColumnRelation extends Relation
         return new MultiColumnRelation(entities, Operator.IN, null, inValues, null);
     }
 
+    public static MultiColumnRelation createNotInRelation(List<ColumnIdentifier> entities, List<? extends Term.MultiColumnRaw> inValues)
+    {
+        return new MultiColumnRelation(entities, Operator.NOT_IN, null, inValues, null);
+    }
+
     /**
      * Creates a multi-column IN relation with a marker for the IN values.
      * For example: "SELECT ... WHERE (a, b) IN ?"
@@ -105,6 +110,18 @@ public class MultiColumnRelation extends Relation
     public static MultiColumnRelation createSingleMarkerInRelation(List<ColumnIdentifier> entities, Tuples.INRaw inMarker)
     {
         return new MultiColumnRelation(entities, Operator.IN, null, null, inMarker);
+    }
+
+    /**
+     * Creates a multi-column NOT IN relation with a marker for the NOT IN values.
+     * For example: "SELECT ... WHERE (a, b) NOT IN ?"
+     * @param entities the columns on the LHS of the relation
+     * @param inMarker a single IN marker
+     * @return a new <code>MultiColumnRelation</code> instance
+     */
+    public static MultiColumnRelation createSingleMarkerNotInRelation(List<ColumnIdentifier> entities, Tuples.INRaw inMarker)
+    {
+        return new MultiColumnRelation(entities, Operator.NOT_IN, null, null, inMarker);
     }
 
     public List<ColumnIdentifier> getEntities()
@@ -118,12 +135,12 @@ public class MultiColumnRelation extends Relation
      */
     public Term.MultiColumnRaw getValue()
     {
-        return relationType == Operator.IN ? inMarker : valuesOrMarker;
+        return (relationType == Operator.IN || relationType == Operator.NOT_IN) ? inMarker : valuesOrMarker;
     }
 
     public List<? extends Term.Raw> getInValues()
     {
-        assert relationType == Operator.IN;
+        assert relationType == Operator.IN || relationType == Operator.NOT_IN;
         return inValues;
     }
 
@@ -154,13 +171,32 @@ public class MultiColumnRelation extends Relation
         if (terms == null)
         {
             Term term = toTerm(receivers, getValue(), table.keyspace, boundNames);
-            return new MultiColumnRestriction.InRestrictionWithMarker(receivers, (AbstractMarker) term);
+            return new MultiColumnRestriction.INRestriction(receivers, MarkerOrList.marker((AbstractMarker) term));
         }
 
         if (terms.size() == 1)
             return new MultiColumnRestriction.EQRestriction(receivers, terms.get(0));
 
-        return new MultiColumnRestriction.InRestrictionWithValues(receivers, terms);
+        return new MultiColumnRestriction.INRestriction(receivers, MarkerOrList.list(terms));
+    }
+
+    @Override
+    protected Restriction newNotINRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        List<ColumnMetadata> receivers = receivers(table);
+        List<Term> terms = toTerms(receivers, inValues, table.keyspace, boundNames);
+        MarkerOrList values;
+        if (terms == null)
+        {
+            Term term = toTerm(receivers, getValue(), table.keyspace, boundNames);
+            values = MarkerOrList.marker((AbstractMarker) term);
+        }
+        else
+        {
+            values = MarkerOrList.list(terms);
+        }
+
+        return MultiColumnRestriction.SliceRestriction.fromSkippedValues(receivers, values);
     }
 
     @Override
@@ -168,7 +204,7 @@ public class MultiColumnRelation extends Relation
     {
         List<ColumnMetadata> receivers = receivers(table);
         Term term = toTerm(receivers(table), getValue(), table.keyspace, boundNames);
-        return new MultiColumnRestriction.SliceRestriction(receivers, bound, inclusive, term);
+        return MultiColumnRestriction.SliceRestriction.fromBound(receivers, bound, inclusive, term);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/MultiColumnRelation.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.cql3;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -158,9 +159,13 @@ public class MultiColumnRelation extends Relation
         return new MultiColumnRestriction.EQRestriction(receivers, term);
     }
 
+    @Override
     protected Restriction newNEQRestriction(TableMetadata table, VariableSpecifications boundNames)
     {
-        throw invalidRequest("%s cannot be used for multi-column relations", operator());
+        List<ColumnMetadata> receivers = receivers(table);
+        Term term = toTerm(receivers, getValue(), table.keyspace, boundNames);
+        MarkerOrList skippedValues = MarkerOrList.list(Collections.singletonList(term));
+        return MultiColumnRestriction.SliceRestriction.fromSkippedValues(receivers, skippedValues);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/Operator.java
+++ b/src/java/org/apache/cassandra/cql3/Operator.java
@@ -161,6 +161,7 @@ public enum Operator
             return map.containsKey(mapType.getKeysType().getSerializer().deserialize(rightOperand));
         }
     },
+
     NEQ(8)
     {
         @Override
@@ -258,7 +259,119 @@ public enum Operator
         {
             throw new UnsupportedOperationException();
         }
-    };
+    },
+    NOT_IN(16)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT IN";
+        }
+
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !IN.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+    },
+    NOT_CONTAINS(17)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT CONTAINS";
+        }
+
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !CONTAINS.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+
+    },
+    NOT_CONTAINS_KEY(18)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT CONTAINS KEY";
+        }
+
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !CONTAINS_KEY.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+    },
+    NOT_LIKE_PREFIX(19)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT LIKE '<term>%'";
+        }
+
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !LIKE_PREFIX.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+    },
+    NOT_LIKE_SUFFIX(20)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT LIKE '%<term>'";
+        }
+
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !LIKE_SUFFIX.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+    },
+    NOT_LIKE_CONTAINS(21)
+    {
+        @Override
+        public String toString()
+        {
+            return "LIKE '%<term>%'";
+        }
+
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return ByteBufferUtil.contains(leftOperand, rightOperand);
+        }
+    },
+    NOT_LIKE_MATCHES(22)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT LIKE '<term>'";
+        }
+
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !LIKE_MATCHES.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+    },
+    NOT_LIKE(23)
+    {
+        @Override
+        public String toString()
+        {
+            return "NOT LIKE";
+        }
+
+        @Override
+        public boolean isSatisfiedBy(AbstractType<?> type, ByteBuffer leftOperand, ByteBuffer rightOperand)
+        {
+            return !LIKE.isSatisfiedBy(type, leftOperand, rightOperand);
+        }
+    },
+    ;
 
     /**
      * The binary representation of this <code>Enum</code> value.

--- a/src/java/org/apache/cassandra/cql3/Relation.java
+++ b/src/java/org/apache/cassandra/cql3/Relation.java
@@ -188,6 +188,7 @@ public abstract class Relation
             case GTE: return newSliceRestriction(table, boundNames, Bound.START, true);
             case GT: return newSliceRestriction(table, boundNames, Bound.START, false);
             case IN: return newINRestriction(table, boundNames);
+            case NOT_IN: return newNotINRestriction(table, boundNames);
             case CONTAINS: return newContainsRestriction(table, boundNames, false, false);
             case CONTAINS_KEY: return newContainsRestriction(table, boundNames, true, false);
             case NOT_CONTAINS: return newContainsRestriction(table, boundNames, false, true);
@@ -233,6 +234,17 @@ public abstract class Relation
      * @throws InvalidRequestException if the relation cannot be converted into an IN restriction.
      */
     protected abstract Restriction newINRestriction(TableMetadata table, VariableSpecifications boundNames);
+
+
+    /**
+     * Creates a new NOT IN restriction instance.
+     *
+     * @param table the table meta data
+     * @param boundNames the variables specification where to collect the bind variables
+     * @return a new NOT IN restriction instance
+     * @throws InvalidRequestException if the relation cannot be converted into an NOT IN restriction.
+     */
+    protected abstract Restriction newNotINRestriction(TableMetadata table, VariableSpecifications boundNames);
 
     /**
      * Creates a new Slice restriction instance.

--- a/src/java/org/apache/cassandra/cql3/Relation.java
+++ b/src/java/org/apache/cassandra/cql3/Relation.java
@@ -87,6 +87,27 @@ public abstract class Relation
     }
 
     /**
+     * Checks if the operator of this relation is a <code>NOT_CONTAINS</code>.
+     * @return <code>true</code>  if the operator of this relation is a <code>NOT_CONTAINS</code>, <code>false</code>
+     * otherwise.
+     */
+    public final boolean isNotContains()
+    {
+        return relationType == Operator.NOT_CONTAINS;
+    }
+
+    /**
+     * Checks if the operator of this relation is a <code>CONTAINS_KEY</code>.
+     * @return <code>true</code>  if the operator of this relation is a <code>NOT_CONTAINS_KEY</code>, <code>false</code>
+     * otherwise.
+     */
+    public final boolean isNotContainsKey()
+    {
+        return relationType == Operator.NOT_CONTAINS_KEY;
+    }
+
+
+    /**
      * Checks if the operator of this relation is a <code>IN</code>.
      * @return <code>true</code>  if the operator of this relation is a <code>IN</code>, <code>false</code>
      * otherwise.
@@ -106,6 +127,16 @@ public abstract class Relation
         return relationType == Operator.EQ;
     }
 
+    /**
+     * Checks if the operator of this relation is a <code>NEQ</code>.
+     * @return <code>true</code>  if the operator of this relation is a <code>NEQ</code>, <code>false</code>
+     * otherwise.
+     */
+    public final boolean isNEQ()
+    {
+        return relationType == Operator.NEQ;
+    }
+
     public final boolean isLIKE()
     {
         return relationType == Operator.LIKE_PREFIX
@@ -114,6 +145,16 @@ public abstract class Relation
                 || relationType == Operator.LIKE_MATCHES
                 || relationType == Operator.LIKE;
     }
+
+    public final boolean isNotLIKE()
+    {
+        return relationType == Operator.NOT_LIKE_PREFIX
+               || relationType == Operator.NOT_LIKE_SUFFIX
+               || relationType == Operator.NOT_LIKE_CONTAINS
+               || relationType == Operator.NOT_LIKE_MATCHES
+               || relationType == Operator.NOT_LIKE;
+    }
+
 
     /**
      * Checks if the operator of this relation is a <code>Slice</code> (GT, GTE, LTE, LT).
@@ -141,13 +182,16 @@ public abstract class Relation
         switch (relationType)
         {
             case EQ: return newEQRestriction(table, boundNames);
+            case NEQ: return newNEQRestriction(table, boundNames);
             case LT: return newSliceRestriction(table, boundNames, Bound.END, false);
             case LTE: return newSliceRestriction(table, boundNames, Bound.END, true);
             case GTE: return newSliceRestriction(table, boundNames, Bound.START, true);
             case GT: return newSliceRestriction(table, boundNames, Bound.START, false);
             case IN: return newINRestriction(table, boundNames);
-            case CONTAINS: return newContainsRestriction(table, boundNames, false);
-            case CONTAINS_KEY: return newContainsRestriction(table, boundNames, true);
+            case CONTAINS: return newContainsRestriction(table, boundNames, false, false);
+            case CONTAINS_KEY: return newContainsRestriction(table, boundNames, true, false);
+            case NOT_CONTAINS: return newContainsRestriction(table, boundNames, false, true);
+            case NOT_CONTAINS_KEY: return newContainsRestriction(table, boundNames, true, true);
             case IS_NOT: return newIsNotRestriction(table, boundNames);
             case LIKE_PREFIX:
             case LIKE_SUFFIX:
@@ -168,6 +212,17 @@ public abstract class Relation
      * @throws InvalidRequestException if the relation cannot be converted into an EQ restriction.
      */
     protected abstract Restriction newEQRestriction(TableMetadata table, VariableSpecifications boundNames);
+
+    /**
+     * Creates a new NEQ restriction instance.
+     *
+     * @param table the table meta data
+     * @param boundNames the variables specification where to collect the bind variables
+     * @return a new EQ restriction instance.
+     * @throws InvalidRequestException if the relation cannot be converted into an NEQ restriction.
+     */
+    protected abstract Restriction newNEQRestriction(TableMetadata table, VariableSpecifications boundNames);
+
 
     /**
      * Creates a new IN restriction instance.
@@ -203,7 +258,7 @@ public abstract class Relation
      * @return a new Contains <code>Restriction</code> instance
      * @throws InvalidRequestException if the <code>Relation</code> is not valid
      */
-    protected abstract Restriction newContainsRestriction(TableMetadata table, VariableSpecifications boundNames, boolean isKey);
+    protected abstract Restriction newContainsRestriction(TableMetadata table, VariableSpecifications boundNames, boolean isKey, boolean isNot);
 
     protected abstract Restriction newIsNotRestriction(TableMetadata table, VariableSpecifications boundNames);
 

--- a/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
@@ -190,7 +190,20 @@ public final class SingleColumnRelation extends Relation
         List<? extends ColumnSpecification> receivers = toReceivers(columnDef);
         Term entryKey = toTerm(Collections.singletonList(receivers.get(0)), mapKey, table.keyspace, boundNames);
         Term entryValue = toTerm(Collections.singletonList(receivers.get(1)), value, table.keyspace, boundNames);
-        return new SingleColumnRestriction.ContainsRestriction(columnDef, entryKey, entryValue);
+        return new SingleColumnRestriction.ContainsRestriction(columnDef, entryKey, entryValue, false);
+    }
+
+    @Override
+    protected Restriction newNEQRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        ColumnMetadata columnDef = table.getExistingColumn(entity);
+        if (mapKey == null)
+            throw invalidRequest("NEQ restrictions are supported only on map columns");
+
+        List<? extends ColumnSpecification> receivers = toReceivers(columnDef);
+        Term entryKey = toTerm(Collections.singletonList(receivers.get(0)), mapKey, table.keyspace, boundNames);
+        Term entryValue = toTerm(Collections.singletonList(receivers.get(1)), value, table.keyspace, boundNames);
+        return new SingleColumnRestriction.ContainsRestriction(columnDef, entryKey, entryValue, true);
     }
 
     @Override
@@ -235,11 +248,12 @@ public final class SingleColumnRelation extends Relation
     @Override
     protected Restriction newContainsRestriction(TableMetadata table,
                                                  VariableSpecifications boundNames,
-                                                 boolean isKey) throws InvalidRequestException
+                                                 boolean isKey,
+                                                 boolean isNot) throws InvalidRequestException
     {
         ColumnMetadata columnDef = table.getExistingColumn(entity);
         Term term = toTerm(toReceivers(columnDef), value, table.keyspace, boundNames);
-        return new SingleColumnRestriction.ContainsRestriction(columnDef, term, isKey);
+        return new SingleColumnRestriction.ContainsRestriction(columnDef, term, isKey, isNot);
     }
 
     @Override
@@ -276,13 +290,15 @@ public final class SingleColumnRelation extends Relation
 
         checkFalse(isContainsKey() && !(receiver.type instanceof MapType), "Cannot use CONTAINS KEY on non-map column %s", receiver.name);
         checkFalse(isContains() && !(receiver.type.isCollection()), "Cannot use CONTAINS on non-collection column %s", receiver.name);
+        checkFalse(isNotContainsKey() && !(receiver.type instanceof MapType), "Cannot use NOT CONTAINS KEY on non-map column %s", receiver.name);
+        checkFalse(isNotContains() && !(receiver.type.isCollection()), "Cannot use NOT CONTAINS on non-collection column %s", receiver.name);
 
         if (mapKey != null)
         {
             checkFalse(receiver.type instanceof ListType, "Indexes on list entries (%s[index] = value) are not currently supported.", receiver.name);
             checkTrue(receiver.type instanceof MapType, "Column %s cannot be used as a map", receiver.name);
             checkTrue(receiver.type.isMultiCell(), "Map-entry equality predicates on frozen map column %s are not supported", receiver.name);
-            checkTrue(isEQ(), "Only EQ relations are supported on map entries");
+            checkTrue(isEQ() || isNEQ(), "Only EQ and NEQ relations are supported on map entries");
         }
 
         // Non-frozen UDTs don't support any operator
@@ -300,11 +316,11 @@ public final class SingleColumnRelation extends Relation
                        receiver.type.asCQL3Type(),
                        operator());
 
-            if (isContainsKey() || isContains())
+            if (isContainsKey() || isContains() || isNotContains() || isNotContainsKey())
             {
-                receiver = makeCollectionReceiver(receiver, isContainsKey());
+                receiver = makeCollectionReceiver(receiver, isContainsKey() || isNotContainsKey());
             }
-            else if (receiver.type.isMultiCell() && mapKey != null && isEQ())
+            else if (receiver.type.isMultiCell() && mapKey != null && (isEQ() || isNEQ()))
             {
                 List<ColumnSpecification> receivers = new ArrayList<>(2);
                 receivers.add(makeCollectionReceiver(receiver, true));
@@ -323,12 +339,12 @@ public final class SingleColumnRelation extends Relation
 
     private boolean isLegalRelationForNonFrozenCollection()
     {
-        return isContainsKey() || isContains() || isMapEntryEquality();
+        return isContainsKey() || isContains() || isNotContains() || isNotContainsKey() || isMapEntryEquality();
     }
 
     private boolean isMapEntryEquality()
     {
-        return mapKey != null && isEQ();
+        return mapKey != null && (isEQ() || isNEQ());
     }
 
     private boolean canHaveOnlyOneValue()

--- a/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
+++ b/src/java/org/apache/cassandra/cql3/SingleColumnRelation.java
@@ -203,7 +203,11 @@ public final class SingleColumnRelation extends Relation
     {
         ColumnMetadata columnDef = table.getExistingColumn(entity);
         if (mapKey == null)
-            throw invalidRequest("NEQ restrictions are supported only on map columns");
+        {
+            Term term = toTerm(toReceivers(columnDef), value, table.keyspace, boundNames);
+            MarkerOrList skippedValues = MarkerOrList.list(Collections.singletonList(term));
+            return SingleColumnRestriction.SliceRestriction.fromSkippedValues(columnDef, skippedValues);
+        }
 
         List<? extends ColumnSpecification> receivers = toReceivers(columnDef);
         Term entryKey = toTerm(Collections.singletonList(receivers.get(0)), mapKey, table.keyspace, boundNames);

--- a/src/java/org/apache/cassandra/cql3/TokenRelation.java
+++ b/src/java/org/apache/cassandra/cql3/TokenRelation.java
@@ -84,6 +84,12 @@ public final class TokenRelation extends Relation
     }
 
     @Override
+    protected Restriction newNEQRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        throw invalidRequest("%s cannot be used with the token function", operator());
+    }
+
+    @Override
     protected Restriction newINRestriction(TableMetadata table, VariableSpecifications boundNames)
     {
         throw invalidRequest("%s cannot be used with the token function", operator());
@@ -101,7 +107,7 @@ public final class TokenRelation extends Relation
     }
 
     @Override
-    protected Restriction newContainsRestriction(TableMetadata table, VariableSpecifications boundNames, boolean isKey)
+    protected Restriction newContainsRestriction(TableMetadata table, VariableSpecifications boundNames, boolean isKey, boolean isNot)
     {
         throw invalidRequest("%s cannot be used with the token function", operator());
     }

--- a/src/java/org/apache/cassandra/cql3/TokenRelation.java
+++ b/src/java/org/apache/cassandra/cql3/TokenRelation.java
@@ -95,6 +95,11 @@ public final class TokenRelation extends Relation
         throw invalidRequest("%s cannot be used with the token function", operator());
     }
 
+    protected Restriction newNotINRestriction(TableMetadata table, VariableSpecifications boundNames)
+    {
+        throw invalidRequest("%s cannot be used with the token function", operator());
+    }
+
     @Override
     protected Restriction newSliceRestriction(TableMetadata table,
                                               VariableSpecifications boundNames,

--- a/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictions.java
@@ -93,19 +93,9 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
         return new ClusteringColumnRestrictions(this.comparator, newRestrictionSet, allowFiltering);
     }
 
-    private boolean hasMultiColumnSlice()
-    {
-        for (SingleRestriction restriction : restrictions)
-        {
-            if (restriction.isMultiColumn() && restriction.isSlice())
-                return true;
-        }
-        return false;
-    }
-
     public NavigableSet<Clustering<?>> valuesAsClustering(QueryOptions options, ClientState state) throws InvalidRequestException
     {
-        MultiCBuilder builder = MultiCBuilder.create(comparator, hasIN());
+        MultiCBuilder builder = MultiCBuilder.create(comparator);
         for (SingleRestriction r : restrictions)
         {
             r.appendTo(builder, options);
@@ -113,7 +103,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
             if (hasIN() && Guardrails.inSelectCartesianProduct.enabled(state))
                 Guardrails.inSelectCartesianProduct.guard(builder.buildSize(), "clustering key", false, state);
 
-            if (builder.hasMissingElements())
+            if (builder.buildSize() == 0)
                 break;
         }
         return builder.build();
@@ -121,7 +111,7 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
 
     public NavigableSet<ClusteringBound<?>> boundsAsClustering(Bound bound, QueryOptions options) throws InvalidRequestException
     {
-        MultiCBuilder builder = MultiCBuilder.create(comparator, hasIN() || hasMultiColumnSlice());
+        MultiCBuilder builder = MultiCBuilder.create(comparator);
         int keyPosition = 0;
 
         for (SingleRestriction r : restrictions)
@@ -129,25 +119,20 @@ final class ClusteringColumnRestrictions extends RestrictionSetWrapper
             if (handleInFilter(r, keyPosition))
                 break;
 
-            if (r.isSlice())
-            {
-                r.appendBoundTo(builder, bound, options);
-                return builder.buildBoundForSlice(bound.isStart(),
-                                                  r.isInclusive(bound),
-                                                  r.isInclusive(bound.reverse()),
-                                                  r.getColumnDefs());
-            }
-
             r.appendBoundTo(builder, bound, options);
 
-            if (builder.hasMissingElements())
+            if (builder.buildSize() == 0)
                 return BTreeSet.empty(comparator);
+
+            // We allow slice restriction only on the last clustering column restricted by the query.
+            // Any further column restrictions must be handled by indexes or filtering.
+            if (r.isSlice())
+                break;
 
             keyPosition = r.getLastColumn().position() + 1;
         }
 
-        // Everything was an equal (or there was nothing)
-        return builder.buildBound(bound.isStart(), true);
+        return builder.buildBound(bound.isStart());
     }
 
     /**

--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.cql3.restrictions;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -28,24 +29,24 @@ import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import org.apache.cassandra.cql3.AbstractMarker;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.MarkerOrList;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.Term;
-import org.apache.cassandra.cql3.Terms;
 import org.apache.cassandra.cql3.Tuples;
 import org.apache.cassandra.cql3.Term.Terminal;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.statements.Bound;
 import org.apache.cassandra.db.MultiCBuilder;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.index.IndexRegistry;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.ListSerializer;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse;
-import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
@@ -191,8 +192,9 @@ public abstract class MultiColumnRestriction implements SingleRestriction
             List<ByteBuffer> values = t.getElements();
             for (int i = 0, m = values.size(); i < m; i++)
             {
-                builder.addElementToAll(values.get(i));
-                checkFalse(builder.containsNull(), "Invalid null value for column %s", columnDefs.get(i).name);
+                ColumnMetadata column = columnDefs.get(i);
+                builder.extend(MultiCBuilder.Element.point(values.get(i)), Collections.singletonList(column));
+                checkFalse(builder.containsNull(), "Invalid null value for column %s", column.name);
             }
             return builder;
         }
@@ -211,11 +213,16 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         }
     }
 
-    public abstract static class INRestriction extends MultiColumnRestriction
+    public static class INRestriction extends MultiColumnRestriction
     {
-        public INRestriction(List<ColumnMetadata> columnDefs)
+        private final MarkerOrList values;
+        private final Collection<ColumnIdentifier> columnIdentifiers;
+
+        public INRestriction(List<ColumnMetadata> columnDefs, MarkerOrList values)
         {
             super(columnDefs);
+            this.values = values;
+            this.columnIdentifiers = ColumnMetadata.toIdentifiers(columnDefs);
         }
 
         /**
@@ -224,11 +231,15 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         @Override
         public MultiCBuilder appendTo(MultiCBuilder builder, QueryOptions options)
         {
-            List<List<ByteBuffer>> splitInValues = splitValues(options);
-            builder.addAllElementsToAll(splitInValues);
+            List<List<ByteBuffer>> splitInValues = values.bindAndGetTuples(options, columnIdentifiers);
+            List<MultiCBuilder.Element> elements = new ArrayList<>(splitInValues.size());
+            for (List<ByteBuffer> value: splitInValues)
+                elements.add(MultiCBuilder.Element.point(value));
+
+            builder.extend(elements, columnDefs);
 
             if (builder.containsNull())
-                throw invalidRequest("Invalid null value in condition for columns: %s", ColumnMetadata.toIdentifiers(columnDefs));
+                throw invalidRequest("Invalid null value in condition for columns: %s", columnIdentifiers);
             return builder;
         }
 
@@ -263,7 +274,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
             // c IN (x, y, z) and we can perform filtering
             if (getColumnDefs().size() == 1)
             {
-                List<List<ByteBuffer>> splitValues = splitValues(options);
+                List<List<ByteBuffer>> splitValues = values.bindAndGetTuples(options, columnIdentifiers);
                 List<ByteBuffer> values = new ArrayList<>(splitValues.size());
                 for (List<ByteBuffer> splitValue : splitValues)
                     values.add(splitValue.get(0));
@@ -277,27 +288,10 @@ public abstract class MultiColumnRestriction implements SingleRestriction
             }
         }
 
-        protected abstract List<List<ByteBuffer>> splitValues(QueryOptions options);
-    }
-
-    /**
-     * An IN restriction that has a set of terms for in values.
-     * For example: "SELECT ... WHERE (a, b, c) IN ((1, 2, 3), (4, 5, 6))" or "WHERE (a, b, c) IN (?, ?)"
-     */
-    public static class InRestrictionWithValues extends INRestriction
-    {
-        protected final List<Term> values;
-
-        public InRestrictionWithValues(List<ColumnMetadata> columnDefs, List<Term> values)
-        {
-            super(columnDefs);
-            this.values = values;
-        }
-
         @Override
         public void addFunctionsTo(List<Function> functions)
         {
-            Terms.addFunctions(values, functions);
+            values.addFunctionsTo(functions);
         }
 
         @Override
@@ -305,68 +299,34 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         {
             return String.format("IN(%s)", values);
         }
-
-        @Override
-        protected List<List<ByteBuffer>> splitValues(QueryOptions options)
-        {
-            List<List<ByteBuffer>> buffers = new ArrayList<>(values.size());
-            for (Term value : values)
-            {
-                Term.MultiItemTerminal term = (Term.MultiItemTerminal) value.bind(options);
-                buffers.add(term.getElements());
-            }
-            return buffers;
-        }
     }
 
-    /**
-     * An IN restriction that uses a single marker for a set of IN values that are tuples.
-     * For example: "SELECT ... WHERE (a, b, c) IN ?"
-     */
-    public static class InRestrictionWithMarker extends INRestriction
-    {
-        protected final AbstractMarker marker;
-
-        public InRestrictionWithMarker(List<ColumnMetadata> columnDefs, AbstractMarker marker)
-        {
-            super(columnDefs);
-            this.marker = marker;
-        }
-
-        @Override
-        public void addFunctionsTo(List<Function> functions)
-        {
-        }
-
-        @Override
-        public String toString()
-        {
-            return "IN ?";
-        }
-
-        @Override
-        protected List<List<ByteBuffer>> splitValues(QueryOptions options)
-        {
-            Tuples.InMarker inMarker = (Tuples.InMarker) marker;
-            Tuples.InValue inValue = inMarker.bind(options);
-            checkNotNull(inValue, "Invalid null value for IN restriction");
-            return inValue.getSplitValues();
-        }
-    }
 
     public static class SliceRestriction extends MultiColumnRestriction
     {
         private final TermSlice slice;
 
-        public SliceRestriction(List<ColumnMetadata> columnDefs, Bound bound, boolean inclusive, Term term)
-        {
-            this(columnDefs, TermSlice.newInstance(bound, inclusive, term));
-        }
+        private final List<MarkerOrList> skippedValues; // values passed in NOT IN
 
-        SliceRestriction(List<ColumnMetadata> columnDefs, TermSlice slice)
+
+        SliceRestriction(List<ColumnMetadata> columnDefs, TermSlice slice, List<MarkerOrList> skippedValues)
         {
             super(columnDefs);
+            assert slice != null;
+            assert skippedValues != null;
             this.slice = slice;
+            this.skippedValues = skippedValues;
+        }
+
+        public static MultiColumnRestriction.SliceRestriction fromBound(List<ColumnMetadata> columnDefs, Bound bound, boolean inclusive, Term term)
+        {
+            TermSlice slice = TermSlice.newInstance(bound, inclusive, term);
+            return new MultiColumnRestriction.SliceRestriction(columnDefs, slice, Collections.emptyList());
+        }
+
+        public static MultiColumnRestriction.SliceRestriction fromSkippedValues(List<ColumnMetadata> columnDefs, MarkerOrList skippedValues)
+        {
+            return new MultiColumnRestriction.SliceRestriction(columnDefs, TermSlice.UNBOUNDED, Collections.singletonList(skippedValues));
         }
 
         @Override
@@ -384,14 +344,47 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         @Override
         public MultiCBuilder appendBoundTo(MultiCBuilder builder, Bound bound, QueryOptions options)
         {
+            List<MultiCBuilder.Element> toAdd = new ArrayList<>();
+            addSliceBounds(bound, options, toAdd);
+            addSkippedValues(bound, options, toAdd);
+            return builder.extend(toAdd, columnDefs);
+        }
+
+        /**
+         * Generates a list of clustering bounds based on this slice bounds and adds them to the toAdd list.
+         * Clustering bounds used for the table range scan might not be equal to this slice bounds.
+         * This method has to generate the TOP/BOTTOM bounds if this slice is unbounded on any side.
+         * It is also possible to generate multiple bounds, if clustering columns have mixed order.
+         * Does not guarantee order of results, but does not generate duplicates.
+         *
+         * @param bound the type of bounds to generate (start or end)
+         * @param options needed to get the actual values bound to markers
+         * @param toAdd receiver of the result
+         */
+        private void addSliceBounds(Bound bound, QueryOptions options, List<MultiCBuilder.Element> toAdd)
+        {
+            // Stores the direction of sorting of the current processed column.
+            // Used to detect when the next processed column has different direction of sorting than the last one.
+            // If clustering columns are all sorted in the same direction (doesn't matter if ASC or DESC, but must be
+            // the same for all), we can just need to generate only one
             boolean reversed = getFirstColumn().isReversedType();
 
             EnumMap<Bound, List<ByteBuffer>> componentBounds = new EnumMap<>(Bound.class);
             componentBounds.put(Bound.START, componentBounds(Bound.START, options));
             componentBounds.put(Bound.END, componentBounds(Bound.END, options));
 
-            List<List<ByteBuffer>> toAdd = new ArrayList<>();
-            List<ByteBuffer> values = new ArrayList<>();
+            // We will pick a prefix of bounds from `componentBounds` into this array, either start or end bounds
+            // depending on the column clustering direction.
+            List<ByteBuffer> values = Collections.emptyList();
+
+            // Tracks whether the last bound added to `values` is inclusive.
+            // We must start from true, because if there are no bounds at all (unbounded slice),
+            // we must not restrict the clusterings added by other restrictions.
+            boolean inclusive = true;
+
+            // Number of components in the last element added to the toAdd collection.
+            // Used to avoid adding the same composite multiple times.
+            int sizeOfLastElement = -1;
 
             for (int i = 0, m = columnDefs.size(); i < m; i++)
             {
@@ -402,44 +395,82 @@ public abstract class MultiColumnRestriction implements SingleRestriction
                 if (reversed != column.isReversedType())
                 {
                     reversed = column.isReversedType();
-                    // As we are switching direction we need to add the current composite
-                    toAdd.add(values);
 
-                    // The new bound side has no value for this component.  just stop
-                    if (!hasComponent(b, i, componentBounds))
-                        continue;
+                    // In the following comments, assume:
+                    // c1 - previous column (== columnDefs.get(i - 1))
+                    // c2 - current column (== columnDefs.get(i))
+                    // x1 - the last bound stored in values (values == [..., x1])
+                    // x2 - the bound of c2
 
-                    // The other side has still some components. We need to end the slice that we have just open.
-                    if (hasComponent(b.reverse(), i, componentBounds))
-                        toAdd.add(values);
-
-                    // We need to rebuild where we are in this bound side
-                    values = new ArrayList<ByteBuffer>();
-
-                    List<ByteBuffer> vals = componentBounds.get(b);
-
-                    int n = Math.min(i, vals.size());
-                    for (int j = 0; j < n; j++)
+                    // Only try to add the current composite if we haven't done it already, to avoid duplicates.
+                    if (values.size() > sizeOfLastElement)
                     {
-                        ByteBuffer v = checkNotNull(vals.get(j),
-                                                    "Invalid null value in condition for column %s",
-                                                    columnDefs.get(j).name);
-                        values.add(v);
+                        sizeOfLastElement = values.size();
+
+                        // note that b.reverse() matches the bound of the last component added to the `values`
+                        if (hasComponent(b.reverse(), i, componentBounds))
+                        {
+                            // (c1, c2) <= (x1, x2) ----> (c1 < x1) || (c1 = x1) && (c2 <= x2)
+                            // (c1, c2) >= (x1, x2) ----> (c1 > x1) || (c1 = x1) && (c2 >= x2)
+                            // (c1, c2) <  (x1, x2) ----> (c1 < x1) || (c1 = x1) && (c2 < x2)
+                            // (c1, c2) >  (x1, x2) ----> (c1 > x1) || (c1 = x1) && (c2 > x2)
+                            //                            ^^^^^^^^^
+                            toAdd.add(MultiCBuilder.Element.bound(values, bound, false));
+
+                            // Now add the other side of the union:
+                            // (c1, c2) <= (x1, x2) ----> (c1 < x1) || (c1 = x1) && (c2 < x2)
+                            // (c1, c2) >= (x1, x2) ----> (c1 > x1) || (c1 = x1) && (c2 > x2)
+                            //                                         ^^^^^^^^^
+                            // The other side has still some components. We need to end the slice that we have just open.
+                            // Note that (c2 > x2) will be added by the call to an opposite bound.
+                            toAdd.add(MultiCBuilder.Element.point(values));
+                        }
+                        else
+                        {
+                            // The new bound side has no value for this component. Just add current composite as-is.
+                            // No value means min or max, depending on the direction of the comparison.
+                            // (c1, c2) <= (x1, no value) ----> (c1 <= x1)
+                            // (c1, c2) >= (x1, no value) ----> (c1 >= x1)
+                            // (c1, c2) <  (x1, no value) ----> (c1 < x1)
+                            // (c1, c2) >  (x1, no value) ----> (c1 > x1)
+                            toAdd.add(MultiCBuilder.Element.bound(values, bound, inclusive));
+                        }
                     }
                 }
 
-                if (!hasComponent(b, i, componentBounds))
-                    continue;
-
-                ByteBuffer v = checkNotNull(componentBounds.get(b).get(i), "Invalid null value in condition for column %s", columnDefs.get(i).name);
-                values.add(v);
+                if (hasComponent(b, i, componentBounds))
+                {
+                    values = componentBounds.get(b).subList(0, i + 1);
+                    inclusive = isInclusive(b);
+                }
             }
-            toAdd.add(values);
 
-            if (bound.isEnd())
-                Collections.reverse(toAdd);
+            if (values.size() > sizeOfLastElement)
+                toAdd.add(MultiCBuilder.Element.bound(values, bound, inclusive));
+        }
 
-            return builder.addAllElementsToAll(toAdd);
+
+
+        /**
+         * Generates a list of clustering bounds that exclude the skipped values.
+         * I.e. for skipped elements (s1, s2, ..., sN), generates the slices
+         * (BOTTOM, s1), (s1, s2), ..., (s(N-1), sN), (sN, TOP) and returns the list of
+         * their start or end bounds depending on the selected `bound` param.
+         *
+         * @param bound which bound of the slices we want to generate
+         * @param options needed to get the actual values bound to markers
+         * @param toAdd receiver of the result
+         */
+        private void addSkippedValues(Bound bound, QueryOptions options, List<MultiCBuilder.Element> toAdd)
+        {
+            for (MarkerOrList markerOrList: skippedValues)
+            {
+                for (List<ByteBuffer> tuple: markerOrList.bindAndGetTuples(options, ColumnMetadata.toIdentifiers(columnDefs)))
+                {
+                    MultiCBuilder.Element element = MultiCBuilder.Element.bound(tuple, bound, false);
+                    toAdd.add(element);
+                }
+            }
         }
 
         @Override
@@ -495,7 +526,12 @@ public abstract class MultiColumnRestriction implements SingleRestriction
             SliceRestriction otherSlice = (SliceRestriction) otherRestriction;
             List<ColumnMetadata> newColumnDefs = columnDefs.size() >= otherSlice.columnDefs.size() ? columnDefs : otherSlice.columnDefs;
 
-            return new SliceRestriction(newColumnDefs, slice.merge(otherSlice.slice));
+            int sizeHint = skippedValues.size() + otherSlice.skippedValues.size();
+            List<MarkerOrList> newSkippedValues = new ArrayList<>(sizeHint);
+            newSkippedValues.addAll(skippedValues);
+            newSkippedValues.addAll(otherSlice.skippedValues);
+            TermSlice newSlice = slice.merge(otherSlice.slice);
+            return new SliceRestriction(newColumnDefs, newSlice, newSkippedValues);
         }
 
         @Override
@@ -509,7 +545,7 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         @Override
         public String toString()
         {
-            return "SLICE" + slice;
+            return String.format("SLICE{%s, NOT IN %s}", slice, skippedValues);
         }
 
         /**
@@ -524,14 +560,22 @@ public abstract class MultiColumnRestriction implements SingleRestriction
             if (!slice.hasBound(b))
                 return Collections.emptyList();
 
-            Terminal terminal = slice.bound(b).bind(options);
+            List<ByteBuffer> bounds = bindTuple(slice.bound(b).bind(options), options);
 
-            if (terminal instanceof Tuples.Value)
-            {
-                return ((Tuples.Value) terminal).getElements();
-            }
+            assert bounds.size() <= columnDefs.size();
+            int hasNullAt = bounds.indexOf(null);
+            if (hasNullAt != -1)
+                throw new InvalidRequestException(String.format(
+                    "Invalid null value in condition for column %s", columnDefs.get(hasNullAt).name));
 
-            return Collections.singletonList(terminal.get(options.getProtocolVersion()));
+            return bounds;
+        }
+
+        private static List<ByteBuffer> bindTuple(Terminal terminal, QueryOptions options)
+        {
+            return terminal instanceof Tuples.Value
+                ? ((Tuples.Value) terminal).getElements()
+                : Collections.singletonList(terminal.get(options.getProtocolVersion()));
         }
 
         private boolean hasComponent(Bound b, int index, EnumMap<Bound, List<ByteBuffer>> componentBounds)

--- a/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/MultiColumnRestriction.java
@@ -172,8 +172,20 @@ public abstract class MultiColumnRestriction implements SingleRestriction
         @Override
         public SingleRestriction doMergeWith(SingleRestriction otherRestriction)
         {
+            if (otherRestriction instanceof SliceRestriction)
+            {
+                SingleRestriction thisAsSlice = this.toSliceRestriction();
+                return thisAsSlice.mergeWith(otherRestriction);
+            }
             throw invalidRequest("%s cannot be restricted by more than one relation if it includes an Equal",
                                  getColumnsInCommons(otherRestriction));
+        }
+
+        private SingleRestriction toSliceRestriction()
+        {
+            SliceRestriction start = SliceRestriction.fromBound(columnDefs, Bound.START, true, this.value);
+            SliceRestriction end = SliceRestriction.fromBound(columnDefs, Bound.END, true, this.value);
+            return start.mergeWith(end);
         }
 
         @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/PartitionKeySingleRestrictionSet.java
@@ -82,7 +82,7 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
     @Override
     public List<ByteBuffer> values(QueryOptions options, ClientState state)
     {
-        MultiCBuilder builder = MultiCBuilder.create(comparator, hasIN());
+        MultiCBuilder builder = MultiCBuilder.create(comparator);
         for (SingleRestriction r : restrictions)
         {
             r.appendTo(builder, options);
@@ -90,7 +90,7 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
             if (hasIN() && Guardrails.inSelectCartesianProduct.enabled(state))
                 Guardrails.inSelectCartesianProduct.guard(builder.buildSize(), "partition key", false, state);
 
-            if (builder.hasMissingElements())
+            if (builder.buildSize() == 0)
                 break;
         }
         return toByteBuffers(builder.build());
@@ -99,14 +99,14 @@ final class PartitionKeySingleRestrictionSet extends RestrictionSetWrapper imple
     @Override
     public List<ByteBuffer> bounds(Bound bound, QueryOptions options)
     {
-        MultiCBuilder builder = MultiCBuilder.create(comparator, hasIN());
+        MultiCBuilder builder = MultiCBuilder.create(comparator);
         for (SingleRestriction r : restrictions)
         {
             r.appendBoundTo(builder, bound, options);
-            if (builder.hasMissingElements())
+            if (builder.buildSize() == 0)
                 return Collections.emptyList();
         }
-        return toByteBuffers(builder.buildBound(bound.isStart(), true));
+        return toByteBuffers(builder.buildBound(bound.isStart()));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -295,7 +295,9 @@ final class RestrictionSet implements Restrictions, Iterable<SingleRestriction>
             if (restriction.isContains())
             {
                 ContainsRestriction contains = (ContainsRestriction) restriction;
-                numberOfContains += (contains.numberOfValues() + contains.numberOfKeys() + contains.numberOfEntries());
+                numberOfContains += (contains.numberOfValues() + contains.numberOfNegativeValues() +
+                                     contains.numberOfKeys() + contains.numberOfNegativeKeys() +
+                                     contains.numberOfEntries() + contains.numberOfNegativeEntries());
             }
         }
         return numberOfContains > 1;

--- a/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/RestrictionSet.java
@@ -178,21 +178,12 @@ final class RestrictionSet implements Restrictions, Iterable<SingleRestriction>
         Collection<ColumnMetadata> columnDefs = restriction.getColumnDefs();
         Set<SingleRestriction> existingRestrictions = getRestrictions(columnDefs);
 
-        if (existingRestrictions.isEmpty())
-        {
-            for (ColumnMetadata columnDef : columnDefs)
-                restrictions.put(columnDef, restriction);
-        }
-        else
-        {
-            for (SingleRestriction existing : existingRestrictions)
-            {
-                SingleRestriction newRestriction = mergeRestrictions(existing, restriction);
+        SingleRestriction merged = restriction;
+        for (SingleRestriction existing : existingRestrictions)
+            merged = mergeRestrictions(existing, merged);
 
-                for (ColumnMetadata columnDef : columnDefs)
-                    restrictions.put(columnDef, newRestriction);
-            }
-        }
+        for (ColumnMetadata columnDef : merged.getColumnDefs())
+            restrictions.put(columnDef, merged);
 
         return restrictions;
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.ListSerializer;
 import org.apache.cassandra.cql3.*;
-import org.apache.cassandra.cql3.Term.Terminal;
 import org.apache.cassandra.cql3.functions.Function;
 import org.apache.cassandra.cql3.statements.Bound;
 import org.apache.cassandra.db.MultiCBuilder;
@@ -37,7 +36,6 @@ import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkBindValueSet;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse;
-import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
 
@@ -161,7 +159,8 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public MultiCBuilder appendTo(MultiCBuilder builder, QueryOptions options)
         {
-            builder.addElementToAll(value.bindAndGet(options));
+            List<MultiCBuilder.Element> element = Collections.singletonList(MultiCBuilder.Element.point(value.bindAndGet(options)));
+            builder.extend(element, getColumnDefs());
             checkFalse(builder.containsNull(), "Invalid null value in condition for column %s", columnDef.name);
             checkFalse(builder.containsUnset(), "Invalid unset value for column %s", columnDef.name);
             return builder;
@@ -186,11 +185,14 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
     }
 
-    public static abstract class INRestriction extends SingleColumnRestriction
+    public static class INRestriction extends SingleColumnRestriction
     {
-        public INRestriction(ColumnMetadata columnDef)
+        protected final MarkerOrList values;
+
+        public INRestriction(ColumnMetadata columnDef, MarkerOrList values)
         {
             super(columnDef);
+            this.values = values;
         }
 
         @Override
@@ -206,9 +208,19 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
 
         @Override
+        MultiColumnRestriction toMultiColumnRestriction()
+        {
+            throw new UnsupportedOperationException("Cannot convert to multicolumn restriction");
+        }
+
+        @Override
         public MultiCBuilder appendTo(MultiCBuilder builder, QueryOptions options)
         {
-            builder.addEachElementToAll(getValues(options));
+            List<ByteBuffer> values = this.values.bindAndGet(options, columnDef.name);
+            List<MultiCBuilder.Element> elements = new ArrayList<>(values.size());
+            for (ByteBuffer value: values)
+                elements.add(MultiCBuilder.Element.point(value));
+            builder.extend(elements, getColumnDefs());
             checkFalse(builder.containsNull(), "Invalid null value in condition for column %s", columnDef.name);
             checkFalse(builder.containsUnset(), "Invalid unset value for column %s", columnDef.name);
             return builder;
@@ -219,49 +231,21 @@ public abstract class SingleColumnRestriction implements SingleRestriction
                                    IndexRegistry indexRegistry,
                                    QueryOptions options)
         {
-            List<ByteBuffer> values = getValues(options);
+            List<ByteBuffer> values = this.values.bindAndGet(options, columnDef.name);
             ByteBuffer buffer = ListSerializer.pack(values, values.size());
             filter.add(columnDef, Operator.IN, buffer);
         }
 
         @Override
-        protected final boolean isSupportedBy(Index index)
-        {
-            return index.supportsExpression(columnDef, Operator.IN);
-        }
-
-        protected abstract List<ByteBuffer> getValues(QueryOptions options);
-    }
-
-    public static class InRestrictionWithValues extends INRestriction
-    {
-        protected final List<Term> values;
-
-        public InRestrictionWithValues(ColumnMetadata columnDef, List<Term> values)
-        {
-            super(columnDef);
-            this.values = values;
-        }
-
-        @Override
-        MultiColumnRestriction toMultiColumnRestriction()
-        {
-            return new MultiColumnRestriction.InRestrictionWithValues(Collections.singletonList(columnDef), values);
-        }
-
-        @Override
         public void addFunctionsTo(List<Function> functions)
         {
-            Terms.addFunctions(values, functions);
+            values.addFunctionsTo(functions);
         }
 
         @Override
-        protected List<ByteBuffer> getValues(QueryOptions options)
+        public final boolean isSupportedBy(Index index)
         {
-            List<ByteBuffer> buffers = new ArrayList<>(values.size());
-            for (Term value : values)
-                buffers.add(value.bindAndGet(options));
-            return buffers;
+            return index.supportsExpression(columnDef, Operator.IN);
         }
 
         @Override
@@ -271,52 +255,29 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
     }
 
-    public static class InRestrictionWithMarker extends INRestriction
-    {
-        protected final AbstractMarker marker;
-
-        public InRestrictionWithMarker(ColumnMetadata columnDef, AbstractMarker marker)
-        {
-            super(columnDef);
-            this.marker = marker;
-        }
-
-        @Override
-        public void addFunctionsTo(List<Function> functions)
-        {
-        }
-
-        @Override
-        MultiColumnRestriction toMultiColumnRestriction()
-        {
-            return new MultiColumnRestriction.InRestrictionWithMarker(Collections.singletonList(columnDef), marker);
-        }
-
-        @Override
-        protected List<ByteBuffer> getValues(QueryOptions options)
-        {
-            Terminal term = marker.bind(options);
-            checkNotNull(term, "Invalid null value for column %s", columnDef.name);
-            checkFalse(term == Constants.UNSET_VALUE, "Invalid unset value for column %s", columnDef.name);
-            Term.MultiItemTerminal lval = (Term.MultiItemTerminal) term;
-            return lval.getElements();
-        }
-
-        @Override
-        public String toString()
-        {
-            return "IN ?";
-        }
-    }
-
     public static class SliceRestriction extends SingleColumnRestriction
     {
         private final TermSlice slice;
+        private final List<MarkerOrList> skippedValues; // values passed in NOT IN
 
-        public SliceRestriction(ColumnMetadata columnDef, Bound bound, boolean inclusive, Term term)
+        private SliceRestriction(ColumnMetadata columnDef, TermSlice slice, List<MarkerOrList> skippedValues)
         {
             super(columnDef);
-            slice = TermSlice.newInstance(bound, inclusive, term);
+            assert slice != null;
+            assert skippedValues != null;
+            this.slice = slice;
+            this.skippedValues = skippedValues;
+        }
+
+        public static SliceRestriction fromBound(ColumnMetadata columnDef, Bound bound, boolean inclusive, Term term)
+        {
+            TermSlice slice = TermSlice.newInstance(bound, inclusive, term);
+            return new SliceRestriction(columnDef, slice, Collections.emptyList());
+        }
+
+        public static SliceRestriction fromSkippedValues(ColumnMetadata columnDef, MarkerOrList skippedValues)
+        {
+            return new SliceRestriction(columnDef, TermSlice.UNBOUNDED, Collections.singletonList(skippedValues));
         }
 
         @Override
@@ -328,7 +289,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         MultiColumnRestriction toMultiColumnRestriction()
         {
-            return new MultiColumnRestriction.SliceRestriction(Collections.singletonList(columnDef), slice);
+            return new MultiColumnRestriction.SliceRestriction(Collections.singletonList(columnDef), slice, skippedValues);
         }
 
         @Override
@@ -354,13 +315,27 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         {
             Bound b = bound.reverseIfNeeded(getFirstColumn());
 
-            if (!hasBound(b))
-                return builder;
+            List<MultiCBuilder.Element> toAdd = new ArrayList<>(skippedValues.size() + 1);
+            if (hasBound(b))
+            {
+                ByteBuffer value = slice.bound(b).bindAndGet(options);
+                checkBindValueSet(value, "Invalid unset value for column %s", columnDef.name);
+                toAdd.add(MultiCBuilder.Element.bound(value, bound, slice.isInclusive(b)));
+            }
+            else
+            {
+                toAdd.add(bound.isStart() ? MultiCBuilder.Element.BOTTOM : MultiCBuilder.Element.TOP);
+            }
 
-            ByteBuffer value = slice.bound(b).bindAndGet(options);
-            checkBindValueSet(value, "Invalid unset value for column %s", columnDef.name);
-            return builder.addElementToAll(value);
-
+            for (MarkerOrList markerOrList: skippedValues)
+            {
+                for (ByteBuffer value: markerOrList.bindAndGet(options, columnDef.name))
+                {
+                    checkBindValueSet(value, "Invalid unset value for column %s", columnDef.name);
+                    toAdd.add(MultiCBuilder.Element.bound(value, bound, false));
+                }
+            }
+            return builder.extend(toAdd, getColumnDefs());
         }
 
         @Override
@@ -384,7 +359,10 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             checkFalse(hasBound(Bound.END) && otherSlice.hasBound(Bound.END),
                        "More than one restriction was found for the end bound on %s", columnDef.name);
 
-            return new SliceRestriction(columnDef,  slice.merge(otherSlice.slice));
+            List<MarkerOrList> newSkippedValues = new ArrayList<>(skippedValues.size() + otherSlice.skippedValues.size());
+            newSkippedValues.addAll(skippedValues);
+            newSkippedValues.addAll(otherSlice.skippedValues);
+            return new SliceRestriction(columnDef,  slice.merge(otherSlice.slice), newSkippedValues);
         }
 
         @Override
@@ -393,6 +371,12 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             for (Bound b : Bound.values())
                 if (hasBound(b))
                     filter.add(columnDef, slice.getIndexOperator(b), slice.bound(b).bindAndGet(options));
+
+            for (MarkerOrList markerOrList: skippedValues)
+            {
+                for (ByteBuffer value : markerOrList.bindAndGet(options, columnDef.name))
+                   filter.add(columnDef, Operator.NEQ, value);
+            }
         }
 
         @Override
@@ -404,14 +388,9 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         @Override
         public String toString()
         {
-            return String.format("SLICE%s", slice);
+            return String.format("SLICE{%s, NOT IN %s}", slice, skippedValues);
         }
 
-        private SliceRestriction(ColumnMetadata columnDef, TermSlice slice)
-        {
-            super(columnDef);
-            this.slice = slice;
-        }
     }
 
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SingleColumnRestriction.java
@@ -414,28 +414,51 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         }
     }
 
-    // This holds CONTAINS, CONTAINS_KEY, and map[key] = value restrictions because we might want to have any combination of them.
+
+    // This holds CONTAINS, CONTAINS_KEY, NOT CONTAINS, NOT CONTAINS KEY and map[key] = value restrictions because we might want to have any combination of them.
     public static final class ContainsRestriction extends SingleColumnRestriction
     {
         private List<Term> values = new ArrayList<>(); // for CONTAINS
+        private List<Term> negativeValues = new ArrayList<>(); // for NOT_CONTAINS
         private List<Term> keys = new ArrayList<>(); // for CONTAINS_KEY
+        private List<Term> negativeKeys = new ArrayList<>(); // for NOT_CONTAINS_KEY
         private List<Term> entryKeys = new ArrayList<>(); // for map[key] = value
         private List<Term> entryValues = new ArrayList<>(); // for map[key] = value
+        private List<Term> negativeEntryKeys = new ArrayList<>(); // for map[key] != value
+        private List<Term> negativeEntryValues = new ArrayList<>(); // for map[key] != value
 
-        public ContainsRestriction(ColumnMetadata columnDef, Term t, boolean isKey)
+        public ContainsRestriction(ColumnMetadata columnDef, Term t, boolean isKey, boolean isNot)
         {
             super(columnDef);
-            if (isKey)
-                keys.add(t);
+            if (isNot)
+            {
+                if (isKey)
+                    negativeKeys.add(t);
+                else
+                    negativeValues.add(t);
+            }
             else
-                values.add(t);
+            {
+                if (isKey)
+                    keys.add(t);
+                else
+                    values.add(t);
+            }
         }
 
-        public ContainsRestriction(ColumnMetadata columnDef, Term mapKey, Term mapValue)
+        public ContainsRestriction(ColumnMetadata columnDef, Term mapKey, Term mapValue, boolean isNot)
         {
             super(columnDef);
-            entryKeys.add(mapKey);
-            entryValues.add(mapValue);
+            if (isNot)
+            {
+                negativeEntryKeys.add(mapKey);
+                negativeEntryValues.add(mapValue);
+            }
+            else
+            {
+                entryKeys.add(mapKey);
+                entryValues.add(mapValue);
+            }
         }
 
         @Override
@@ -470,7 +493,6 @@ public abstract class SingleColumnRestriction implements SingleRestriction
                       columnDef.name);
 
             SingleColumnRestriction.ContainsRestriction newContains = new ContainsRestriction(columnDef);
-
             copyKeysAndValues(this, newContains);
             copyKeysAndValues((ContainsRestriction) otherRestriction, newContains);
 
@@ -484,12 +506,23 @@ public abstract class SingleColumnRestriction implements SingleRestriction
                 filter.add(columnDef, Operator.CONTAINS, value);
             for (ByteBuffer key : bindAndGet(keys, options))
                 filter.add(columnDef, Operator.CONTAINS_KEY, key);
+            for (ByteBuffer value : bindAndGet(negativeValues, options))
+                filter.add(columnDef, Operator.NOT_CONTAINS, value);
+            for (ByteBuffer key : bindAndGet(negativeKeys, options))
+                filter.add(columnDef, Operator.NOT_CONTAINS_KEY, key);
 
             List<ByteBuffer> eks = bindAndGet(entryKeys, options);
             List<ByteBuffer> evs = bindAndGet(entryValues, options);
             assert eks.size() == evs.size();
             for (int i = 0; i < eks.size(); i++)
                 filter.addMapEquality(columnDef, eks.get(i), Operator.EQ, evs.get(i));
+
+            List<ByteBuffer> neks = bindAndGet(negativeEntryKeys, options);
+            List<ByteBuffer> nevs = bindAndGet(negativeEntryValues, options);
+            assert neks.size() == nevs.size();
+            for (int i = 0; i < neks.size(); i++)
+                filter.addMapEquality(columnDef, neks.get(i), Operator.NEQ, nevs.get(i));
+
         }
 
         @Override
@@ -503,8 +536,17 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             if (numberOfKeys() > 0)
                 supported |= index.supportsExpression(columnDef, Operator.CONTAINS_KEY);
 
+            if (numberOfNegativeValues() > 0)
+                supported |= index.supportsExpression(columnDef, Operator.NOT_CONTAINS);
+
+            if (numberOfNegativeKeys() > 0)
+                supported |= index.supportsExpression(columnDef, Operator.NOT_CONTAINS_KEY);
+
             if (numberOfEntries() > 0)
                 supported |= index.supportsExpression(columnDef, Operator.EQ);
+
+            if (numberOfNegativeEntries() > 0)
+                supported |= index.supportsExpression(columnDef, Operator.NEQ);
 
             return supported;
         }
@@ -514,14 +556,29 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             return values.size();
         }
 
+        public int numberOfNegativeValues()
+        {
+            return negativeValues.size();
+        }
+
         public int numberOfKeys()
         {
             return keys.size();
         }
 
+        public int numberOfNegativeKeys()
+        {
+            return negativeKeys.size();
+        }
+
         public int numberOfEntries()
         {
             return entryKeys.size();
+        }
+
+        public int numberOfNegativeEntries()
+        {
+            return negativeEntryKeys.size();
         }
 
         @Override
@@ -531,12 +588,18 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             Terms.addFunctions(keys, functions);
             Terms.addFunctions(entryKeys, functions);
             Terms.addFunctions(entryValues, functions);
+
+            Terms.addFunctions(negativeValues, functions);
+            Terms.addFunctions(negativeKeys, functions);
+            Terms.addFunctions(negativeEntryKeys, functions);
+            Terms.addFunctions(negativeEntryValues, functions);
         }
 
         @Override
         public String toString()
         {
-            return String.format("CONTAINS(values=%s, keys=%s, entryKeys=%s, entryValues=%s)", values, keys, entryKeys, entryValues);
+            return String.format("CONTAINS(values=%s, keys=%s, entryKeys=%s, entryValues=%s)",
+                                 values, keys, entryKeys, entryValues);
         }
 
         @Override
@@ -581,9 +644,14 @@ public abstract class SingleColumnRestriction implements SingleRestriction
         private static void copyKeysAndValues(ContainsRestriction from, ContainsRestriction to)
         {
             to.values.addAll(from.values);
+            to.negativeValues.addAll(from.negativeValues);
             to.keys.addAll(from.keys);
+            to.negativeKeys.addAll(from.negativeKeys);
             to.entryKeys.addAll(from.entryKeys);
             to.entryValues.addAll(from.entryValues);
+            to.negativeEntryKeys.addAll(from.negativeEntryKeys);
+            to.negativeEntryValues.addAll(from.negativeEntryValues);
+
         }
 
         private ContainsRestriction(ColumnMetadata columnDef)
@@ -591,6 +659,7 @@ public abstract class SingleColumnRestriction implements SingleRestriction
             super(columnDef);
         }
     }
+
 
     public static final class IsNotNullRestriction extends SingleColumnRestriction
     {

--- a/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/StatementRestrictions.java
@@ -177,7 +177,8 @@ public final class StatementRestrictions
          */
         for (Relation relation : whereClause.relations)
         {
-            if ((relation.isContains() || relation.isContainsKey()) && (type.isUpdate() || type.isDelete()))
+            if ((relation.isContains() || relation.isContainsKey() || relation.isNotContains() || relation.isNotContainsKey())
+                && (type.isUpdate() || type.isDelete()))
             {
                 throw invalidRequest("Cannot use %s with %s", type, relation.operator());
             }
@@ -189,7 +190,7 @@ public final class StatementRestrictions
 
                 this.notNullColumns.addAll(relation.toRestriction(table, boundNames).getColumnDefs());
             }
-            else if (relation.isLIKE())
+            else if (relation.isLIKE() || relation.isNotLIKE())
             {
                 Restriction restriction = relation.toRestriction(table, boundNames);
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/TermSlice.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/TermSlice.java
@@ -29,6 +29,12 @@ import org.apache.cassandra.index.Index;
 final class TermSlice
 {
     /**
+     * Represents a slice with no bounds.
+     * Can be merged with any other slice.
+     */
+    public static final TermSlice UNBOUNDED = new TermSlice(null, false, null, false);
+
+    /**
      * The slice boundaries.
      */
     private final Term[] bounds;
@@ -108,21 +114,16 @@ final class TermSlice
      */
     public TermSlice merge(TermSlice otherSlice)
     {
-        if (hasBound(Bound.START))
-        {
-            assert !otherSlice.hasBound(Bound.START);
+        assert !(hasBound(Bound.START) && otherSlice.hasBound(Bound.START));
+        assert !(hasBound(Bound.END) && otherSlice.hasBound(Bound.END));
 
-            return new TermSlice(bound(Bound.START),
-                                  isInclusive(Bound.START),
-                                  otherSlice.bound(Bound.END),
-                                  otherSlice.isInclusive(Bound.END));
-        }
-        assert !otherSlice.hasBound(Bound.END);
+        TermSlice sliceForStart = hasBound(Bound.START) ? this : otherSlice;
+        TermSlice sliceForEnd = hasBound(Bound.END) ? this : otherSlice;
 
-        return new TermSlice(otherSlice.bound(Bound.START),
-                              otherSlice.isInclusive(Bound.START),
-                              bound(Bound.END),
-                              isInclusive(Bound.END));
+        return new TermSlice(sliceForStart.bound(Bound.START),
+                             sliceForStart.isInclusive(Bound.START),
+                             sliceForEnd.bound(Bound.END),
+                             sliceForEnd.isInclusive(Bound.END));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -655,6 +655,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             {
                 case EQ:
                 case IN:
+                case NOT_IN:
                 case LT:
                 case LTE:
                 case GTE:

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -692,63 +692,77 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
                         return foundValue != null && operator.isSatisfiedBy(column.type, foundValue, value);
                     }
                 case CONTAINS:
-                    assert column.type.isCollection();
-                    CollectionType<?> type = (CollectionType<?>)column.type;
-                    if (column.isComplex())
-                    {
-                        ComplexColumnData complexData = row.getComplexColumnData(column);
-                        if (complexData != null)
-                        {
-                            for (Cell<?> cell : complexData)
-                            {
-                                if (type.kind == CollectionType.Kind.SET)
-                                {
-                                    if (type.nameComparator().compare(cell.path().get(0), value) == 0)
-                                        return true;
-                                }
-                                else
-                                {
-                                    if (type.valueComparator().compare(cell.buffer(), value) == 0)
-                                        return true;
-                                }
-                            }
-                        }
-                        return false;
-                    }
-                    else
-                    {
-                        ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                        if (foundValue == null)
-                            return false;
-
-                        switch (type.kind)
-                        {
-                            case LIST:
-                                ListType<?> listType = (ListType<?>)type;
-                                return listType.compose(foundValue).contains(listType.getElementsType().compose(value));
-                            case SET:
-                                SetType<?> setType = (SetType<?>)type;
-                                return setType.compose(foundValue).contains(setType.getElementsType().compose(value));
-                            case MAP:
-                                MapType<?,?> mapType = (MapType<?, ?>)type;
-                                return mapType.compose(foundValue).containsValue(mapType.getValuesType().compose(value));
-                        }
-                        throw new AssertionError();
-                    }
+                    return contains(metadata, partitionKey, row);
                 case CONTAINS_KEY:
-                    assert column.type.isCollection() && column.type instanceof MapType;
-                    MapType<?, ?> mapType = (MapType<?, ?>)column.type;
-                    if (column.isComplex())
-                    {
-                         return row.getCell(column, CellPath.create(value)) != null;
-                    }
-                    else
-                    {
-                        ByteBuffer foundValue = getValue(metadata, partitionKey, row);
-                        return foundValue != null && mapType.getSerializer().getSerializedValue(foundValue, value, mapType.getKeysType()) != null;
-                    }
+                    return containsKey(metadata, partitionKey, row);
+                case NOT_CONTAINS:
+                    return !contains(metadata, partitionKey, row);
+                case NOT_CONTAINS_KEY:
+                    return !containsKey(metadata, partitionKey, row);
             }
             throw new AssertionError();
+        }
+
+        private boolean contains(TableMetadata metadata, DecoratedKey partitionKey, Row row)
+        {
+            assert column.type.isCollection();
+            CollectionType<?> type = (CollectionType<?>)column.type;
+            if (column.isComplex())
+            {
+                ComplexColumnData complexData = row.getComplexColumnData(column);
+                if (complexData != null)
+                {
+                    for (Cell<?> cell : complexData)
+                    {
+                        if (type.kind == CollectionType.Kind.SET)
+                        {
+                            if (type.nameComparator().compare(cell.path().get(0), value) == 0)
+                                return true;
+                        }
+                        else
+                        {
+                            if (type.valueComparator().compare(cell.buffer(), value) == 0)
+                                return true;
+                        }
+                    }
+                }
+                return false;
+            }
+            else
+            {
+                ByteBuffer foundValue = getValue(metadata, partitionKey, row);
+                if (foundValue == null)
+                    return false;
+
+                switch (type.kind)
+                {
+                    case LIST:
+                        ListType<?> listType = (ListType<?>)type;
+                        return listType.compose(foundValue).contains(listType.getElementsType().compose(value));
+                    case SET:
+                        SetType<?> setType = (SetType<?>)type;
+                        return setType.compose(foundValue).contains(setType.getElementsType().compose(value));
+                    case MAP:
+                        MapType<?,?> mapType = (MapType<?, ?>)type;
+                        return mapType.compose(foundValue).containsValue(mapType.getValuesType().compose(value));
+                }
+                throw new AssertionError();
+            }
+        }
+
+        private boolean containsKey(TableMetadata metadata, DecoratedKey partitionKey, Row row)
+        {
+            assert column.type.isCollection() && column.type instanceof MapType;
+            MapType<?, ?> mapType = (MapType<?, ?>)column.type;
+            if (column.isComplex())
+            {
+                return row.getCell(column, CellPath.create(value)) != null;
+            }
+            else
+            {
+                ByteBuffer foundValue = getValue(metadata, partitionKey, row);
+                return foundValue != null && mapType.getSerializer().getSerializedValue(foundValue, value, mapType.getKeysType()) != null;
+            }
         }
 
         @Override
@@ -795,7 +809,7 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         public MapEqualityExpression(ColumnMetadata column, ByteBuffer key, Operator operator, ByteBuffer value)
         {
             super(column, operator, value);
-            assert column.type instanceof MapType && operator == Operator.EQ;
+            assert column.type instanceof MapType && (operator == Operator.EQ || operator == Operator.NEQ);
             this.key = key;
         }
 
@@ -815,6 +829,11 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
         }
 
         public boolean isSatisfiedBy(TableMetadata metadata, DecoratedKey partitionKey, Row row)
+        {
+            return isSatisfiedByEq(metadata, partitionKey, row) ^ (operator == Operator.NEQ);
+        }
+
+        private boolean isSatisfiedByEq(TableMetadata metadata, DecoratedKey partitionKey, Row row)
         {
             assert key != null;
             // We support null conditions for LWT (in ColumnCondition) but not for RowFilter.
@@ -848,8 +867,8 @@ public abstract class RowFilter implements Iterable<RowFilter.Expression>
             AbstractType<?> nt = mt.nameComparator();
             AbstractType<?> vt = mt.valueComparator();
             return cql
-                 ? String.format("%s[%s] = %s", column.name.toCQLString(), nt.toCQLString(key), vt.toCQLString(value))
-                 : String.format("%s[%s] = %s", column.name.toString(), nt.getString(key), vt.getString(value));
+                 ? String.format("%s[%s] %s %s", column.name.toCQLString(), operator, nt.toCQLString(key), vt.toCQLString(value))
+                 : String.format("%s[%s] %s %s", column.name.toString(), operator, nt.getString(key), vt.getString(value));
         }
 
         @Override

--- a/src/java/org/apache/cassandra/utils/UniqueComparator.java
+++ b/src/java/org/apache/cassandra/utils/UniqueComparator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils;
+
+import java.util.Comparator;
+
+/**
+ * Converts any comparator to a comparator that never treats distinct objects as equal,
+ * even if the original comparator considers them equal.
+ * For all other items, the order of the original comparator is preserved.
+ * Allows to store duplicate items in sorted sets.
+ */
+public class UniqueComparator<T> implements Comparator<T>
+{
+    private final Comparator<T> comparator;
+
+    public UniqueComparator(Comparator<T> comparator)
+    {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public int compare(T o1, T o2)
+    {
+        int result = comparator.compare(o1, o2);
+        if (result == 0 && o1 != o2)
+        {
+            // If the wrapped comparator considers the items equal,
+            // but they are not actually the same object, distinguish them
+            return System.identityHashCode(o1) - System.identityHashCode(o2);
+        }
+        return result;
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictionsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/restrictions/ClusteringColumnRestrictionsTest.java
@@ -1808,7 +1808,7 @@ public class ClusteringColumnRestrictionsTest
             columnMetadatas.add(getClusteringColumnDefinition(tableMetadata, firstIndex + i));
             terms.add(toMultiItemTerminal(values[i].toArray(new ByteBuffer[0])));
         }
-        return new MultiColumnRestriction.InRestrictionWithValues(columnMetadatas, terms);
+        return new MultiColumnRestriction.INRestriction(columnMetadatas, MarkerOrList.list(terms));
     }
 
     /**
@@ -1822,7 +1822,7 @@ public class ClusteringColumnRestrictionsTest
     private static Restriction newSingleIN(TableMetadata tableMetadata, int index, ByteBuffer... values)
     {
         ColumnMetadata columnDef = getClusteringColumnDefinition(tableMetadata, index);
-        return new SingleColumnRestriction.InRestrictionWithValues(columnDef, toTerms(values));
+        return new SingleColumnRestriction.INRestriction(columnDef, MarkerOrList.list(toTerms(values)));
     }
 
     /**
@@ -1850,7 +1850,7 @@ public class ClusteringColumnRestrictionsTest
     private static Restriction newSingleSlice(TableMetadata tableMetadata, int index, Bound bound, boolean inclusive, ByteBuffer value)
     {
         ColumnMetadata columnDef = getClusteringColumnDefinition(tableMetadata, index);
-        return new SingleColumnRestriction.SliceRestriction(columnDef, bound, inclusive, toTerm(value));
+        return SingleColumnRestriction.SliceRestriction.fromBound(columnDef, bound, inclusive, toTerm(value));
     }
 
     /**
@@ -1870,7 +1870,7 @@ public class ClusteringColumnRestrictionsTest
         {
             columnMetadatas.add(getClusteringColumnDefinition(tableMetadata, i + firstIndex));
         }
-        return new MultiColumnRestriction.SliceRestriction(columnMetadatas, bound, inclusive, toMultiItemTerminal(values));
+        return MultiColumnRestriction.SliceRestriction.fromBound(columnMetadatas, bound, inclusive, toMultiItemTerminal(values));
     }
 
     /**

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectMultiColumnRelationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectMultiColumnRelationTest.java
@@ -932,13 +932,13 @@ public class SelectMultiColumnRelationTest extends CQLTester
                    row(0, 0, 1, 1, 1, 5));
 
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) ALLOW FILTERING", 0, 1, 1),
-                row(0, 0, 1, 1, 0, 4),
-                row(0, 0, 1, 1, 1, 5));
+                   row(0, 0, 1, 1, 0, 4),
+                   row(0, 0, 1, 1, 1, 5));
 
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) ALLOW FILTERING", 0, 1, 1),
-                row(0, 0, 1, 1, 0, 4),
-                row(0, 0, 1, 1, 1, 5),
-                row(0, 0, 2, 0, 0, 5));
+                   row(0, 0, 1, 1, 0, 4),
+                   row(0, 0, 1, 1, 1, 5),
+                   row(0, 0, 2, 0, 0, 5));
 
         assertRows(execute("SELECT * FROM %s WHERE a = ? AND b = ? AND (c) IN ((?)) AND f = ?", 0, 0, 1, 5),
                    row(0, 0, 1, 1, 1, 5));
@@ -1049,10 +1049,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         execute("INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, -1, 0);
         execute("INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, 0, 0);
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>(?)", 0, 2, 0, 1, 1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<=(?,?,?,?) " +
+                   "AND (b)>(?)", 0, 2, 0, 1, 1, -1),
 
                    row(0, 2, 0, 1, 1),
                    row(0, 2, 0, -1, 0),
@@ -1075,10 +1075,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
 
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>=(?)", 0, 2, 0, 1, 1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<=(?,?,?,?) " +
+                   "AND (b)>=(?)", 0, 2, 0, 1, 1, -1),
 
                    row(0, 2, 0, 1, 1),
                    row(0, 2, 0, -1, 0),
@@ -1102,20 +1102,20 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d)>=(?,?,?)" +
-        "AND (b,c,d,e)<(?,?,?,?) ", 0, 1, 1, 0, 1, 1, 0, 1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d)>=(?,?,?)" +
+                   "AND (b,c,d,e)<(?,?,?,?) ", 0, 1, 1, 0, 1, 1, 0, 1),
                    row(0, 1, 1, 0, -1),
                    row(0, 1, 1, 0, 0)
 
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)>(?,?,?,?)" +
-        "AND (b,c,d)<=(?,?,?) ", 0, -1, 0, -1, -1, 2, 0, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)>(?,?,?,?)" +
+                   "AND (b,c,d)<=(?,?,?) ", 0, -1, 0, -1, -1, 2, 0, -1),
 
                    row(0, 2, 0, -1, 0),
                    row(0, 2, 0, -1, 1),
@@ -1138,27 +1138,27 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) < (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e) < (?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
                    row(0, 1, 0, 0, -1)
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) <= (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e) <= (?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
                    row(0, 1, 0, 0, -1),
                    row(0, 1, 0, 0, 0)
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b)<(?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b)<(?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, -1, 0, -1, -1),
 
                    row(0, 1, -1, 1, 0),
                    row(0, 1, -1, 1, 1),
@@ -1181,10 +1181,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
 
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b)<(?) " +
-        "AND (b)>(?)", 0, 2, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b)<(?) " +
+                   "AND (b)>(?)", 0, 2, -1),
 
                    row(0, 1, -1, 1, 0),
                    row(0, 1, -1, 1, 1),
@@ -1204,10 +1204,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b)<(?) " +
-        "AND (b)>=(?)", 0, 2, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b)<(?) " +
+                   "AND (b)>=(?)", 0, 2, -1),
 
                    row(0, 1, -1, 1, 0),
                    row(0, 1, -1, 1, 1),
@@ -1228,10 +1228,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<=(?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
 
                    row(0, 2, 0, 1, 1),
                    row(0, 2, 0, -1, 0),
@@ -1255,10 +1255,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<=(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c)<=(?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
 
                    row(0, 2, 0, 1, 1),
                    row(0, 2, 0, -1, 0),
@@ -1282,10 +1282,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d)<=(?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d)<=(?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, -1, 0, -1, -1),
 
                    row(0, 2, 0, -1, 0),
                    row(0, 2, 0, -1, 1),
@@ -1308,10 +1308,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)>(?,?,?,?)" +
-        "AND (b,c,d)<=(?,?,?) ", 0, -1, 0, -1, -1, 2, 0, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)>(?,?,?,?)" +
+                   "AND (b,c,d)<=(?,?,?) ", 0, -1, 0, -1, -1, 2, 0, -1),
 
                    row(0, 2, 0, -1, 0),
                    row(0, 2, 0, -1, 1),
@@ -1334,28 +1334,28 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d)>=(?,?,?)" +
-        "AND (b,c,d,e)<(?,?,?,?) ", 0, 1, 1, 0, 1, 1, 0, 1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d)>=(?,?,?)" +
+                   "AND (b,c,d,e)<(?,?,?,?) ", 0, 1, 1, 0, 1, 1, 0, 1),
                    row(0, 1, 1, 0, -1),
                    row(0, 1, 1, 0, 0)
         );
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<(?,?,?,?) " +
-        "AND (b,c,d)>=(?,?,?)", 0, 1, 1, 0, 1, 1, 1, 0),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<(?,?,?,?) " +
+                   "AND (b,c,d)>=(?,?,?)", 0, 1, 1, 0, 1, 1, 1, 0),
                    row(0, 1, 1, 0, -1),
                    row(0, 1, 1, 0, 0)
 
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c)<(?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
                    row(0, 1, -1, 1, 0),
                    row(0, 1, -1, 1, 1),
                    row(0, 1, -1, 0, 0),
@@ -1375,10 +1375,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c)<(?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
                    row(0, 1, -1, 1, 0),
                    row(0, 1, -1, 1, 1),
                    row(0, 1, -1, 0, 0),
@@ -1589,10 +1589,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         execute("INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, 0, 0);
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<(?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<(?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
 
                    row(0, -1, 0, 0, 0),
                    row(0, -1, 0, -1, 0),
@@ -1619,28 +1619,28 @@ public class SelectMultiColumnRelationTest extends CQLTester
 
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) < (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e) < (?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
                    row(0, 1, 0, 0, -1)
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) <= (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e) <= (?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
                    row(0, 1, 0, 0, -1),
                    row(0, 1, 0, 0, 0)
         );
 
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<=(?,?,?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
 
                    row(0, -1, 0, 0, 0),
                    row(0, -1, 0, -1, 0),
@@ -1666,10 +1666,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<=(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c)<=(?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
 
                    row(0, -1, 0, 0, 0),
                    row(0, -1, 0, -1, 0),
@@ -1695,10 +1695,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c)<(?,?) " +
+                   "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
                    row(0, -1, 0, 0, 0),
                    row(0, -1, 0, -1, 0),
                    row(0, 0, 0, 0, 0),
@@ -1720,10 +1720,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>=(?)", 0, 2, 0, 1, 1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<=(?,?,?,?) " +
+                   "AND (b)>=(?)", 0, 2, 0, 1, 1, -1),
 
                    row(0, -1, 0, 0, 0),
                    row(0, -1, 0, -1, 0),
@@ -1749,10 +1749,10 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>(?)", 0, 2, 0, 1, 1, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e)<=(?,?,?,?) " +
+                   "AND (b)>(?)", 0, 2, 0, 1, 1, -1),
 
                    row(0, 0, 0, 0, 0),
                    row(0, 1, 1, 0, -1),
@@ -1851,21 +1851,21 @@ public class SelectMultiColumnRelationTest extends CQLTester
         );
 
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b) < (?) ", 0, 0),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b) < (?) ", 0, 0),
                    row(0, -1, 0, 0, 0), row(0, -1, 0, -1, 0)
         );
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b) <= (?) ", 0, -1),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b) <= (?) ", 0, -1),
                    row(0, -1, 0, 0, 0), row(0, -1, 0, -1, 0)
         );
         assertRows(execute(
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) < (?,?,?,?) and (b,c,d,e) > (?,?,?,?) ", 0, 2, 0, 0, 0, 2, -2, 0, 0),
+                   "SELECT * FROM %s" +
+                   " WHERE a = ? " +
+                   "AND (b,c,d,e) < (?,?,?,?) and (b,c,d,e) > (?,?,?,?) ", 0, 2, 0, 0, 0, 2, -2, 0, 0),
                    row(0, 2, 0, -1, 0),
                    row(0, 2, 0, -1, 1),
                    row(0, 2, -1, 1, 1)
@@ -1928,6 +1928,7 @@ public class SelectMultiColumnRelationTest extends CQLTester
         assertInvalidMessage("Undefined column name e", "SELECT * FROM %s WHERE (b, e) > (0, 1) and b <= 2");
         assertInvalidMessage("Undefined column name e", "SELECT c AS e FROM %s WHERE (b, e) = (0, 0)");
         assertInvalidMessage("Undefined column name e", "SELECT c AS e FROM %s WHERE (b, e) IN ((0, 1), (2, 4))");
+        assertInvalidMessage("Undefined column name e", "SELECT c AS e FROM %s WHERE (b, e) NOT IN ((0, 1), (2, 4))");
         assertInvalidMessage("Undefined column name e", "SELECT c AS e FROM %s WHERE (b, e) > (0, 1) and b <= 2");
     }
 
@@ -1972,4 +1973,477 @@ public class SelectMultiColumnRelationTest extends CQLTester
         assertInvalidMessage("Multicolumn IN filters are not supported",
                              "SELECT * FROM %s WHERE (c2, c3) IN ((?, ?), (?, ?)) ALLOW FILTERING", 1, 0, 2, 0);
     }
- }
+
+    @Test
+    public void testNotInRestrictionsWithClustering()
+    {
+        createTable("CREATE TABLE %s (pk int, c1 int, c2 int, v int, primary key(pk, c1, c2))");
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 1, 11);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 2, 12);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 3, 13);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 4, 14);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 1, 21);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 2, 22);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 3, 23);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 4, 24);
+
+        // empty NOT IN
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN ()", 1),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+        // non existent NOT IN:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN ((?, ?))", 1, 2000, 2001),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+        // existing values in NOT IN, different ways of passing them:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN ((0, 2), (0, 3), (1, 1), (1, 4))", 1),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN ((?, ?), (?, ?), (?, ?), (?, ?))",
+                           1, 0, 2, 0, 3, 1, 1, 1, 4),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN (?, ?, ?, ?)",
+                           1, tuple(0, 2), tuple(0, 3), tuple(1, 1), tuple(1, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN ?",
+                           1, list(tuple(0, 2), tuple(0, 3), tuple(1, 1), tuple(1, 4))),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        // Tuples given in arbitrary order:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN (?, ?, ?, ?)",
+                           1, tuple(0, 3), tuple(1, 4), tuple(1, 1), tuple(0, 2)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        // Multiple NOT IN:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN (?, ?) AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(0, 2), tuple(0, 3), tuple(1, 1), tuple(1, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        // Multiple NOT IN, mixed markers:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN (?, ?) AND (c1, c2) NOT IN ?",
+                           1, tuple(0, 2), tuple(0, 3), list(tuple(1, 1), tuple(1, 4))),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        // Multiple NOT IN, mixed markers and values:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) NOT IN ((0, 2), (0, 3)) AND (c1, c2) NOT IN ?",
+                           1, list(tuple(1, 1), tuple(1, 4))),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        // Mixed single-column and multicolumn restrictions:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 NOT IN ? AND (c1, c2) NOT IN ?",
+                           1, list(0), list(tuple(1, 1), tuple(1, 4))),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 NOT IN (?) AND (c1, c2) NOT IN (?, ?)",
+                           1, 0, tuple(1, 1), tuple(1, 4)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+    }
+
+    @Test
+    public void testNotInRestrictionsWithClusteringAndSlices()
+    {
+        createTable("CREATE TABLE %s (pk int, c1 int, c2 int, v int, primary key(pk, c1, c2))");
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 1, 11);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 2, 12);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 3, 13);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 4, 14);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 1, 21);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 2, 22);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 3, 23);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 4, 24);
+
+        // NOT IN values outside of slice bounds
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(2, 5)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21));
+
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(1, 1)),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+        // Empty result set
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(1, 2), tuple(1, 3), tuple(1, 4)));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(0, 3), tuple(0, 2), tuple(0, 1)));
+
+        // NOT IN values inside slice bounds
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(0, 2)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(0, 2)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 3)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 3)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 4, 24));
+
+
+        // One NOT IN value exactly the same as the slice bound
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(1, 2), tuple(0, 2), tuple(1, 2)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(1, 2), tuple(0, 2), tuple(1, 2)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14),
+                   row(1, 1, 1, 21));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 1)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 1)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+        // NOT IN with both upper and lower bound
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 0, 3, 13),
+                   row(1, 1, 1, 21));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 1, 1, 21));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 0, 3, 13),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22));
+
+        // Mixed multi-column NOT IN with single column slice restriction:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 > ? AND (c1, c2) NOT IN (?)",
+                           1, 0, tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 >= ? AND (c1, c2) NOT IN (?)",
+                           1, 1, tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 < ? AND (c1, c2) NOT IN (?)",
+                           1, 1, tuple(0, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 <= ? AND (c1, c2) NOT IN (?)",
+                           1, 0, tuple(0, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 >= ? AND c1 <= ? AND (c1, c2) NOT IN (?)",
+                           1, 0, 1, tuple(0, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+        // Mixed single-column NOT IN with multi-column slice restriction:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND c1 NOT IN (?)",
+                           1, tuple(0, 1), 1),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND c1 NOT IN (?)",
+                           1, tuple(0, 1), 1),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND c1 NOT IN (?)",
+                           1, tuple(1, 3), 1),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND c1 NOT IN (?)",
+                           1, tuple(1, 3), 0),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) <= ? AND c1 NOT IN (?)",
+                           1, tuple(1, 3), 0),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) <= ? AND c1 NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 3), 0),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+    }
+
+    @Test
+    public void testNotInRestrictionsWithMixedOrderClusteringAndSlices()
+    {
+        createTable("CREATE TABLE %s (pk int, c1 int, c2 int, v int, primary key(pk, c1, c2)) WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)");
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 1, 11);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 2, 12);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 3, 13);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 0, 4, 14);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 1, 21);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 2, 22);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 3, 23);
+        execute("INSERT INTO %s (pk, c1, c2, v) values (?, ?, ?, ?)", 1, 1, 4, 24);
+
+        // NOT IN values outside of slice bounds
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(2, 5)),
+                   row(1, 1, 1, 21),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(1, 1)),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+        // Empty result set
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(1, 2), tuple(1, 3), tuple(1, 4)));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(0, 3), tuple(0, 2), tuple(0, 1)));
+
+        // NOT IN values inside slice bounds
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(0, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 2), tuple(0, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 3)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 3)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 4, 24));
+
+        // One NOT IN value exactly the same as the slice bound
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(1, 2), tuple(0, 2), tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?, ?)",
+                           1, tuple(1, 2), tuple(0, 2), tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 1)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(1, 1), tuple(1, 1)),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+
+
+        // NOT IN with both upper and lower bound
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 1, 1, 21),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 1, 1, 21),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 2), tuple(0, 4)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+
+        // Mixed multi-column NOT IN with single column slice restriction:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 > ? AND (c1, c2) NOT IN (?)",
+                           1, 0, tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 >= ? AND (c1, c2) NOT IN (?)",
+                           1, 1, tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 < ? AND (c1, c2) NOT IN (?)",
+                           1, 1, tuple(0, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 <= ? AND (c1, c2) NOT IN (?)",
+                           1, 0, tuple(0, 4)),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 >= ? AND c1 <= ? AND (c1, c2) NOT IN (?)",
+                           1, 0, 1, tuple(0, 4)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13));
+
+        // Mixed single-column NOT IN with multi-column slice restriction:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND c1 NOT IN (?)",
+                           1, tuple(0, 1), 1),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND c1 NOT IN (?)",
+                           1, tuple(0, 1), 1),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND c1 NOT IN (?)",
+                           1, tuple(1, 3), 1),
+                   row(1, 0, 1, 11),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 3, 13),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) < ? AND c1 NOT IN (?)",
+                           1, tuple(1, 3), 0),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) <= ? AND c1 NOT IN (?)",
+                           1, tuple(1, 3), 0),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) >= ? AND (c1, c2) <= ? AND c1 NOT IN (?)",
+                           1, tuple(0, 2), tuple(1, 3), 0),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 2, 22),
+                   row(1, 1, 3, 23));
+
+        // Mixed single-column and multi column slices with multi column NOT IN:
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND c1 < ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 1), 1, tuple(0, 3)),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND (c1, c2) > ? AND c1 <= ? AND (c1, c2) NOT IN (?)",
+                           1, tuple(0, 1), 0, tuple(0, 3)),
+                   row(1, 0, 2, 12),
+                   row(1, 0, 4, 14));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 > ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, 0, tuple(1, 4), tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 >= ? AND (c1, c2) < ? AND (c1, c2) NOT IN (?)",
+                           1, 1, tuple(1, 4), tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 > ? AND c1 < ? AND (c1, c2) NOT IN (?)",
+                           1, 0, 2, tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+        assertRows(execute("SELECT * FROM %s WHERE pk = ? AND c1 >= ? AND c1 <= ? AND (c1, c2) NOT IN (?)",
+                           1, 1, 1, tuple(1, 2)),
+                   row(1, 1, 1, 21),
+                   row(1, 1, 3, 23),
+                   row(1, 1, 4, 24));
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectMultiColumnRelationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectMultiColumnRelationTest.java
@@ -368,7 +368,7 @@ public class SelectMultiColumnRelationTest extends CQLTester
     public void testNonEqualsRelation() throws Throwable
     {
         createTable("CREATE TABLE %s (a int PRIMARY KEY, b int)");
-        assertInvalidMessage("Unsupported \"!=\" relation: (b) != (0)",
+        assertInvalidMessage("!= cannot be used for multi-column relations",
                              "SELECT * FROM %s WHERE a = 0 AND (b) != (0)");
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectSingleColumnRelationTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectSingleColumnRelationTest.java
@@ -62,7 +62,7 @@ public class SelectSingleColumnRelationTest extends CQLTester
                              "SELECT * FROM %s WHERE c = 0 AND b <= ?", set(0));
         assertInvalidMessage("Collection column 'b' (set<int>) cannot be restricted by a 'IN' relation",
                              "SELECT * FROM %s WHERE c = 0 AND b IN (?)", set(0));
-        assertInvalidMessage("Unsupported \"!=\" relation: b != 5",
+        assertInvalidMessage("NEQ restrictions are supported only on map columns",
                 "SELECT * FROM %s WHERE c = 0 AND b != 5");
         assertInvalidMessage("Unsupported restriction: b IS NOT NULL",
                 "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL");
@@ -616,11 +616,15 @@ public class SelectSingleColumnRelationTest extends CQLTester
         assertInvalidMessage("Undefined column name d", "SELECT * FROM %s WHERE d > 0 and d <= 2");
         assertInvalidMessage("Undefined column name d", "SELECT * FROM %s WHERE d CONTAINS 0");
         assertInvalidMessage("Undefined column name d", "SELECT * FROM %s WHERE d CONTAINS KEY 0");
+        assertInvalidMessage("Undefined column name d", "SELECT * FROM %s WHERE d NOT CONTAINS 0");
+        assertInvalidMessage("Undefined column name d", "SELECT * FROM %s WHERE d NOT CONTAINS KEY 0");
         assertInvalidMessage("Undefined column name d", "SELECT a AS d FROM %s WHERE d = 0");
         assertInvalidMessage("Undefined column name d", "SELECT b AS d FROM %s WHERE d IN (0, 1)");
         assertInvalidMessage("Undefined column name d", "SELECT b AS d FROM %s WHERE d > 0 and d <= 2");
         assertInvalidMessage("Undefined column name d", "SELECT c AS d FROM %s WHERE d CONTAINS 0");
         assertInvalidMessage("Undefined column name d", "SELECT c AS d FROM %s WHERE d CONTAINS KEY 0");
+        assertInvalidMessage("Undefined column name d", "SELECT c AS d FROM %s WHERE d NOT CONTAINS 0");
+        assertInvalidMessage("Undefined column name d", "SELECT c AS d FROM %s WHERE d NOT CONTAINS KEY 0");
         assertInvalidMessage("Undefined column name d", "SELECT d FROM %s WHERE a = 0");
     }
 
@@ -640,12 +644,14 @@ public class SelectSingleColumnRelationTest extends CQLTester
         assertInvalidMessage(msg, "SELECT * FROM %s WHERE b <= ?", udt);
         assertInvalidMessage(msg, "SELECT * FROM %s WHERE b IN (?)", udt);
         assertInvalidMessage(msg, "SELECT * FROM %s WHERE b LIKE ?", udt);
-        assertInvalidMessage("Unsupported \"!=\" relation: b != {a: 0}",
+        assertInvalidMessage("NEQ restrictions are supported only on map columns",
                              "SELECT * FROM %s WHERE b != {a: 0}", udt);
         assertInvalidMessage("Unsupported restriction: b IS NOT NULL",
                              "SELECT * FROM %s WHERE b IS NOT NULL", udt);
         assertInvalidMessage("Cannot use CONTAINS on non-collection column b",
                              "SELECT * FROM %s WHERE b CONTAINS ?", udt);
+        assertInvalidMessage("Cannot use NOT CONTAINS on non-collection column b",
+                             "SELECT * FROM %s WHERE b NOT CONTAINS ?", udt);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/SelectTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/SelectTest.java
@@ -1358,6 +1358,9 @@ public class SelectTest extends CQLTester
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE c CONTAINS 2");
 
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE c NOT CONTAINS 2");
+
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
@@ -1365,9 +1368,22 @@ public class SelectTest extends CQLTester
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE c NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE c NOT CONTAINS 2 AND c NOT CONTAINS 3 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND c NOT CONTAINS 3 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
+
             // Checks filtering for sets
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE d CONTAINS 4");
+
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE d NOT CONTAINS 4");
 
             assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
@@ -1376,25 +1392,67 @@ public class SelectTest extends CQLTester
             assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE d NOT CONTAINS 4 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE d NOT CONTAINS 4 AND d NOT CONTAINS 6 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 AND d NOT CONTAINS 6 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
+
             // Checks filtering for maps
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE e CONTAINS 2");
+
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE e NOT CONTAINS 2");
 
             assertRows(execute("SELECT * FROM %s WHERE e CONTAINS 2 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE e NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 ALLOW FILTERING"),
                        row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE e NOT CONTAINS KEY 1 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE e CONTAINS 2 AND e NOT CONTAINS KEY 1 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
             assertRows(execute("SELECT * FROM %s WHERE e[1] = 6 ALLOW FILTERING"),
                        row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE e[1] != 6 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE e[1] != 6 AND e[3] != 2 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e[1] != 6 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
             assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING"),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e NOT CONTAINS KEY 1 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
         });
 
@@ -1411,6 +1469,19 @@ public class SelectTest extends CQLTester
                              "SELECT * FROM %s WHERE e[null] = 2 ALLOW FILTERING");
         assertInvalidMessage("Unsupported null map value for column e",
                              "SELECT * FROM %s WHERE e[1] = null ALLOW FILTERING");
+
+        assertInvalidMessage("Unsupported null value for column c",
+                             "SELECT * FROM %s WHERE c NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column d",
+                             "SELECT * FROM %s WHERE d NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS KEY null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null map key for column e",
+                             "SELECT * FROM %s WHERE e[null] != 2 ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null map value for column e",
+                             "SELECT * FROM %s WHERE e[1] != null ALLOW FILTERING");
 
         // Checks filtering with unset
         assertInvalidMessage("Unsupported unset value for column c",
@@ -1431,6 +1502,26 @@ public class SelectTest extends CQLTester
         assertInvalidMessage("Unsupported unset map value for column e",
                              "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
                              unset());
+
+        assertInvalidMessage("Unsupported unset value for column c",
+                             "SELECT * FROM %s WHERE c NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column d",
+                             "SELECT * FROM %s WHERE d NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS KEY ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset map key for column e",
+                             "SELECT * FROM %s WHERE e[?] != 2 ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset map value for column e",
+                             "SELECT * FROM %s WHERE e[1] != ? ALLOW FILTERING",
+                             unset());
+
     }
 
     @Test
@@ -1466,12 +1557,22 @@ public class SelectTest extends CQLTester
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE c CONTAINS 2");
 
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE c NOT CONTAINS 2");
+
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE c NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE c NOT CONTAINS 2 AND c NOT CONTAINS 3 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
 
             // Checks filtering for sets
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -1493,12 +1594,22 @@ public class SelectTest extends CQLTester
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE d CONTAINS 4");
 
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE d NOT CONTAINS 4");
+
             assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE d NOT CONTAINS 4 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE d NOT CONTAINS 4 AND d NOT CONTAINS 6 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
 
             // Checks filtering for maps
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
@@ -1521,21 +1632,41 @@ public class SelectTest extends CQLTester
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE e CONTAINS 2");
 
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE e NOT CONTAINS 2");
+
             assertRows(execute("SELECT * FROM %s WHERE e CONTAINS 2 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE e NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
 
             assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 ALLOW FILTERING"),
                        row(1, 2, list(1, 6), set(2, 12), map(1, 6)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE e NOT CONTAINS KEY 1 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)));
+
             assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
                                  "SELECT * FROM %s WHERE e[1] = 6 ALLOW FILTERING");
+
+            assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
+                                 "SELECT * FROM %s WHERE e[1] != 6 ALLOW FILTERING");
 
             assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING"),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e NOT CONTAINS KEY 1 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
         });
 
@@ -1558,6 +1689,19 @@ public class SelectTest extends CQLTester
                              "SELECT * FROM %s WHERE e[null] = 2 ALLOW FILTERING");
         assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
                              "SELECT * FROM %s WHERE e[1] = null ALLOW FILTERING");
+
+        assertInvalidMessage("Unsupported null value for column c",
+                             "SELECT * FROM %s WHERE c NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column d",
+                             "SELECT * FROM %s WHERE d NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS KEY null ALLOW FILTERING");
+        assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
+                             "SELECT * FROM %s WHERE e[null] != 2 ALLOW FILTERING");
+        assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
+                             "SELECT * FROM %s WHERE e[1] != null ALLOW FILTERING");
 
         // Checks filtering with unset
         assertInvalidMessage("Unsupported unset value for column c",
@@ -1587,6 +1731,25 @@ public class SelectTest extends CQLTester
         assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
                              "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
                              unset());
+        assertInvalidMessage("Unsupported unset value for column c",
+                             "SELECT * FROM %s WHERE c NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column d",
+                             "SELECT * FROM %s WHERE d NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column e",
+                             "SELECT * FROM %s WHERE e NOT CONTAINS KEY ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
+                             "SELECT * FROM %s WHERE e[?] != 2 ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Map-entry equality predicates on frozen map column e are not supported",
+                             "SELECT * FROM %s WHERE e[1] != ? ALLOW FILTERING",
+                             unset());
+
     }
 
 
@@ -1896,29 +2059,56 @@ public class SelectTest extends CQLTester
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                     "SELECT * FROM %s WHERE b < 0 AND c CONTAINS 2");
 
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE b < 0 AND c NOT CONTAINS 2");
+
             assertRows(execute("SELECT * FROM %s WHERE b >= 4 AND c CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE b >= 4 AND c NOT CONTAINS 3 ALLOW FILTERING"),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
             assertRows(
                     execute("SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
 
+            assertRows(
+                    execute("SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c NOT CONTAINS 1 AND c NOT CONTAINS 6 ALLOW FILTERING"),
+                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
             // Checks filtering for sets
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                     "SELECT * FROM %s WHERE a = 1 AND d CONTAINS 4");
+
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE a = 1 AND d NOT CONTAINS 4");
 
             assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE d NOT CONTAINS 4 ALLOW FILTERING"),
+                       row(2, 3, list(3, 6), set(6, 12), map(3, 6)),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE d NOT CONTAINS 4 AND d NOT CONTAINS 6 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
 
             // Checks filtering for maps
             assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                                  "SELECT * FROM %s WHERE e CONTAINS 2");
 
+            assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                                 "SELECT * FROM %s WHERE e NOT CONTAINS 2");
+
             assertRows(execute("SELECT * FROM %s WHERE a < 2 AND b >= 3 AND e CONTAINS 2 ALLOW FILTERING"),
+                       row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
+
+            assertRows(execute("SELECT * FROM %s WHERE a < 2 AND b >= 3 AND e NOT CONTAINS 6 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
@@ -1926,15 +2116,29 @@ public class SelectTest extends CQLTester
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)),
                        row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
 
+            assertRows(execute("SELECT * FROM %s WHERE a = 1 AND e NOT CONTAINS KEY 3 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
             assertRows(execute("SELECT * FROM %s WHERE a in (1) AND b in (2) AND e[1] = 6 ALLOW FILTERING"),
+                       row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
+
+            assertRows(execute("SELECT * FROM %s WHERE a in (1) AND b in (2) AND e[1] != 2 ALLOW FILTERING"),
                        row(1, 2, list(1, 6), set(2, 12), map(1, 6)));
 
             assertRows(execute("SELECT * FROM %s WHERE a = 1 AND e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING"),
                        row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
 
+            assertRows(execute("SELECT * FROM %s WHERE a = 1 AND e CONTAINS KEY 1 AND e NOT CONTAINS 6 ALLOW FILTERING"),
+                       row(1, 4, list(1, 2), set(2, 4), map(1, 2)));
+
             assertRows(
                     execute("SELECT * FROM %s WHERE a >= 1 AND b in (3) AND c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING"),
                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
+
+            assertRows(
+                    execute("SELECT * FROM %s WHERE a >= 1 AND b in (3) AND c CONTAINS 2 AND d CONTAINS 4 AND e NOT CONTAINS KEY 1 ALLOW FILTERING"),
+                        row(1, 3, list(3, 2), set(6, 4), map(3, 2)));
         });
 
         // Checks filtering with null
@@ -1950,6 +2154,18 @@ public class SelectTest extends CQLTester
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[null] = 2 ALLOW FILTERING");
         assertInvalidMessage("Unsupported null map value for column e",
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] = null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column c",
+                             "SELECT * FROM %s WHERE a > 1 AND c NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column d",
+                             "SELECT * FROM %s WHERE b < 1 AND d NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e NOT CONTAINS null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null value for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e NOT CONTAINS KEY null ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null map key for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[null] != 2 ALLOW FILTERING");
+        assertInvalidMessage("Unsupported null map value for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] != null ALLOW FILTERING");
 
         // Checks filtering with unset
         assertInvalidMessage("Unsupported unset value for column c",
@@ -1969,6 +2185,24 @@ public class SelectTest extends CQLTester
                              unset());
         assertInvalidMessage("Unsupported unset map value for column e",
                              "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] = ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column c",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND c NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column d",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND d NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e NOT CONTAINS ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset value for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e NOT CONTAINS KEY ? ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset map key for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[?] != 2 ALLOW FILTERING",
+                             unset());
+        assertInvalidMessage("Unsupported unset map value for column e",
+                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] != ? ALLOW FILTERING",
                              unset());
     }
 
@@ -2134,18 +2368,32 @@ public class SelectTest extends CQLTester
 
             assertRows(execute("SELECT * FROM %s WHERE a = 21 AND b CONTAINS 2 ALLOW FILTERING"),
                        row(21, list(2, 3), 24));
+
+            assertRows(execute("SELECT * FROM %s WHERE a = 21 AND b NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(21, list(3, 3), 34));
+
             assertInvalidMessage("Clustering columns can only be restricted with CONTAINS with a secondary index or filtering",
                                  "SELECT * FROM %s WHERE a = 21 AND b CONTAINS 2");
 
             assertRows(execute("SELECT * FROM %s WHERE b CONTAINS 2 ALLOW FILTERING"),
                        row(21, list(2, 3), 24));
+
+            assertRows(execute("SELECT * FROM %s WHERE b NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(11, list(1, 3), 14),
+                       row(21, list(3, 3), 34));
+
             assertInvalidMessage("Clustering columns can only be restricted with CONTAINS with a secondary index or filtering",
                                  "SELECT * FROM %s WHERE b CONTAINS 2");
+
+            assertInvalidMessage("Clustering columns can only be restricted with CONTAINS with a secondary index or filtering",
+                                 "SELECT * FROM %s WHERE b NOT CONTAINS 2");
 
             assertRows(execute("SELECT * FROM %s WHERE b CONTAINS 3 ALLOW FILTERING"),
                        row(11, list(1, 3), 14),
                        row(21, list(2, 3), 24),
                        row(21, list(3, 3), 34));
+
+            assertRows(execute("SELECT * FROM %s WHERE b NOT CONTAINS 3 ALLOW FILTERING"));
         });
 
         // non-first clustering column
@@ -2159,18 +2407,34 @@ public class SelectTest extends CQLTester
 
             assertRows(execute("SELECT * FROM %s WHERE a = 21 AND c CONTAINS 2 ALLOW FILTERING"),
                        row(21, 22, list(2, 3), 24));
+
+            assertRows(execute("SELECT * FROM %s WHERE a = 21 AND c NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(21, 22, list(3, 3), 34));
+
             assertInvalidMessage("Clustering columns can only be restricted with CONTAINS with a secondary index or filtering",
                                  "SELECT * FROM %s WHERE a = 21 AND c CONTAINS 2");
 
+            assertInvalidMessage("Clustering columns can only be restricted with CONTAINS with a secondary index or filtering",
+                                 "SELECT * FROM %s WHERE a = 21 AND c NOT CONTAINS 2");
+
             assertRows(execute("SELECT * FROM %s WHERE b > 20 AND c CONTAINS 2 ALLOW FILTERING"),
                        row(21, 22, list(2, 3), 24));
+
+            assertRows(execute("SELECT * FROM %s WHERE b > 20 AND c NOT CONTAINS 2 ALLOW FILTERING"),
+                       row(21, 22, list(3, 3), 34));
+
             assertInvalidMessage("Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
                                  "SELECT * FROM %s WHERE b > 20 AND c CONTAINS 2");
+
+            assertInvalidMessage("Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
+                                 "SELECT * FROM %s WHERE b > 20 AND c NOT CONTAINS 2");
 
             assertRows(execute("SELECT * FROM %s WHERE c CONTAINS 3 ALLOW FILTERING"),
                        row(11, 12, list(1, 3), 14),
                        row(21, 22, list(2, 3), 24),
                        row(21, 22, list(3, 3), 34));
+
+            assertEmpty(execute("SELECT * FROM %s WHERE c NOT CONTAINS 3 ALLOW FILTERING"));
         });
 
         createTable("CREATE TABLE %s (a int, b int, c frozen<map<text, text>>, d int, PRIMARY KEY (a, b, c))");
@@ -2182,8 +2446,15 @@ public class SelectTest extends CQLTester
         beforeAndAfterFlush(() -> {
             assertRows(execute("SELECT * FROM %s WHERE b > 20 AND c CONTAINS KEY '2' ALLOW FILTERING"),
                        row(21, 22, map("2", "3"), 24));
+
+            assertRows(execute("SELECT * FROM %s WHERE b > 20 AND c NOT CONTAINS KEY '2' ALLOW FILTERING"),
+                       row(21, 22, map("3", "3"), 34));
+
             assertInvalidMessage("Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
                                  "SELECT * FROM %s WHERE b > 20 AND c CONTAINS KEY '2'");
+
+            assertInvalidMessage("Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
+                                 "SELECT * FROM %s WHERE b > 20 AND c NOT CONTAINS KEY '2'");
         });
     }
 
@@ -2215,6 +2486,9 @@ public class SelectTest extends CQLTester
         assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
                              "SELECT * FROM %s WHERE pk CONTAINS KEY 1");
 
+        assertInvalidMessage(StatementRestrictions.REQUIRES_ALLOW_FILTERING_MESSAGE,
+                             "SELECT * FROM %s WHERE pk NOT CONTAINS KEY 1");
+
         beforeAndAfterFlush(() -> {
             assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk CONTAINS KEY 1 ALLOW FILTERING"),
                                     row(map(1, 2), 1, 1),
@@ -2236,6 +2510,24 @@ public class SelectTest extends CQLTester
 
             assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND ck = 1 AND v = 3 ALLOW FILTERING"),
                                     row(map(1, 2, 3, 4), 1, 3));
+
+            assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk NOT CONTAINS KEY 1 ALLOW FILTERING"),
+                                    row(map(5, 6), 5, 5),
+                                    row(map(7, 8), 6, 6));
+
+            assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND pk NOT CONTAINS 4 ALLOW FILTERING"),
+                                    row(map(1, 2), 1, 1),
+                                    row(map(1, 2), 2, 2));
+
+            assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk NOT CONTAINS KEY 1 AND pk CONTAINS 8 ALLOW FILTERING"),
+                                    row(map(7, 8), 6, 6));
+
+            assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk NOT CONTAINS KEY 1 AND pk NOT CONTAINS 8 ALLOW FILTERING"),
+                                    row(map(5, 6), 5, 5));
+
+            assertRowsIgnoringOrder(execute("SELECT * FROM %s WHERE pk NOT CONTAINS KEY 1 AND v = 5 ALLOW FILTERING"),
+                                    row(map(5, 6), 5, 5));
+
         });
     }
 
@@ -2317,8 +2609,16 @@ public class SelectTest extends CQLTester
                        row(21, 22, 23, list(2, 4)),
                        row(21, 25, 26, list(2, 7)));
 
-            assertRows(executeFilteringOnly("SELECT a, b, c, d FROM %s WHERE b > 20 AND d CONTAINS 2 AND d contains 4"),
+            assertRows(executeFilteringOnly("SELECT a, b, c, d FROM %s WHERE b > 20 AND d NOT CONTAINS 2"),
+                       row(31, 32, 33, list(3, 4)));
+
+            assertRows(executeFilteringOnly("SELECT a, b, c, d FROM %s WHERE b > 20 AND d CONTAINS 2 AND d CONTAINS 4"),
                        row(21, 22, 23, list(2, 4)));
+
+            assertRows(executeFilteringOnly("SELECT a, b, c, d FROM %s WHERE b > 20 AND d NOT CONTAINS 2 AND d CONTAINS 4"),
+                       row(31, 32, 33, list(3, 4)));
+
+            assertRows(executeFilteringOnly("SELECT a, b, c, d FROM %s WHERE b > 20 AND d NOT CONTAINS 2 AND d NOT CONTAINS 4"));
         });
     }
 
@@ -2943,6 +3243,10 @@ public class SelectTest extends CQLTester
             assertRows(execute("SELECT * FROM %s WHERE m CONTAINS 1s ALLOW FILTERING"),
                        row(0, map(1, Duration.from("1s"), 2, Duration.from("2s"))),
                        row(2, map(1, Duration.from("1s"), 3, Duration.from("3s"))));
+
+            assertRows(execute("SELECT * FROM %s WHERE m NOT CONTAINS 1s ALLOW FILTERING"),
+                       row(1, map(2, Duration.from("2s"), 3, Duration.from("3s"))));
+
         }
     }
 
@@ -3040,25 +3344,36 @@ public class SelectTest extends CQLTester
         beforeAndAfterFlush(() -> {
             // lists
             assertRows(execute("SELECT k, v FROM %s WHERE l CONTAINS 1 ALLOW FILTERING"), row(1, 0), row(0, 0), row(0, 2));
+            assertRows(execute("SELECT k, v FROM %s WHERE l NOT CONTAINS 4 ALLOW FILTERING"), row(1, 2), row(0, 0), row(0, 2));
             assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND l CONTAINS 1 ALLOW FILTERING"), row(0, 0), row(0, 2));
+            assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND l NOT CONTAINS 4 ALLOW FILTERING"), row(0, 0), row(0, 2));
             assertRows(execute("SELECT k, v FROM %s WHERE l CONTAINS 2 ALLOW FILTERING"), row(1, 0), row(0, 0));
             assertEmpty(execute("SELECT k, v FROM %s WHERE l CONTAINS 6 ALLOW FILTERING"));
 
             // sets
             assertRows(execute("SELECT k, v FROM %s WHERE s CONTAINS 'a' ALLOW FILTERING" ), row(0, 0), row(0, 2));
+            assertRowsIgnoringOrder(execute("SELECT k, v FROM %s WHERE s NOT CONTAINS 'a' ALLOW FILTERING" ),  row(1, 2), row(0, 1), row(1, 0), row(1, 1));
             assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND s CONTAINS 'a' ALLOW FILTERING"), row(0, 0), row(0, 2));
+            assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND s NOT CONTAINS 'a' ALLOW FILTERING" ), row(0, 1));
             assertRows(execute("SELECT k, v FROM %s WHERE s CONTAINS 'd' ALLOW FILTERING"), row(1, 1));
             assertEmpty(execute("SELECT k, v FROM %s  WHERE s CONTAINS 'e' ALLOW FILTERING"));
+            assertRows(execute("SELECT k, v FROM %s  WHERE s NOT CONTAINS 'a' AND s NOT CONTAINS 'c' ALLOW FILTERING"), row(1, 0), row(1, 1), row(1, 2));
 
             // maps
             assertRows(execute("SELECT k, v FROM %s WHERE m CONTAINS 1 ALLOW FILTERING"), row(1, 0), row(1, 1), row(0, 0), row(0, 1));
+            assertRows(execute("SELECT k, v FROM %s WHERE m NOT CONTAINS 1 ALLOW FILTERING"), row(1, 2), row(0, 2));
             assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS 1 ALLOW FILTERING"), row(0, 0), row(0, 1));
+            assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND m NOT CONTAINS 1 ALLOW FILTERING"), row(0, 2));
             assertRows(execute("SELECT k, v FROM %s WHERE m CONTAINS 2 ALLOW FILTERING"), row(0, 1));
             assertEmpty(execute("SELECT k, v FROM %s  WHERE m CONTAINS 4 ALLOW FILTERING"));
+            assertRows(execute("SELECT k, v FROM %s  WHERE m NOT CONTAINS 1 AND m NOT CONTAINS 3 ALLOW FILTERING"), row(1, 2));
 
             assertRows(execute("SELECT k, v FROM %s WHERE m CONTAINS KEY 'a' ALLOW FILTERING"), row(1, 1), row(0, 0), row(0, 1));
+            assertRows(execute("SELECT k, v FROM %s WHERE m NOT CONTAINS KEY 'a' ALLOW FILTERING"), row(1, 0), row(1, 2), row(0, 2));
             assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS KEY 'a' ALLOW FILTERING"), row(0, 0), row(0, 1));
+            assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND m NOT CONTAINS KEY 'a' ALLOW FILTERING"), row(0, 2));
             assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS KEY 'c' ALLOW FILTERING"), row(0, 2));
+            assertRows(execute("SELECT k, v FROM %s WHERE k = 0 AND m NOT CONTAINS KEY 'c' ALLOW FILTERING"), row(0, 0), row(0, 1));
         });
     }
 


### PR DESCRIPTION
Adds new CQL operators: NOT CONTAINS, NOT CONTAINS KEY, NOT IN, NOT LIKE.
Adds ability to filter map entries by inequality e.g. `map[key] != value`.

https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-29%3A+CQL+NOT+operator

