### PR TITLE
CASSANDRA-17433 Remove dependency on pytz library for setting CQLSH t…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0
+ * Remove dependency on pytz library for setting CQLSH timezones on versions >= 3.9 (CASSANDRA-17433)
  * Print header and statistics for cassandra-stress output with arbitrary frequency (CASSANDRA-12972)
  * CEP-25: Trie-indexed SSTable format (CASSANDRA-18398)
  * Make cassandra-stress able to read all credentials from a file (CASSANDRA-18544)

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -7,8 +7,6 @@ executable.
 
 == Compatibility
 
-`cqlsh` is compatible with Python 2.7.
-
 In general, a given version of `cqlsh` is only guaranteed to work with the
 version of Cassandra that it was released with. 
 In some cases, `cqlsh` may work with older or newer versions of Cassandra, but this is not
@@ -22,11 +20,12 @@ of `cqlsh`.
 
 === pytz
 
-By default, `cqlsh` displays all timestamps with a UTC timezone. 
-To support display of timestamps with another timezone, install
-the http://pytz.sourceforge.net/[pytz] library. 
-See the `timezone` option in xref:cql/tools/cqlsh.adoc#cqlshrc[cqlshrc] for specifying a timezone to
-use.
+By default, `cqlsh` displays all timestamps with a UTC timezone.
+For Python 3.9 or higher, timestamps can be displayed in different timezones by modifying the
+`timezone` option in xref:cql/tools/cqlsh.adoc#cqlshrc[cqlshrc] or by setting the environment
+variable `TZ`.
+Python 3.8 or lower, however, will also require the installation of the
+the http://pytz.sourceforge.net/[pytz] library.
 
 === cython
 

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -2287,20 +2287,37 @@ def main(cmdline, pkgpath):
     # create timezone based on settings, environment or auto-detection
     timezone = None
     if options.timezone or 'TZ' in os.environ:
-        try:
-            import pytz
-            if options.timezone:
-                try:
-                    timezone = pytz.timezone(options.timezone)
-                except Exception:
-                    sys.stderr.write("Warning: could not recognize timezone '%s' specified in cqlshrc\n\n" % (options.timezone))
-            if 'TZ' in os.environ:
-                try:
-                    timezone = pytz.timezone(os.environ['TZ'])
-                except Exception:
-                    sys.stderr.write("Warning: could not recognize timezone '%s' from environment value TZ\n\n" % (os.environ['TZ']))
-        except ImportError:
-            sys.stderr.write("Warning: Timezone defined and 'pytz' module for timezone conversion not installed. Timestamps will be displayed in UTC timezone.\n\n")
+        if sys.version_info >= (3, 9):
+            try:
+                import zoneinfo
+                if options.timezone:
+                    try:
+                        timezone = zoneinfo.ZoneInfo(options.timezone)
+                    except Exception:
+                        sys.stderr.write("Warning: could not recognize timezone '%s' specified in cqlshrc\n\n" % (options.timezone))
+                if 'TZ' in os.environ:
+                    try:
+                        timezone = zoneinfo.ZoneInfo(os.environ['TZ'])
+                    except Exception:
+                        sys.stderr.write("Warning: could not recognize timezone '%s' from environment value TZ\n\n" % (os.environ['TZ']))
+            except ImportError:
+                sys.stderr.write("Warning: Timezone defined but unable to perform timezone conversion using 'zoneinfo' "
+                                 "module. Timestamps will be displayed in UTC timezone.\n\n")
+        else:
+            try:
+                import pytz
+                if options.timezone:
+                    try:
+                        timezone = pytz.timezone(options.timezone)
+                    except Exception:
+                        sys.stderr.write("Warning: could not recognize timezone '%s' specified in cqlshrc\n\n" % (options.timezone))
+                if 'TZ' in os.environ:
+                    try:
+                        timezone = pytz.timezone(os.environ['TZ'])
+                    except Exception:
+                        sys.stderr.write("Warning: could not recognize timezone '%s' from environment value TZ\n\n" % (os.environ['TZ']))
+            except ImportError:
+                sys.stderr.write("Warning: Timezone defined and 'pytz' module for timezone conversion not installed. Timestamps will be displayed in UTC timezone.\n\n")
 
     # try auto-detect timezone if tzlocal is installed
     if not timezone:

--- a/pylib/cqlshlib/test/test_cqlsh_output.py
+++ b/pylib/cqlshlib/test/test_cqlsh_output.py
@@ -20,6 +20,7 @@
 import locale
 import os
 import re
+import sys
 
 from .basecase import (BaseTestCase, TEST_HOST, TEST_PORT,
                        at_a_time, cqlshlog, dedent)
@@ -402,7 +403,8 @@ class TestCqlshOutput(BaseTestCase):
             """),
         ), env=env)
         try:
-            import pytz  # test only if pytz is available on PYTHONPATH
+            if sys.version_info < (3, 9):
+                import pytz  # on older versions without zoneinfo, test only if pytz is available on PYTHONPATH
             env['TZ'] = 'America/Sao_Paulo'
             self.assertQueriesGiveColoredOutput((
                 ('''select timestampcol from has_all_types where num = 0;''', """


### PR DESCRIPTION
PEP 615 added support for the IANA Time Zone Database in the standard python library.  This removed the dependency on the pytz library to be able to set the timezone in CQLSH on versions >= 3.9.  This MR contains a version check where we will use the standard library on versions >= 3.9.