### PR TITLE
Fix incorrect docs since `cqlsh` no longer supports Python 2.7

### DIFF
--- a/doc/modules/cassandra/pages/installing/installing.adoc
+++ b/doc/modules/cassandra/pages/installing/installing.adoc
@@ -32,8 +32,7 @@ verify that you have the correct version of java installed, type
 Full support is effective Cassandra 4.0.2 version (https://issues.apache.org/jira/browse/CASSANDRA-16894[CASSANDRA-16894])
 For more information, see
 https://github.com/apache/cassandra/blob/trunk/NEWS.txt[NEWS.txt].
-* For using cqlsh, the latest version of
-Python 3.6+ or Python 2.7 (support deprecated). To verify
+* For using cqlsh, the latest version of Python 3.6+. To verify
 that you have the correct version of Python installed, type
 `python --version`.
 


### PR DESCRIPTION
`cqlsh` completely stopped supporting Python 2.7 several releases ago.

polandll writes: 
`* Remove python 2.x support from cqlsh (CASSANDRA-17242)` in 4.1-alpha1 release.

4.1 branch will also need the same change.
Search verifies that no other changes in docs are required: https://github.com/search?q=repo%3Aapache%2Fcassandra++python+2.&type=code&p=3