### PR TITLE
CASSANDRA-17818-3.11: Fix error message handling when trying to use CLUSTERING ORDER with non-clustering column

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CreateTableStatement.java
@@ -345,7 +345,8 @@ public class CreateTableStatement extends SchemaAlteringStatement
             if (!properties.definedOrdering.isEmpty())
             {
                 List<ColumnIdentifier> nonClusterColumn = properties.definedOrdering.keySet().stream()
-                                                          .filter((id) -> !columnAliases.contains(id)).collect(Collectors.toList());
+                                                                                    .filter((id) -> !columnAliases.contains(id))
+                                                                                    .collect(Collectors.toList());
 
                 if (!nonClusterColumn.isEmpty())
                 {

--- a/src/java/org/apache/cassandra/cql3/statements/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CreateTableStatement.java
@@ -345,6 +345,14 @@ public class CreateTableStatement extends SchemaAlteringStatement
                 if (properties.definedOrdering.size() > columnAliases.size())
                     throw new InvalidRequestException("Only clustering key columns can be defined in CLUSTERING ORDER directive");
 
+                for (ColumnIdentifier orderId: properties.definedOrdering.keySet())
+                {
+                    if (!columnAliases.contains(orderId))
+                    {
+                        throw new InvalidRequestException("Only clustering key columns can be defined in CLUSTERING ORDER directive");
+                    }
+                }
+
                 int i = 0;
                 for (ColumnIdentifier id : properties.definedOrdering.keySet())
                 {

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -20,9 +20,11 @@ package org.apache.cassandra.schema;
 
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -77,13 +79,8 @@ public class CreateTableValidationTest extends CQLTester
 
     private void expectedFailure(String statement, String errorMsg)
     {
-        try
-        {
-            createTableMayThrow(statement);
-        }
-        catch (Throwable ex)
-        {
-            assertTrue(ex.getMessage().contains(errorMsg));
-        }
+        assertThatExceptionOfType(InvalidRequestException.class)
+        .isThrownBy(() -> createTableMayThrow(statement)) .withMessageContaining(errorMsg);
+
     }
 }

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -25,7 +25,6 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class CreateTableValidationTest extends CQLTester

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -53,6 +53,17 @@ public class CreateTableValidationTest extends CQLTester
     }
 
     @Test
+    public void testCreateTableOnSelectedClusterColumn()
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+    }
+
+    @Test
+    public void testCreateTableOnAllClusterColumns()
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC);");
+    }
+    @Test
     public void testCreateTableErrorOnNonClusterKey()
     {
         String expectedMessage = "Only clustering key columns can be defined in CLUSTERING ORDER directive";
@@ -74,6 +85,20 @@ public class CreateTableValidationTest extends CQLTester
                         expectedMessage+": [v]");
         expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);",
                         expectedMessage+": [v]");
+    }
+
+    @Test
+    public void testCreateTableInWrongOrdering()
+    {
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC, ck1 DESC);",
+                        "The order of columns in the CLUSTERING ORDER directive must be the one of the clustering key");
+    }
+
+    @Test
+    public void testCreateTableWithMissingClusterColumn()
+    {
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC);",
+                        "Missing CLUSTERING ORDER for column ck1");
     }
 
     private void expectedFailure(String statement, String errorMsg)

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -23,7 +23,6 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -20,8 +20,11 @@ package org.apache.cassandra.schema;
 
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class CreateTableValidationTest extends CQLTester
@@ -47,5 +50,90 @@ public class CreateTableValidationTest extends CQLTester
 
         // sanity check
         createTable("CREATE TABLE %s (a int PRIMARY KEY, b int) WITH bloom_filter_fp_chance = 0.1");
+    }
+
+    @Test
+    public void testCreateTableErrorOnNonClusterKey()
+    {
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, v ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC, ck1 DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, pk DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC, ck1 DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, v ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -20,11 +20,11 @@ package org.apache.cassandra.schema;
 
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class CreateTableValidationTest extends CQLTester
@@ -55,85 +55,36 @@ public class CreateTableValidationTest extends CQLTester
     @Test
     public void testCreateTableErrorOnNonClusterKey()
     {
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, v ASC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
+        String expectedMessage = "Only clustering key columns can be defined in CLUSTERING ORDER directive";
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, v ASC);",
+                        expectedMessage+": [v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC);",
+                        expectedMessage+": [v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC);",
+                        expectedMessage+": [pk]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC, ck1 DESC);",
+                        expectedMessage+": [pk]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, pk DESC);",
+                        expectedMessage+": [pk]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC);",
+                        expectedMessage+": [pk, v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC, ck1 DESC);",
+                        expectedMessage+": [pk, v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, v ASC);",
+                        expectedMessage+": [v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);",
+                        expectedMessage+": [v]");
+    }
 
+    private void expectedFailure(String statement, String errorMsg)
+    {
         try
         {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC);");
+            createTableMayThrow(statement);
         }
         catch (Throwable ex)
         {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC, ck1 DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, pk DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC, ck1 DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, v ASC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering key columns can be defined in CLUSTERING ORDER directive");
+            assertTrue(ex.getMessage().contains(errorMsg));
         }
     }
 }


### PR DESCRIPTION
Fix error message handling when trying to use CLUSTERING ORDER with non-clustering column

Patch: Throw error message after finding there are non-cluster columns in order definition. 

patch by <Ningzi Zhan>

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-17818)

