### PR TITLE
CASSANDRA-17818-4.0 or more: Fix error message handling when trying to use CLUSTERING ORDER with non-clustering column

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -217,7 +217,8 @@ public final class CreateTableStatement extends AlterSchemaStatement
         });
 
         List<ColumnIdentifier> nonClusterColumn = clusteringOrder.keySet().stream()
-                                                  .filter((id) -> !clusteringColumns.contains(id)).collect(Collectors.toList());
+                                                                 .filter((id) -> !clusteringColumns.contains(id))
+                                                                 .collect(Collectors.toList());
         if (!nonClusterColumn.isEmpty())
         {
             throw ire("Only clustering key columns can be defined in CLUSTERING ORDER directive: " + nonClusterColumn + " are not clustering column");

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -218,6 +218,13 @@ public final class CreateTableStatement extends AlterSchemaStatement
         if (clusteringOrder.size() > clusteringColumns.size())
             throw ire("Only clustering columns can be defined in CLUSTERING ORDER directive");
 
+        for (ColumnIdentifier orederId: clusteringOrder.keySet())
+        {
+            if (!clusteringColumns.contains(orederId)){
+                throw ire("Only clustering columns can be defined in CLUSTERING ORDER directive");
+            }
+        }
+
         int n = 0;
         for (ColumnIdentifier id : clusteringOrder.keySet())
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.cql3.statements.schema;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -215,14 +216,11 @@ public final class CreateTableStatement extends AlterSchemaStatement
             clusteringTypes.add(reverse ? ReversedType.getInstance(type.getType()) : type.getType());
         });
 
-        if (clusteringOrder.size() > clusteringColumns.size())
-            throw ire("Only clustering columns can be defined in CLUSTERING ORDER directive");
-
-        for (ColumnIdentifier orederId: clusteringOrder.keySet())
+        List<ColumnIdentifier> nonClusterColumn = clusteringOrder.keySet().stream()
+                                                  .filter((id) -> !clusteringColumns.contains(id)).collect(Collectors.toList());
+        if (!nonClusterColumn.isEmpty())
         {
-            if (!clusteringColumns.contains(orederId)){
-                throw ire("Only clustering columns can be defined in CLUSTERING ORDER directive");
-            }
+            throw ire("Only clustering key columns can be defined in CLUSTERING ORDER directive: " + nonClusterColumn + " are not clustering column");
         }
 
         int n = 0;

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -146,7 +146,7 @@ public class CreateTableValidationTest extends CQLTester
     public void testCreateTableInWrongOrdering()
     {
         expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC, ck1 DESC);",
-                        "The order of columns in the CLUSTERING ORDER directive must be the one of the clustering key");
+                        "The order of columns in the CLUSTERING ORDER directive must match that of the clustering columns");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.SimpleClient;
@@ -32,6 +33,7 @@ import org.apache.cassandra.transport.messages.QueryMessage;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -130,13 +132,8 @@ public class CreateTableValidationTest extends CQLTester
 
     private void expectedFailure(String statement, String errorMsg)
     {
-        try
-        {
-            createTableMayThrow(statement);
-        }
-        catch (Throwable ex)
-        {
-            assertTrue(ex.getMessage().contains(errorMsg));
-        }
+
+        assertThatExceptionOfType(InvalidRequestException.class)
+        .isThrownBy(() -> createTableMayThrow(statement)) .withMessageContaining(errorMsg);
     }
 }

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -32,7 +32,6 @@ import org.apache.cassandra.transport.messages.QueryMessage;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -107,6 +107,18 @@ public class CreateTableValidationTest extends CQLTester
     }
 
     @Test
+    public void testCreateTableOnSelectedClusterColumn()
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+    }
+
+    @Test
+    public void testCreateTableOnAllClusterColumns()
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC);");
+    }
+
+    @Test
     public void testCreateTableErrorOnNonClusterKey()
     {
         String expectedMessage = "Only clustering key columns can be defined in CLUSTERING ORDER directive";
@@ -128,6 +140,20 @@ public class CreateTableValidationTest extends CQLTester
                         expectedMessage+": [v]");
         expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);",
                         expectedMessage+": [v]");
+    }
+
+    @Test
+    public void testCreateTableInWrongOrdering()
+    {
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC, ck1 DESC);",
+                        "The order of columns in the CLUSTERING ORDER directive must be the one of the clustering key");
+    }
+
+    @Test
+    public void testCreateTableWithMissingClusterColumn()
+    {
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC);",
+                        "Missing CLUSTERING ORDER for column ck1");
     }
 
     private void expectedFailure(String statement, String errorMsg)

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -108,85 +108,36 @@ public class CreateTableValidationTest extends CQLTester
     @Test
     public void testCreateTableErrorOnNonClusterKey()
     {
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, v ASC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
+        String expectedMessage = "Only clustering key columns can be defined in CLUSTERING ORDER directive";
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, v ASC);",
+                        expectedMessage+": [v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC);",
+                        expectedMessage+": [v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC);",
+                        expectedMessage+": [pk]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC, ck1 DESC);",
+                        expectedMessage+": [pk]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, pk DESC);",
+                        expectedMessage+": [pk]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC);",
+                        expectedMessage+": [pk, v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC, ck1 DESC);",
+                        expectedMessage+": [pk, v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, v ASC);",
+                        expectedMessage+": [v]");
+        expectedFailure("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);",
+                        expectedMessage+": [v]");
+    }
 
+    private void expectedFailure(String statement, String errorMsg)
+    {
         try
         {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC);");
+            createTableMayThrow(statement);
         }
         catch (Throwable ex)
         {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC, ck1 DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, pk DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC, ck1 DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, v ASC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
-        }
-
-        try
-        {
-            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);");
-        }
-        catch (Throwable ex)
-        {
-            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+            assertTrue(ex.getMessage().contains(errorMsg));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.transport.messages.QueryMessage;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -101,6 +102,91 @@ public class CreateTableValidationTest extends CQLTester
         {
             DatabaseDescriptor.setTableCountWarnThreshold(tableCountWarn);
             DatabaseDescriptor.setKeyspaceCountWarnThreshold(keyspaceCountWarn);
+        }
+    }
+
+    @Test
+    public void testCreateTableErrorOnNonClusterKey()
+    {
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, v ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk ASC, ck1 DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, ck2 DESC, pk DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (pk DESC, v DESC, ck1 DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC, v ASC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
+        }
+
+        try
+        {
+            createTableMayThrow("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (v ASC, ck1 DESC);");
+        }
+        catch (Throwable ex)
+        {
+            assertEquals(ex.getMessage(), "Only clustering columns can be defined in CLUSTERING ORDER directive");
         }
     }
 }


### PR DESCRIPTION
Fix error message handling when trying to use CLUSTERING ORDER with non-clustering column

Patch: Throw error message after finding there are non-cluster columns in order definition. 

patch by <Ningzi Zhan>

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-17818)

