### PR TITLE
Replica nodes for batch operation are picked by response time

### DIFF
--- a/src/java/org/apache/cassandra/gms/IFailureDetector.java
+++ b/src/java/org/apache/cassandra/gms/IFailureDetector.java
@@ -19,6 +19,9 @@ package org.apache.cassandra.gms;
 
 import org.apache.cassandra.locator.InetAddressAndPort;
 
+import java.util.List;
+import java.util.Collections;
+
 /**
  * An interface that provides an application with the ability
  * to query liveness information of a node in the cluster. It
@@ -36,6 +39,28 @@ public interface IFailureDetector
      * @return true if UP and false if DOWN.
      */
     public boolean isAlive(InetAddressAndPort ep);
+
+    /**
+     * Sorts the endpoints based on their response time.
+     * Nodes at smaller indexes have faster response time than nodes at higher indexes.
+     * @param List<InetAddressAndPort> endpoints.
+     * @return void.
+     */
+    public default void sortEndpointsByResponseTime(List<InetAddressAndPort> endpoints)
+    {
+        Collections.sort(endpoints, (InetAddressAndPort epA, InetAddressAndPort epB) -> { return isEpAResponseTimeSlowerThanEpB(epA, epB) ? 1 : -1; });
+    }
+
+    /**
+     * Indicates if endpoint A has longer response time than endpoint B.
+     * @param InetAddressAndPort epA.
+     * @param InetAddressAndPort epB.
+     * @return boolean.
+     */
+    public default boolean isEpAResponseTimeSlowerThanEpB(InetAddressAndPort epA, InetAddressAndPort epB)
+    {
+        throw new UnsupportedOperationException("Method that compares Endpoint A response time VS Endpoint B was not implemented.");
+    }
 
     /**
      * This method is invoked by any entity wanting to interrogate the status of an endpoint.

--- a/test/unit/org/apache/cassandra/batchlog/BatchlogEndpointFilterByResponseTimeTest.java
+++ b/test/unit/org/apache/cassandra/batchlog/BatchlogEndpointFilterByResponseTimeTest.java
@@ -1,0 +1,152 @@
+package org.apache.cassandra.batchlog;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import java.net.UnknownHostException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.dht.RandomPartitioner;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.ReplicaPlans;
+import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.service.StorageService;
+
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class BatchlogEndpointFilterByResponseTimeTest
+{
+  private int sufficient_gossip_history = 30; // amount of gossips that are expected to suffice in identifying nodes' response time
+  private int lag_factor = 3; // amount of fast gossip completions for each slow gossip completion
+
+  @BeforeClass
+  public static void setup()
+  {
+    System.setProperty("cassandra.max_local_pause_in_ms", "20000"); // ref: org.apache.cassandra.batchlog.BatchlogEndpointFilter
+    DatabaseDescriptor.daemonInitialization();
+    DatabaseDescriptor.setPhiConvictThreshold(2); // should be high enough to not "convict" endpoints with high Phi in the tests
+    CommitLog.instance.start();
+  }
+
+  @Test
+  public void absenceOfPhiDoesNotBreakCodeExecutionTest() throws UnknownHostException
+  {
+    List<InetAddressAndPort> endpoints = new ArrayList<>();
+
+    Util.createInitialRing(StorageService.instance, new RandomPartitioner(), new ArrayList<>(), new ArrayList<>(), endpoints, new ArrayList<>(), 5);
+
+    Multimap<String, InetAddressAndPort> rackToEndpoints = HashMultimap.create(1, 5);
+    rackToEndpoints.putAll("local", endpoints);
+    
+    Collection<InetAddressAndPort> filteredEndpoints = ReplicaPlans.filterBatchlogEndpoints(
+      "local",
+      rackToEndpoints,
+      FailureDetector.instance::sortEndpointsByResponseTime,
+      FailureDetector.isEpASlowerThanEpB,
+      FailureDetector.isEndpointAlive
+    );
+
+    assertTrue(filteredEndpoints.size() == 2);
+  }
+  
+  @Test
+  public void singleRackForReplicationTest() throws UnknownHostException
+  {
+    List<InetAddressAndPort> endpoints = new ArrayList<>();
+
+    Util.createInitialRing(StorageService.instance, new RandomPartitioner(), new ArrayList<>(), new ArrayList<>(), endpoints, new ArrayList<>(), 5);
+
+    for (int gossip_counter = 0; gossip_counter < sufficient_gossip_history; gossip_counter++)
+    {
+      FailureDetector.instance.report(endpoints.get(1));
+      FailureDetector.instance.report(endpoints.get(3));
+      if (gossip_counter % lag_factor == 0)
+      {
+        FailureDetector.instance.report(endpoints.get(2));
+        FailureDetector.instance.report(endpoints.get(4));
+      }
+      for (int idx = 1; idx < endpoints.size(); idx++)
+        FailureDetector.instance.interpret(endpoints.get(idx));
+    }
+    
+    Multimap<String, InetAddressAndPort> rackToEndpoints = HashMultimap.create(1, 5);
+    rackToEndpoints.putAll("local", endpoints);
+    
+    Collection<InetAddressAndPort> filteredEndpoints = ReplicaPlans.filterBatchlogEndpoints(
+      "local",
+      rackToEndpoints,
+      FailureDetector.instance::sortEndpointsByResponseTime,
+      FailureDetector.isEpASlowerThanEpB,
+      FailureDetector.isEndpointAlive
+    );
+
+    assertTrue(filteredEndpoints.size() == 2);
+    assertTrue(filteredEndpoints.contains(endpoints.get(1)));
+    assertTrue(filteredEndpoints.contains(endpoints.get(3)));
+  }
+
+  @Test
+  public void aCoupleOfRacksForReplicationTest() throws UnknownHostException
+  {
+    int nodes_per_rack = 2;
+    List<String> racks = new ArrayList<String>();
+    racks.add("local");
+    racks.add("rack_a");
+    racks.add("rack_b");
+    racks.add("rack_c");
+    List<InetAddressAndPort> endpoints = new ArrayList<>();
+
+    Util.createInitialRing(
+      StorageService.instance,
+      new RandomPartitioner(),
+      new ArrayList<>(),
+      new ArrayList<>(),
+      endpoints,
+      new ArrayList<>(),
+      nodes_per_rack * racks.size()
+    );
+
+    for (int gossip_counter = 0; gossip_counter < sufficient_gossip_history; gossip_counter++)
+    {
+      FailureDetector.instance.report(endpoints.get(3));
+      FailureDetector.instance.report(endpoints.get(4));
+      if (gossip_counter % lag_factor == 0)
+      {
+        FailureDetector.instance.report(endpoints.get(1));
+        FailureDetector.instance.report(endpoints.get(2));
+        FailureDetector.instance.report(endpoints.get(5));
+        FailureDetector.instance.report(endpoints.get(6));
+        FailureDetector.instance.report(endpoints.get(7));
+      }
+      for (int idx = 1; idx < endpoints.size(); idx++)
+        FailureDetector.instance.interpret(endpoints.get(idx));
+    }
+    
+    Multimap<String, InetAddressAndPort> racksToEndpoints = HashMultimap.create(racks.size(), nodes_per_rack);
+    for (int i = 0; i < racks.size(); i++)
+      racksToEndpoints.putAll(racks.get(i), endpoints.subList(2 * i, 2 * i + 2));
+    
+    Collection<InetAddressAndPort> filteredEndpoints = ReplicaPlans.filterBatchlogEndpoints(
+      racks.get(0),
+      racksToEndpoints,
+      FailureDetector.instance::sortEndpointsByResponseTime,
+      FailureDetector.isEpASlowerThanEpB,
+      FailureDetector.isEndpointAlive
+    );
+
+    assertTrue(filteredEndpoints.size() == 2);
+    assertTrue(filteredEndpoints.contains(endpoints.get(3)));
+    assertTrue(filteredEndpoints.contains(endpoints.get(4)));
+  }
+}

--- a/test/unit/org/apache/cassandra/batchlog/BatchlogEndpointFilterTest.java
+++ b/test/unit/org/apache/cassandra/batchlog/BatchlogEndpointFilterTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.locator.ReplicaPlans;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class BatchlogEndpointFilterTest
 {
@@ -49,8 +50,8 @@ public class BatchlogEndpointFilterTest
                 .build();
         Collection<InetAddressAndPort> result = filterBatchlogEndpoints(endpoints);
         assertThat(result.size(), is(2));
-        assertTrue(result.contains(InetAddressAndPort.getByName("11")));
-        assertTrue(result.contains(InetAddressAndPort.getByName("22")));
+        assertFalse(result.contains(InetAddressAndPort.getByName("0")));
+        assertFalse(result.contains(InetAddressAndPort.getByName("00")));
     }
 
     @Test
@@ -67,11 +68,6 @@ public class BatchlogEndpointFilterTest
         
         Collection<InetAddressAndPort> result = filterBatchlogEndpoints(endpoints);
         assertThat(result.size(), is(2));
-
-        // result should be the last replicas of the last two racks
-        // (Collections.shuffle has been replaced with Collections.reverse for testing)
-        assertTrue(result.contains(InetAddressAndPort.getByName("22")));
-        assertTrue(result.contains(InetAddressAndPort.getByName("33")));
     }
 
     @Test
@@ -152,9 +148,9 @@ public class BatchlogEndpointFilterTest
         return ReplicaPlans.filterBatchlogEndpoints(LOCAL, endpoints,
                                                     // Reverse instead of shuffle
                                                     Collections::reverse,
+                                                    // epA always faster than epB
+                                                    (epA, epB) -> false,
                                                     // Always alive
-                                                    (addr) -> true,
-                                                    // Always pick the last
-                                                    (size) -> size - 1);
+                                                    (addr) -> true);
     }
 }


### PR DESCRIPTION
[CASSANDRA-18120](https://issues.apache.org/jira/browse/CASSANDRA-18120). Random replica node pick for batch operations was changed to a pick by the nodes' response time. 

Motivation:

- Avoid any potential followup change by the end-users.
- Minimize scope of the change.
- Do not introduce expensive logic.

The idea is to use readily-available interpretation of the potential replica node's communication time as a proxy indicator.  
It indicates if the node will take longer to complete batch operation than other nodes.

Value [PHI](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.80.7427&rep=rep1&type=pdf) is used as an indicator. It is calculated during gossip. The longer it takes node to complete gossip operation, the higher PHI value gets.  
The assumption here is that longer gossip completion surely indicates a longer batch operation completion. Additional PHI description is available at [CASSANDRA-2597](https://issues.apache.org/jira/browse/CASSANDRA-2597)'s comment section.

patch by Maxim Chanturiay; reviewed by <Reviewers> for CASSANDRA-18120

Co-authored-by: Dan Sarisky <email1>

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

