### PR TITLE
Add jvmarg into microbench target to run microbench tests for jdk8 and jdk11

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1968,6 +1968,7 @@
           <arg value="${build.test.dir}/jmh-result.json"/>
           <arg value="-v"/>
           <arg value="EXTRA"/>
+          <jvmarg line="${java11-jvmargs}"/>
 
           <!-- Broken: ZeroCopyStreamingBench,MutationBench,FastThreadLocalBench  (FIXME) -->
           <arg value="-e"/><arg value="ZeroCopyStreamingBench|MutationBench|FastThreadLocalBench"/>


### PR DESCRIPTION
This PR adds jvmarg lines into microbench target to run microbench tests for jdk8 and jdk11 on Cassandra 4.0 to be able to run microbench tests.


patch by @marianne-manaog; to be reviewed by @ekaterinadimitrova2 and @driftx for CASSANDRA-18658



[CASSANDRA-18658](https://issues.apache.org/jira/browse/CASSANDRA-18658)