### PR TITLE
CASSANDRA-18689 : documentation fix

### DIFF
--- a/doc/modules/cassandra/pages/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/operating/metrics.adoc
@@ -913,12 +913,6 @@ Reported name format:
 |Name |Type |Description
 |connectedNativeClients |Gauge<Integer> |Number of clients connected to
 this nodes native protocol server
-
-|connections |Gauge<List<Map<String, String>> |List of all connections
-and their state information
-
-|connectedNativeClientsByUser |Gauge<Map<String, Int> |Number of
-connnective native clients by username
 |===
 
 == Batch Metrics


### PR DESCRIPTION
CASSANDRA-18689 (https://issues.apache.org/jira/browse/CASSANDRA-18689)

https://issues.apache.org/jira/browse/CASSANDRA-13665 introduced 2 new metrics on the client metrics, connections and connectedNativeClientsByUser - the 3.11 docs list these metrics as being available when they are not.
 