### PR TITLE
CASSANDRA-18697 Skip ColumnFamilyStore#topPartitions initialization when client or tool mode

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -558,7 +558,7 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         repairManager = new CassandraTableRepairManager(this);
         sstableImporter = new SSTableImporter(this);
 
-        if (SchemaConstants.isSystemKeyspace(getKeyspaceName()))
+        if (DatabaseDescriptor.isClientOrToolInitialized() || SchemaConstants.isSystemKeyspace(getKeyspaceName()))
             topPartitions = null;
         else
             topPartitions = new TopPartitionTracker(metadata());

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreClientModeTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreClientModeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.schema.MockSchema;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link ColumnFamilyStore} when the library is running as tool
+ * or client mode.
+ */
+public class ColumnFamilyStoreClientModeTest
+{
+    @Before
+    public void setUp()
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
+    @Test
+    public void testTopPartitionsAreNotInitialized()
+    {
+        ColumnFamilyStore columnFamilyStore = MockSchema.newCFS();
+        assertNull(columnFamilyStore.topPartitions);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/ColumnFamilyStoreClientModeTest.java
+++ b/test/unit/org/apache/cassandra/db/ColumnFamilyStoreClientModeTest.java
@@ -70,15 +70,11 @@ public class ColumnFamilyStoreClientModeTest
     @Test
     public void testTopPartitionsAreNotInitialized() throws IOException
     {
-        CreateTableStatement.Raw schemaStatement = parseStatement("CREATE TABLE " + KEYSPACE + ".test1 (a int, b text, PRIMARY KEY (a))", CreateTableStatement.Raw.class, "CREATE TABLE");
+        CreateTableStatement.Raw schemaStatement = parseStatement("CREATE TABLE " + KEYSPACE + '.' + TABLE + " (a int, b text, PRIMARY KEY (a))", CreateTableStatement.Raw.class, "CREATE TABLE");
 
         Schema.instance.transform(SchemaTransformations.addKeyspace(KeyspaceMetadata.create(KEYSPACE, KeyspaceParams.simple(1)), true));
 
-        Schema.instance.getKeyspaceMetadata(KEYSPACE);
-        Types.RawBuilder builder = Types.rawBuilder(KEYSPACE);
-
-        Types types = builder.build();
-
+        Types types = Types.rawBuilder(KEYSPACE).build();
         Schema.instance.transform(SchemaTransformations.addTypes(types, true));
 
         ClientState state = ClientState.forInternalCalls(KEYSPACE);
@@ -92,7 +88,7 @@ public class ColumnFamilyStoreClientModeTest
         Keyspace.setInitialized();
         Directories directories = new Directories(tableMetadata, new Directories.DataDirectory[]{ new Directories.DataDirectory(new org.apache.cassandra.io.util.File(tempFolder.newFolder("datadir"))) });
         Keyspace ks = Keyspace.openWithoutSSTables(KEYSPACE);
-        ColumnFamilyStore cfs = ColumnFamilyStore.createColumnFamilyStore(ks, "table1", TableMetadataRef.forOfflineTools(tableMetadata), directories, false, false, true);
+        ColumnFamilyStore cfs = ColumnFamilyStore.createColumnFamilyStore(ks, TABLE, TableMetadataRef.forOfflineTools(tableMetadata), directories, false, false, true);
 
         assertNull(cfs.topPartitions);
     }


### PR DESCRIPTION
This commit skips the initialization of `topPartitions` in `org.apache.cassandra.db.ColumnFamilyStore` when running in client or tool mode. The `TopPartitionTracker` class will attempt to query the system keyspace, which when running in client or tool mode will not be part of the KeyspaceMetadata. This causes a warning to be printed out with a stacktrace that can be misleading. The warning is similar to this:

```
WARN org.apache.cassandra.db.SystemKeyspace: Could not load stored top SIZES partitions for ...
org.apache.cassandra.db.KeyspaceNotDefinedException: keyspace system does not exist
	at org.apache.cassandra.schema.Schema.validateTable(Schema.java:xxx) ~[?:?]
	at org.apache.cassandra.cql3.statements.SelectStatement$RawStatement.prepare(SelectStatement.java:xxx) ~[?:?]
	at org.apache.cassandra.cql3.statements.SelectStatement$RawStatement.prepare(SelectStatement.java:xxx) ~[?:?]
	at org.apache.cassandra.cql3.statements.SelectStatement$RawStatement.prepare(SelectStatement.java:xxx) ~[?:?]
	at org.apache.cassandra.cql3.QueryProcessor.parseAndPrepare(QueryProcessor.java:xxx) ~[?:?]
        ...
```

In this commit, we check whether we run in client or tool mode, and skip initialization of `topPartitions` in those cases.

Thanks for sending a pull request! Here are some tips if you're new here:
 

[CASSANDRA-18697](https://issues.apache.org/jira/browse/CASSANDRA-18697)

