### PR TITLE
CASSANDRA-18466 Paxos only repair is treated as an incremental repair

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/Repair.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Repair.java
@@ -149,7 +149,7 @@ public class Repair extends NodeToolCmd
                 parallelismDegree = RepairParallelism.DATACENTER_AWARE;
             options.put(RepairOption.PARALLELISM_KEY, parallelismDegree.getName());
             options.put(RepairOption.PRIMARY_RANGE_KEY, Boolean.toString(primaryRange));
-            options.put(RepairOption.INCREMENTAL_KEY, Boolean.toString(!fullRepair));
+            options.put(RepairOption.INCREMENTAL_KEY, Boolean.toString(!(fullRepair || (paxosOnly && getPreviewKind() == PreviewKind.NONE))));
             options.put(RepairOption.JOB_THREADS_KEY, Integer.toString(numJobThreads));
             options.put(RepairOption.TRACE_KEY, Boolean.toString(trace));
             options.put(RepairOption.COLUMNFAMILIES_KEY, StringUtils.join(cfnames, ","));


### PR DESCRIPTION
CASSANDRA-18466 Paxos only repair is treated as an incremental repair

Change Paxos-only repair to full repair in default.

patch by Ningzi Zhan


The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-18466)

