### PR TITLE
Fix Network Topology Replication log message when an unrecognized strategy options is passed

### DIFF
--- a/src/java/org/apache/cassandra/locator/NetworkTopologyStrategy.java
+++ b/src/java/org/apache/cassandra/locator/NetworkTopologyStrategy.java
@@ -90,7 +90,6 @@ public class NetworkTopologyStrategy extends AbstractReplicationStrategy
 
         datacenters = Collections.unmodifiableMap(newDatacenters);
         aggregateRf = ReplicationFactor.withTransient(replicas, trans);
-        logger.info("Configured datacenter replicas are {}", FBUtilities.toString(datacenters));
     }
 
     /**
@@ -324,6 +323,7 @@ public class NetworkTopologyStrategy extends AbstractReplicationStrategy
                 throw new ConfigurationException("Following datacenters have active nodes and must be present in replication options for keyspace " + SchemaConstants.AUTH_KEYSPACE_NAME + ": " + differenceSet.toString());
             }
         }
+        logger.info("Configured datacenter replicas are {}", FBUtilities.toString(datacenters));
     }
 
     @Override


### PR DESCRIPTION
Fix Network Topology Replication log message when an unrecognized strategy options is passed

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

