### PR TITLE
Disable heap dump creation by default on crash for tests that use test/conf/cassandra.yaml

### DIFF
--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -56,7 +56,7 @@ full_query_logging_options:
 auto_hints_cleanup_enabled: true
 
 heap_dump_path: build/test
-dump_heap_on_uncaught_exception: true
+dump_heap_on_uncaught_exception: false
 
 read_thresholds_enabled: true
 coordinator_read_size_warn_threshold: 1024KiB


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by ? for CASSANDRA-18741