### PR TITLE
CASSANDRA-18725: IsolatedJmx should only remove the endpoints it created when stopping (4.0)

### DIFF
--- a/.build/build-resolver.xml
+++ b/.build/build-resolver.xml
@@ -62,7 +62,7 @@
 
         <macrodef name="resolve">
             <!--
-              maven-resolver-ant-tasks's resolve logic doesn't have retry logic and does not respect settings.xml, 
+              maven-resolver-ant-tasks's resolve logic doesn't have retry logic and does not respect settings.xml,
               this causes issues when overriding maven central is required (such as when behind a corporate firewall);
               it is critical to always provide the 'all' remoterepos to override resolve's default hard coded logic.
 
@@ -229,7 +229,7 @@
             <url url="${lib.download.base.url}/lib/sigar-bin/sigar-x86-winnt.dll"/>
             <url url="${lib.download.base.url}/lib/sigar-bin/sigar-x86-winnt.lib"/>
         </get>
-        
+
         <copy todir="${build.lib}" quiet="true">
             <file file="${local.repository}/org/apache/cassandra/deps/futures-2.1.6-py2.py3-none-any.zip"/>
             <file file="${local.repository}/org/apache/cassandra/deps/six-1.12.0-py2.py3-none-any.zip"/>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8078 +14,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-version: 2
 jobs:
-  j8_jvm_upgrade_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_utests_fqltool_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_FQLTOOL_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_FQLTOOL_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS_FQLTOOL} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=fqltool-test
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant fqltool-test $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh-dtests-py2-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python2.7' ]; then
-            export CQLSH_PYTHON=/usr/bin/python2.7
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh_dtests_py311_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.11' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.11
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests_vnode_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if true; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests_large_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_large_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_large_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --only-resource-intensive-tests --force-resource-intensive-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_large_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_large_with_vnodes_raw /tmp/all_dtest_tests_j8_large_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_large_with_vnodes_raw > /tmp/all_dtest_tests_j8_large_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_large_with_vnodes > /tmp/split_dtest_tests_j8_large_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_large_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_large_with_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_large_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_large_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_large_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_utests_system_keyspace_directory:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-system-keyspace-directory)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-system-keyspace-directory -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_utests_stress:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (stress-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant stress-test -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_utests_stress_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_STRESS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_STRESS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS_STRESS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=stress-test-some
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant stress-test-some $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlsh_dtests_py311:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.11' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.11
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_utests_compression_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-compression
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-compression $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_unit_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh_dtests_py3:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh_dtests_py38:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_utests_compression_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-compression
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-compression $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_repeated_ant_test:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run repeated JUnit test
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_ANT_TEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_ANT_TEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_ANT_TEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_ANT_TEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_ANT_TEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_ANT_TEST_TARGET} ${REPEATED_ANT_TEST_CLASS} ${REPEATED_ANT_TEST_METHODS} ${REPEATED_ANT_TEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=${REPEATED_ANT_TEST_TARGET}
-              class_path=${REPEATED_ANT_TEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_ANT_TEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_ANT_TEST_METHODS}"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${REPEATED_ANT_TEST_TARGET}-${REPEATED_ANT_TEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results/repeated_utest/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_dtests_large_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_large_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_large_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --only-resource-intensive-tests --force-resource-intensive-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_large_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_large_with_vnodes_raw /tmp/all_dtest_tests_j11_large_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_large_with_vnodes_raw > /tmp/all_dtest_tests_j11_large_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_large_with_vnodes > /tmp/split_dtest_tests_j11_large_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_large_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_large_with_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_large_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_large_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_large_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_dtests_large_vnode_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_LARGE_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_LARGE_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if true; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh_dtests_py311:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
-
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.11' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.11
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh_dtests_py38_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j11_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_dtests_large:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_large_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_large_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --only-resource-intensive-tests --force-resource-intensive-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_large_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_large_without_vnodes_raw /tmp/all_dtest_tests_j11_large_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_large_without_vnodes_raw > /tmp/all_dtest_tests_j11_large_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_large_without_vnodes > /tmp/split_dtest_tests_j11_large_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_large_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_large_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_large_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_large_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_large_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_utests_system_keyspace_directory_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-system-keyspace-directory
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-system-keyspace-directory $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh_dtests_py3_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh_dtests_py3:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_utests_cdc:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-cdc)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-cdc -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_utests_fqltool:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (fqltool-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant fqltool-test -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_utests_system_keyspace_directory:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-system-keyspace-directory)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-system-keyspace-directory -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtests_offheap_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if true; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir --use-off-heap-memtables --skip-resource-intensive-tests $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py2-offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j8_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python2.7' ]; then
-            export CQLSH_PYTHON=/usr/bin/python2.7
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests_offheap_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if true; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir --use-off-heap-memtables --skip-resource-intensive-tests $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests_large_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_LARGE_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_LARGE_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_utests_compression:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-compression)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-compression -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_utests_long:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (long-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant long-test -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_unit_tests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=testsome
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant testsome $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtests_large:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_large_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_large_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --only-resource-intensive-tests --force-resource-intensive-tests --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_large_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_large_without_vnodes_raw /tmp/all_dtest_tests_j8_large_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_large_without_vnodes_raw > /tmp/all_dtest_tests_j8_large_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_large_without_vnodes > /tmp/split_dtest_tests_j8_large_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_large_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_large_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_large_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_large_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_large_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh-dtests-py2-no-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python2.7' ]; then
-            export CQLSH_PYTHON=/usr/bin/python2.7
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_utests_stress:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (stress-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant stress-test -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh_dtests_py38_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j8_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_upgrade_dtests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_UPGRADE_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UPGRADE_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_UPGRADE_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_UPGRADE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_UPGRADE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_UPGRADE_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_UPGRADE_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if true; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh-dtests-py2-with-vnodes:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python2.7' ]; then
-            export CQLSH_PYTHON=/usr/bin/python2.7
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_utests_cdc_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-cdc
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-cdc $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_dtests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_utests_fqltool_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_FQLTOOL_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_FQLTOOL_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS_FQLTOOL} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=fqltool-test
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant fqltool-test $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_utests_compression:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-compression)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-compression -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh_dtests_py38:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh_dtests_py3_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j11_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlsh_dtests_py311_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j11_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt
-
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.11' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.11
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_utests_system_keyspace_directory_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-system-keyspace-directory
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-system-keyspace-directory $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests_large_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_LARGE_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_LARGE_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_cqlsh_dtests_py3_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j8_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_utests_stress_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_STRESS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_STRESS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS_STRESS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=stress-test-some
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant stress-test-some $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtests_vnode_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if true; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh_dtests_py3_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.6' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.6
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_upgrade_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_upgradetests_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection all --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_upgradetests_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection all --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_upgradetests_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_upgradetests_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j11_dtests_offheap)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\"\ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_jvm_upgrade_dtests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_JVM_UPGRADE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_UPGRADE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_JVM_UPGRADE_DTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-jvm-dtest-some
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-jvm-dtest-some $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlsh_dtests_py38_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_jvm_dtests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_JVM_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_JVM_DTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-jvm-dtest-some
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-jvm-dtest-some $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_cqlsh_dtests_py311_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt
-
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.11' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.11
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_utests_long_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_LONG_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_LONG_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS_LONG} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=long-testsome
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant long-testsome $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtests_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j8_dtests_offheap)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\"\ncat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_unit_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_jvm_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
   j11_build:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra Repository (via git)
-        command: |
-          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
-    - run:
-        name: Build Cassandra
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant clean realclean jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-        no_output_timeout: 15m
-    - run:
-        name: Run eclipse-warnings
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          ant eclipse-warnings
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - cassandra
-        - .m2
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -8128,1836 +61,342 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j8_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    parallelism: 1
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
-    - attach_workspace:
-        at: /home/cassandra
     - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
+        command: 'git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          ~/cassandra
+
+          '
+        name: Clone Cassandra Repository (via git)
     - run:
-        name: Determine Tests to Run (j8_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_without_vnodes)
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\n# Loop to prevent\
+          \ failure due to maven-ant-tasks not downloading a jar..\nfor x in $(seq\
+          \ 1 3); do\n    ${ANT_HOME}/bin/ant clean realclean jar\n    RETURN=\"$?\"\
+          \n    if [ \"${RETURN}\" -eq \"0\" ]; then\n        break\n    fi\ndone\n\
+          # Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"0\" ];\
+          \ then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit ${RETURN}\n\
+          fi\n"
+        name: Build Cassandra
         no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          cd ~/cassandra
+
+          ant eclipse-warnings
+
+          '
+        name: Run eclipse-warnings
+    - persist_to_workspace:
+        paths:
+        - cassandra
+        - .m2
+        root: /home/cassandra
+    working_directory: ~/
   j11_cqlsh-dtests-py2-no-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 50
+    resource_class: large
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
         name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
           source ~/env3.6/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
           pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
           pip3 uninstall -y cqlsh
+
           pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
     - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
         name: Determine Tests to Run (j11_without_vnodes)
         no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
     - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python2.7'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python2.7\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
         name: Run dtests (j11_without_vnodes)
         no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python2.7' ]; then
-            export CQLSH_PYTHON=/usr/bin/python2.7
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
-        path: /tmp/dtest
         destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
     - store_artifacts:
-        path: ~/cassandra-dtest/logs
         destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_dtests_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
         path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_cqlshlib_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
     working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run cqlshlib Unit Tests
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra/pylib
-          ./cassandra-cqlsh-tests.sh ..
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/pylib
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_jvm_dtests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_JVM_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_JVM_DTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-jvm-dtest-some
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-jvm-dtest-some $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_without_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_without_vnodes)
-        no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_without_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_without_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j8_repeated_ant_test:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run repeated JUnit test
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_ANT_TEST_CLASS}" == "<nil>" ]; then
-            echo "Repeated utest class name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_ANT_TEST_COUNT}" == "<nil>" ]; then
-            echo "Repeated utest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_ANT_TEST_COUNT}" -le 0 ]; then
-            echo "Repeated utest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_ANT_TEST_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_ANT_TEST_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_ANT_TEST_TARGET} ${REPEATED_ANT_TEST_CLASS} ${REPEATED_ANT_TEST_METHODS} ${REPEATED_ANT_TEST_COUNT} times"
-
-              set -x
-              export PATH=$JAVA_HOME/bin:$PATH
-              time mv ~/cassandra /tmp
-              cd /tmp/cassandra
-              if [ -d ~/dtest_jars ]; then
-                cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-              fi
-
-              target=${REPEATED_ANT_TEST_TARGET}
-              class_path=${REPEATED_ANT_TEST_CLASS}
-              class_name="${class_path##*.}"
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name="-Dtest.name=$class_name"
-              else
-                name="-Dtest.name=$class_path"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [ "${REPEATED_ANT_TEST_METHODS}" == "<nil>" ]; then
-                methods=""
-              else
-                methods="-Dtest.methods=${REPEATED_ANT_TEST_METHODS}"
-              fi
-
-              # Run the test target as many times as requested collecting the exit code,
-              # stopping the iteration only if stop_on_failure is set.
-              exit_code="$?"
-              for i in $(seq -w 1 $count); do
-
-                echo "Running test iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && ant $target $name $methods -Dno-build-test=true | tee stdout.txt ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utest/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${REPEATED_ANT_TEST_TARGET}-${REPEATED_ANT_TEST_CLASS}.txt
-
-                # move the XML output files
-                source=build/test/output
-                dest=/tmp/results/repeated_utest/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs
-                dest=/tmp/results/repeated_utest/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-
-              (exit ${exit_code})
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results/repeated_utest/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utest/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_utests_long:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run Unit Tests (long-test)
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant long-test -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_utests_cdc:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine unit Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g" | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist-cdc)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.unit.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist-cdc -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh_dtests_py311_offheap:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_dtests_offheap)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
-    - run:
-        name: Run dtests (j8_dtests_offheap)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt
-
-          source ~/env3.11/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.11' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.11
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_dtests_offheap
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtests_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
-        no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
-
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
-
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_DTESTS} $count times"
-
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
-
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
-
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
-
-              tests_arg=$(echo ${REPEATED_DTESTS} | sed -e "s/,/ /g")
-
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
-
-              vnodes_args=""
-              if false; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
-
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
-
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_jvm_dtests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Determine distributed Tests to Run
-        command: |
-          # reminder: this code (along with all the steps) is independently executed on every circle container
-          # so the goal here is to get the circleci script to return the tests *this* container will run
-          # which we do via the `circleci` cli tool.
-
-          rm -fr ~/cassandra-dtest/upgrade_tests
-          echo "***java tests***"
-
-          # get all of our unit test filenames
-          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java" > /tmp/all_java_unit_tests.txt
-
-          # split up the unit tests into groups based on the number of containers we have
-          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
-          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g" | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
-          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
-        no_output_timeout: 15m
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Run Unit Tests (testclasslist)
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          test_timeout=$(grep 'name="test.distributed.timeout"' build.xml | awk -F'"' '{print $4}' || true)
-          if [ -z "$test_timeout" ]; then
-            test_timeout=$(grep 'name="test.timeout"' build.xml | awk -F'"' '{print $4}')
-          fi
-          ant testclasslist -Dtest.timeout="$test_timeout" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed -Dno-build-test=true
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/build/test/output/
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
-        destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Clone Cassandra Repository (via git)
-        command: |
-          git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git ~/cassandra
-    - run:
-        name: Build Cassandra
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant clean realclean jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-        no_output_timeout: 15m
-    - run:
-        name: Run eclipse-warnings
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          ant eclipse-warnings
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - cassandra
-        - .m2
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlsh_dtests_py38_vnode:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j8_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j8_with_vnodes)
-        no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt"
-          cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt
-
-          source ~/env3.8/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python3.8' ]; then
-            export CQLSH_PYTHON=/usr/bin/python3.8
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
-    - store_test_results:
-        path: /tmp/results
-    - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j8_with_vnodes
-    - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j8_with_vnodes_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
   j11_cqlsh-dtests-py2-offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 50
+    resource_class: large
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
         name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
     - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
           source ~/env3.6/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
           pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
           pip3 uninstall -y cqlsh
+
           pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
     - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
         name: Determine Tests to Run (j11_dtests_offheap)
         no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
     - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python2.7'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python2.7\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
         name: Run dtests (j11_dtests_offheap)
         no_output_timeout: 15m
-        command: |
-          echo "cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt"
-          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt
-
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          if [ -n 'CQLSH_PYTHON=/usr/bin/python2.7' ]; then
-            export CQLSH_PYTHON=/usr/bin/python2.7
-          fi
-
-          java -version
-          cd ~/cassandra-dtest
-          mkdir -p /tmp/dtest
-
-          echo "env: $(env)"
-          echo "** done env"
-          mkdir -p /tmp/results/dtests
-          # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-          export SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`
-          if [ ! -z "$SPLIT_TESTS" ]; then
-            set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt
-          else
-            echo "Tune your parallelism, there are more containers than test classes. Nothing to do in this container"
-            (exit 1)
-          fi
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
-        path: /tmp/dtest
         destination: dtest_j11_dtests_offheap
+        path: /tmp/dtest
     - store_artifacts:
-        path: ~/cassandra-dtest/logs
         destination: dtest_j11_dtests_offheap_logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - CASSANDRA_USE_JDK11: true
-  j11_unit_tests_repeat:
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh-dtests-py2-with-vnodes:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=testsome
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant testsome $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -10000,201 +439,3069 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j8_utests_fqltool:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
-    working_directory: ~/
+    parallelism: 50
+    resource_class: large
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Run Unit Tests (fqltool-test)
-        command: |
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
           export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python2.7'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python2.7\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py3:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py311:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.11/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.11'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.11\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py311_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.11/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j11_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.11'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.11\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py311_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.11/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.11'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.11\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py38:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py38_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j11_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py38_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py3_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j11_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlsh_dtests_py3_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_cqlshlib_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
           time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-          ant fqltool-test -Dno-build-test=true
+
+          cd /tmp/cassandra/pylib
+
+          ./cassandra-cqlsh-tests.sh ..
+
+          '
+        name: Run cqlshlib Unit Tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/pylib
+    working_directory: ~/
+  j11_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_large:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 4
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_large_without_vnodes)***\"\nset -eo pipefail\
+          \ && ./run_dtests.py --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_large_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_large_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_large_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_large_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_large_without_vnodes || { echo \"Filter did\
+          \ not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail\
+          \ && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_large_without_vnodes\
+          \ > /tmp/split_dtest_tests_j11_large_without_vnodes.txt\ncat /tmp/split_dtest_tests_j11_large_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_large_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt\n\nsource\
+          \ ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ];\
+          \ then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\
+          \necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n\
+          # we need the \"set -o pipefail\" here so that the exit code that circleci\
+          \ will actually use is from pytest and not the exit code from tee\nexport\
+          \ SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_large_without_vnodes_final.txt`\n\
+          if [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest\
+          \ && pytest --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_large_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_large_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_large_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_large_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_large_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_LARGE_DTESTS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated dtest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" -le 0 ]; then\n  echo\
+          \ \"Repeated dtest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX\
+          \ < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n\
+          \  fi\n\n  if (($count <= 0)); then\n    echo \"No tests to run in this\
+          \ runner\"\n  else\n    echo \"Running ${REPEATED_LARGE_DTESTS} $count times\"\
+          \n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e \"s/,/ /g\")\n\n\
+          \    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_large_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 4
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_large_with_vnodes)***\"\nset -eo pipefail\
+          \ && ./run_dtests.py --use-vnodes --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_large_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_large_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_large_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_large_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_large_with_vnodes || { echo \"Filter did not\
+          \ match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail &&\
+          \ circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_large_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_large_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_large_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_large_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_large_with_vnodes_final.txt`\nif [ ! -z \"\
+          $SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest\
+          \ --use-vnodes --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_large_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_large_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_large_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_large_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_large_vnode_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_LARGE_DTESTS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated dtest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" -le 0 ]; then\n  echo\
+          \ \"Repeated dtest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX\
+          \ < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n\
+          \  fi\n\n  if (($count <= 0)); then\n    echo \"No tests to run in this\
+          \ runner\"\n  else\n    echo \"Running ${REPEATED_LARGE_DTESTS} $count times\"\
+          \n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e \"s/,/ /g\")\n\n\
+          \    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if true; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\n\
+          \    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j11_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j11_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j11_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j11_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j11_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j11_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j11_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_offheap_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTESTS}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest name hasn't been defined, exiting without running any test\"\nelif\
+          \ [ \"${REPEATED_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTESTS_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTESTS} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    tests_arg=$(echo ${REPEATED_DTESTS}\
+          \ | sed -e \"s/,/ /g\")\n\n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if true; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\n\
+          \    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTESTS}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest name hasn't been defined, exiting without running any test\"\nelif\
+          \ [ \"${REPEATED_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTESTS_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTESTS} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    tests_arg=$(echo ${REPEATED_DTESTS}\
+          \ | sed -e \"s/,/ /g\")\n\n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes\
+          \ > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j11_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j11_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j11_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_dtests_vnode_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTESTS}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest name hasn't been defined, exiting without running any test\"\nelif\
+          \ [ \"${REPEATED_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTESTS_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTESTS} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    tests_arg=$(echo ${REPEATED_DTESTS}\
+          \ | sed -e \"s/,/ /g\")\n\n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if true; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\n\
+          \    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j11_jvm_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 28
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist)
         no_output_timeout: 15m
     - store_test_results:
         path: /tmp/cassandra/build/test/output/
     - store_artifacts:
-        path: /tmp/cassandra/build/test/output
         destination: junitxml
+        path: /tmp/cassandra/build/test/output
     - store_artifacts:
-        path: /tmp/cassandra/build/test/logs
         destination: logs
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_cqlshlib_tests:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+        path: /tmp/cassandra/build/test/logs
     working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 1
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Run cqlshlib Unit Tests
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra/pylib
-          ./cassandra-cqlsh-tests.sh ..
-        no_output_timeout: 15m
-    - store_test_results:
-        path: /tmp/cassandra/pylib
-    environment:
-    - ANT_HOME: /usr/share/ant
-    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - LANG: en_US.UTF-8
-    - KEEP_TEST_DIR: true
-    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
-    - PYTHONIOENCODING: utf-8
-    - PYTHONUNBUFFERED: true
-    - CASS_DRIVER_NO_EXTENSIONS: true
-    - CASS_DRIVER_NO_CYTHON: true
-    - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
-    - CCM_MAX_HEAP_SIZE: 1024M
-    - CCM_HEAP_NEWSIZE: 256M
-    - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
-    - REPEATED_UTESTS_COUNT: 500
-    - REPEATED_UTESTS_FQLTOOL: null
-    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
-    - REPEATED_UTESTS_LONG_COUNT: 100
-    - REPEATED_UTESTS_STRESS: null
-    - REPEATED_UTESTS_STRESS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
-    - REPEATED_JVM_DTESTS_COUNT: 500
-    - REPEATED_JVM_UPGRADE_DTESTS: null
-    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
-    - REPEATED_DTESTS_COUNT: 500
-    - REPEATED_LARGE_DTESTS: null
-    - REPEATED_LARGE_DTESTS_COUNT: 100
-    - REPEATED_UPGRADE_DTESTS: null
-    - REPEATED_UPGRADE_DTESTS_COUNT: 25
-    - REPEATED_ANT_TEST_TARGET: testsome
-    - REPEATED_ANT_TEST_CLASS: null
-    - REPEATED_ANT_TEST_METHODS: null
-    - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j11_dtests_vnode:
+  j11_jvm_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ResourceLeakTest,org.apache.cassandra.distributed.test.jmx.JMXFeatureTest,org.apache.cassandra.distributed.test.jmx.JMXGetterCheckTest
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 28
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Determine Tests to Run (j11_with_vnodes)
-        no_output_timeout: 5m
-        command: "# reminder: this code (along with all the steps) is independently executed on every circle container\n# so the goal here is to get the circleci script to return the tests *this* container will run\n# which we do via the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\necho \"***Collected DTests (j11_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j11_with_vnodes_raw --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j11_with_vnodes_raw /tmp/all_dtest_tests_j11_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j11_with_vnodes_raw > /tmp/all_dtest_tests_j11_with_vnodes || { echo \"Filter did not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j11_with_vnodes > /tmp/split_dtest_tests_j11_with_vnodes.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes.txt | tr '\\n' ' ' > /tmp/split_dtest_tests_j11_with_vnodes_final.txt\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n"
-    - run:
-        name: Run dtests (j11_with_vnodes)
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_JVM_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_JVM_DTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/\
+          \ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho\
+          \ \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the target,\
+          \ used by the test macro in build.xml to group the output files\ntarget=test-jvm-dtest-some\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-jvm-dtest-some $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
         no_output_timeout: 15m
-        command: "echo \"cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\"\ncat /tmp/split_dtest_tests_j11_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j11_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j11_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism, there are more containers than test classes. Nothing to do in this container\"\n  (exit 1)\nfi\n"
     - store_test_results:
-        path: /tmp/results
+        path: /tmp/results/repeated_utests/output
     - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest_j11_with_vnodes
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
     - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_j11_with_vnodes_logs
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_repeated_ant_test:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -10237,157 +3544,421 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j8_utests_cdc_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    parallelism: 25
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
+        command: 'echo ''*** id ***''
+
           id
-          echo '*** cat /proc/cpuinfo ***'
+
+          echo ''*** cat /proc/cpuinfo ***''
+
           cat /proc/cpuinfo
-          echo '*** free -m ***'
+
+          echo ''*** free -m ***''
+
           free -m
-          echo '*** df -m ***'
+
+          echo ''*** df -m ***''
+
           df -m
-          echo '*** ifconfig -a ***'
+
+          echo ''*** ifconfig -a ***''
+
           ifconfig -a
-          echo '*** uname -a ***'
+
+          echo ''*** uname -a ***''
+
           uname -a
-          echo '*** mount ***'
+
+          echo ''*** mount ***''
+
           mount
-          echo '*** env ***'
+
+          echo ''*** env ***''
+
           env
-          echo '*** java ***'
+
+          echo ''*** java ***''
+
           which java
+
           java -version
+
+          '
+        name: Log Environment Information
     - run:
+        command: "if [ \"${REPEATED_ANT_TEST_CLASS}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated utest class name hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_ANT_TEST_COUNT}\" == \"<nil>\" ]; then\n\
+          \  echo \"Repeated utest count hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_ANT_TEST_COUNT}\" -le 0 ]; then\n  echo\
+          \ \"Repeated utest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_ANT_TEST_COUNT} / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX\
+          \ < (${REPEATED_ANT_TEST_COUNT} % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n\
+          \  fi\n\n  if (($count <= 0)); then\n    echo \"No tests to run in this\
+          \ runner\"\n  else\n    echo \"Running ${REPEATED_ANT_TEST_TARGET} ${REPEATED_ANT_TEST_CLASS}\
+          \ ${REPEATED_ANT_TEST_METHODS} ${REPEATED_ANT_TEST_COUNT} times\"\n\n  \
+          \  set -x\n    export PATH=$JAVA_HOME/bin:$PATH\n    time mv ~/cassandra\
+          \ /tmp\n    cd /tmp/cassandra\n    if [ -d ~/dtest_jars ]; then\n      cp\
+          \ ~/dtest_jars/dtest* /tmp/cassandra/build/\n    fi\n\n    target=${REPEATED_ANT_TEST_TARGET}\n\
+          \    class_path=${REPEATED_ANT_TEST_CLASS}\n    class_name=\"${class_path##*.}\"\
+          \n\n    # Prepare the -Dtest.name argument.\n    # It can be the fully qualified\
+          \ class name or the short class name, depending on the target.\n    if [[\
+          \ $target == \"test\" || \\\n          $target == \"test-cdc\" || \\\n \
+          \         $target == \"test-compression\" || \\\n          $target == \"\
+          test-system-keyspace-directory\" || \\\n          $target == \"fqltool-test\"\
+          \ || \\\n          $target == \"long-test\" || \\\n          $target ==\
+          \ \"stress-test\" ]]; then\n      name=\"-Dtest.name=$class_name\"\n   \
+          \ else\n      name=\"-Dtest.name=$class_path\"\n    fi\n\n    # Prepare\
+          \ the -Dtest.methods argument, which is optional\n    if [ \"${REPEATED_ANT_TEST_METHODS}\"\
+          \ == \"<nil>\" ]; then\n      methods=\"\"\n    else\n      methods=\"-Dtest.methods=${REPEATED_ANT_TEST_METHODS}\"\
+          \n    fi\n\n    # Run the test target as many times as requested collecting\
+          \ the exit code,\n    # stopping the iteration only if stop_on_failure is\
+          \ set.\n    exit_code=\"$?\"\n    for i in $(seq -w 1 $count); do\n\n  \
+          \    echo \"Running test iteration $i of $count\"\n\n      # run the test\n\
+          \      status=\"passes\"\n      if !( set -o pipefail && ant $target $name\
+          \ $methods -Dno-build-test=true | tee stdout.txt ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n \
+          \     mkdir -p $dest\n      mv stdout.txt $dest/${REPEATED_ANT_TEST_TARGET}-${REPEATED_ANT_TEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\n\
+          \    (exit ${exit_code})\n  fi\nfi\n"
+        name: Run repeated JUnit test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utest/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  j11_unit_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 35
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_unit_tests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 35
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=testsome\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant testsome $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
         name: Repeatedly run new or modifed JUnit tests
         no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=test-cdc
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant test-cdc $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
     - store_test_results:
         path: /tmp/results/repeated_utests/output
     - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
         destination: stdout
+        path: /tmp/results/repeated_utests/stdout
     - store_artifacts:
-        path: /tmp/results/repeated_utests/output
         destination: junitxml
+        path: /tmp/results/repeated_utests/output
     - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
         destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_utests_cdc:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -10427,98 +3998,117 @@ jobs:
     - REPEATED_ANT_TEST_CLASS: null
     - REPEATED_ANT_TEST_METHODS: null
     - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-  j8_dtests_large_vnode_repeat:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Clone Cassandra dtest Repository (via git)
-        command: |
-          git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO ~/cassandra-dtest
-    - run:
-        name: Configure virtualenv and python Dependencies
-        command: |
-          # note, this should be super quick as all dependencies should be pre-installed in the docker image
-          # if additional dependencies were added to requirmeents.txt and the docker image hasn't been updated
-          # we'd have to install it here at runtime -- which will make things slow, so do yourself a favor and
-          # rebuild the docker image! (it automatically pulls the latest requirements.txt on build)
-          source ~/env3.6/bin/activate
-          export PATH=$JAVA_HOME/bin:$PATH
-          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
-          pip3 uninstall -y cqlsh
-          pip3 freeze
-    - run:
-        name: Run repeated Python dtest
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
         no_output_timeout: 15m
-        command: |
-          if [ "${REPEATED_LARGE_DTESTS}" == "<nil>" ]; then
-            echo "Repeated dtest name hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" == "<nil>" ]; then
-            echo "Repeated dtest count hasn't been defined, exiting without running any test"
-          elif [ "${REPEATED_LARGE_DTESTS_COUNT}" -le 0 ]; then
-            echo "Repeated dtest count is lesser or equals than zero, exiting without running any test"
-          else
+    - run:
+        command: 'echo ''*** id ***''
 
-            # Calculate the number of test iterations to be run by the current parallel runner.
-            # Since we are running the same test multiple times there is no need to use `circleci tests split`.
-            count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))
-            if (($CIRCLE_NODE_INDEX < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then
-              count=$((count+1))
-            fi
+          id
 
-            if (($count <= 0)); then
-              echo "No tests to run in this runner"
-            else
-              echo "Running ${REPEATED_LARGE_DTESTS} $count times"
+          echo ''*** cat /proc/cpuinfo ***''
 
-              source ~/env3.6/bin/activate
-              export PATH=$JAVA_HOME/bin:$PATH
+          cat /proc/cpuinfo
 
-              java -version
-              cd ~/cassandra-dtest
-              mkdir -p /tmp/dtest
+          echo ''*** free -m ***''
 
-              echo "env: $(env)"
-              echo "** done env"
-              mkdir -p /tmp/results/dtests
+          free -m
 
-              tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e "s/,/ /g")
+          echo ''*** df -m ***''
 
-              stop_on_failure_arg=""
-              if ${REPEATED_TESTS_STOP_ON_FAILURE}; then
-                stop_on_failure_arg="-x"
-              fi
+          df -m
 
-              vnodes_args=""
-              if true; then
-                vnodes_args="--use-vnodes --num-tokens=16"
-              fi
+          echo ''*** ifconfig -a ***''
 
-              upgrade_arg=""
-              if false; then
-                upgrade_arg="--execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection all"
-              fi
+          ifconfig -a
 
-              # we need the "set -o pipefail" here so that the exit code that circleci will actually use is from pytest and not the exit code from tee
-              set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests $tests_arg | tee /tmp/dtest/stdout.txt
-            fi
-          fi
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-cdc -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist-cdc)
+        no_output_timeout: 15m
     - store_test_results:
-        path: /tmp/results
+        path: /tmp/cassandra/build/test/output/
     - store_artifacts:
-        path: /tmp/dtest
-        destination: dtest
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
     - store_artifacts:
-        path: ~/cassandra-dtest/logs
-        destination: dtest_logs
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_utests_cdc_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -10558,159 +4148,708 @@ jobs:
     - REPEATED_ANT_TEST_CLASS: null
     - REPEATED_ANT_TEST_METHODS: null
     - REPEATED_ANT_TEST_COUNT: 500
-    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=test-cdc\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-cdc $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_utests_compression:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-compression -Dtest.timeout=\"\
+          $test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist-compression)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_utests_compression_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=test-compression\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-compression $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_utests_fqltool:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant fqltool-test -Dno-build-test=true\n"
+        name: Run Unit Tests (fqltool-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_utests_fqltool_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_FQLTOOL_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_FQLTOOL_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS_FQLTOOL} | sed -e \"s/<nil>//\" | sed -e\
+          \ \"s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\n\
+          echo \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the\
+          \ target, used by the test macro in build.xml to group the output files\n\
+          target=fqltool-test\ntesttag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n\
+          \  testtag=\"cdc\"\nelif [[ $target == \"test-compression\" ]]; then\n \
+          \ testtag=\"compression\"\nelif [[ $target == \"test-system-keyspace-directory\"\
+          \ ]]; then\n  testtag=\"system_keyspace_directory\"\nfi\n\n# Run each test\
+          \ class as many times as requested.\nexit_code=\"$?\"\nfor test in $tests;\
+          \ do\n\n    # Split class and method names from the test name\n    if [[\
+          \ $test =~ \"#\" ]]; then\n      class=${test%\"#\"*}\n      method=${test#*\"\
+          #\"}\n    else\n      class=$test\n      method=\"\"\n    fi\n\n    # Prepare\
+          \ the -Dtest.name argument.\n    # It can be the fully qualified class name\
+          \ or the short class name, depending on the target.\n    if [[ $target ==\
+          \ \"test\" || \\\n          $target == \"test-cdc\" || \\\n          $target\
+          \ == \"test-compression\" || \\\n          $target == \"test-system-keyspace-directory\"\
+          \ || \\\n          $target == \"fqltool-test\" || \\\n          $target\
+          \ == \"long-test\" || \\\n          $target == \"stress-test\" ]]; then\n\
+          \      name_arg=\"-Dtest.name=${class##*.}\"\n    else\n      name_arg=\"\
+          -Dtest.name=$class\"\n    fi\n\n    # Prepare the -Dtest.methods argument,\
+          \ which is optional\n    if [[ $method == \"\" ]]; then\n      methods_arg=\"\
+          \"\n    else\n      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n \
+          \   for i in $(seq -w 1 $count); do\n      echo \"Running test $test, iteration\
+          \ $i of $count\"\n\n      # run the test\n      status=\"passes\"\n    \
+          \  if !( set -o pipefail && \\\n            ant fqltool-test $name_arg $methods_arg\
+          \ -Dno-build-test=true | \\\n            tee stdout.txt \\\n          );\
+          \ then\n        status=\"fails\"\n        exit_code=1\n      fi\n\n    \
+          \  # move the stdout output file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_utests_long:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant long-test -Dno-build-test=true\n"
+        name: Run Unit Tests (long-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
   j11_utests_long_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
-    working_directory: ~/
-    shell: /bin/bash -eo pipefail -l
-    parallelism: 4
-    steps:
-    - attach_workspace:
-        at: /home/cassandra
-    - run:
-        name: Log Environment Information
-        command: |
-          echo '*** id ***'
-          id
-          echo '*** cat /proc/cpuinfo ***'
-          cat /proc/cpuinfo
-          echo '*** free -m ***'
-          free -m
-          echo '*** df -m ***'
-          df -m
-          echo '*** ifconfig -a ***'
-          ifconfig -a
-          echo '*** uname -a ***'
-          uname -a
-          echo '*** mount ***'
-          mount
-          echo '*** env ***'
-          env
-          echo '*** java ***'
-          which java
-          java -version
-    - run:
-        name: Repeatedly run new or modifed JUnit tests
-        no_output_timeout: 15m
-        command: |
-          set -x
-          export PATH=$JAVA_HOME/bin:$PATH
-          time mv ~/cassandra /tmp
-          cd /tmp/cassandra
-          if [ -d ~/dtest_jars ]; then
-            cp ~/dtest_jars/dtest* /tmp/cassandra/build/
-          fi
-
-          # Calculate the number of test iterations to be run by the current parallel runner.
-          count=$((${REPEATED_UTESTS_LONG_COUNT} / CIRCLE_NODE_TOTAL))
-          if (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_LONG_COUNT} % CIRCLE_NODE_TOTAL))); then
-            count=$((count+1))
-          fi
-
-          # Put manually specified tests and automatically detected tests together, removing duplicates
-          tests=$(echo ${REPEATED_UTESTS_LONG} | sed -e "s/<nil>//" | sed -e "s/ //" | tr "," "\n" | tr " " "\n" | sort -n | uniq -u)
-          echo "Tests to be repeated: ${tests}"
-
-          # Prepare the testtag for the target, used by the test macro in build.xml to group the output files
-          target=long-testsome
-          testtag=""
-          if [[ $target == "test-cdc" ]]; then
-            testtag="cdc"
-          elif [[ $target == "test-compression" ]]; then
-            testtag="compression"
-          elif [[ $target == "test-system-keyspace-directory" ]]; then
-            testtag="system_keyspace_directory"
-          fi
-
-          # Run each test class as many times as requested.
-          exit_code="$?"
-          for test in $tests; do
-
-              # Split class and method names from the test name
-              if [[ $test =~ "#" ]]; then
-                class=${test%"#"*}
-                method=${test#*"#"}
-              else
-                class=$test
-                method=""
-              fi
-
-              # Prepare the -Dtest.name argument.
-              # It can be the fully qualified class name or the short class name, depending on the target.
-              if [[ $target == "test" || \
-                    $target == "test-cdc" || \
-                    $target == "test-compression" || \
-                    $target == "test-system-keyspace-directory" || \
-                    $target == "fqltool-test" || \
-                    $target == "long-test" || \
-                    $target == "stress-test" ]]; then
-                name_arg="-Dtest.name=${class##*.}"
-              else
-                name_arg="-Dtest.name=$class"
-              fi
-
-              # Prepare the -Dtest.methods argument, which is optional
-              if [[ $method == "" ]]; then
-                methods_arg=""
-              else
-                methods_arg="-Dtest.methods=$method"
-              fi
-
-              for i in $(seq -w 1 $count); do
-                echo "Running test $test, iteration $i of $count"
-
-                # run the test
-                status="passes"
-                if !( set -o pipefail && \
-                      ant long-testsome $name_arg $methods_arg -Dno-build-test=true | \
-                      tee stdout.txt \
-                    ); then
-                  status="fails"
-                  exit_code=1
-                fi
-
-                # move the stdout output file
-                dest=/tmp/results/repeated_utests/stdout/${status}/${i}
-                mkdir -p $dest
-                mv stdout.txt $dest/${test}.txt
-
-                # move the XML output files
-                source=build/test/output/${testtag}
-                dest=/tmp/results/repeated_utests/output/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # move the log files
-                source=build/test/logs/${testtag}
-                dest=/tmp/results/repeated_utests/logs/${status}/${i}
-                mkdir -p $dest
-                if [[ -d $source && -n "$(ls $source)" ]]; then
-                  mv $source/* $dest/
-                fi
-
-                # maybe stop iterations on test failure
-                if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true ]] && (( $exit_code > 0 )); then
-                  break
-                fi
-              done
-          done
-          (exit ${exit_code})
-    - store_test_results:
-        path: /tmp/results/repeated_utests/output
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/stdout
-        destination: stdout
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/output
-        destination: junitxml
-    - store_artifacts:
-        path: /tmp/results/repeated_utests/logs
-        destination: logs
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -10753,67 +4892,639 @@ jobs:
     - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
     - CASSANDRA_USE_JDK11: true
-  j8_dtest_jars_build:
-    docker:
-    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    parallelism: 25
     resource_class: medium
-    working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
     steps:
     - attach_workspace:
         at: /home/cassandra
     - run:
-        name: Build Cassandra DTest jars
-        command: |
-          export PATH=$JAVA_HOME/bin:$PATH
-          cd ~/cassandra
-          mkdir ~/dtest_jars
-          git remote add apache https://github.com/apache/cassandra.git
-          for branch in cassandra-2.2 cassandra-3.0 cassandra-3.11 cassandra-4.0 cassandra-4.1; do
-            # check out the correct cassandra version:
-            git remote set-branches --add apache '$branch'
-            git fetch --depth 1 apache $branch
-            git checkout $branch
-            git clean -fd
-            # Loop to prevent failure due to maven-ant-tasks not downloading a jar..
-            for x in $(seq 1 3); do
-                ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar
-                RETURN="$?"
-                if [ "${RETURN}" -eq "0" ]; then
-                    cp build/dtest*.jar ~/dtest_jars
-                    break
-                fi
-            done
-            # Exit, if we didn't build successfully
-            if [ "${RETURN}" -ne "0" ]; then
-                echo "Build failed with exit code: ${RETURN}"
-                exit ${RETURN}
-            fi
-          done
-          # and build the dtest-jar for the branch under test
-          ${ANT_HOME}/bin/ant realclean
-          git checkout origin/$CIRCLE_BRANCH
-          git clean -fd
-          for x in $(seq 1 3); do
-              ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant jar dtest-jar
-              RETURN="$?"
-              if [ "${RETURN}" -eq "0" ]; then
-                  cp build/dtest*.jar ~/dtest_jars
-                  break
-              fi
-          done
-          # Exit, if we didn't build successfully
-          if [ "${RETURN}" -ne "0" ]; then
-              echo "Build failed with exit code: ${RETURN}"
-              exit ${RETURN}
-          fi
-          ls -l ~/dtest_jars
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_LONG_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_LONG_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS_LONG} | sed -e \"s/<nil>//\" | sed -e \"\
+          s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho\
+          \ \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the target,\
+          \ used by the test macro in build.xml to group the output files\ntarget=long-testsome\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant long-testsome $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
         no_output_timeout: 15m
-    - persist_to_workspace:
-        root: /home/cassandra
-        paths:
-        - dtest_jars
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_utests_stress:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant stress-test -Dno-build-test=true\n"
+        name: Run Unit Tests (stress-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_utests_stress_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_STRESS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_STRESS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS_STRESS} | sed -e \"s/<nil>//\" | sed -e \"\
+          s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho\
+          \ \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the target,\
+          \ used by the test macro in build.xml to group the output files\ntarget=stress-test-some\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant stress-test-some $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j11_utests_system_keyspace_directory:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-system-keyspace-directory\
+          \ -Dtest.timeout=\"$test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist-system-keyspace-directory)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j11_utests_system_keyspace_directory_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - CASSANDRA_USE_JDK11: true
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=test-system-keyspace-directory\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-system-keyspace-directory $name_arg $methods_arg\
+          \ -Dno-build-test=true | \\\n            tee stdout.txt \\\n          );\
+          \ then\n        status=\"fails\"\n        exit_code=1\n      fi\n\n    \
+          \  # move the stdout output file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_build:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
     environment:
     - ANT_HOME: /usr/share/ant
     - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
@@ -10855,134 +5566,5992 @@ jobs:
     - REPEATED_ANT_TEST_COUNT: 500
     - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: 'git clone --single-branch --depth 1 --branch $CIRCLE_BRANCH https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git
+          ~/cassandra
+
+          '
+        name: Clone Cassandra Repository (via git)
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\n# Loop to prevent\
+          \ failure due to maven-ant-tasks not downloading a jar..\nfor x in $(seq\
+          \ 1 3); do\n    ${ANT_HOME}/bin/ant clean realclean jar\n    RETURN=\"$?\"\
+          \n    if [ \"${RETURN}\" -eq \"0\" ]; then\n        break\n    fi\ndone\n\
+          # Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"0\" ];\
+          \ then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit ${RETURN}\n\
+          fi\n"
+        name: Build Cassandra
+        no_output_timeout: 15m
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          cd ~/cassandra
+
+          ant eclipse-warnings
+
+          '
+        name: Run eclipse-warnings
+    - persist_to_workspace:
+        paths:
+        - cassandra
+        - .m2
+        root: /home/cassandra
+    working_directory: ~/
+  j8_cqlsh-dtests-py2-no-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python2.7'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python2.7\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py2-offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j8_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python2.7'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python2.7\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh-dtests-py2-with-vnodes:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python2.7'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python2.7\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py3:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py311:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.11/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.11'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.11\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py311_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.11/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j8_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.11'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.11\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py311_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.11/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.11/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.11'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.11\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py38:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py38_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j8_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py38_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.8/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.8/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.8'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.8\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py3_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j8_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlsh_dtests_py3_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k cql'\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n 'CQLSH_PYTHON=/usr/bin/python3.6'\
+          \ ]; then\n  export CQLSH_PYTHON=/usr/bin/python3.6\nfi\n\njava -version\n\
+          cd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env: $(env)\"\necho\
+          \ \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need the \"set -o\
+          \ pipefail\" here so that the exit code that circleci will actually use\
+          \ is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_cqlshlib_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'export PATH=$JAVA_HOME/bin:$PATH
+
+          time mv ~/cassandra /tmp
+
+          cd /tmp/cassandra/pylib
+
+          ./cassandra-cqlsh-tests.sh ..
+
+          '
+        name: Run cqlshlib Unit Tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/pylib
+    working_directory: ~/
+  j8_dtest_jars_build:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ncd ~/cassandra\nmkdir ~/dtest_jars\n\
+          git remote add apache https://github.com/apache/cassandra.git\nfor branch\
+          \ in cassandra-2.2 cassandra-3.0 cassandra-3.11 cassandra-4.0 cassandra-4.1;\
+          \ do\n  # check out the correct cassandra version:\n  git remote set-branches\
+          \ --add apache '$branch'\n  git fetch --depth 1 apache $branch\n  git checkout\
+          \ $branch\n  git clean -fd\n  # Loop to prevent failure due to maven-ant-tasks\
+          \ not downloading a jar..\n  for x in $(seq 1 3); do\n      ${ANT_HOME}/bin/ant\
+          \ realclean; ${ANT_HOME}/bin/ant jar dtest-jar\n      RETURN=\"$?\"\n  \
+          \    if [ \"${RETURN}\" -eq \"0\" ]; then\n          cp build/dtest*.jar\
+          \ ~/dtest_jars\n          break\n      fi\n  done\n  # Exit, if we didn't\
+          \ build successfully\n  if [ \"${RETURN}\" -ne \"0\" ]; then\n      echo\
+          \ \"Build failed with exit code: ${RETURN}\"\n      exit ${RETURN}\n  fi\n\
+          done\n# and build the dtest-jar for the branch under test\n${ANT_HOME}/bin/ant\
+          \ realclean\ngit checkout origin/$CIRCLE_BRANCH\ngit clean -fd\nfor x in\
+          \ $(seq 1 3); do\n    ${ANT_HOME}/bin/ant realclean; ${ANT_HOME}/bin/ant\
+          \ jar dtest-jar\n    RETURN=\"$?\"\n    if [ \"${RETURN}\" -eq \"0\" ];\
+          \ then\n        cp build/dtest*.jar ~/dtest_jars\n        break\n    fi\n\
+          done\n# Exit, if we didn't build successfully\nif [ \"${RETURN}\" -ne \"\
+          0\" ]; then\n    echo \"Build failed with exit code: ${RETURN}\"\n    exit\
+          \ ${RETURN}\nfi\nls -l ~/dtest_jars\n"
+        name: Build Cassandra DTest jars
+        no_output_timeout: 15m
+    - persist_to_workspace:
+        paths:
+        - dtest_jars
+        root: /home/cassandra
+    working_directory: ~/
+  j8_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_without_vnodes)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_without_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_without_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_without_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_large:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 4
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_large_without_vnodes)***\"\nset -eo pipefail\
+          \ && ./run_dtests.py --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_large_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_large_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_large_without_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_large_without_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_large_without_vnodes || { echo \"Filter did\
+          \ not match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail\
+          \ && circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_large_without_vnodes\
+          \ > /tmp/split_dtest_tests_j8_large_without_vnodes.txt\ncat /tmp/split_dtest_tests_j8_large_without_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_large_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt\n\nsource\
+          \ ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ];\
+          \ then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\
+          \necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n\
+          # we need the \"set -o pipefail\" here so that the exit code that circleci\
+          \ will actually use is from pytest and not the exit code from tee\nexport\
+          \ SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_large_without_vnodes_final.txt`\n\
+          if [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest\
+          \ && pytest --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_large_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_large_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_large_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_large_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_large_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_LARGE_DTESTS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated dtest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" -le 0 ]; then\n  echo\
+          \ \"Repeated dtest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX\
+          \ < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n\
+          \  fi\n\n  if (($count <= 0)); then\n    echo \"No tests to run in this\
+          \ runner\"\n  else\n    echo \"Running ${REPEATED_LARGE_DTESTS} $count times\"\
+          \n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e \"s/,/ /g\")\n\n\
+          \    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_large_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 4
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_large_with_vnodes)***\"\nset -eo pipefail\
+          \ && ./run_dtests.py --use-vnodes --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_large_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_large_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_large_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_large_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_large_with_vnodes || { echo \"Filter did not\
+          \ match any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail &&\
+          \ circleci tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_large_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_large_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_large_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_large_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_large_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_large_with_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_large_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_large_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_large_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_large_vnode_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_LARGE_DTESTS}\" == \"<nil>\" ]; then\n  echo \"\
+          Repeated dtest name hasn't been defined, exiting without running any test\"\
+          \nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated dtest count hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_LARGE_DTESTS_COUNT}\" -le 0 ]; then\n  echo\
+          \ \"Repeated dtest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_LARGE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX\
+          \ < (${REPEATED_LARGE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n\
+          \  fi\n\n  if (($count <= 0)); then\n    echo \"No tests to run in this\
+          \ runner\"\n  else\n    echo \"Running ${REPEATED_LARGE_DTESTS} $count times\"\
+          \n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    tests_arg=$(echo ${REPEATED_LARGE_DTESTS} | sed -e \"s/,/ /g\")\n\n\
+          \    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if true; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\n\
+          \    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir --only-resource-intensive-tests --force-resource-intensive-tests\
+          \ $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_offheap:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_dtests_offheap)***\"\nset -eo pipefail &&\
+          \ ./run_dtests.py --use-vnodes --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --pytest-options '-k not cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ /tmp/all_dtest_tests_j8_dtests_offheap\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_dtests_offheap_raw\
+          \ > /tmp/all_dtest_tests_j8_dtests_offheap || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_dtests_offheap\
+          \ > /tmp/split_dtest_tests_j8_dtests_offheap.txt\ncat /tmp/split_dtest_tests_j8_dtests_offheap.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n"
+        name: Determine Tests to Run (j8_dtests_offheap)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\"\n\
+          cat /tmp/split_dtest_tests_j8_dtests_offheap_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_dtests_offheap_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_dtests_offheap.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_dtests_offheap)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_dtests_offheap_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_offheap_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTESTS}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest name hasn't been defined, exiting without running any test\"\nelif\
+          \ [ \"${REPEATED_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTESTS_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTESTS} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    tests_arg=$(echo ${REPEATED_DTESTS}\
+          \ | sed -e \"s/,/ /g\")\n\n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if true; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\n\
+          \    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir --use-off-heap-memtables --skip-resource-intensive-tests\
+          \ $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTESTS}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest name hasn't been defined, exiting without running any test\"\nelif\
+          \ [ \"${REPEATED_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTESTS_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTESTS} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    tests_arg=$(echo ${REPEATED_DTESTS}\
+          \ | sed -e \"s/,/ /g\")\n\n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_vnode:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 50
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_with_vnodes)***\"\nset -eo pipefail && ./run_dtests.py\
+          \ --use-vnodes --skip-resource-intensive-tests --pytest-options '-k not\
+          \ cql' --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_with_vnodes\nelse\n  grep -e '' /tmp/all_dtest_tests_j8_with_vnodes_raw\
+          \ > /tmp/all_dtest_tests_j8_with_vnodes || { echo \"Filter did not match\
+          \ any tests! Exiting build.\"; exit 0; }\nfi\nset -eo pipefail && circleci\
+          \ tests split --split-by=timings --timings-type=classname /tmp/all_dtest_tests_j8_with_vnodes\
+          \ > /tmp/split_dtest_tests_j8_with_vnodes.txt\ncat /tmp/split_dtest_tests_j8_with_vnodes.txt\
+          \ | tr '\\n' ' ' > /tmp/split_dtest_tests_j8_with_vnodes_final.txt\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_with_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_with_vnodes_final.txt\"\ncat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt\n\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\nif [ -n '' ]; then\n  export \nfi\n\n\
+          java -version\ncd ~/cassandra-dtest\nmkdir -p /tmp/dtest\n\necho \"env:\
+          \ $(env)\"\necho \"** done env\"\nmkdir -p /tmp/results/dtests\n# we need\
+          \ the \"set -o pipefail\" here so that the exit code that circleci will\
+          \ actually use is from pytest and not the exit code from tee\nexport SPLIT_TESTS=`cat\
+          \ /tmp/split_dtest_tests_j8_with_vnodes_final.txt`\nif [ ! -z \"$SPLIT_TESTS\"\
+          \ ]; then\n  set -o pipefail && cd ~/cassandra-dtest && pytest --use-vnodes\
+          \ --num-tokens=16 --skip-resource-intensive-tests --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result_j8_with_vnodes.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir $SPLIT_TESTS 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n\
+          \  echo \"Tune your parallelism, there are more containers than test classes.\
+          \ Nothing to do in this container\"\n  (exit 1)\nfi\n"
+        name: Run dtests (j8_with_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_with_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_dtests_vnode_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_DTESTS}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest name hasn't been defined, exiting without running any test\"\nelif\
+          \ [ \"${REPEATED_DTESTS_COUNT}\" == \"<nil>\" ]; then\n  echo \"Repeated\
+          \ dtest count hasn't been defined, exiting without running any test\"\n\
+          elif [ \"${REPEATED_DTESTS_COUNT}\" -le 0 ]; then\n  echo \"Repeated dtest\
+          \ count is lesser or equals than zero, exiting without running any test\"\
+          \nelse\n\n  # Calculate the number of test iterations to be run by the current\
+          \ parallel runner.\n  # Since we are running the same test multiple times\
+          \ there is no need to use `circleci tests split`.\n  count=$((${REPEATED_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX < (${REPEATED_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n  fi\n\n  if (($count\
+          \ <= 0)); then\n    echo \"No tests to run in this runner\"\n  else\n  \
+          \  echo \"Running ${REPEATED_DTESTS} $count times\"\n\n    source ~/env3.6/bin/activate\n\
+          \    export PATH=$JAVA_HOME/bin:$PATH\n\n    java -version\n    cd ~/cassandra-dtest\n\
+          \    mkdir -p /tmp/dtest\n\n    echo \"env: $(env)\"\n    echo \"** done\
+          \ env\"\n    mkdir -p /tmp/results/dtests\n\n    tests_arg=$(echo ${REPEATED_DTESTS}\
+          \ | sed -e \"s/,/ /g\")\n\n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if true; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\n\
+          \    fi\n\n    upgrade_arg=\"\"\n    if false; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_jvm_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 28
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep -v upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_jvm_dtests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.ResourceLeakTest,org.apache.cassandra.distributed.test.jmx.JMXFeatureTest,org.apache.cassandra.distributed.test.jmx.JMXGetterCheckTest
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 28
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_JVM_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_JVM_DTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/\
+          \ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho\
+          \ \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the target,\
+          \ used by the test macro in build.xml to group the output files\ntarget=test-jvm-dtest-some\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-jvm-dtest-some $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_jvm_upgrade_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 15
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/distributed/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/distributed/;;g"
+          | grep "Test\.java$" | grep upgrade > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine distributed Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.distributed.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=distributed\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_jvm_upgrade_dtests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 15
+    resource_class: large
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_JVM_UPGRADE_DTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_JVM_UPGRADE_DTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_JVM_UPGRADE_DTESTS} | sed -e \"s/<nil>//\" | sed\
+          \ -e \"s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\n\
+          echo \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the\
+          \ target, used by the test macro in build.xml to group the output files\n\
+          target=test-jvm-dtest-some\ntesttag=\"\"\nif [[ $target == \"test-cdc\"\
+          \ ]]; then\n  testtag=\"cdc\"\nelif [[ $target == \"test-compression\" ]];\
+          \ then\n  testtag=\"compression\"\nelif [[ $target == \"test-system-keyspace-directory\"\
+          \ ]]; then\n  testtag=\"system_keyspace_directory\"\nfi\n\n# Run each test\
+          \ class as many times as requested.\nexit_code=\"$?\"\nfor test in $tests;\
+          \ do\n\n    # Split class and method names from the test name\n    if [[\
+          \ $test =~ \"#\" ]]; then\n      class=${test%\"#\"*}\n      method=${test#*\"\
+          #\"}\n    else\n      class=$test\n      method=\"\"\n    fi\n\n    # Prepare\
+          \ the -Dtest.name argument.\n    # It can be the fully qualified class name\
+          \ or the short class name, depending on the target.\n    if [[ $target ==\
+          \ \"test\" || \\\n          $target == \"test-cdc\" || \\\n          $target\
+          \ == \"test-compression\" || \\\n          $target == \"test-system-keyspace-directory\"\
+          \ || \\\n          $target == \"fqltool-test\" || \\\n          $target\
+          \ == \"long-test\" || \\\n          $target == \"stress-test\" ]]; then\n\
+          \      name_arg=\"-Dtest.name=${class##*.}\"\n    else\n      name_arg=\"\
+          -Dtest.name=$class\"\n    fi\n\n    # Prepare the -Dtest.methods argument,\
+          \ which is optional\n    if [[ $method == \"\" ]]; then\n      methods_arg=\"\
+          \"\n    else\n      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n \
+          \   for i in $(seq -w 1 $count); do\n      echo \"Running test $test, iteration\
+          \ $i of $count\"\n\n      # run the test\n      status=\"passes\"\n    \
+          \  if !( set -o pipefail && \\\n            ant test-jvm-dtest-some $name_arg\
+          \ $methods_arg -Dno-build-test=true | \\\n            tee stdout.txt \\\n\
+          \          ); then\n        status=\"fails\"\n        exit_code=1\n    \
+          \  fi\n\n      # move the stdout output file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_repeated_ant_test:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "if [ \"${REPEATED_ANT_TEST_CLASS}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated utest class name hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_ANT_TEST_COUNT}\" == \"<nil>\" ]; then\n\
+          \  echo \"Repeated utest count hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_ANT_TEST_COUNT}\" -le 0 ]; then\n  echo\
+          \ \"Repeated utest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_ANT_TEST_COUNT} / CIRCLE_NODE_TOTAL))\n  if (($CIRCLE_NODE_INDEX\
+          \ < (${REPEATED_ANT_TEST_COUNT} % CIRCLE_NODE_TOTAL))); then\n    count=$((count+1))\n\
+          \  fi\n\n  if (($count <= 0)); then\n    echo \"No tests to run in this\
+          \ runner\"\n  else\n    echo \"Running ${REPEATED_ANT_TEST_TARGET} ${REPEATED_ANT_TEST_CLASS}\
+          \ ${REPEATED_ANT_TEST_METHODS} ${REPEATED_ANT_TEST_COUNT} times\"\n\n  \
+          \  set -x\n    export PATH=$JAVA_HOME/bin:$PATH\n    time mv ~/cassandra\
+          \ /tmp\n    cd /tmp/cassandra\n    if [ -d ~/dtest_jars ]; then\n      cp\
+          \ ~/dtest_jars/dtest* /tmp/cassandra/build/\n    fi\n\n    target=${REPEATED_ANT_TEST_TARGET}\n\
+          \    class_path=${REPEATED_ANT_TEST_CLASS}\n    class_name=\"${class_path##*.}\"\
+          \n\n    # Prepare the -Dtest.name argument.\n    # It can be the fully qualified\
+          \ class name or the short class name, depending on the target.\n    if [[\
+          \ $target == \"test\" || \\\n          $target == \"test-cdc\" || \\\n \
+          \         $target == \"test-compression\" || \\\n          $target == \"\
+          test-system-keyspace-directory\" || \\\n          $target == \"fqltool-test\"\
+          \ || \\\n          $target == \"long-test\" || \\\n          $target ==\
+          \ \"stress-test\" ]]; then\n      name=\"-Dtest.name=$class_name\"\n   \
+          \ else\n      name=\"-Dtest.name=$class_path\"\n    fi\n\n    # Prepare\
+          \ the -Dtest.methods argument, which is optional\n    if [ \"${REPEATED_ANT_TEST_METHODS}\"\
+          \ == \"<nil>\" ]; then\n      methods=\"\"\n    else\n      methods=\"-Dtest.methods=${REPEATED_ANT_TEST_METHODS}\"\
+          \n    fi\n\n    # Run the test target as many times as requested collecting\
+          \ the exit code,\n    # stopping the iteration only if stop_on_failure is\
+          \ set.\n    exit_code=\"$?\"\n    for i in $(seq -w 1 $count); do\n\n  \
+          \    echo \"Running test iteration $i of $count\"\n\n      # run the test\n\
+          \      status=\"passes\"\n      if !( set -o pipefail && ant $target $name\
+          \ $methods -Dno-build-test=true | tee stdout.txt ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utest/stdout/${status}/${i}\n \
+          \     mkdir -p $dest\n      mv stdout.txt $dest/${REPEATED_ANT_TEST_TARGET}-${REPEATED_ANT_TEST_CLASS}.txt\n\
+          \n      # move the XML output files\n      source=build/test/output\n  \
+          \    dest=/tmp/results/repeated_utest/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs\n      dest=/tmp/results/repeated_utest/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\n\
+          \    (exit ${exit_code})\n  fi\nfi\n"
+        name: Run repeated JUnit test
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utest/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utest/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utest/logs
+    working_directory: ~/
+  j8_unit_tests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 35
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_unit_tests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 35
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=testsome\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant testsome $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_upgrade_dtests:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 20
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "# reminder: this code (along with all the steps) is independently\
+          \ executed on every circle container\n# so the goal here is to get the circleci\
+          \ script to return the tests *this* container will run\n# which we do via\
+          \ the `circleci` cli tool.\n\ncd cassandra-dtest\nsource ~/env3.6/bin/activate\n\
+          export PATH=$JAVA_HOME/bin:$PATH\n\nif [ -n '' ]; then\n  export \nfi\n\n\
+          echo \"***Collected DTests (j8_upgradetests_without_vnodes)***\"\nset -eo\
+          \ pipefail && ./run_dtests.py --execute-upgrade-tests-only --upgrade-target-version-only\
+          \ --upgrade-version-selection all --dtest-print-tests-only --dtest-print-tests-output=/tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw\
+          \ --cassandra-dir=../cassandra\nif [ -z '' ]; then\n  mv /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\nelse\n  grep -e ''\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes_raw > /tmp/all_dtest_tests_j8_upgradetests_without_vnodes\
+          \ || { echo \"Filter did not match any tests! Exiting build.\"; exit 0;\
+          \ }\nfi\nset -eo pipefail && circleci tests split --split-by=timings --timings-type=classname\
+          \ /tmp/all_dtest_tests_j8_upgradetests_without_vnodes > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt\n\
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes.txt | tr '\\n'\
+          \ ' ' > /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\
+          cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n"
+        name: Determine Tests to Run (j8_upgradetests_without_vnodes)
+        no_output_timeout: 5m
+    - run:
+        command: "echo \"cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\"\
+          \ncat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt\n\n\
+          source ~/env3.6/bin/activate\nexport PATH=$JAVA_HOME/bin:$PATH\nif [ -n\
+          \ '' ]; then\n  export \nfi\n\njava -version\ncd ~/cassandra-dtest\nmkdir\
+          \ -p /tmp/dtest\n\necho \"env: $(env)\"\necho \"** done env\"\nmkdir -p\
+          \ /tmp/results/dtests\n# we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\nexport SPLIT_TESTS=`cat /tmp/split_dtest_tests_j8_upgradetests_without_vnodes_final.txt`\n\
+          if [ ! -z \"$SPLIT_TESTS\" ]; then\n  set -o pipefail && cd ~/cassandra-dtest\
+          \ && pytest --execute-upgrade-tests-only --upgrade-target-version-only --upgrade-version-selection\
+          \ all --log-cli-level=DEBUG --junit-xml=/tmp/results/dtests/pytest_result_j8_upgradetests_without_vnodes.xml\
+          \ -s --cassandra-dir=/home/cassandra/cassandra --keep-test-dir $SPLIT_TESTS\
+          \ 2>&1 | tee /tmp/dtest/stdout.txt\nelse\n  echo \"Tune your parallelism,\
+          \ there are more containers than test classes. Nothing to do in this container\"\
+          \n  (exit 1)\nfi\n"
+        name: Run dtests (j8_upgradetests_without_vnodes)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest_j8_upgradetests_without_vnodes
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_j8_upgradetests_without_vnodes_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_upgrade_dtests_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: xlarge
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'git clone --single-branch --branch $DTEST_BRANCH --depth 1 $DTEST_REPO
+          ~/cassandra-dtest
+
+          '
+        name: Clone Cassandra dtest Repository (via git)
+    - run:
+        command: '# note, this should be super quick as all dependencies should be
+          pre-installed in the docker image
+
+          # if additional dependencies were added to requirmeents.txt and the docker
+          image hasn''t been updated
+
+          # we''d have to install it here at runtime -- which will make things slow,
+          so do yourself a favor and
+
+          # rebuild the docker image! (it automatically pulls the latest requirements.txt
+          on build)
+
+          source ~/env3.6/bin/activate
+
+          export PATH=$JAVA_HOME/bin:$PATH
+
+          pip3 install --exists-action w --upgrade -r ~/cassandra-dtest/requirements.txt
+
+          pip3 uninstall -y cqlsh
+
+          pip3 freeze
+
+          '
+        name: Configure virtualenv and python Dependencies
+    - run:
+        command: "if [ \"${REPEATED_UPGRADE_DTESTS}\" == \"<nil>\" ]; then\n  echo\
+          \ \"Repeated dtest name hasn't been defined, exiting without running any\
+          \ test\"\nelif [ \"${REPEATED_UPGRADE_DTESTS_COUNT}\" == \"<nil>\" ]; then\n\
+          \  echo \"Repeated dtest count hasn't been defined, exiting without running\
+          \ any test\"\nelif [ \"${REPEATED_UPGRADE_DTESTS_COUNT}\" -le 0 ]; then\n\
+          \  echo \"Repeated dtest count is lesser or equals than zero, exiting without\
+          \ running any test\"\nelse\n\n  # Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\n  # Since we are running the\
+          \ same test multiple times there is no need to use `circleci tests split`.\n\
+          \  count=$((${REPEATED_UPGRADE_DTESTS_COUNT} / CIRCLE_NODE_TOTAL))\n  if\
+          \ (($CIRCLE_NODE_INDEX < (${REPEATED_UPGRADE_DTESTS_COUNT} % CIRCLE_NODE_TOTAL)));\
+          \ then\n    count=$((count+1))\n  fi\n\n  if (($count <= 0)); then\n   \
+          \ echo \"No tests to run in this runner\"\n  else\n    echo \"Running ${REPEATED_UPGRADE_DTESTS}\
+          \ $count times\"\n\n    source ~/env3.6/bin/activate\n    export PATH=$JAVA_HOME/bin:$PATH\n\
+          \n    java -version\n    cd ~/cassandra-dtest\n    mkdir -p /tmp/dtest\n\
+          \n    echo \"env: $(env)\"\n    echo \"** done env\"\n    mkdir -p /tmp/results/dtests\n\
+          \n    tests_arg=$(echo ${REPEATED_UPGRADE_DTESTS} | sed -e \"s/,/ /g\")\n\
+          \n    stop_on_failure_arg=\"\"\n    if ${REPEATED_TESTS_STOP_ON_FAILURE};\
+          \ then\n      stop_on_failure_arg=\"-x\"\n    fi\n\n    vnodes_args=\"\"\
+          \n    if false; then\n      vnodes_args=\"--use-vnodes --num-tokens=16\"\
+          \n    fi\n\n    upgrade_arg=\"\"\n    if true; then\n      upgrade_arg=\"\
+          --execute-upgrade-tests --upgrade-target-version-only --upgrade-version-selection\
+          \ all\"\n    fi\n\n    # we need the \"set -o pipefail\" here so that the\
+          \ exit code that circleci will actually use is from pytest and not the exit\
+          \ code from tee\n    set -o pipefail && cd ~/cassandra-dtest && pytest $vnodes_args\
+          \ --count=$count $stop_on_failure_arg $upgrade_arg --log-cli-level=DEBUG\
+          \ --junit-xml=/tmp/results/dtests/pytest_result.xml -s --cassandra-dir=/home/cassandra/cassandra\
+          \ --keep-test-dir  $tests_arg | tee /tmp/dtest/stdout.txt\n  fi\nfi\n"
+        name: Run repeated Python dtest
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results
+    - store_artifacts:
+        destination: dtest
+        path: /tmp/dtest
+    - store_artifacts:
+        destination: dtest_logs
+        path: ~/cassandra-dtest/logs
+    working_directory: ~/
+  j8_utests_cdc:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-cdc -Dtest.timeout=\"$test_timeout\"\
+          \ -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt  -Dtest.classlistprefix=unit\
+          \ -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist-cdc)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_utests_cdc_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=test-cdc\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-cdc $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_utests_compression:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-compression -Dtest.timeout=\"\
+          $test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist-compression)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_utests_compression_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=test-compression\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-compression $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_utests_fqltool:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant fqltool-test -Dno-build-test=true\n"
+        name: Run Unit Tests (fqltool-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_utests_fqltool_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_FQLTOOL_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_FQLTOOL_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS_FQLTOOL} | sed -e \"s/<nil>//\" | sed -e\
+          \ \"s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\n\
+          echo \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the\
+          \ target, used by the test macro in build.xml to group the output files\n\
+          target=fqltool-test\ntesttag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n\
+          \  testtag=\"cdc\"\nelif [[ $target == \"test-compression\" ]]; then\n \
+          \ testtag=\"compression\"\nelif [[ $target == \"test-system-keyspace-directory\"\
+          \ ]]; then\n  testtag=\"system_keyspace_directory\"\nfi\n\n# Run each test\
+          \ class as many times as requested.\nexit_code=\"$?\"\nfor test in $tests;\
+          \ do\n\n    # Split class and method names from the test name\n    if [[\
+          \ $test =~ \"#\" ]]; then\n      class=${test%\"#\"*}\n      method=${test#*\"\
+          #\"}\n    else\n      class=$test\n      method=\"\"\n    fi\n\n    # Prepare\
+          \ the -Dtest.name argument.\n    # It can be the fully qualified class name\
+          \ or the short class name, depending on the target.\n    if [[ $target ==\
+          \ \"test\" || \\\n          $target == \"test-cdc\" || \\\n          $target\
+          \ == \"test-compression\" || \\\n          $target == \"test-system-keyspace-directory\"\
+          \ || \\\n          $target == \"fqltool-test\" || \\\n          $target\
+          \ == \"long-test\" || \\\n          $target == \"stress-test\" ]]; then\n\
+          \      name_arg=\"-Dtest.name=${class##*.}\"\n    else\n      name_arg=\"\
+          -Dtest.name=$class\"\n    fi\n\n    # Prepare the -Dtest.methods argument,\
+          \ which is optional\n    if [[ $method == \"\" ]]; then\n      methods_arg=\"\
+          \"\n    else\n      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n \
+          \   for i in $(seq -w 1 $count); do\n      echo \"Running test $test, iteration\
+          \ $i of $count\"\n\n      # run the test\n      status=\"passes\"\n    \
+          \  if !( set -o pipefail && \\\n            ant fqltool-test $name_arg $methods_arg\
+          \ -Dno-build-test=true | \\\n            tee stdout.txt \\\n          );\
+          \ then\n        status=\"fails\"\n        exit_code=1\n      fi\n\n    \
+          \  # move the stdout output file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_utests_long:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant long-test -Dno-build-test=true\n"
+        name: Run Unit Tests (long-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_utests_long_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_LONG_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_LONG_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS_LONG} | sed -e \"s/<nil>//\" | sed -e \"\
+          s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho\
+          \ \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the target,\
+          \ used by the test macro in build.xml to group the output files\ntarget=long-testsome\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant long-testsome $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_utests_stress:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 1
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: "export PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\ncd /tmp/cassandra\n\
+          if [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest* /tmp/cassandra/build/\n\
+          fi\nant stress-test -Dno-build-test=true\n"
+        name: Run Unit Tests (stress-test)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_utests_stress_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_STRESS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_STRESS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS_STRESS} | sed -e \"s/<nil>//\" | sed -e \"\
+          s/ //\" | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho\
+          \ \"Tests to be repeated: ${tests}\"\n\n# Prepare the testtag for the target,\
+          \ used by the test macro in build.xml to group the output files\ntarget=stress-test-some\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant stress-test-some $name_arg $methods_arg -Dno-build-test=true\
+          \ | \\\n            tee stdout.txt \\\n          ); then\n        status=\"\
+          fails\"\n        exit_code=1\n      fi\n\n      # move the stdout output\
+          \ file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+  j8_utests_system_keyspace_directory:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: '# reminder: this code (along with all the steps) is independently
+          executed on every circle container
+
+          # so the goal here is to get the circleci script to return the tests *this*
+          container will run
+
+          # which we do via the `circleci` cli tool.
+
+
+          rm -fr ~/cassandra-dtest/upgrade_tests
+
+          echo "***java tests***"
+
+
+          # get all of our unit test filenames
+
+          set -eo pipefail && circleci tests glob "$HOME/cassandra/test/unit/**/*.java"
+          > /tmp/all_java_unit_tests.txt
+
+
+          # split up the unit tests into groups based on the number of containers
+          we have
+
+          set -eo pipefail && circleci tests split --split-by=timings --timings-type=filename
+          --index=${CIRCLE_NODE_INDEX} --total=${CIRCLE_NODE_TOTAL} /tmp/all_java_unit_tests.txt
+          > /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt
+
+          set -eo pipefail && cat /tmp/java_tests_${CIRCLE_NODE_INDEX}.txt | sed "s;^/home/cassandra/cassandra/test/unit/;;g"
+          | grep "Test\.java$"  > /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          echo "** /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt"
+
+          cat /tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt
+
+          '
+        name: Determine unit Tests to Run
+        no_output_timeout: 15m
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\ntest_timeout=$(grep 'name=\"test.unit.timeout\"\
+          ' build.xml | awk -F'\"' '{print $4}' || true)\nif [ -z \"$test_timeout\"\
+          \ ]; then\n  test_timeout=$(grep 'name=\"test.timeout\"' build.xml | awk\
+          \ -F'\"' '{print $4}')\nfi\nant testclasslist-system-keyspace-directory\
+          \ -Dtest.timeout=\"$test_timeout\" -Dtest.classlistfile=/tmp/java_tests_${CIRCLE_NODE_INDEX}_final.txt\
+          \  -Dtest.classlistprefix=unit -Dno-build-test=true\n"
+        name: Run Unit Tests (testclasslist-system-keyspace-directory)
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/cassandra/build/test/output/
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/cassandra/build/test/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/cassandra/build/test/logs
+    working_directory: ~/
+  j8_utests_system_keyspace_directory_repeat:
+    docker:
+    - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
+    environment:
+    - ANT_HOME: /usr/share/ant
+    - JAVA11_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    - JAVA8_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - LANG: en_US.UTF-8
+    - KEEP_TEST_DIR: true
+    - DEFAULT_DIR: /home/cassandra/cassandra-dtest
+    - PYTHONIOENCODING: utf-8
+    - PYTHONUNBUFFERED: true
+    - CASS_DRIVER_NO_EXTENSIONS: true
+    - CASS_DRIVER_NO_CYTHON: true
+    - CASSANDRA_SKIP_SYNC: true
+    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
+    - DTEST_BRANCH: trunk
+    - CCM_MAX_HEAP_SIZE: 1024M
+    - CCM_HEAP_NEWSIZE: 256M
+    - REPEATED_TESTS_STOP_ON_FAILURE: false
+    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS_COUNT: 500
+    - REPEATED_UTESTS_FQLTOOL: null
+    - REPEATED_UTESTS_FQLTOOL_COUNT: 500
+    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG_COUNT: 100
+    - REPEATED_UTESTS_STRESS: null
+    - REPEATED_UTESTS_STRESS_COUNT: 500
+    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS_COUNT: 500
+    - REPEATED_JVM_UPGRADE_DTESTS: null
+    - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
+    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS_COUNT: 500
+    - REPEATED_LARGE_DTESTS: null
+    - REPEATED_LARGE_DTESTS_COUNT: 100
+    - REPEATED_UPGRADE_DTESTS: null
+    - REPEATED_UPGRADE_DTESTS_COUNT: 25
+    - REPEATED_ANT_TEST_TARGET: testsome
+    - REPEATED_ANT_TEST_CLASS: null
+    - REPEATED_ANT_TEST_METHODS: null
+    - REPEATED_ANT_TEST_COUNT: 500
+    - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    - JDK_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+    parallelism: 25
+    resource_class: medium
+    shell: /bin/bash -eo pipefail -l
+    steps:
+    - attach_workspace:
+        at: /home/cassandra
+    - run:
+        command: 'echo ''*** id ***''
+
+          id
+
+          echo ''*** cat /proc/cpuinfo ***''
+
+          cat /proc/cpuinfo
+
+          echo ''*** free -m ***''
+
+          free -m
+
+          echo ''*** df -m ***''
+
+          df -m
+
+          echo ''*** ifconfig -a ***''
+
+          ifconfig -a
+
+          echo ''*** uname -a ***''
+
+          uname -a
+
+          echo ''*** mount ***''
+
+          mount
+
+          echo ''*** env ***''
+
+          env
+
+          echo ''*** java ***''
+
+          which java
+
+          java -version
+
+          '
+        name: Log Environment Information
+    - run:
+        command: "set -x\nexport PATH=$JAVA_HOME/bin:$PATH\ntime mv ~/cassandra /tmp\n\
+          cd /tmp/cassandra\nif [ -d ~/dtest_jars ]; then\n  cp ~/dtest_jars/dtest*\
+          \ /tmp/cassandra/build/\nfi\n\n# Calculate the number of test iterations\
+          \ to be run by the current parallel runner.\ncount=$((${REPEATED_UTESTS_COUNT}\
+          \ / CIRCLE_NODE_TOTAL))\nif (($CIRCLE_NODE_INDEX < (${REPEATED_UTESTS_COUNT}\
+          \ % CIRCLE_NODE_TOTAL))); then\n  count=$((count+1))\nfi\n\n# Put manually\
+          \ specified tests and automatically detected tests together, removing duplicates\n\
+          tests=$(echo ${REPEATED_UTESTS} | sed -e \"s/<nil>//\" | sed -e \"s/ //\"\
+          \ | tr \",\" \"\\n\" | tr \" \" \"\\n\" | sort -n | uniq -u)\necho \"Tests\
+          \ to be repeated: ${tests}\"\n\n# Prepare the testtag for the target, used\
+          \ by the test macro in build.xml to group the output files\ntarget=test-system-keyspace-directory\n\
+          testtag=\"\"\nif [[ $target == \"test-cdc\" ]]; then\n  testtag=\"cdc\"\n\
+          elif [[ $target == \"test-compression\" ]]; then\n  testtag=\"compression\"\
+          \nelif [[ $target == \"test-system-keyspace-directory\" ]]; then\n  testtag=\"\
+          system_keyspace_directory\"\nfi\n\n# Run each test class as many times as\
+          \ requested.\nexit_code=\"$?\"\nfor test in $tests; do\n\n    # Split class\
+          \ and method names from the test name\n    if [[ $test =~ \"#\" ]]; then\n\
+          \      class=${test%\"#\"*}\n      method=${test#*\"#\"}\n    else\n   \
+          \   class=$test\n      method=\"\"\n    fi\n\n    # Prepare the -Dtest.name\
+          \ argument.\n    # It can be the fully qualified class name or the short\
+          \ class name, depending on the target.\n    if [[ $target == \"test\" ||\
+          \ \\\n          $target == \"test-cdc\" || \\\n          $target == \"test-compression\"\
+          \ || \\\n          $target == \"test-system-keyspace-directory\" || \\\n\
+          \          $target == \"fqltool-test\" || \\\n          $target == \"long-test\"\
+          \ || \\\n          $target == \"stress-test\" ]]; then\n      name_arg=\"\
+          -Dtest.name=${class##*.}\"\n    else\n      name_arg=\"-Dtest.name=$class\"\
+          \n    fi\n\n    # Prepare the -Dtest.methods argument, which is optional\n\
+          \    if [[ $method == \"\" ]]; then\n      methods_arg=\"\"\n    else\n\
+          \      methods_arg=\"-Dtest.methods=$method\"\n    fi\n\n    for i in $(seq\
+          \ -w 1 $count); do\n      echo \"Running test $test, iteration $i of $count\"\
+          \n\n      # run the test\n      status=\"passes\"\n      if !( set -o pipefail\
+          \ && \\\n            ant test-system-keyspace-directory $name_arg $methods_arg\
+          \ -Dno-build-test=true | \\\n            tee stdout.txt \\\n          );\
+          \ then\n        status=\"fails\"\n        exit_code=1\n      fi\n\n    \
+          \  # move the stdout output file\n      dest=/tmp/results/repeated_utests/stdout/${status}/${i}\n\
+          \      mkdir -p $dest\n      mv stdout.txt $dest/${test}.txt\n\n      #\
+          \ move the XML output files\n      source=build/test/output/${testtag}\n\
+          \      dest=/tmp/results/repeated_utests/output/${status}/${i}\n      mkdir\
+          \ -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]]; then\n  \
+          \      mv $source/* $dest/\n      fi\n\n      # move the log files\n   \
+          \   source=build/test/logs/${testtag}\n      dest=/tmp/results/repeated_utests/logs/${status}/${i}\n\
+          \      mkdir -p $dest\n      if [[ -d $source && -n \"$(ls $source)\" ]];\
+          \ then\n        mv $source/* $dest/\n      fi\n\n      # maybe stop iterations\
+          \ on test failure\n      if [[ ${REPEATED_TESTS_STOP_ON_FAILURE} = true\
+          \ ]] && (( $exit_code > 0 )); then\n        break\n      fi\n    done\n\
+          done\n(exit ${exit_code})\n"
+        name: Repeatedly run new or modifed JUnit tests
+        no_output_timeout: 15m
+    - store_test_results:
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: stdout
+        path: /tmp/results/repeated_utests/stdout
+    - store_artifacts:
+        destination: junitxml
+        path: /tmp/results/repeated_utests/output
+    - store_artifacts:
+        destination: logs
+        path: /tmp/results/repeated_utests/logs
+    working_directory: ~/
+version: 2
 workflows:
-  version: 2
-  java8_separate_tests:
+  java11_tests:
     jobs:
-    - start_j8_build:
-        type: approval
-    - j8_build:
-        requires:
-        - start_j8_build
-    - start_j8_unit_tests:
-        type: approval
-    - j8_unit_tests:
-        requires:
-        - start_j8_unit_tests
-        - j8_build
-    - start_j8_jvm_dtests:
-        type: approval
-    - j8_jvm_dtests:
-        requires:
-        - start_j8_jvm_dtests
-        - j8_build
-    - start_j8_cqlshlib_tests:
-        type: approval
-    - j8_cqlshlib_tests:
-        requires:
-        - start_j8_cqlshlib_tests
-        - j8_build
-    - start_j11_unit_tests:
-        type: approval
+    - j11_build: {}
     - j11_unit_tests:
         requires:
-        - start_j11_unit_tests
-        - j8_build
-    - start_j8_utests_long:
-        type: approval
-    - j8_utests_long:
+        - j11_build
+    - j11_jvm_dtests:
         requires:
-        - start_j8_utests_long
-        - j8_build
-    - start_j11_utests_long:
+        - j11_build
+    - j11_cqlshlib_tests:
+        requires:
+        - j11_build
+    - j11_dtests:
+        requires:
+        - j11_build
+    - j11_dtests_vnode:
+        requires:
+        - j11_build
+    - start_j11_dtests_offheap:
         type: approval
+    - j11_dtests_offheap:
+        requires:
+        - start_j11_dtests_offheap
+        - j11_build
+    - j11_cqlsh-dtests-py2-with-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh_dtests_py3_vnode:
+        requires:
+        - j11_build
+    - j11_cqlsh_dtests_py38_vnode:
+        requires:
+        - j11_build
+    - j11_cqlsh_dtests_py311_vnode:
+        requires:
+        - j11_build
+    - j11_cqlsh-dtests-py2-no-vnodes:
+        requires:
+        - j11_build
+    - j11_cqlsh_dtests_py3:
+        requires:
+        - j11_build
+    - j11_cqlsh_dtests_py38:
+        requires:
+        - j11_build
+    - j11_cqlsh_dtests_py311:
+        requires:
+        - j11_build
+    - start_j11_cqlsh-dtests-offheap:
+        type: approval
+    - j11_cqlsh-dtests-py2-offheap:
+        requires:
+        - start_j11_cqlsh-dtests-offheap
+        - j11_build
+    - j11_cqlsh_dtests_py3_offheap:
+        requires:
+        - start_j11_cqlsh-dtests-offheap
+        - j11_build
+    - j11_cqlsh_dtests_py38_offheap:
+        requires:
+        - start_j11_cqlsh-dtests-offheap
+        - j11_build
+    - j11_cqlsh_dtests_py311_offheap:
+        requires:
+        - start_j11_cqlsh-dtests-offheap
+        - j11_build
+    - start_j11_dtests_large:
+        type: approval
+    - j11_dtests_large:
+        requires:
+        - start_j11_dtests_large
+        - j11_build
+    - start_j11_dtests_large_vnode:
+        type: approval
+    - j11_dtests_large_vnode:
+        requires:
+        - start_j11_dtests_large_vnode
+        - j11_build
     - j11_utests_long:
         requires:
-        - start_j11_utests_long
-        - j8_build
-    - start_j8_utests_cdc:
-        type: approval
-    - j8_utests_cdc:
-        requires:
-        - start_j8_utests_cdc
-        - j8_build
-    - start_j11_utests_cdc:
-        type: approval
+        - j11_build
     - j11_utests_cdc:
         requires:
-        - start_j11_utests_cdc
-        - j8_build
-    - start_j8_utests_compression:
-        type: approval
-    - j8_utests_compression:
-        requires:
-        - start_j8_utests_compression
-        - j8_build
-    - start_j11_utests_compression:
-        type: approval
+        - j11_build
     - j11_utests_compression:
         requires:
-        - start_j11_utests_compression
-        - j8_build
-    - start_j8_utests_stress:
-        type: approval
-    - j8_utests_stress:
-        requires:
-        - start_j8_utests_stress
-        - j8_build
-    - start_j11_utests_stress:
-        type: approval
+        - j11_build
     - j11_utests_stress:
         requires:
-        - start_j11_utests_stress
-        - j8_build
-    - start_j8_utests_fqltool:
-        type: approval
-    - j8_utests_fqltool:
-        requires:
-        - start_j8_utests_fqltool
-        - j8_build
-    - start_j11_utests_fqltool:
-        type: approval
+        - j11_build
     - j11_utests_fqltool:
         requires:
-        - start_j11_utests_fqltool
-        - j8_build
-    - start_j8_utests_system_keyspace_directory:
-        type: approval
-    - j8_utests_system_keyspace_directory:
-        requires:
-        - start_j8_utests_system_keyspace_directory
-        - j8_build
-    - start_j11_utests_system_keyspace_directory:
-        type: approval
+        - j11_build
     - j11_utests_system_keyspace_directory:
         requires:
-        - start_j11_utests_system_keyspace_directory
+        - j11_build
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j11_build
+  java8_tests:
+    jobs:
+    - j8_build: {}
+    - j8_unit_tests:
+        requires:
         - j8_build
-    - start_j8_dtest_jars_build:
-        type: approval
+    - j8_jvm_dtests:
+        requires:
+        - j8_build
+    - j8_cqlshlib_tests:
+        requires:
+        - j8_build
+    - j8_utests_long:
+        requires:
+        - j8_build
+    - j8_utests_cdc:
+        requires:
+        - j8_build
+    - j8_utests_compression:
+        requires:
+        - j8_build
+    - j8_utests_stress:
+        requires:
+        - j8_build
+    - j8_utests_fqltool:
+        requires:
+        - j8_build
+    - j8_utests_system_keyspace_directory:
+        requires:
+        - j8_build
     - j8_dtest_jars_build:
         requires:
         - j8_build
-        - start_j8_dtest_jars_build
-    - start_jvm_upgrade_dtests:
-        type: approval
     - j8_jvm_upgrade_dtests:
         requires:
-        - start_jvm_upgrade_dtests
         - j8_dtest_jars_build
-    - start_j8_dtests:
-        type: approval
     - j8_dtests:
         requires:
-        - start_j8_dtests
         - j8_build
-    - start_j8_dtests_vnode:
-        type: approval
     - j8_dtests_vnode:
         requires:
-        - start_j8_dtests_vnode
         - j8_build
     - start_j8_dtests_offheap:
         type: approval
@@ -11002,75 +11571,32 @@ workflows:
         requires:
         - start_j8_dtests_large_vnode
         - j8_build
-    - start_j11_dtests:
-        type: approval
-    - j11_dtests:
-        requires:
-        - start_j11_dtests
-        - j8_build
-    - start_j11_dtests_vnode:
-        type: approval
-    - j11_dtests_vnode:
-        requires:
-        - start_j11_dtests_vnode
-        - j8_build
-    - start_j11_dtests_offheap:
-        type: approval
-    - j11_dtests_offheap:
-        requires:
-        - start_j11_dtests_offheap
-        - j8_build
-    - start_j11_dtests_large:
-        type: approval
-    - j11_dtests_large:
-        requires:
-        - start_j11_dtests_large
-        - j8_build
-    - start_j11_dtests_large_vnode:
-        type: approval
-    - j11_dtests_large_vnode:
-        requires:
-        - start_j11_dtests_large_vnode
-        - j8_build
-    - start_upgrade_tests:
-        type: approval
     - j8_upgrade_dtests:
         requires:
-        - start_upgrade_tests
         - j8_build
-    - start_j8_cqlsh_tests:
-        type: approval
     - j8_cqlsh-dtests-py2-with-vnodes:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh_dtests_py3_vnode:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh_dtests_py38_vnode:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh_dtests_py311_vnode:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh-dtests-py2-no-vnodes:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh_dtests_py3:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh_dtests_py38:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - j8_cqlsh_dtests_py311:
         requires:
-        - start_j8_cqlsh_tests
         - j8_build
     - start_j8_cqlsh_tests_offheap:
         type: approval
@@ -11090,541 +11616,7 @@ workflows:
         requires:
         - start_j8_cqlsh_tests_offheap
         - j8_build
-    - start_j11_cqlsh_tests:
-        type: approval
-    - j11_cqlsh-dtests-py2-with-vnodes:
+    - j8_jvm_dtests_repeat:
         requires:
-        - start_j11_cqlsh_tests
         - j8_build
-    - j11_cqlsh_dtests_py3_vnode:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh_dtests_py38_vnode:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh_dtests_py311_vnode:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh-dtests-py2-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh_dtests_py3:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh_dtests_py38:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - j11_cqlsh_dtests_py311:
-        requires:
-        - start_j11_cqlsh_tests
-        - j8_build
-    - start_j11_cqlsh_tests_offheap:
-        type: approval
-    - j11_cqlsh-dtests-py2-offheap:
-        requires:
-        - start_j11_cqlsh_tests_offheap
-        - j8_build
-    - j11_cqlsh_dtests_py3_offheap:
-        requires:
-        - start_j11_cqlsh_tests_offheap
-        - j8_build
-    - j11_cqlsh_dtests_py38_offheap:
-        requires:
-        - start_j11_cqlsh_tests_offheap
-        - j8_build
-    - j11_cqlsh_dtests_py311_offheap:
-        requires:
-        - start_j11_cqlsh_tests_offheap
-        - j8_build
-  java8_pre-commit_tests:
-    jobs:
-    - start_pre-commit_tests:
-        type: approval
-    - j8_build:
-        requires:
-        - start_pre-commit_tests
-    - j8_unit_tests:
-        requires:
-        - j8_build
-    - j8_jvm_dtests:
-        requires:
-        - j8_build
-    - j8_cqlshlib_tests:
-        requires:
-        - j8_build
-    - j11_unit_tests:
-        requires:
-        - j8_build
-    - start_utests_long:
-        type: approval
-    - j8_utests_long:
-        requires:
-        - start_utests_long
-        - j8_build
-    - j11_utests_long:
-        requires:
-        - start_utests_long
-        - j8_build
-    - start_utests_cdc:
-        type: approval
-    - j8_utests_cdc:
-        requires:
-        - start_utests_cdc
-        - j8_build
-    - j11_utests_cdc:
-        requires:
-        - start_utests_cdc
-        - j8_build
-    - start_utests_compression:
-        type: approval
-    - j8_utests_compression:
-        requires:
-        - start_utests_compression
-        - j8_build
-    - j11_utests_compression:
-        requires:
-        - start_utests_compression
-        - j8_build
-    - start_utests_stress:
-        type: approval
-    - j8_utests_stress:
-        requires:
-        - start_utests_stress
-        - j8_build
-    - j11_utests_stress:
-        requires:
-        - start_utests_stress
-        - j8_build
-    - start_utests_fqltool:
-        type: approval
-    - j8_utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j8_build
-    - j11_utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j8_build
-    - start_utests_system_keyspace_directory:
-        type: approval
-    - j8_utests_system_keyspace_directory:
-        requires:
-        - j8_build
-    - j11_utests_system_keyspace_directory:
-        requires:
-        - start_utests_system_keyspace_directory
-        - j8_build
-    - start_jvm_upgrade_dtests:
-        type: approval
-    - j8_dtest_jars_build:
-        requires:
-        - j8_build
-        - start_jvm_upgrade_dtests
-    - j8_jvm_upgrade_dtests:
-        requires:
-        - j8_dtest_jars_build
-    - j8_dtests:
-        requires:
-        - j8_build
-    - j8_dtests_vnode:
-        requires:
-        - j8_build
-    - start_j8_dtests_offheap:
-        type: approval
-    - j8_dtests_offheap:
-        requires:
-        - start_j8_dtests_offheap
-        - j8_build
-    - j11_dtests:
-        requires:
-        - j8_build
-    - j11_dtests_vnode:
-        requires:
-        - j8_build
-    - start_j11_dtests_offheap:
-        type: approval
-    - j11_dtests_offheap:
-        requires:
-        - start_j11_dtests_offheap
-        - j8_build
-    - start_j8_dtests_large:
-        type: approval
-    - j8_dtests_large:
-        requires:
-        - start_j8_dtests_large
-        - j8_build
-    - j8_dtests_large_vnode:
-        requires:
-        - start_j8_dtests_large
-        - j8_build
-    - start_j11_dtests_large:
-        type: approval
-    - j11_dtests_large:
-        requires:
-        - start_j11_dtests_large
-        - j8_build
-    - j11_dtests_large_vnode:
-        requires:
-        - start_j11_dtests_large
-        - j8_build
-    - start_upgrade_tests:
-        type: approval
-    - j8_upgrade_dtests:
-        requires:
-        - j8_build
-        - start_upgrade_tests
-    - j8_cqlsh-dtests-py2-with-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh_dtests_py3_vnode:
-        requires:
-        - j8_build
-    - j8_cqlsh_dtests_py38_vnode:
-        requires:
-        - j8_build
-    - j8_cqlsh_dtests_py311_vnode:
-        requires:
-        - j8_build
-    - j8_cqlsh-dtests-py2-no-vnodes:
-        requires:
-        - j8_build
-    - j8_cqlsh_dtests_py3:
-        requires:
-        - j8_build
-    - j8_cqlsh_dtests_py38:
-        requires:
-        - j8_build
-    - j8_cqlsh_dtests_py311:
-        requires:
-        - j8_build
-    - start_j8_cqlsh_dtests_offheap:
-        type: approval
-    - j8_cqlsh-dtests-py2-offheap:
-        requires:
-        - start_j8_cqlsh_dtests_offheap
-        - j8_build
-    - j8_cqlsh_dtests_py3_offheap:
-        requires:
-        - start_j8_cqlsh_dtests_offheap
-        - j8_build
-    - j8_cqlsh_dtests_py38_offheap:
-        requires:
-        - start_j8_cqlsh_dtests_offheap
-        - j8_build
-    - j8_cqlsh_dtests_py311_offheap:
-        requires:
-        - start_j8_cqlsh_dtests_offheap
-        - j8_build
-    - j11_cqlsh-dtests-py2-with-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh_dtests_py3_vnode:
-        requires:
-        - j8_build
-    - j11_cqlsh_dtests_py38_vnode:
-        requires:
-        - j8_build
-    - j11_cqlsh_dtests_py311_vnode:
-        requires:
-        - j8_build
-    - j11_cqlsh-dtests-py2-no-vnodes:
-        requires:
-        - j8_build
-    - j11_cqlsh_dtests_py3:
-        requires:
-        - j8_build
-    - j11_cqlsh_dtests_py38:
-        requires:
-        - j8_build
-    - j11_cqlsh_dtests_py311:
-        requires:
-        - j8_build
-    - start_j11_cqlsh-dtests-offheap:
-        type: approval
-    - j11_cqlsh-dtests-py2-offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j8_build
-    - j11_cqlsh_dtests_py3_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j8_build
-    - j11_cqlsh_dtests_py38_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j8_build
-    - j11_cqlsh_dtests_py311_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j8_build
-  java11_separate_tests:
-    jobs:
-    - start_j11_build:
-        type: approval
-    - j11_build:
-        requires:
-        - start_j11_build
-    - start_j11_unit_tests:
-        type: approval
-    - j11_unit_tests:
-        requires:
-        - start_j11_unit_tests
-        - j11_build
-    - start_j11_jvm_dtests:
-        type: approval
-    - j11_jvm_dtests:
-        requires:
-        - start_j11_jvm_dtests
-        - j11_build
-    - start_j11_cqlshlib_tests:
-        type: approval
-    - j11_cqlshlib_tests:
-        requires:
-        - start_j11_cqlshlib_tests
-        - j11_build
-    - start_j11_dtests:
-        type: approval
-    - j11_dtests:
-        requires:
-        - start_j11_dtests
-        - j11_build
-    - start_j11_dtests_vnode:
-        type: approval
-    - j11_dtests_vnode:
-        requires:
-        - start_j11_dtests_vnode
-        - j11_build
-    - start_j11_dtests_offheap:
-        type: approval
-    - j11_dtests_offheap:
-        requires:
-        - start_j11_dtests_offheap
-        - j11_build
-    - start_j11_cqlsh_tests:
-        type: approval
-    - j11_cqlsh-dtests-py2-with-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh_dtests_py3_vnode:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh_dtests_py38_vnode:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh_dtests_py311_vnode:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh-dtests-py2-no-vnodes:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh_dtests_py3:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh_dtests_py38:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - j11_cqlsh_dtests_py311:
-        requires:
-        - start_j11_cqlsh_tests
-        - j11_build
-    - start_j11_cqlsh-dtests-offheap:
-        type: approval
-    - j11_cqlsh-dtests-py2-offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - j11_cqlsh_dtests_py3_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - j11_cqlsh_dtests_py38_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - j11_cqlsh_dtests_py311_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - start_j11_dtests_large:
-        type: approval
-    - j11_dtests_large:
-        requires:
-        - start_j11_dtests_large
-        - j11_build
-    - start_j11_dtests_large_vnode:
-        type: approval
-    - j11_dtests_large_vnode:
-        requires:
-        - start_j11_dtests_large_vnode
-        - j11_build
-    - start_j11_utests_long:
-        type: approval
-    - j11_utests_long:
-        requires:
-        - start_j11_utests_long
-        - j11_build
-    - start_j11_utests_cdc:
-        type: approval
-    - j11_utests_cdc:
-        requires:
-        - start_j11_utests_cdc
-        - j11_build
-    - start_j11_utests_compression:
-        type: approval
-    - j11_utests_compression:
-        requires:
-        - start_j11_utests_compression
-        - j11_build
-    - start_j11_utests_stress:
-        type: approval
-    - j11_utests_stress:
-        requires:
-        - start_j11_utests_stress
-        - j11_build
-    - start_j11_utests_fqltool:
-        type: approval
-    - j11_utests_fqltool:
-        requires:
-        - start_j11_utests_fqltool
-        - j11_build
-    - start_j11_utests_system_keyspace_directory:
-        type: approval
-    - j11_utests_system_keyspace_directory:
-        requires:
-        - start_j11_utests_system_keyspace_directory
-        - j11_build
-  java11_pre-commit_tests:
-    jobs:
-    - start_pre-commit_tests:
-        type: approval
-    - j11_build:
-        requires:
-        - start_pre-commit_tests
-    - j11_unit_tests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests:
-        requires:
-        - j11_build
-    - j11_cqlshlib_tests:
-        requires:
-        - j11_build
-    - j11_jvm_dtests:
-        requires:
-        - j11_build
-    - j11_cqlshlib_tests:
-        requires:
-        - j11_build
-    - j11_dtests:
-        requires:
-        - j11_build
-    - j11_dtests_vnode:
-        requires:
-        - j11_build
-    - start_j11_dtests_offheap:
-        type: approval
-    - j11_dtests_offheap:
-        requires:
-        - start_j11_dtests_offheap
-        - j11_build
-    - j11_cqlsh-dtests-py2-with-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh_dtests_py3_vnode:
-        requires:
-        - j11_build
-    - j11_cqlsh_dtests_py38_vnode:
-        requires:
-        - j11_build
-    - j11_cqlsh_dtests_py311_vnode:
-        requires:
-        - j11_build
-    - j11_cqlsh-dtests-py2-no-vnodes:
-        requires:
-        - j11_build
-    - j11_cqlsh_dtests_py3:
-        requires:
-        - j11_build
-    - j11_cqlsh_dtests_py38:
-        requires:
-        - j11_build
-    - j11_cqlsh_dtests_py311:
-        requires:
-        - j11_build
-    - start_j11_cqlsh-dtests-offheap:
-        type: approval
-    - j11_cqlsh-dtests-py2-offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - j11_cqlsh_dtests_py3_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - j11_cqlsh_dtests_py38_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - j11_cqlsh_dtests_py311_offheap:
-        requires:
-        - start_j11_cqlsh-dtests-offheap
-        - j11_build
-    - start_j11_dtests_large:
-        type: approval
-    - j11_dtests_large:
-        requires:
-        - start_j11_dtests_large
-        - j11_build
-    - j11_dtests_large_vnode:
-        requires:
-        - start_j11_dtests_large
-        - j11_build
-    - start_utests_long:
-        type: approval
-    - j11_utests_long:
-        requires:
-        - start_utests_long
-        - j11_build
-    - start_utests_cdc:
-        type: approval
-    - j11_utests_cdc:
-        requires:
-        - start_utests_cdc
-        - j11_build
-    - start_utests_compression:
-        type: approval
-    - j11_utests_compression:
-        requires:
-        - start_utests_compression
-        - j11_build
-    - start_utests_stress:
-        type: approval
-    - j11_utests_stress:
-        requires:
-        - start_utests_stress
-        - j11_build
-    - start_utests_fqltool:
-        type: approval
-    - j11_utests_fqltool:
-        requires:
-        - start_utests_fqltool
-        - j11_build
-    - start_utests_system_keyspace_directory:
-        type: approval
-    - j11_utests_system_keyspace_directory:
-        requires:
-        - start_utests_system_keyspace_directory
-        - j11_build
+  version: 2

--- a/build.xml
+++ b/build.xml
@@ -206,6 +206,7 @@
         <string>--add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED</string>
         <string>--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED</string>
         <string>--add-exports java.rmi/sun.rmi.server=ALL-UNNAMED</string>
+        <string>--add-exports java.rmi/sun.rmi.transport=ALL-UNNAMED</string>
         <string>--add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED</string>
         <string>--add-exports java.sql/java.sql=ALL-UNNAMED</string>
 
@@ -556,7 +557,8 @@
           <dependency groupId="com.google.code.java-allocation-instrumenter" artifactId="java-allocation-instrumenter" version="${allocation-instrumenter.version}" scope="test">
             <exclusion groupId="com.google.guava" artifactId="guava"/>
           </dependency>
-          <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.15" scope="test"/>
+            <!-- TODO: Remove -SNAPSHOT once dtest api is published -->
+          <dependency groupId="org.apache.cassandra" artifactId="dtest-api" version="0.0.16" scope="test"/>
           <dependency groupId="org.reflections" artifactId="reflections" version="0.10.2" scope="test"/>
           <dependency groupId="org.apache.hadoop" artifactId="hadoop-core" version="1.0.3" scope="provided">
             <exclusion groupId="org.mortbay.jetty" artifactId="servlet-api"/>
@@ -572,7 +574,7 @@
             <exclusion groupId="org.slf4j" artifactId="slf4j-api"/>
             <exclusion groupId="org.codehaus.jackson" artifactId="jackson-mapper-asl"/>
           </dependency>
-          <dependency groupId="net.java.dev.jna" artifactId="jna" version="5.6.0"/>
+          <dependency groupId="net.java.dev.jna" artifactId="jna" version="5.8.0"/>
 
           <dependency groupId="org.jacoco" artifactId="org.jacoco.agent" version="${jacoco.version}" scope="test"/>
           <dependency groupId="org.jacoco" artifactId="org.jacoco.ant" version="${jacoco.version}" scope="test"/>
@@ -2015,7 +2017,7 @@
       <echo file=".idea/compiler.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavacSettings">
-    <option name="ADDITIONAL_OPTIONS_STRING" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED" />
+    <option name="ADDITIONAL_OPTIONS_STRING" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-exports java.rmi/sun.rmi.transport=ALL-UNNAMED" />
   </component>
 </project>]]></echo>
   </target>

--- a/src/java/org/apache/cassandra/utils/RMIClientSocketFactoryImpl.java
+++ b/src/java/org/apache/cassandra/utils/RMIClientSocketFactoryImpl.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.rmi.server.RMIClientSocketFactory;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -32,6 +34,7 @@ import java.util.Objects;
  */
 public class RMIClientSocketFactoryImpl implements RMIClientSocketFactory, Serializable
 {
+    List<Socket> sockets = new ArrayList<>();
     private final InetAddress localAddress;
 
     public RMIClientSocketFactoryImpl(InetAddress localAddress)
@@ -42,7 +45,24 @@ public class RMIClientSocketFactoryImpl implements RMIClientSocketFactory, Seria
     @Override
     public Socket createSocket(String host, int port) throws IOException
     {
-        return new Socket(localAddress, port);
+        Socket socket = new Socket(localAddress, port);
+        sockets.add(socket);
+        return socket;
+    }
+
+    public void close() throws IOException
+    {
+        for (Socket socket: sockets)
+        {
+            try
+            {
+                socket.close();
+            }
+            catch (IOException ignored)
+            {
+                // intentionally ignored
+            }
+        }
     }
 
     @Override

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -641,17 +641,18 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
         initialized = true;
     }
 
-    private void startJmx()
+    private synchronized void startJmx()
     {
         isolatedJmx = new IsolatedJmx(this, inInstancelogger);
         isolatedJmx.startJmx();
     }
 
-    private void stopJmx() throws NoSuchFieldException, InterruptedException, IllegalAccessException
+    private synchronized void stopJmx()
     {
         if (config.has(JMX))
         {
             isolatedJmx.stopJmx();
+            isolatedJmx = null;
         }
     }
 

--- a/test/distributed/org/apache/cassandra/distributed/impl/IsolatedJmx.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/IsolatedJmx.java
@@ -18,38 +18,40 @@
 
 package org.apache.cassandra.distributed.impl;
 
-import java.lang.reflect.Field;
+import java.io.IOException;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 import javax.management.remote.rmi.RMIJRMPServerImpl;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 
 import org.apache.cassandra.distributed.api.IInstance;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
+import org.apache.cassandra.distributed.shared.JMXUtil;
 import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.MBeanWrapper;
 import org.apache.cassandra.utils.RMIClientSocketFactoryImpl;
-import org.apache.cassandra.utils.ReflectionUtils;
 import sun.rmi.transport.tcp.TCPEndpoint;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.JAVA_RMI_DGC_LEASE_VALUE_IN_JVM_DTEST;
 import static org.apache.cassandra.config.CassandraRelevantProperties.ORG_APACHE_CASSANDRA_DISABLE_MBEAN_REGISTRATION;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SUN_RMI_TRANSPORT_TCP_THREADKEEPALIVETIME;
 import static org.apache.cassandra.distributed.api.Feature.JMX;
+import static org.apache.cassandra.utils.ReflectionUtils.clearMapField;
 
 public class IsolatedJmx
 {
-    private static final int RMI_KEEPALIVE_TIME = 1000;
+    public static final int RMI_KEEPALIVE_TIME = 1000;
+    public static final String UNKNOWN_JMX_CONNECTION_ERROR = "Could not connect to JMX due to an unknown error";
 
     private JMXConnectorServer jmxConnectorServer;
     private JMXServerUtils.JmxRegistry registry;
@@ -127,7 +129,7 @@ public class IsolatedJmx
 
             registry.setRemoteServerStub(jmxRmiServer.toStub());
             JMXServerUtils.logJmxServiceUrl(addr, jmxPort);
-            waitForJmxAvailability(hostname, jmxPort, env);
+            waitForJmxAvailability(env);
         }
         catch (Throwable t)
         {
@@ -135,36 +137,20 @@ public class IsolatedJmx
         }
     }
 
-    private void waitForJmxAvailability(String hostname, int rmiPort, Map<String, Object> env) throws InterruptedException, MalformedURLException
+    private void waitForJmxAvailability(Map<String, ?> env)
     {
-        String url = String.format("service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi", hostname, rmiPort);
-        JMXServiceURL serviceURL = new JMXServiceURL(url);
-        int attempts = 0;
-        Throwable lastThrown = null;
-        while (attempts < 20)
-        {
-            attempts++;
-            try (JMXConnector ignored = JMXConnectorFactory.connect(serviceURL, env))
-            {
-                inInstancelogger.info("Connected to JMX server at {} after {} attempt(s)",
-                                      url, attempts);
-                return;
-            }
-            catch (MalformedURLException e)
-            {
-                throw new RuntimeException(e);
-            }
-            catch (Throwable thrown)
-            {
-                lastThrown = thrown;
-            }
-            inInstancelogger.info("Could not connect to JMX on {} after {} attempts. Will retry.", url, attempts);
-            Thread.sleep(1000);
+        try (JMXConnector ignored = JMXUtil.getJmxConnector(config, 20, env)) {
+            // Do nothing - JMXUtil now retries
         }
-        throw new RuntimeException("Could not start JMX - unreachable after 20 attempts", lastThrown);
+        catch (IOException iex)
+        {
+            // If we land here, there's something more than a timeout
+            inInstancelogger.error(UNKNOWN_JMX_CONNECTION_ERROR, iex);
+            throw new RuntimeException(UNKNOWN_JMX_CONNECTION_ERROR, iex);
+        }
     }
 
-    public void stopJmx() throws IllegalAccessException, NoSuchFieldException, InterruptedException
+    public void stopJmx()
     {
         if (!config.has(JMX))
             return;
@@ -198,6 +184,14 @@ public class IsolatedJmx
         }
         try
         {
+            clientSocketFactory.close();
+        }
+        catch (Throwable e)
+        {
+            inInstancelogger.warn("failed to close clientSocketFactory.", e);
+        }
+        try
+        {
             serverSocketFactory.close();
         }
         catch (Throwable e)
@@ -206,25 +200,18 @@ public class IsolatedJmx
         }
         // The TCPEndpoint class holds references to a class in the in-jvm dtest framework
         // which transitively has a reference to the InstanceClassLoader, so we need to
-        // make sure to remove the reference to them when the instance is shutting down
-        clearMapField(TCPEndpoint.class, null, "localEndpoints");
-        Thread.sleep(2 * RMI_KEEPALIVE_TIME); // Double the keep-alive time to give Distributed GC some time to clean up
+        // make sure to remove the reference to them when the instance is shutting down.
+        // Additionally, we must make sure to only clear endpoints created by this instance
+        // As clearning the entire map can cause issues with starting and stopping nodes mid-test.
+        clearMapField(TCPEndpoint.class, null, "localEndpoints", this::endpointCreateByThisInstance);
+        Uninterruptibles.sleepUninterruptibly(2 * RMI_KEEPALIVE_TIME, TimeUnit.MILLISECONDS); // Double the keep-alive time to give Distributed GC some time to clean up
     }
 
-    private <K, V> void clearMapField(Class<?> clazz, Object instance, String mapName)
-    throws IllegalAccessException, NoSuchFieldException {
-        Field mapField = ReflectionUtils.getField(clazz, mapName);
-        mapField.setAccessible(true);
-        Map<K, V> map = (Map<K, V>) mapField.get(instance);
-        // Because multiple instances can be shutting down at once,
-        // synchronize on the map to avoid ConcurrentModificationException
-        synchronized (map)
-        {
-            for (Iterator<Map.Entry<K, V>> it = map.entrySet().iterator(); it.hasNext(); )
-            {
-                it.next();
-                it.remove();
-            }
-        }
+    private boolean endpointCreateByThisInstance(Map.Entry<Object, LinkedList<TCPEndpoint>> entry)
+    {
+        return entry.getValue()
+                    .stream()
+                    .anyMatch(ep -> ep.getServerSocketFactory() == this.serverSocketFactory &&
+                                    ep.getClientSocketFactory() == this.clientSocketFactory);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/shared/ClusterUtils.java
+++ b/test/distributed/org/apache/cassandra/distributed/shared/ClusterUtils.java
@@ -391,6 +391,20 @@ public class ClusterUtils
     }
 
     /**
+     * Wait for the ring to have the target instance with the provided status.
+     *
+     * @param instance instance to check on
+     * @param expectedInRing to look for
+     * @param status expected
+     * @return the ring
+     */
+    public static List<RingInstanceDetails> awaitRingStatus(IInstance instance, IInstance expectedInRing, String status)
+    {
+        return awaitInstanceMatching(instance, expectedInRing, d -> d.status.equals(status),
+                                     "Timeout waiting for " + expectedInRing + " to have status " + status);
+    }
+
+    /**
      * Wait for the ring to have the target instance with the provided state.
      *
      * @param instance instance to check on
@@ -400,12 +414,20 @@ public class ClusterUtils
      */
     public static List<RingInstanceDetails> awaitRingState(IInstance instance, IInstance expectedInRing, String state)
     {
-        return awaitRing(instance, "Timeout waiting for " + expectedInRing + " to have state " + state,
-                         ring ->
-                         ring.stream()
-                             .filter(d -> d.address.equals(getBroadcastAddressHostString(expectedInRing)))
-                             .filter(d -> d.state.equals(state))
-                             .findAny().isPresent());
+        return awaitInstanceMatching(instance, expectedInRing, d -> d.state.equals(state),
+                                     "Timeout waiting for " + expectedInRing + " to have state " + state);
+    }
+
+    private static List<RingInstanceDetails> awaitInstanceMatching(IInstance instance,
+                                                                   IInstance expectedInRing,
+                                                                   Predicate<RingInstanceDetails> predicate,
+                                                                   String errorMessage)
+    {
+        return awaitRing(instance,
+                         errorMessage,
+                         ring -> ring.stream()
+                                     .filter(d -> d.address.equals(getBroadcastAddressHostString(expectedInRing)))
+                                     .anyMatch(predicate));
     }
 
     /**

--- a/test/distributed/org/apache/cassandra/distributed/test/ResourceLeakTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ResourceLeakTest.java
@@ -48,6 +48,7 @@ import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.JMX;
 import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.apache.cassandra.distributed.test.jmx.JMXGetterCheckTest.testAllValidGetters;
 import static org.hamcrest.Matchers.startsWith;
 
 /* Resource Leak Test - useful when tracking down issues with in-JVM framework cleanup.
@@ -70,7 +71,7 @@ public class ResourceLeakTest extends TestBaseImpl
     final boolean dumpEveryLoop = false;   // Dump heap & possibly files every loop
     final boolean dumpFileHandles = false; // Call lsof whenever dumping resources
     final boolean forceCollection = false; // Whether to explicitly force finalization/gc for smaller heap dumps
-    final long finalWaitMillis = 0l;       // Number of millis to wait before final resource dump to give gc a chance
+    final long finalWaitMillis = 0L;       // Number of millis to wait before final resource dump to give gc a chance
 
     static final SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
     static final String when = format.format(Date.from(Instant.now()));
@@ -142,6 +143,30 @@ public class ResourceLeakTest extends TestBaseImpl
         if (dumpFileHandles)
         {
             dumpOpenFiles(description);
+        }
+    }
+
+    static void testJmx(Cluster cluster)
+    {
+        try
+        {
+            for (IInvokableInstance instance : cluster.get(1, cluster.size()))
+            {
+                IInstanceConfig config = instance.config();
+                try (JMXConnector jmxc = JMXUtil.getJmxConnector(config, 5))
+                {
+                    MBeanServerConnection mbsc = jmxc.getMBeanServerConnection();
+                    // instances get their default domain set to their IP address, so us it
+                    // to check that we are actually connecting to the correct instance
+                    String defaultDomain = mbsc.getDefaultDomain();
+                    Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ":" + config.jmxPort()));
+                }
+            }
+            testAllValidGetters(cluster);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
         }
     }
 
@@ -225,27 +250,7 @@ public class ResourceLeakTest extends TestBaseImpl
     @Test
     public void looperJmxTest() throws Throwable
     {
-        doTest(1, config -> config.with(JMX), cluster -> {
-            // NOTE: At some point, the hostname of the broadcastAddress can be resolved
-            // and then the `getHostString`, which would otherwise return the IP address,
-            // starts returning `localhost` - use `.getAddress().getHostAddress()` to work around this.
-            for (IInvokableInstance instance:cluster.get(1, cluster.size()))
-            {
-                IInstanceConfig config = instance.config();
-                try (JMXConnector jmxc = JMXUtil.getJmxConnector(config))
-                {
-                    MBeanServerConnection mbsc = jmxc.getMBeanServerConnection();
-                    // instances get their default domain set to their IP address, so us it
-                    // to check that we are actually connecting to the correct instance
-                    String defaultDomain = mbsc.getDefaultDomain();
-                    Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ":" + config.jmxPort()));
-                }
-                catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
+        doTest(2, config -> config.with(JMX), ResourceLeakTest::testJmx);
         if (forceCollection)
         {
             System.runFinalization();
@@ -258,7 +263,10 @@ public class ResourceLeakTest extends TestBaseImpl
     @Test
     public void looperEverythingTest() throws Throwable
     {
-        doTest(1, config -> config.with(Feature.values()));
+        doTest(2, config -> config.with(Feature.values()),
+               cluster -> {
+                   testJmx(cluster);
+               });
         if (forceCollection)
         {
             System.runFinalization();

--- a/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXFeatureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXFeatureTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.distributed.test.jmx;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import javax.management.MBeanServerConnection;
@@ -31,10 +30,16 @@ import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.NodeToolResult;
 import org.apache.cassandra.distributed.impl.INodeProvisionStrategy;
+import org.apache.cassandra.distributed.shared.ClusterUtils;
 import org.apache.cassandra.distributed.shared.JMXUtil;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 
+import static org.apache.cassandra.distributed.test.jmx.JMXGetterCheckTest.testAllValidGetters;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
 public class JMXFeatureTest extends TestBaseImpl
@@ -46,59 +51,83 @@ public class JMXFeatureTest extends TestBaseImpl
      * - Test that when connecting, we get the correct MBeanServer by checking the default domain, which is set to the IP of the instance
      * - Run the test multiple times to ensure cleanup of the JMX servers is complete so the next test can run successfully using the same host/port.
      *
-     * @throws Exception
+     * @throws Exception it's a test that calls JMX endpoints - lots of different Jmx exceptions are possible
      */
     @Test
     public void testMultipleNetworkInterfacesProvisioning() throws Exception
     {
-        int iterations = 2; // Make sure the JMX infrastructure all cleans up properly by running this multiple times.
-        Set<String> allInstances = new HashSet<>();
-        for (int i = 0; i < iterations; i++)
-        {
-            try (Cluster cluster = Cluster.build(2)
-                                          .withNodeProvisionStrategy(INodeProvisionStrategy.Strategy.MultipleNetworkInterfaces)
-                                          .withConfig(c -> c.with(Feature.values())).start())
-            {
-                Set<String> instancesContacted = new HashSet<>();
-                for (IInvokableInstance instance : cluster.get(1, 2))
-                {
-                    testInstance(instancesContacted, instance);
-                }
-                Assert.assertEquals("Should have connected with both JMX instances.", 2, instancesContacted.size());
-                allInstances.addAll(instancesContacted);
-            }
-        }
-        Assert.assertEquals("Each instance from each cluster should have been unique", iterations * 2, allInstances.size());
+        testJmxFeatures(INodeProvisionStrategy.Strategy.MultipleNetworkInterfaces);
     }
 
     @Test
     public void testOneNetworkInterfaceProvisioning() throws Exception
     {
-        int iterations = 2; // Make sure the JMX infrastructure all cleans up properly by running this multiple times.
+        testJmxFeatures(INodeProvisionStrategy.Strategy.OneNetworkInterface);
+    }
+
+    private void testJmxFeatures(INodeProvisionStrategy.Strategy provisionStrategy) throws Exception
+    {
         Set<String> allInstances = new HashSet<>();
+        int iterations = 2; // Make sure the JMX infrastructure all cleans up properly by running this multiple times.
         for (int i = 0; i < iterations; i++)
         {
             try (Cluster cluster = Cluster.build(2)
-                                          .withNodeProvisionStrategy(INodeProvisionStrategy.Strategy.OneNetworkInterface)
+                                          .withNodeProvisionStrategy(provisionStrategy)
                                           .withConfig(c -> c.with(Feature.values())).start())
             {
                 Set<String> instancesContacted = new HashSet<>();
-                for (IInvokableInstance instance : cluster.get(1, 2))
+                for (IInvokableInstance instance : cluster)
                 {
                     testInstance(instancesContacted, instance);
                 }
                 Assert.assertEquals("Should have connected with both JMX instances.", 2, instancesContacted.size());
                 allInstances.addAll(instancesContacted);
+                // Make sure we actually exercise the mbeans by testing a bunch of getters.
+                // Without this it's possible for the test to pass as we don't touch any mBeans that we register.
+                testAllValidGetters(cluster);
             }
         }
         Assert.assertEquals("Each instance from each cluster should have been unique", iterations * 2, allInstances.size());
     }
 
-    private void testInstance(Set<String> instancesContacted, IInvokableInstance instance) throws IOException
+    @Test
+    public void testShutDownAndRestartInstances() throws Exception
     {
-        // NOTE: At some point, the hostname of the broadcastAddress can be resolved
-        // and then the `getHostString`, which would otherwise return the IP address,
-        // starts returning `localhost` - use `.getAddress().getHostAddress()` to work around this.
+        HashSet<String> instances = new HashSet<>();
+        try (Cluster cluster = Cluster.build(2).withConfig(c -> c.with(Feature.values())).start())
+        {
+            IInvokableInstance instanceToStop = cluster.get(1);
+            IInvokableInstance otherInstance = cluster.get(2);
+            testInstance(instances, cluster.get(1));
+            ClusterUtils.stopUnchecked(instanceToStop);
+            // NOTE: This would previously fail because we cleared everything from the TCPEndpoint map in IsolatedJmx.
+            // Now, we only clear the endpoints related to that instance, which prevents this code from
+            // breaking with a `java.net.BindException: Address already in use (Bind failed)`
+            ClusterUtils.awaitRingStatus(otherInstance, instanceToStop, "Down");
+            NodeToolResult statusResult = cluster.get(2).nodetoolResult("status");
+            Assert.assertEquals(0, statusResult.getRc());
+            Assert.assertThat(statusResult.getStderr(), is(blankOrNullString()));
+            Assert.assertThat(statusResult.getStdout(), containsString("DN  127.0.0.1"));
+            testInstance(instances, cluster.get(2));
+            ClusterUtils.start(instanceToStop, props -> {
+            });
+            ClusterUtils.awaitRingState(otherInstance, instanceToStop, "Normal");
+            ClusterUtils.awaitRingStatus(otherInstance, instanceToStop, "Up");
+            statusResult = cluster.get(1).nodetoolResult("status");
+            Assert.assertEquals(0, statusResult.getRc());
+            Assert.assertThat(statusResult.getStderr(), is(blankOrNullString()));
+            Assert.assertThat(statusResult.getStdout(), containsString("UN  127.0.0.1"));
+            statusResult = cluster.get(2).nodetoolResult("status");
+            Assert.assertEquals(0, statusResult.getRc());
+            Assert.assertThat(statusResult.getStderr(), is(blankOrNullString()));
+            Assert.assertThat(statusResult.getStdout(), containsString("UN  127.0.0.1"));
+            testInstance(instances, cluster.get(1));
+            testAllValidGetters(cluster);
+        }
+    }
+
+    private void testInstance(Set<String> instancesContacted, IInvokableInstance instance)
+    {
         IInstanceConfig config = instance.config();
         try (JMXConnector jmxc = JMXUtil.getJmxConnector(config))
         {
@@ -108,6 +137,10 @@ public class JMXFeatureTest extends TestBaseImpl
             String defaultDomain = mbsc.getDefaultDomain();
             instancesContacted.add(defaultDomain);
             Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ":" + config.jmxPort()));
+        }
+        catch (Throwable t)
+        {
+            throw new RuntimeException("Could not connect to JMX", t);
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXGetterCheckTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXGetterCheckTest.java
@@ -29,42 +29,66 @@ import javax.management.MBeanOperationInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.IInstanceConfig;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.shared.JMXUtil;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 
 public class JMXGetterCheckTest extends TestBaseImpl
 {
     private static final Set<String> IGNORE_ATTRIBUTES = ImmutableSet.of(
-    "org.apache.cassandra.net:type=MessagingService:BackPressurePerHost" // throws unsupported saying the feature was removed... dropped in CASSANDRA-15375
+    "org.apache.cassandra.net:type=MessagingService:BackPressurePerHost", // throws unsupported saying the feature was removed... dropped in CASSANDRA-15375
+    "org.apache.cassandra.db:type=DynamicEndpointSnitch:Scores" // when running in multiple-port-one-IP mode, this fails
+
     );
     private static final Set<String> IGNORE_OPERATIONS = ImmutableSet.of(
     "org.apache.cassandra.db:type=StorageService:stopDaemon", // halts the instance, which then causes the JVM to exit
     "org.apache.cassandra.db:type=StorageService:drain", // don't drain, it stops things which can cause other APIs to be unstable as we are in a stopped state
     "org.apache.cassandra.db:type=StorageService:stopGossiping", // if we stop gossip this can cause other issues, so avoid
-    "org.apache.cassandra.db:type=StorageService:resetLocalSchema" // this will fail when there are no other nodes which can serve schema
+    "org.apache.cassandra.db:type=StorageService:resetLocalSchema", // this will fail when there are no other nodes which can serve schema
+    "org.apache.cassandra.db:type=StorageService:joinRing", // Causes bootstrapping errors
+    "org.apache.cassandra.db:type=StorageService:clearConnectionHistory", // Throws a NullPointerException
+    "org.apache.cassandra.db:type=StorageService:startGossiping", // causes multiple loops to fail
+    "org.apache.cassandra.db:type=StorageService:startNativeTransport", // causes multiple loops to fail
+    "org.apache.cassandra.db:type=Tables,keyspace=system,table=local:loadNewSSTables" // Shouldn't attempt to load SSTables as sometimes the temp directories don't work
     );
-
-    public static final String JMX_SERVICE_URL_FMT = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
 
     @Test
     public void testGetters() throws Exception
     {
-        try (Cluster cluster = Cluster.build(1).withConfig(c -> c.with(Feature.values())).start())
+        for (int i=0; i < 2; i++)
         {
-            IInvokableInstance instance = cluster.get(1);
+            try (Cluster cluster = Cluster.build(1).withConfig(c -> c.with(Feature.values())).start())
+            {
+                testAllValidGetters(cluster);
+            }
+        }
+    }
 
-            String jmxHost = instance.config().broadcastAddress().getAddress().getHostAddress();
-            String url = String.format(JMX_SERVICE_URL_FMT, jmxHost, instance.config().jmxPort());
+    /**
+     * Tests JMX getters and operations.
+     * Useful for more than just testing getters, it also is used in JMXFeatureTest
+     * to make sure we've touched the complete JMX code path.
+     * @param cluster the cluster to test
+     * @throws Exception several kinds of exceptions can be thrown, mostly from JMX infrastructure issues.
+     */
+    public static void testAllValidGetters(Cluster cluster) throws Exception
+    {
+        for (IInvokableInstance instance: cluster)
+        {
+            if (instance.isShutdown())
+            {
+                continue;
+            }
+            IInstanceConfig config = instance.config();
             List<Named> errors = new ArrayList<>();
-            try (JMXConnector jmxc = JMXConnectorFactory.connect(new JMXServiceURL(url), null))
+            try (JMXConnector jmxc = JMXUtil.getJmxConnector(config))
             {
                 MBeanServerConnection mbsc = jmxc.getMBeanServerConnection();
                 Set<ObjectName> metricNames = new TreeSet<>(mbsc.queryNames(null, null));


### PR DESCRIPTION
CASSANDRA-18725: IsolatedJmx should only remove the endpoints it created when stopping

    IsolatedJmx previously cleared the entire TCPEndpoint map field, which could remove the endpoints from other,
    running instances. Now, we make sure to only clear the endpoints created by that instance, which allows for
    other instances to keep running and for this instance to restart without issues.
    Also reworked the JMX tests to exercise more of the JMX functionality to help find leaks and other
    potential issues like this.

    Additional changes include setting up `looperEverythingTest` to add increased testing like the JMX looper
    test did, so we can add more extensive exercise of native/gossip/network features in the future.