### PR TITLE
CASSANDRA-18585: Alter Type does not validate changes (4.0)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Fix NTS log message when an unrecognized strategy option is passed (CASSANDRA-18679)
  * Fix BulkLoader ignoring cipher suites options (CASSANDRA-18582)
  * Migrate Python optparse to argparse (CASSANDRA-17914)
+ * Fix Alter Type does not validate changes like Create Type does (CASSANDRA-18585)
 Merged from 3.11:
  * Moved jflex from runtime to build dependencies (CASSANDRA-18664)
 Merged from 3.0:

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -110,6 +110,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
             if (type.isCounter())
                 throw ire("A user type cannot contain counters");
 
+            if (type.isUDT() && !type.isFrozen())
+                throw ire("A user type cannot contain non-frozen UDTs");
+
             if (userType.fieldPosition(fieldName) >= 0)
                 throw ire("Cannot add field %s to type %s: a field with name %s already exists", fieldName, userType.getCqlTypeName(), fieldName);
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -107,6 +107,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
 
         UserType apply(KeyspaceMetadata keyspace, UserType userType)
         {
+            if (type.isCounter())
+                throw ire("A user type cannot contain counters");
+
             if (userType.fieldPosition(fieldName) >= 0)
                 throw ire("Cannot add field %s to type %s: a field with name %s already exists", fieldName, userType.getCqlTypeName(), fieldName);
 

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -685,7 +685,6 @@ public abstract class CQLTester
     {
         String typeName = createTypeName();
         String fullQuery = String.format(query, keyspace + "." + typeName);
-        types.add(typeName);
         logger.info(fullQuery);
         schemaChange(fullQuery);
         return typeName;

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -691,6 +691,13 @@ public abstract class CQLTester
         return typeName;
     }
 
+    protected String createTypeName()
+    {
+        String typeName = String.format("type_%02d", seqNumber.getAndIncrement());
+        types.add(typeName);
+        return typeName;
+    }
+
     protected String createFunctionName(String keyspace)
     {
         return String.format("%s.function_%02d", keyspace, seqNumber.getAndIncrement());

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -683,7 +683,7 @@ public abstract class CQLTester
 
     protected String createType(String keyspace, String query)
     {
-        String typeName = String.format("type_%02d", seqNumber.getAndIncrement());
+        String typeName = createTypeName();
         String fullQuery = String.format(query, keyspace + "." + typeName);
         types.add(typeName);
         logger.info(fullQuery);

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
@@ -132,6 +132,10 @@ public class UserTypesTest extends CQLTester
         assertInvalidMessage("A user type cannot contain non-frozen UDTs",
                 "CREATE TYPE " + KEYSPACE + ".wrong (a int, b " + myType + ")");
 
+        String ut1 = createType(KEYSPACE, "CREATE TYPE %s (a int)");
+        assertInvalidMessage("A user type cannot contain non-frozen UDTs",
+                "ALTER TYPE " + KEYSPACE + "." + ut1 + " ADD b " + myType);
+
         // referencing a UDT in another keyspace
         assertInvalidMessage("Statement on keyspace " + KEYSPACE + " cannot refer to a user type in keyspace otherkeyspace;" +
                              " user types can only be used in the keyspace they are defined in",

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
@@ -476,6 +476,20 @@ public class UserTypesTest extends CQLTester
         execute("SELECT addresses FROM %s WHERE id = ? ", userID_1);
     }
 
+    @Test
+    public void testCreateTypeWithUndesiredFieldType() throws Throwable
+    {
+        String typeName = createTypeName();
+        assertInvalidMessage("A user type cannot contain counters", "CREATE TYPE " + typeWithKs(typeName) + " (f counter)");
+    }
+
+    @Test
+    public void testAlterTypeWithUndesiredFieldType() throws Throwable
+    {
+        String typeName = createType("CREATE TYPE %s (a int)");
+        assertInvalidMessage("A user type cannot contain counters", "ALTER TYPE " + typeWithKs(typeName) + " ADD f counter");
+    }
+
     /**
      * Test user type test that does a little more nesting,
      * migrated from cql_tests.py:TestCQL.more_user_types_test()


### PR DESCRIPTION
This fixes bug [CASSANDRA-18585](https://issues.apache.org/jira/browse/CASSANDRA-18585) for Cassandra 4.0
Unit tests included.