### PR TITLE
CASSANDRA-18585: Alter Type does not validate changes (trunk)

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -130,6 +130,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
             if (type.isCounter())
                 throw ire("A user type cannot contain counters");
 
+            if (type.isUDT() && !type.isFrozen())
+                throw ire("A user type cannot contain non-frozen UDTs");
+
             if (userType.fieldPosition(fieldName) >= 0)
             {
                 if (!ifFieldNotExists)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTypeStatement.java
@@ -127,6 +127,9 @@ public abstract class AlterTypeStatement extends AlterSchemaStatement
 
         UserType apply(KeyspaceMetadata keyspace, UserType userType)
         {
+            if (type.isCounter())
+                throw ire("A user type cannot contain counters");
+
             if (userType.fieldPosition(fieldName) >= 0)
             {
                 if (!ifFieldNotExists)

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
@@ -136,6 +136,10 @@ public class UserTypesTest extends CQLTester
         assertInvalidMessage("A user type cannot contain non-frozen UDTs",
                 "CREATE TYPE " + KEYSPACE + ".wrong (a int, b " + myType + ")");
 
+        String ut1 = createType(KEYSPACE, "CREATE TYPE %s (a int)");
+        assertInvalidMessage("A user type cannot contain non-frozen UDTs",
+                "ALTER TYPE " + KEYSPACE + "." + ut1 + " ADD b " + myType);
+
         // referencing a UDT in another keyspace
         assertInvalidMessage("Statement on keyspace " + KEYSPACE + " cannot refer to a user type in keyspace otherkeyspace;" +
                              " user types can only be used in the keyspace they are defined in",

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/UserTypesTest.java
@@ -530,6 +530,20 @@ public class UserTypesTest extends CQLTester
         execute("SELECT addresses FROM %s WHERE id = ? ", userID_1);
     }
 
+    @Test
+    public void testCreateTypeWithUndesiredFieldType() throws Throwable
+    {
+        String typeName = createTypeName();
+        assertInvalidMessage("A user type cannot contain counters", "CREATE TYPE " + typeWithKs(typeName) + " (f counter)");
+    }
+
+    @Test
+    public void testAlterTypeWithUndesiredFieldType() throws Throwable
+    {
+        String typeName = createType("CREATE TYPE %s (a int)");
+        assertInvalidMessage("A user type cannot contain counters", "ALTER TYPE " + typeWithKs(typeName) + " ADD f counter");
+    }
+
     /**
      * Test user type test that does a little more nesting,
      * migrated from cql_tests.py:TestCQL.more_user_types_test()


### PR DESCRIPTION
This fixes bug [CASSANDRA-18585](https://issues.apache.org/jira/browse/CASSANDRA-18585) for Cassandra trunk
Unit tests included.