### PR TITLE
Detect and fix Gossip and Service cache mismatches

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Merged from 3.11:
 Merged from 3.0:
  * Fix CQLSH online help topic link (CASSANDRA-17534)
  * Remove unused suppressions (CASSANDRA-18724)
+ * Detect token-ownership mismatch (CASSANDRA-18758)
 
 
 5.0

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -917,6 +917,23 @@ public class Config
     public volatile DurationSpec.LongMicrosecondsBound minimum_timestamp_warn_threshold = null;
     public volatile DurationSpec.LongMicrosecondsBound minimum_timestamp_fail_threshold = null;
 
+    /** Cassandra maintains the Gossip info (Token, Status, etc.) in two caches 1) Gossip cache 2) Storage Service cache
+     * The source of truth is the Gossip cache, which then updates the Storage service cache - but there exists no guarantee.
+     * As a result, a wide variety of problems could occur, and one of the problems is a node could see different token ownership
+     * than its peers.
+     * If this config is enabled, then it will compare these two caches at a gossip_and_storage_service_cache_comparison_interval_in_sec frequency
+     */
+    public volatile Boolean should_compare_gossip_and_storage_service_cache = false;
+
+    // The frequency at which the Gossip and the Storage Service caches are validated
+    public volatile Long gossip_and_storage_service_cache_comparison_interval_in_sec = 900L;
+
+    // Should we fix the Gossip and Storage service cache in case of a mismatch. By default, do not fix
+    public volatile Boolean should_fix_gossip_and_storage_service_cache_mismatch = false;
+
+    // Number of consecutive mismatch occurrences after which we declare caches are not in sync */
+    public volatile Integer gossip_and_storage_service_cache_mismatch_conviction_threshold = 5;
+
     /**
      * The variants of paxos implementation and semantics supported by Cassandra.
      */

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -4906,4 +4906,48 @@ public class DatabaseDescriptor
     {
         return conf.sai_options.segment_write_buffer_size;
     }
+
+    public static boolean getCompareGossipAndStorageServiceCache()
+    {
+        return conf.should_compare_gossip_and_storage_service_cache;
+    }
+
+    @VisibleForTesting
+    public static void setCompareGossipAndStorageServiceCache(boolean compareGossipAndStorageServiceCache)
+    {
+        conf.should_compare_gossip_and_storage_service_cache = compareGossipAndStorageServiceCache;
+    }
+
+    public static long getGossipAndStorageServiceCacheComparisonIntervalInSec()
+    {
+        return conf.gossip_and_storage_service_cache_comparison_interval_in_sec;
+    }
+
+    @VisibleForTesting
+    public static void setGossipAndStorageServiceCacheComparisonIntervalInSec(long gossipAndStorageServiceCacheComparisonIntervalInSec)
+    {
+        conf.gossip_and_storage_service_cache_comparison_interval_in_sec = gossipAndStorageServiceCacheComparisonIntervalInSec;
+    }
+
+    public static boolean shouldFixGossipAndStorageServiceCacheMismatch()
+    {
+        return conf.should_fix_gossip_and_storage_service_cache_mismatch;
+    }
+
+    @VisibleForTesting
+    public static void setFixGossipAndStorageServiceCacheMismatch(boolean enableCacheRepair)
+    {
+        conf.should_fix_gossip_and_storage_service_cache_mismatch = enableCacheRepair;
+    }
+
+    public static int gossipAndStorageServiceCacheMismatchConvictionThreshold()
+    {
+        return conf.gossip_and_storage_service_cache_mismatch_conviction_threshold;
+    }
+
+    @VisibleForTesting
+    public static void setGossipAndStorageServiceCacheMismatchConvictionThreshold(int threshold)
+    {
+        conf.gossip_and_storage_service_cache_mismatch_conviction_threshold = threshold;
+    }
 }

--- a/src/java/org/apache/cassandra/metrics/GossipMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/GossipMetrics.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+import java.util.function.ToLongFunction;
+import java.util.stream.StreamSupport;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import org.apache.cassandra.db.Keyspace;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+
+/**
+ * Metrics related to Gossip.
+ */
+public class GossipMetrics
+{
+    private static final MetricNameFactory factory = new DefaultNameFactory("Gossip");
+    public static final Counter gossipAndStorageServiceCacheMismatch = Metrics.counter(factory.createMetricName("GossipAndStorageServiceCacheMismatch"));
+    public static final Counter gossipAndStorageServiceCacheRepair = Metrics.counter(factory.createMetricName("GossipAndStorageServiceCacheRepair"));
+    public static final Counter gossipAndStorageServiceCacheError = Metrics.counter(factory.createMetricName("GossipAndStorageServiceCacheError"));
+}

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2965,7 +2965,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             Gossiper.instance.addLocalApplicationState(ApplicationState.RPC_READY, valueFactory.rpcReady(value));
     }
 
-    private Collection<Token> getTokensFor(InetAddressAndPort endpoint)
+    public Collection<Token> getTokensFor(InetAddressAndPort endpoint)
     {
         try
         {
@@ -3078,7 +3078,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
-    private void updateTokenMetadata(InetAddressAndPort endpoint, Iterable<Token> tokens)
+    public void updateTokenMetadata(InetAddressAndPort endpoint, Iterable<Token> tokens)
     {
         updateTokenMetadata(endpoint, tokens, new HashSet<>());
     }


### PR DESCRIPTION
Detect token-ownership mismatch (CASSANDRA-18758)

As we know, Cassandra exchanges important topology and token-ownership-related details over Gossip. Cassandra internally maintains two separate caches with the token-ownership information maintained: 1) Gossip cache and 2) Storage Service cache. The first Gossip cache is updated on a node, followed by the storage service cache. In the hot path, ownership is calculated from the storage service cache. Since two separate caches maintain the same information, then inconsistencies are bound to happen. It is feasible that the Gossip cache has up-to-date ownership of the Cassandra cluster, but the service cache does not, and in that scenario, inconsistent data will be served to the user.

Currently, no mechanism in Cassandra detects and fixes these two caches. 

Long-term solution
We are going with the long-term transactional metadata (https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-21) to handle such inconsistencies, and that’s the right thing to do.

Short-term solution
But CEP-21 might take some time, and until then, there is a need to detect such inconsistencies. Once we detect inconsistencies, then we could have two options: 1) restart the node or 2) Fix the inconsistencies on-the-fly.

patch by Jaydeepkumar Chovatia; reviewed by <Reviewers> for CASSANDRA-18758
