### PR TITLE
CASSANDRA-18722 Support Dynamic Port Allocation for in-jvm dtest fram…

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/INodeProvisionStrategy.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/INodeProvisionStrategy.java
@@ -58,7 +58,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("storagePort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7011 + nodeNum));
+                            return portMap.computeIfAbsent("storagePort@node" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7011 + nodeNum));
                         }
                         return 7011 + nodeNum;
                     }
@@ -68,7 +68,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("nativeTransportPort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 9041 + nodeNum));
+                            return portMap.computeIfAbsent("nativeTransportPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 9041 + nodeNum));
                         }
                         return 9041 + nodeNum;
                     }
@@ -78,7 +78,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("jmxPort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7199 + nodeNum));
+                            return portMap.computeIfAbsent("jmxPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7199 + nodeNum));
                         }
                         return 7199 + nodeNum;
                     }
@@ -117,7 +117,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("storagePort" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7012));
+                            return portMap.computeIfAbsent("storagePort@node" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7012));
                         }
                         return 7012;
                     }
@@ -127,7 +127,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("nativeTransportPort:" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 9042));
+                            return portMap.computeIfAbsent("nativeTransportPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 9042));
                         }
                         return 9042;
                     }
@@ -137,7 +137,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("jmxPort:" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7199));
+                            return portMap.computeIfAbsent("jmxPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7199));
                         }
                         return 7199;
                     }

--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -110,7 +110,7 @@ public class InstanceConfig implements IInstanceConfig
                 .set("native_transport_port", native_transport_port)
                 .set("endpoint_snitch", DistributedTestSnitch.class.getName())
                 .set("seed_provider", new ParameterizedClass(SimpleSeedProvider.class.getName(),
-                        Collections.singletonMap("seeds", seedIp + ":" + seedPort)))
+                        Collections.singletonMap("seeds", seedIp + ':' + seedPort)))
                 // required settings for dtest functionality
                 .set("diagnostic_events_enabled", true)
                 .set("auto_bootstrap", false)

--- a/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXFeatureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXFeatureTest.java
@@ -56,6 +56,7 @@ public class JMXFeatureTest extends TestBaseImpl
         for (int i = 0; i < iterations; i++)
         {
             try (Cluster cluster = Cluster.build(2)
+                                          .withDynamicPortAllocation(true)
                                           .withNodeProvisionStrategy(INodeProvisionStrategy.Strategy.MultipleNetworkInterfaces)
                                           .withConfig(c -> c.with(Feature.values())).start())
             {
@@ -79,6 +80,7 @@ public class JMXFeatureTest extends TestBaseImpl
         for (int i = 0; i < iterations; i++)
         {
             try (Cluster cluster = Cluster.build(2)
+                                          .withDynamicPortAllocation(true)
                                           .withNodeProvisionStrategy(INodeProvisionStrategy.Strategy.OneNetworkInterface)
                                           .withConfig(c -> c.with(Feature.values())).start())
             {
@@ -107,7 +109,7 @@ public class JMXFeatureTest extends TestBaseImpl
             // to check that we are actually connecting to the correct instance
             String defaultDomain = mbsc.getDefaultDomain();
             instancesContacted.add(defaultDomain);
-            Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ":" + config.jmxPort()));
+            Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ':' + config.jmxPort()));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/net/SocketUtils.java
+++ b/test/unit/org/apache/cassandra/net/SocketUtils.java
@@ -19,39 +19,54 @@
 package org.apache.cassandra.net;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 
 import com.google.common.base.Throwables;
 
 public class SocketUtils
 {
-    public static synchronized int findAvailablePort() throws RuntimeException
+    /**
+     * Returns an available port for the given {@code bindAddress}. When an {@link IOException} occurs when opening a
+     * socket or if a {@link SecurityException} is raised because a manager exists and its checkListen method does
+     * not allow the operation, the {@code fallbackPort} is returned.
+     *
+     * @param bindAddress  the ip address for the interface where we need an available port number
+     * @param fallbackPort a port to return in case {@link SecurityException} or {@link IOException} is encountered
+     * @return an available port the given {@code bindAddress} when succeeds, otherwise the {@code fallbackPort}
+     * @throws RuntimeException if no IP address for the {@code bindAddress} could be found
+     */
+    public static synchronized int findAvailablePort(String bindAddress, int fallbackPort) throws RuntimeException
     {
-        ServerSocket ss = null;
         try
         {
-            // let the system pick an ephemeral port
-            ss = new ServerSocket(0);
-            ss.setReuseAddress(true);
-            return ss.getLocalPort();
+            return findAvailablePort(InetAddress.getByName(bindAddress), fallbackPort);
         }
-        catch (IOException e)
+        catch (UnknownHostException e)
         {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
-        finally
+    }
+
+    /**
+     * Returns an available port for the given {@code bindAddress}. When an {@link IOException} occurs when opening a
+     * socket or if a {@link SecurityException} is raised because a manager exists and its checkListen method does
+     * not allow the operation, the {@code fallbackPort} is returned.
+     *
+     * @param bindAddress  the ip address for the interface where we need an available port number
+     * @param fallbackPort a port to return in case {@link SecurityException} or {@link IOException} is encountered
+     * @return an available port the given {@code bindAddress} when succeeds, otherwise the {@code fallbackPort}
+     */
+    public static synchronized int findAvailablePort(InetAddress bindAddress, int fallbackPort)
+    {
+        try (ServerSocket socket = new ServerSocket(0, 50, bindAddress))
         {
-            if (ss != null)
-            {
-                try
-                {
-                    ss.close();
-                }
-                catch (IOException e)
-                {
-                    Throwables.propagate(e);
-                }
-            }
+            return socket.getLocalPort();
+        }
+        catch (SecurityException | IOException exception)
+        {
+            return fallbackPort;
         }
     }
 }


### PR DESCRIPTION
…ework (4.0 patch)

Currently, `INodeProvisionStrategy` supports two strategies `OneNetworkInterface` and `MultipleNetworkInterfaces`. However the `seedPort`, `storagePorts`, `nativeTransportPorts`, and `jmxPorts` are always fixed or a function of the node number.

In order to better support parallel test runs, this commit introduces support for dynamic port allocation for the `seedPort`, `storagePorts`, `nativeTransportPorts`, and `jmxPorts`.

When enabled, the port allocation will be dynamic, an available port for the given bind address will be used instead of the previously statically allocated port number. This would allow us to run multiple clusters within the same test, or it will enable us to run in-jvm dtests in parallel given that the tests do not have other inter-test dependencies.

A new option in the cluster builder is introduced `.withDynamicPortAllocation(boolean)`. To enable the new feature one must request dynamic port allocation while building the cluster.

[CASSANDRA-18722](https://issues.apache.org/jira/browse/CASSANDRA-18722)