### PR TITLE
CASSANDRA-18722 Support Dynamic Port Allocation for in-jvm dtest fram…

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/AbstractCluster.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/AbstractCluster.java
@@ -155,6 +155,7 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
     private final Map<Integer, NetworkTopology.DcAndRack> nodeIdTopology;
     private final Consumer<IInstanceConfig> configUpdater;
     private final int broadcastPort;
+    private final Map<String, Integer> portMap;
 
     // mutated by starting/stopping a node
     private final List<I> instances;
@@ -184,6 +185,7 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
     {
         private INodeProvisionStrategy.Strategy nodeProvisionStrategy = INodeProvisionStrategy.Strategy.MultipleNetworkInterfaces;
         private ShutdownExecutor shutdownExecutor = DEFAULT_SHUTDOWN_EXECUTOR;
+        private boolean dynamicPortAllocation = false;
 
         {
             // Indicate that we are running in the in-jvm dtest environment
@@ -200,16 +202,38 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
             withSharedClasses(SHARED_PREDICATE);
         }
 
+        @SuppressWarnings("unchecked")
+        private B self()
+        {
+            return (B) this;
+        }
+
         public B withNodeProvisionStrategy(INodeProvisionStrategy.Strategy nodeProvisionStrategy)
         {
             this.nodeProvisionStrategy = nodeProvisionStrategy;
-            return (B) this;
+            return self();
         }
 
         public B withShutdownExecutor(ShutdownExecutor shutdownExecutor)
         {
             this.shutdownExecutor = shutdownExecutor;
-            return (B) this;
+            return self();
+        }
+
+        /**
+         * When {@code dynamicPortAllocation} is {@code true}, it will ask {@link INodeProvisionStrategy} to provision
+         * available storage, native and JMX ports in the given interface. When {@code dynamicPortAllocation} is
+         * {@code false} (the default behavior), it will use statically allocated ports based on the number of
+         * interfaces available and the node number.
+         *
+         * @param dynamicPortAllocation {@code true} for dynamic port allocation, {@code false} for static port
+         *                              allocation
+         * @return a reference to this Builder
+         */
+        public B withDynamicPortAllocation(boolean dynamicPortAllocation)
+        {
+            this.dynamicPortAllocation = dynamicPortAllocation;
+            return self();
         }
 
         @Override
@@ -539,6 +563,7 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
         this.filters = new MessageFilters();
         this.instanceInitializer = builder.getInstanceInitializer2();
         this.datadirCount = builder.getDatadirCount();
+        this.portMap = builder.dynamicPortAllocation ? new ConcurrentHashMap<>() : null;
 
         for (int i = 0; i < builder.getNodeCount(); ++i)
         {
@@ -562,7 +587,7 @@ public abstract class AbstractCluster<I extends IInstance> implements ICluster<I
     @VisibleForTesting
     InstanceConfig createInstanceConfig(int nodeNum)
     {
-        INodeProvisionStrategy provisionStrategy = nodeProvisionStrategy.create(subnet);
+        INodeProvisionStrategy provisionStrategy = nodeProvisionStrategy.create(subnet, portMap);
         Collection<String> tokens = tokenSupplier.tokens(nodeNum);
         NetworkTopology topology = buildNetworkTopology(provisionStrategy, nodeIdTopology);
         InstanceConfig config = InstanceConfig.generate(nodeNum, provisionStrategy, topology, root, tokens, datadirCount);

--- a/test/distributed/org/apache/cassandra/distributed/impl/INodeProvisionStrategy.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/INodeProvisionStrategy.java
@@ -62,7 +62,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("storagePort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7011 + nodeNum));
+                            return portMap.computeIfAbsent("storagePort@node" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7011 + nodeNum));
                         }
                         return 7011 + nodeNum;
                     }
@@ -72,7 +72,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("nativeTransportPort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 9041 + nodeNum));
+                            return portMap.computeIfAbsent("nativeTransportPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 9041 + nodeNum));
                         }
                         return 9041 + nodeNum;
                     }
@@ -82,7 +82,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("jmxPort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7199 + nodeNum));
+                            return portMap.computeIfAbsent("jmxPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7199 + nodeNum));
                         }
                         return 7199 + nodeNum;
                     }
@@ -121,7 +121,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("storagePort" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7012));
+                            return portMap.computeIfAbsent("storagePort@node" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7012));
                         }
                         return 7012;
                     }
@@ -131,7 +131,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("nativeTransportPort:" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 9042));
+                            return portMap.computeIfAbsent("nativeTransportPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 9042));
                         }
                         return 9042;
                     }
@@ -141,7 +141,7 @@ public interface INodeProvisionStrategy
                     {
                         if (portMap != null)
                         {
-                            return portMap.computeIfAbsent("jmxPort:" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7199));
+                            return portMap.computeIfAbsent("jmxPort@node" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7199));
                         }
                         return 7199;
                     }

--- a/test/distributed/org/apache/cassandra/distributed/impl/INodeProvisionStrategy.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/INodeProvisionStrategy.java
@@ -18,6 +18,10 @@
 
 package org.apache.cassandra.distributed.impl;
 
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import org.apache.cassandra.net.SocketUtils;
 import org.apache.cassandra.utils.Shared;
 
 import static org.apache.cassandra.utils.Shared.Recursive.INTERFACES;
@@ -25,40 +29,61 @@ import static org.apache.cassandra.utils.Shared.Recursive.INTERFACES;
 @Shared(inner = INTERFACES)
 public interface INodeProvisionStrategy
 {
-    public enum Strategy
+    enum Strategy
     {
         OneNetworkInterface
         {
-            INodeProvisionStrategy create(int subnet) {
+            @Override
+            INodeProvisionStrategy create(int subnet, @Nullable Map<String, Integer> portMap)
+            {
+                String ipAdress = "127.0." + subnet + ".1";
                 return new INodeProvisionStrategy()
                 {
+                    @Override
                     public String seedIp()
                     {
-                        return "127.0." + subnet + ".1";
+                        return ipAdress;
                     }
 
+                    @Override
                     public int seedPort()
                     {
-                        return 7012;
+                        return storagePort(1);
                     }
 
+                    @Override
                     public String ipAddress(int nodeNum)
                     {
-                        return "127.0." + subnet + ".1";
+                        return ipAdress;
                     }
 
+                    @Override
                     public int storagePort(int nodeNum)
                     {
+                        if (portMap != null)
+                        {
+                            return portMap.computeIfAbsent("storagePort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7011 + nodeNum));
+                        }
                         return 7011 + nodeNum;
                     }
 
+                    @Override
                     public int nativeTransportPort(int nodeNum)
                     {
+                        if (portMap != null)
+                        {
+                            return portMap.computeIfAbsent("nativeTransportPort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 9041 + nodeNum));
+                        }
                         return 9041 + nodeNum;
                     }
 
+                    @Override
                     public int jmxPort(int nodeNum)
                     {
+                        if (portMap != null)
+                        {
+                            return portMap.computeIfAbsent("jmxPort:" + nodeNum, key -> SocketUtils.findAvailablePort(seedIp(), 7199 + nodeNum));
+                        }
                         return 7199 + nodeNum;
                     }
                 };
@@ -66,49 +91,81 @@ public interface INodeProvisionStrategy
         },
         MultipleNetworkInterfaces
         {
-            INodeProvisionStrategy create(int subnet) {
-                String ipPrefix = "127.0." + subnet + ".";
+            @Override
+            INodeProvisionStrategy create(int subnet, @Nullable Map<String, Integer> portMap)
+            {
+                String ipPrefix = "127.0." + subnet + '.';
                 return new INodeProvisionStrategy()
                 {
+
+                    @Override
                     public String seedIp()
                     {
-                        return ipPrefix + "1";
+                        return ipPrefix + '1';
                     }
 
+                    @Override
                     public int seedPort()
                     {
-                        return 7012;
+                        return storagePort(1);
                     }
 
+                    @Override
                     public String ipAddress(int nodeNum)
                     {
                         return ipPrefix + nodeNum;
                     }
 
+                    @Override
                     public int storagePort(int nodeNum)
                     {
+                        if (portMap != null)
+                        {
+                            return portMap.computeIfAbsent("storagePort" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7012));
+                        }
                         return 7012;
                     }
 
+                    @Override
                     public int nativeTransportPort(int nodeNum)
                     {
+                        if (portMap != null)
+                        {
+                            return portMap.computeIfAbsent("nativeTransportPort:" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 9042));
+                        }
                         return 9042;
                     }
 
+                    @Override
                     public int jmxPort(int nodeNum)
                     {
+                        if (portMap != null)
+                        {
+                            return portMap.computeIfAbsent("jmxPort:" + nodeNum, key -> SocketUtils.findAvailablePort(ipAddress(nodeNum), 7199));
+                        }
                         return 7199;
                     }
                 };
             }
         };
-        abstract INodeProvisionStrategy create(int subnet);
+
+        INodeProvisionStrategy create(int subnet)
+        {
+            return create(subnet, null);
+        }
+
+        abstract INodeProvisionStrategy create(int subnet, @Nullable Map<String, Integer> portMap);
     }
 
-    abstract String seedIp();
-    abstract int seedPort();
-    abstract String ipAddress(int nodeNum);
-    abstract int storagePort(int nodeNum);
-    abstract int nativeTransportPort(int nodeNum);
-    abstract int jmxPort(int nodeNum);
+    String seedIp();
+
+    int seedPort();
+
+    String ipAddress(int nodeNum);
+
+    int storagePort(int nodeNum);
+
+    int nativeTransportPort(int nodeNum);
+
+    int jmxPort(int nodeNum);
 }

--- a/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/InstanceConfig.java
@@ -105,7 +105,7 @@ public class InstanceConfig implements IInstanceConfig
                 .set("native_transport_port", native_transport_port)
                 .set("endpoint_snitch", DistributedTestSnitch.class.getName())
                 .set("seed_provider", new ParameterizedClass(SimpleSeedProvider.class.getName(),
-                        Collections.singletonMap("seeds", seedIp + ":" + seedPort)))
+                        Collections.singletonMap("seeds", seedIp + ':' + seedPort)))
                 // required settings for dtest functionality
                 .set("diagnostic_events_enabled", true)
                 .set("auto_bootstrap", false)

--- a/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXFeatureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/jmx/JMXFeatureTest.java
@@ -56,6 +56,7 @@ public class JMXFeatureTest extends TestBaseImpl
         for (int i = 0; i < iterations; i++)
         {
             try (Cluster cluster = Cluster.build(2)
+                                          .withDynamicPortAllocation(true)
                                           .withNodeProvisionStrategy(INodeProvisionStrategy.Strategy.MultipleNetworkInterfaces)
                                           .withConfig(c -> c.with(Feature.values())).start())
             {
@@ -79,6 +80,7 @@ public class JMXFeatureTest extends TestBaseImpl
         for (int i = 0; i < iterations; i++)
         {
             try (Cluster cluster = Cluster.build(2)
+                                          .withDynamicPortAllocation(true)
                                           .withNodeProvisionStrategy(INodeProvisionStrategy.Strategy.OneNetworkInterface)
                                           .withConfig(c -> c.with(Feature.values())).start())
             {
@@ -107,7 +109,7 @@ public class JMXFeatureTest extends TestBaseImpl
             // to check that we are actually connecting to the correct instance
             String defaultDomain = mbsc.getDefaultDomain();
             instancesContacted.add(defaultDomain);
-            Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ":" + config.jmxPort()));
+            Assert.assertThat(defaultDomain, startsWith(JMXUtil.getJmxHost(config) + ':' + config.jmxPort()));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/net/SocketUtils.java
+++ b/test/unit/org/apache/cassandra/net/SocketUtils.java
@@ -19,37 +19,52 @@
 package org.apache.cassandra.net;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 
 public class SocketUtils
 {
-    public static synchronized int findAvailablePort() throws RuntimeException
+    /**
+     * Returns an available port for the given {@code bindAddress}. When an {@link IOException} occurs when opening a
+     * socket or if a {@link SecurityException} is raised because a manager exists and its checkListen method does
+     * not allow the operation, the {@code fallbackPort} is returned.
+     *
+     * @param bindAddress  the ip address for the interface where we need an available port number
+     * @param fallbackPort a port to return in case {@link SecurityException} or {@link IOException} is encountered
+     * @return an available port the given {@code bindAddress} when succeeds, otherwise the {@code fallbackPort}
+     * @throws RuntimeException if no IP address for the {@code bindAddress} could be found
+     */
+    public static synchronized int findAvailablePort(String bindAddress, int fallbackPort) throws RuntimeException
     {
-        ServerSocket ss = null;
         try
         {
-            // let the system pick an ephemeral port
-            ss = new ServerSocket(0);
-            ss.setReuseAddress(true);
-            return ss.getLocalPort();
+            return findAvailablePort(InetAddress.getByName(bindAddress), fallbackPort);
         }
-        catch (IOException e)
+        catch (UnknownHostException e)
         {
             throw new RuntimeException(e);
         }
-        finally
+    }
+
+    /**
+     * Returns an available port for the given {@code bindAddress}. When an {@link IOException} occurs when opening a
+     * socket or if a {@link SecurityException} is raised because a manager exists and its checkListen method does
+     * not allow the operation, the {@code fallbackPort} is returned.
+     *
+     * @param bindAddress  the ip address for the interface where we need an available port number
+     * @param fallbackPort a port to return in case {@link SecurityException} or {@link IOException} is encountered
+     * @return an available port the given {@code bindAddress} when succeeds, otherwise the {@code fallbackPort}
+     */
+    public static synchronized int findAvailablePort(InetAddress bindAddress, int fallbackPort)
+    {
+        try (ServerSocket socket = new ServerSocket(0, 50, bindAddress))
         {
-            if (ss != null)
-            {
-                try
-                {
-                    ss.close();
-                }
-                catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
+            return socket.getLocalPort();
+        }
+        catch (SecurityException | IOException exception)
+        {
+            return fallbackPort;
         }
     }
 }


### PR DESCRIPTION
…ework (5.0 patch)

Currently, `INodeProvisionStrategy` supports two strategies `OneNetworkInterface` and `MultipleNetworkInterfaces`. However the `seedPort`, `storagePorts`, `nativeTransportPorts`, and `jmxPorts` are always fixed or a function of the node number.

In order to better support parallel test runs, this commit introduces support for dynamic port allocation for the `seedPort`, `storagePorts`, `nativeTransportPorts`, and `jmxPorts`.

When enabled, the port allocation will be dynamic, an available port for the given bind address will be used instead of the previously statically allocated port number. This would allow us to run multiple clusters within the same test, or it will enable us to run in-jvm dtests in parallel given that the tests do not have other inter-test dependencies.

A new option in the cluster builder is introduced `.withDynamicPortAllocation(boolean)`. To enable the new feature one must request dynamic port allocation while building the cluster.

[CASSANDRA-18722](https://issues.apache.org/jira/browse/CASSANDRA-18722)

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

