### PR TITLE
Refactor assertFalse(equals()) with assertNotEquals

### DIFF
--- a/test/unit/org/apache/cassandra/cql3/KeyCacheCqlTest.java
+++ b/test/unit/org/apache/cassandra/cql3/KeyCacheCqlTest.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.service.StorageService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 
@@ -403,7 +404,7 @@ public class KeyCacheCqlTest extends CQLTester
         {
             KeyCacheKey key = iter.next();
             TableMetadataRef tableMetadataRef = Schema.instance.getTableMetadataRef(key.tableId);
-            Assert.assertFalse(tableMetadataRef.keyspace.equals("KEYSPACE_PER_TEST"));
+            Assert.assertNotEquals(tableMetadataRef.keyspace, "KEYSPACE_PER_TEST");
             Assert.assertFalse(tableMetadataRef.name.startsWith(table));
         }
     }

--- a/test/unit/org/apache/cassandra/db/DiskBoundaryManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/DiskBoundaryManagerTest.java
@@ -44,7 +44,7 @@ import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
@@ -101,7 +101,7 @@ public class DiskBoundaryManagerTest extends CQLTester
         DiskBoundaries dbv1 = dbm.getDiskBoundaries(mock);
         StorageService.instance.getTokenMetadata().updateNormalTokens(BootStrapper.getRandomTokens(StorageService.instance.getTokenMetadata(), 10), InetAddressAndPort.getByName("127.0.0.10"));
         DiskBoundaries dbv2 = dbm.getDiskBoundaries(mock);
-        assertFalse(dbv1.equals(dbv2));
+        assertNotEquals(dbv1, dbv2);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sasi/SASICQLTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASICQLTest.java
@@ -165,7 +165,7 @@ public class SASICQLTest extends CQLTester
                         stmt = new SimpleStatement("SELECT * FROM " + KEYSPACE + '.' + currentTable() + " WHERE v > 'ab'");
                         stmt.setFetchSize(5);
                         rs = session.execute(stmt).all();
-                        Assert.assertFalse("CONTAINS mode on non-literal string type should not support RANGE operators", "CONTAINS".equals(mode));
+                        Assert.assertNotEquals("CONTAINS mode on non-literal string type should not support RANGE operators", "CONTAINS", mode);
                         Assert.assertEquals(2, rs.size());
                         Assert.assertEquals(1, rs.get(0).getInt("pk"));
                     }
@@ -293,7 +293,7 @@ public class SASICQLTest extends CQLTester
                     SimpleStatement stmt = new SimpleStatement("SELECT * FROM " + KEYSPACE + '.' + currentTable() + " WHERE v > 0x1234");
                     stmt.setFetchSize(5);
                     List<Row> rs = session.execute(stmt).all();
-                    Assert.assertFalse("CONTAINS mode on non-literal blob type should not support RANGE operators", "CONTAINS".equals(mode));
+                    Assert.assertNotEquals("CONTAINS mode on non-literal blob type should not support RANGE operators", "CONTAINS", mode);
                     Assert.assertEquals(2, rs.size());
                     Assert.assertEquals(1, rs.get(0).getInt("pk"));
                 }
@@ -334,7 +334,7 @@ public class SASICQLTest extends CQLTester
                     SimpleStatement stmt = new SimpleStatement("SELECT * FROM " + KEYSPACE + '.' + currentTable() + " WHERE v > 200");
                     stmt.setFetchSize(5);
                     List<Row> rs = session.execute(stmt).all();
-                    Assert.assertFalse("CONTAINS mode on non-literal int type should not support RANGE operators", "CONTAINS".equals(mode));
+                    Assert.assertNotEquals("CONTAINS mode on non-literal int type should not support RANGE operators", "CONTAINS", mode);
                     Assert.assertEquals(1, rs.size());
                     Assert.assertEquals(2, rs.get(0).getInt("pk"));
                 }

--- a/test/unit/org/apache/cassandra/index/sasi/analyzer/DelimiterAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/analyzer/DelimiterAnalyzerTest.java
@@ -59,7 +59,7 @@ public class DelimiterAnalyzerTest
             output.append(ByteBufferUtil.string(analyzer.next()) + (analyzer.hasNext() ? ' ' : ""));
 
         Assert.assertEquals(testString, output.toString());
-        Assert.assertFalse(testString.toLowerCase().equals(output.toString()));
+        Assert.assertNotEquals(testString.toLowerCase(), output.toString());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class DelimiterAnalyzerTest
             output.append(ByteBufferUtil.string(analyzer.next()) + (analyzer.hasNext() ? ',' : ""));
 
         Assert.assertEquals("Nip,it,in,the,bud", output.toString());
-        Assert.assertFalse(testString.toLowerCase().equals(output.toString()));
+        Assert.assertNotEquals(testString.toLowerCase(), output.toString());
     }
 
     @Test(expected = ConfigurationException.class)

--- a/test/unit/org/apache/cassandra/index/sasi/analyzer/NonTokenizingAnalyzerTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/analyzer/NonTokenizingAnalyzerTest.java
@@ -61,7 +61,7 @@ public class NonTokenizingAnalyzerTest
         ByteBuffer analyzed = null;
         while (analyzer.hasNext())
             analyzed = analyzer.next();
-        Assert.assertFalse(testString.toLowerCase().equals(ByteBufferUtil.string(analyzed)));
+        Assert.assertNotEquals(testString.toLowerCase(), ByteBufferUtil.string(analyzed));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/index/sasi/plan/ExpressionTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/plan/ExpressionTest.java
@@ -46,7 +46,7 @@ public class ExpressionTest
         Expression.Bound b1 = new Expression.Bound(buf1, true);
         ByteBuffer buf2 = UTF8Type.instance.decompose("blah2");
         Expression.Bound b2 = new Expression.Bound(buf2, true);
-        assertFalse(b1.equals(b2));
+        assertNotEquals(b1, b2);
         assertFalse(b1.hashCode() == b2.hashCode());
     }
 }

--- a/test/unit/org/apache/cassandra/metrics/LatencyMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/LatencyMetricsTest.java
@@ -23,7 +23,8 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
 
 public class LatencyMetricsTest
 {
@@ -57,7 +58,7 @@ public class LatencyMetricsTest
         for (int i = 0; i < 10000; i++)
         {
             Double recent = l.latency.getOneMinuteRate();
-            assertFalse(recent.equals(Double.POSITIVE_INFINITY));
+            assertNotEquals(recent, Double.POSITIVE_INFINITY);
         }
     }
 

--- a/test/unit/org/apache/cassandra/schema/MigrationManagerTest.java
+++ b/test/unit/org/apache/cassandra/schema/MigrationManagerTest.java
@@ -53,6 +53,7 @@ import static org.apache.cassandra.cql3.CQLTester.assertRows;
 import static org.apache.cassandra.cql3.CQLTester.row;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -340,7 +341,7 @@ public class MigrationManagerTest
 
         KeyspaceMetadata newFetchedKs = Schema.instance.getKeyspaceMetadata(newKs.name);
         assertEquals(newFetchedKs.params.replication.klass, newKs.params.replication.klass);
-        assertFalse(newFetchedKs.params.replication.klass.equals(oldKs.params.replication.klass));
+        assertNotEquals(newFetchedKs.params.replication.klass, oldKs.params.replication.klass);
     }
 
     /*


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

This smell occurs when inappropriate assertions are used, while there exist better alternatives. For example, in [DiskBoundaryManagerTest.java](https://github.com/apache/cassandra/commit/bf2c5a44e86ef1b36c9ce756ad5fac1ec8e200e6#diff-2c0a8482948514ed8944fec2a26aa6af798d25351fd87c36c5f318181f30db71), I refactored `assertFalse(dbv1.equals(dbv2));` with `assertNotEquals(dbv1, dbv2);`.

I would like to get your feedback on this particular test smell and its refactoring. Thanks in advance for your input.