### PR TITLE
Ensure unit tests honor tmp.dir

### DIFF
--- a/.build/checkstyle_test.xml
+++ b/.build/checkstyle_test.xml
@@ -59,6 +59,13 @@
       <property name="classes" value=""/>
     </module>
 
+    <module name="RegexpSinglelineJava">
+      <property name="id" value="hardcodeTmpDirectoryUsage"/>
+      <property name="format" value="(File|Directory)\(&quot;/tmp"/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="Please do not hardcode '/tmp' for test files and directories. Use Files.createTempDirectory to create a base test directory instead." />
+    </module>
+
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
   </module>

--- a/build.xml
+++ b/build.xml
@@ -81,7 +81,10 @@
     <property name="test.driver.read_timeout_ms" value="24000"/>
     <property name="test.jvm.args" value="" />
     <property name="dist.dir" value="${build.dir}/dist"/>
-    <property name="tmp.dir" value="${java.io.tmpdir}"/>
+
+    <!-- Use build/tmp for temp files if not otherwise specified. Because Ant properties are immutable, this has no effect if
+         the user specifies the tmp.dir property -->
+    <property name="tmp.dir" value="${build.dir}/tmp"/>
 
     <property name="doc.dir" value="${basedir}/doc"/>
 
@@ -401,6 +404,7 @@
 
     <target name="clean" description="Remove all locally created artifacts">
         <delete dir="${build.test.dir}" />
+        <delete dir="${build.dir}/tmp" />
         <delete dir="${build.classes}" />
         <delete dir="${build.src.gen-java}" />
         <delete dir="${version.properties.dir}" />
@@ -1531,6 +1535,7 @@
       <mkdir dir="${build.test.dir}/cassandra"/>
       <mkdir dir="${build.test.dir}/output"/>
       <mkdir dir="${build.test.dir}/output/@{testtag}"/>
+      <mkdir dir="${tmp.dir}"/>
       <junit-timeout fork="on" forkmode="@{forkmode}" failureproperty="testfailed" maxmemory="1024m" timeout="@{timeout}" showoutput="@{showoutput}">
         <formatter classname="org.apache.cassandra.CassandraXMLJUnitResultFormatter" extension=".xml" usefile="true"/>
         <formatter classname="org.apache.cassandra.CassandraBriefJUnitResultFormatter" usefile="false"/>

--- a/test/unit/org/apache/cassandra/db/DirectoriesTest.java
+++ b/test/unit/org/apache/cassandra/db/DirectoriesTest.java
@@ -705,12 +705,14 @@ public class DirectoriesTest
     }
 
     @Test
-    public void testGetLocationForDisk()
+    public void testGetLocationForDisk() throws IOException
     {
         Collection<DataDirectory> paths = new ArrayList<>();
-        paths.add(new DataDirectory(new File("/tmp/aaa")));
-        paths.add(new DataDirectory(new File("/tmp/aa")));
-        paths.add(new DataDirectory(new File("/tmp/a")));
+
+        Path tmpDir = Files.createTempDirectory("testGetLocationForDisk");
+        paths.add(new DataDirectory(tmpDir.resolve("aaa")));
+        paths.add(new DataDirectory(tmpDir.resolve("aa")));
+        paths.add(new DataDirectory(tmpDir.resolve("a")));
 
         for (TableMetadata cfm : CFM)
         {
@@ -745,12 +747,14 @@ public class DirectoriesTest
     }
 
     @Test
-    public void getDataDirectoryForFile()
+    public void getDataDirectoryForFile() throws IOException
     {
         Collection<DataDirectory> paths = new ArrayList<>();
-        paths.add(new DataDirectory("/tmp/a"));
-        paths.add(new DataDirectory("/tmp/aa"));
-        paths.add(new DataDirectory("/tmp/aaa"));
+
+        Path tmpDir = Files.createTempDirectory("getDataDirectoryForFile");
+        paths.add(new DataDirectory(tmpDir.resolve("a")));
+        paths.add(new DataDirectory(tmpDir.resolve("aa")));
+        paths.add(new DataDirectory(tmpDir.resolve("aaa")));
 
         for (TableMetadata cfm : CFM)
         {

--- a/test/unit/org/apache/cassandra/db/ImportTest.java
+++ b/test/unit/org/apache/cassandra/db/ImportTest.java
@@ -283,9 +283,11 @@ public class ImportTest extends CQLTester
         getCurrentColumnFamilyStore().clearUnsafe();
         File dir = moveToBackupDir(toMove);
 
-        Directories dirs = new Directories(getCurrentColumnFamilyStore().metadata(), Lists.newArrayList(new Directories.DataDirectory(new File("/tmp/1")),
-                                                                                                        new Directories.DataDirectory(new File("/tmp/2")),
-                                                                                                        new Directories.DataDirectory(new File("/tmp/3"))));
+        Path tmpDir = Files.createTempDirectory("ImportTest");
+
+        Directories dirs = new Directories(getCurrentColumnFamilyStore().metadata(), Lists.newArrayList(new Directories.DataDirectory(new File(tmpDir, "1")),
+                                                                                                        new Directories.DataDirectory(new File(tmpDir, "2")),
+                                                                                                        new Directories.DataDirectory(new File(tmpDir, "3"))));
         MockCFS mock = new MockCFS(getCurrentColumnFamilyStore(), dirs);
         SSTableImporter importer = new SSTableImporter(mock);
 

--- a/test/unit/org/apache/cassandra/db/compaction/writers/CompactionAwareWriterTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/writers/CompactionAwareWriterTest.java
@@ -17,8 +17,17 @@
  */
 package org.apache.cassandra.db.compaction.writers;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 import com.google.common.primitives.Longs;
 import org.junit.*;
@@ -169,15 +178,17 @@ public class CompactionAwareWriterTest extends CQLTester
     }
 
     @Test
-    public void testMultiDatadirCheck()
+    public void testMultiDatadirCheck() throws IOException
     {
         createTable("create table %s (id int primary key)");
+        Path tmpDir = Files.createTempDirectory("testMultiDatadirCheck");
+
         Directories.DataDirectory [] dataDirs = new Directories.DataDirectory[] {
-        new MockDataDirectory(new File("/tmp/1")),
-        new MockDataDirectory(new File("/tmp/2")),
-        new MockDataDirectory(new File("/tmp/3")),
-        new MockDataDirectory(new File("/tmp/4")),
-        new MockDataDirectory(new File("/tmp/5"))
+        new MockDataDirectory(new File(tmpDir, "1")),
+        new MockDataDirectory(new File(tmpDir, "2")),
+        new MockDataDirectory(new File(tmpDir, "3")),
+        new MockDataDirectory(new File(tmpDir, "4")),
+        new MockDataDirectory(new File(tmpDir, "5"))
         };
         Set<SSTableReader> sstables = new HashSet<>();
         for (int i = 0; i < 100; i++)

--- a/test/unit/org/apache/cassandra/fql/FullQueryLoggerTest.java
+++ b/test/unit/org/apache/cassandra/fql/FullQueryLoggerTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.cassandra.fql;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -674,7 +676,7 @@ public class FullQueryLoggerTest extends CQLTester
     }
 
     @Test
-    public void testJMXArchiveCommand()
+    public void testJMXArchiveCommand() throws IOException
     {
         FullQueryLoggerOptions options = new FullQueryLoggerOptions();
 
@@ -691,7 +693,8 @@ public class FullQueryLoggerTest extends CQLTester
 
         options.allow_nodetool_archive_command = true;
         options.archive_command = "/xyz/not/null";
-        options.log_dir = "/tmp/abc";
+        Path tmpDir = Files.createTempDirectory("FullQueryLoggerTest");
+        options.log_dir = tmpDir.resolve("abc").toString();
         DatabaseDescriptor.setFullQueryLogOptions(options);
         StorageService.instance.enableFullQueryLogger(options.log_dir, options.roll_cycle, false, 1000, 1000, null, 0);
         assertTrue(FullQueryLogger.instance.isEnabled());

--- a/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
@@ -247,42 +247,42 @@ public class DescriptorTest
         testKeyspaceTableParsing(filePathsWithBackupsKeyspaceAndTableWithIndices, "backups", "backups.index");
 
         String[] outsideOfCassandra = new String[]{
-        "/tmp/some/path/tests/keyspace/table-3424234234234/na-1-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-3424234234234/snapshots/snapshots/na-1-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-3424234234234/backups/na-1-big-Index.db",
-        "/tmp/tests/keyspace/table-3424234234234/na-1-big-Index.db",
-        "/keyspace/table-3424234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-3424234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-3424234234234/snapshots/snapshots/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-3424234234234/backups/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/tests/keyspace/table-3424234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/keyspace/table-3424234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db"
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/na-1-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/snapshots/snapshots/na-1-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/backups/na-1-big-Index.db",
+        "/testroot/tests/keyspace/table-34234234234234234234234234234234/na-1-big-Index.db",
+        "/keyspace/table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/snapshots/snapshots/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/backups/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/tests/keyspace/table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/keyspace/table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db"
         };
 
         testKeyspaceTableParsing(outsideOfCassandra, "keyspace", "table");
 
         String[] outsideOfCassandraUppercaseKeyspaceAndTable = new String[]{
-        "/tmp/some/path/tests/Keyspace/Table-23424324234234/na-1-big-Index.db",
-        "/tmp/some/path/tests/Keyspace/Table-23424324234234/snapshots/snapshots/na-1-big-Index.db",
-        "/tmp/some/path/tests/Keyspace/Table-23424324234234/backups/na-1-big-Index.db",
-        "/tmp/tests/Keyspace/Table-23424324234234/na-1-big-Index.db",
-        "/Keyspace/Table-23424324234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/Keyspace/Table-23424324234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/Keyspace/Table-23424324234234/snapshots/snapshots/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/Keyspace/Table-23424324234234/backups/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/tests/Keyspace/Table-23424324234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/Keyspace/Table-23424324234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db"
+        "/testroot/some/path/tests/Keyspace/Table-34234234234234234234234234234234/na-1-big-Index.db",
+        "/testroot/some/path/tests/Keyspace/Table-34234234234234234234234234234234/snapshots/snapshots/na-1-big-Index.db",
+        "/testroot/some/path/tests/Keyspace/Table-34234234234234234234234234234234/backups/na-1-big-Index.db",
+        "/testroot/tests/Keyspace/Table-34234234234234234234234234234234/na-1-big-Index.db",
+        "/Keyspace/Table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/Keyspace/Table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/Keyspace/Table-34234234234234234234234234234234/snapshots/snapshots/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/Keyspace/Table-34234234234234234234234234234234/backups/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/tests/Keyspace/Table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/Keyspace/Table-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db"
         };
 
         testKeyspaceTableParsing(outsideOfCassandraUppercaseKeyspaceAndTable, "Keyspace", "Table");
 
         String[] outsideOfCassandraIndexes = new String[]{
-        "/tmp/some/path/tests/keyspace/table-32423423423423/.index/na-1-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-32423423423423/snapshots/snapshots/.index/na-1-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-32423423423423/backups/.index/na-1-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-32423423423423/.index/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-32423423423423/snapshots/snapshots/.index/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
-        "/tmp/some/path/tests/keyspace/table-32423423423423/backups/.index/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db"
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/.index/na-1-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/snapshots/snapshots/.index/na-1-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/backups/.index/na-1-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/.index/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/snapshots/snapshots/.index/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/testroot/some/path/tests/keyspace/table-34234234234234234234234234234234/backups/.index/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db"
         };
 
         testKeyspaceTableParsing(outsideOfCassandraIndexes, "keyspace", "table.index");

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -752,7 +752,7 @@ public class SSTableReaderTest
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD);
         SSTableReader sstable = getNewSSTable(cfs);
-        Descriptor notLiveDesc = new Descriptor(new File("/tmp"), "", "", SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
+        Descriptor notLiveDesc = new Descriptor(new File("/testdir"), "", "", SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
         SSTableReader.moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
     }
 
@@ -762,7 +762,7 @@ public class SSTableReaderTest
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD);
         SSTableReader sstable = getNewSSTable(cfs);
-        Descriptor notLiveDesc = new Descriptor(new File("/tmp"), "", "", SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
+        Descriptor notLiveDesc = new Descriptor(new File("/testdir"), "", "", SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
         SSTableReader.moveAndOpenSSTable(cfs, notLiveDesc, sstable.descriptor, sstable.components, false);
     }
 

--- a/test/unit/org/apache/cassandra/io/util/FileUtilsTest.java
+++ b/test/unit/org/apache/cassandra/io/util/FileUtilsTest.java
@@ -122,11 +122,11 @@ public class FileUtilsTest
     @Test
     public void testIsContained()
     {
-        assertTrue(FileUtils.isContained(new File("/tmp/abc"), new File("/tmp/abc")));
-        assertFalse(FileUtils.isContained(new File("/tmp/abc"), new File("/tmp/abcd")));
-        assertTrue(FileUtils.isContained(new File("/tmp/abc"), new File("/tmp/abc/d")));
-        assertTrue(FileUtils.isContained(new File("/tmp/abc/../abc"), new File("/tmp/abc/d")));
-        assertFalse(FileUtils.isContained(new File("/tmp/abc/../abc"), new File("/tmp/abcc")));
+        assertTrue(FileUtils.isContained(new File("/testroot/abc"), new File("/testroot/abc")));
+        assertFalse(FileUtils.isContained(new File("/testroot/abc"), new File("/testroot/abcd")));
+        assertTrue(FileUtils.isContained(new File("/testroot/abc"), new File("/testroot/abc/d")));
+        assertTrue(FileUtils.isContained(new File("/testroot/abc/../abc"), new File("/testroot/abc/d")));
+        assertFalse(FileUtils.isContained(new File("/testroot/abc/../abc"), new File("/testroot/abcc")));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/StartupChecksTest.java
+++ b/test/unit/org/apache/cassandra/service/StartupChecksTest.java
@@ -146,7 +146,7 @@ public class StartupChecksTest
         Path dirWithoutNumbers = StartupChecks.getReadAheadKBPath("/dev/sca");
         Assert.assertEquals(Paths.get("/sys/block/sca/queue/read_ahead_kb"), dirWithoutNumbers);
 
-        Path invalidDir = StartupChecks.getReadAheadKBPath("/tmp/xpto");
+        Path invalidDir = StartupChecks.getReadAheadKBPath("/invaliddir/xpto");
         Assert.assertNull(invalidDir);
     }
 


### PR DESCRIPTION
Modify unit tests so that any files created are rooted in the directory specified by the "tmp.dir" Ant property. Ant already passes the value of tmp.dir to the JVM's java.io.tmpdir parameter, so the primary changes are to make use of Files.createTempDirectory to generate per-test work directories. Also update the test checkstyle rules to catch any future usage of hardcoded "/tmp".

Patch by Derek Chen-Becker; reviewed by Brandon Williams for CASSANDRA-18750