### PR TITLE
CASSANDRA-18756

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -79,13 +79,10 @@ public class CompactionController implements AutoCloseable
              cfs.getCompactionStrategyManager().getCompactionParams().tombstoneOption());
     }
 
-    /**
-     * Make sure all parameters are properly initialized
-     *
-     * Do not call ignoreOverlaps() in constructor
-     */
     public CompactionController(ColumnFamilyStore cfs, Set<SSTableReader> compacting, int gcBefore, RateLimiter limiter, TombstoneOption tombstoneOption)
     {
+        //When making changes to the method, be aware that some of the state of the controller may still be uninitialized
+        //(e.g. TWCS sets up the value of ignoreOverlaps() after this completes)
         assert cfs != null;
         this.cfs = cfs;
         this.gcBefore = gcBefore;

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -81,11 +81,8 @@ public class CompactionController implements AutoCloseable
 
     /**
      * Make sure all parameters are properly initialized
-     * @param cfs
-     * @param compacting
-     * @param gcBefore
-     * @param limiter
-     * @param tombstoneOption
+     *
+     * Do not call ignoreOverlaps() in constructor
      */
     public CompactionController(ColumnFamilyStore cfs, Set<SSTableReader> compacting, int gcBefore, RateLimiter limiter, TombstoneOption tombstoneOption)
     {

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -79,6 +79,14 @@ public class CompactionController implements AutoCloseable
              cfs.getCompactionStrategyManager().getCompactionParams().tombstoneOption());
     }
 
+    /**
+     * Make sure all parameters are properly initialized
+     * @param cfs
+     * @param compacting
+     * @param gcBefore
+     * @param limiter
+     * @param tombstoneOption
+     */
     public CompactionController(ColumnFamilyStore cfs, Set<SSTableReader> compacting, int gcBefore, RateLimiter limiter, TombstoneOption tombstoneOption)
     {
         assert cfs != null;
@@ -351,6 +359,8 @@ public class CompactionController implements AutoCloseable
      * of this time range is fully expired before considering to drop the sstable.
      * This strategy can retain for a long time a lot of sstables on disk (see CASSANDRA-13418) so this option
      * control whether or not this check should be ignored.
+     *
+     * Do NOT call this method in the CompactionController constructor
      *
      * @return false by default
      */

--- a/src/java/org/apache/cassandra/db/compaction/CompactionController.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionController.java
@@ -105,12 +105,6 @@ public class CompactionController implements AutoCloseable
             return;
         }
 
-        if (ignoreOverlaps())
-        {
-            logger.debug("not refreshing overlaps - running with ignoreOverlaps activated");
-            return;
-        }
-
         for (SSTableReader reader : overlappingSSTables)
         {
             if (reader.isMarkedCompacted())
@@ -129,7 +123,7 @@ public class CompactionController implements AutoCloseable
         if (this.overlappingSSTables != null)
             close();
 
-        if (compacting == null || ignoreOverlaps())
+        if (compacting == null)
             overlappingSSTables = Refs.tryRef(Collections.<SSTableReader>emptyList());
         else
             overlappingSSTables = cfs.getAndReferenceOverlappingLiveSSTables(compacting);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -68,7 +68,6 @@ public class CompactionControllerTest extends SchemaLoader
     private static CountDownLatch createCompactionControllerLatch = new CountDownLatch(1);
     private static CountDownLatch compaction1RefreshLatch = new CountDownLatch(1);
     private static CountDownLatch refreshCheckLatch = new CountDownLatch(1);
-    private static CountDownLatch compaction1FinishLatch = new CountDownLatch(1);
     private static int overlapRefreshCounter = 0;
 
     @BeforeClass
@@ -234,7 +233,6 @@ public class CompactionControllerTest extends SchemaLoader
         createCompactionControllerLatch = new CountDownLatch(1);
         compaction1RefreshLatch = new CountDownLatch(1);
         refreshCheckLatch = new CountDownLatch(1);
-        compaction1FinishLatch = new CountDownLatch(1);
         testOverlapIterator(false);
     }
 
@@ -283,7 +281,6 @@ public class CompactionControllerTest extends SchemaLoader
         //this compaction will be paused by the BMRule
         Thread t = new Thread(() -> {
             task.run();
-            compaction1FinishLatch.countDown();
         });
 
         //start a compaction for the second sstable (compaction2)
@@ -319,7 +316,7 @@ public class CompactionControllerTest extends SchemaLoader
         assertEquals(2, overlapRefreshCounter);
 
         refreshCheckLatch.countDown();
-        compaction1FinishLatch.await();
+        t.join();
     }
 
     private void applyMutation(CFMetaData cfm, DecoratedKey key, long timestamp)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -19,12 +19,19 @@
 package org.apache.cassandra.db.compaction;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
@@ -41,17 +48,28 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
+@RunWith(BMUnitRunner.class)
 public class CompactionControllerTest extends SchemaLoader
 {
     private static final String KEYSPACE = "CompactionControllerTest";
     private static final String CF1 = "Standard1";
     private static final String CF2 = "Standard2";
+    private static final int TTL_SECONDS = 10;
+    private static final CountDownLatch latch = new CountDownLatch(1);
+    private static final CountDownLatch latch2 = new CountDownLatch(1);
+    private static final CountDownLatch latch3 = new CountDownLatch(1);
+    private static final CountDownLatch latch4 = new CountDownLatch(1);
+    private static final CountDownLatch latch5 = new CountDownLatch(1);
+    private static int overlapRefreshCounter = 0;
 
     @BeforeClass
     public static void defineSchema() throws ConfigurationException
@@ -184,6 +202,114 @@ public class CompactionControllerTest extends SchemaLoader
         assertEquals(1, expired.size());
     }
 
+    @Test
+    @BMRules(rules = {
+    @BMRule(name = "Pause compaction",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "AT LINE 165",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.latch2.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.latch);"),
+    @BMRule(name = "Check overlaps",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "AT LINE 222",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.latch3.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.latch4);"),
+    @BMRule(name = "Increment overlap refresh counter",
+    targetClass = "ColumnFamilyStore",
+    targetMethod = "getAndReferenceOverlappingLiveSSTables",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.incrementOverlapRefreshCounter();")
+    })
+    public void testOverlapIterator() throws Exception
+    {
+
+        Keyspace keyspace = Keyspace.open(KEYSPACE);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF1);
+        cfs.truncateBlocking();
+        cfs.disableAutoCompaction();
+
+        //create 2 overlapping sstables
+        DecoratedKey key = Util.dk("k1");
+        long timestamp1 = FBUtilities.timestampMicros();
+        long timestamp2 = timestamp1 - 5;
+        applyMutation(cfs.metadata, key, timestamp1);
+        cfs.forceBlockingFlush();
+        assertEquals(cfs.getLiveSSTables().size(), 1);
+        Set<SSTableReader> sstables = cfs.getLiveSSTables();
+
+        applyMutation(cfs.metadata, key, timestamp2);
+        cfs.forceBlockingFlush();
+        assertEquals(cfs.getLiveSSTables().size(), 2);
+        String sstable2 = cfs.getLiveSSTables().iterator().next().getFilename();
+
+        System.setProperty(TimeWindowCompactionStrategyOptions.UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_PROPERTY, "true");
+        Map<String, String> options = new HashMap<>();
+        options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_SIZE_KEY, "30");
+        options.put(TimeWindowCompactionStrategyOptions.COMPACTION_WINDOW_UNIT_KEY, "SECONDS");
+        options.put(TimeWindowCompactionStrategyOptions.TIMESTAMP_RESOLUTION_KEY, "MILLISECONDS");
+        options.put(TimeWindowCompactionStrategyOptions.EXPIRED_SSTABLE_CHECK_FREQUENCY_SECONDS_KEY, "0");
+        options.put(TimeWindowCompactionStrategyOptions.UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_KEY, "true");
+        TimeWindowCompactionStrategy twcs = new TimeWindowCompactionStrategy(cfs, options);
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            twcs.addSSTable(sstable);
+
+        twcs.startup();
+
+        CompactionTask task = (CompactionTask)twcs.getUserDefinedTask(sstables, 0);
+
+        assertNotNull(task);
+        assertEquals(1, Iterables.size(task.transaction.originals()));
+
+        //start a compaction for the first sstable (compaction1)
+        //the overlap iterator should contain sstable2
+        //this compaction will be paused by the BMRule
+        Thread t = new Thread(() -> {
+            task.run();
+            latch5.countDown();
+        });
+
+        //start a compaction for the second sstable (compaction2)
+        //the overlap iterator should contain sstable1
+        //this compaction should complete as normal
+        Thread t2 = new Thread(() -> {
+            Uninterruptibles.awaitUninterruptibly(latch2);
+            assertEquals(1, overlapRefreshCounter);
+            CompactionManager.instance.forceUserDefinedCompaction(sstable2);
+
+            //after compaction2 is finished, wait 1 minute and then resume compaction1 (this gives enough time for the overlapIterator to be refreshed)
+            //after resuming, the overlap iterator for compaction1 should be updated to include the new sstable created by compaction2,
+            //and it should not contain sstable2
+            try
+            {
+                TimeUnit.MINUTES.sleep(1);
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+            latch.countDown();
+        });
+
+        t.setName("compaction1");
+        t.start();
+        t2.start();
+
+        latch3.await();
+        //at this point, the overlap iterator for compaction1 should be refreshed
+
+        //verify that the overlap iterator for compaction1 is refreshed twice, (once during the constructor, and again after compaction2 finishes)
+        assertEquals(2, overlapRefreshCounter);
+
+        latch4.countDown();
+        latch5.await();
+    }
+
     private void applyMutation(CFMetaData cfm, DecoratedKey key, long timestamp)
     {
         ByteBuffer val = ByteBufferUtil.bytes(1L);
@@ -205,5 +331,10 @@ public class CompactionControllerTest extends SchemaLoader
     {
         assertFalse(evaluator.test(boundary));
         assertTrue(evaluator.test(boundary - 1));
+    }
+
+    public static void incrementOverlapRefreshCounter()
+    {
+        overlapRefreshCounter++;
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -206,7 +206,7 @@ public class CompactionControllerTest extends SchemaLoader
     @BMRule(name = "Pause compaction",
     targetClass = "CompactionTask",
     targetMethod = "runMayThrow",
-    targetLocation = "AFTER INVOKE getCompactionController",
+    targetLocation = "INVOKE getCompactionAwareWriter",
     condition = "Thread.currentThread().getName().equals(\"compaction1\")",
     action = "org.apache.cassandra.db.compaction.CompactionControllerTest.createCompactionControllerLatch.countDown();" +
              "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
@@ -280,7 +280,7 @@ public class CompactionControllerTest extends SchemaLoader
         //the overlap iterator should contain sstable2
         //this compaction will be paused by the BMRule
         Thread t = new Thread(() -> {
-            task.run();
+            task.execute(null);
         });
 
         //start a compaction for the second sstable (compaction2)


### PR DESCRIPTION
TimeWindowCompactionStrategy with unsafe_aggressive_sstable_expiration keeps overlaping SSTable references.

To avoid data resurrection, the Overlap Iterator owned by `CompactionController` should be updated regardless if `unsafe_aggressive_sstable_expiration` is set.

patch by @ethan-brown2022; reviewed by @blambov for CASSANDRA-18756

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-18756)

