### PR TITLE
CASSANDRA-18801 Fixed the link to non-existing cleaner Runnable

### DIFF
--- a/src/java/org/apache/cassandra/utils/memory/MemtableCleanerThread.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtableCleanerThread.java
@@ -35,7 +35,7 @@ import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFac
 
 /**
  * A thread that reclaims memory from a MemtablePool on demand.  The actual reclaiming work is delegated to the
- * cleaner Runnable, e.g., FlushLargestColumnFamily
+ * cleaner Runnable, e.g., MemtableCleaner {@link AbstractAllocatorMemtable#flushLargestMemtable()}.
  */
 public class MemtableCleanerThread<P extends MemtablePool> implements Interruptible
 {


### PR DESCRIPTION
An update to `MemtableCleanerThread` documentation, following Ling Mao's improvement suggestion (in ticket).

patch by Maxim Chanturiay; reviewed by _to_be_filled_by_reviewer_ for CASSANDRA-18801

Co-authored-by: Ling Mao

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

