### PR TITLE
CASSANDRA-18838: make stop-server shell out of the box

### DIFF
--- a/bin/stop-server
+++ b/bin/stop-server
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,18 +16,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+show_help() {
+    echo "Usage: $0 [-p <pidfile>] | [-l] | [-e] | [-h]"
+    echo "  -p <pidfile>    Stop the process using the specified pidfile"
+    echo "  -l              Stop the process with the name like 'cassandra'"
+    echo "  -e              Stop the process with the name equal 'CassandraDaemon'"
+    echo "  -h              Show the help message"
+}
 
-echo "please read the stop-server script before use"
+if [ $# -eq 0 ]; then
+    echo "please read the stop-server script before use. use -h for help and usage."
+    exit 1
+fi
 
-# if you are using the cassandra start script with -p, this
-# is the best way to stop:
+case "$1" in
+    -p)
+        if [ -z "$2" ]; then
+            echo "Missing pidfile argument after -p."
+            exit 1
+        fi
+        # if you are using the cassandra start script with -p, this
+        # is the best way to stop:
+        kill "$(cat "$2")"
+        ;;
+    -l)
+        # you can run something like this, but
+        # this is a shotgun approach and will kill other processes
+        # with cassandra in their name or arguments too:
+        user=$(whoami)
+        pgrep -u "$user" -f cassandra | xargs kill -9
+        ;;
+    -e)
+        pids=$(ps ax | grep -i 'org.apache.cassandra.service.CassandraDaemon' | grep java | grep -v grep | awk '{print $1}')
 
-# kill `cat <pidfile>` 
+        if [ -n "$pids" ]; then
+            echo "Killing CassandraDaemon process..."
+            echo "$pids" | xargs kill -9
+            echo "CassandraDaemon process killed."
+        else
+            echo "CassandraDaemon process not found."
+        fi
+        ;;
+    -h)
+        show_help
+        exit 0
+        ;;
+    *)
+        echo "Invalid argument. Please use -h for help and usage."
+        exit 1
+        ;;
+esac
 
-
-# otherwise, you can run something like this, but
-# this is a shotgun approach and will kill other processes
-# with cassandra in their name or arguments too:
-
-# user=`whoami`
-# pgrep -u $user -f cassandra | xargs kill -9
+exit 0


### PR DESCRIPTION
- Making `stop-server` shell out of the box. The original shell needs users to uncomment the snippet to work for them, which's not user-friendly.
- The original shotgun approach is also not suitable for the scenario when we have cassandra sidecar process which also has the naming keyword: cassandra. By using the new added `./stop-server -e`, we can kill the `CassandraDaemon` exactly.
- Tested by `MacOS 12.1` and `Linux version 5.10.124`
- more details in the [CASSANDRA-18838](https://issues.apache.org/jira/browse/CASSANDRA-18838)