### PR TITLE
CASSANDRA-18844: Fix Debian packaging forcing users to use OpenJDK

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: extra
 Maintainer: Eric Evans <eevans@apache.org>
 Uploaders: Sylvain Lebresne <slebresne@apache.org>
-Build-Depends: debhelper (>= 11), java11-jdk | openjdk-11-jdk-headless | java17-jdk | openjdk-17-jdk-headless, ant (>= 1.10), ant-optional (>= 1.10), dh-python, python3-dev (>= 3.6), quilt, bash-completion
+Build-Depends: debhelper (>= 11), java11-sdk | openjdk-11-jdk-headless | java17-sdk | openjdk-17-jdk-headless, ant (>= 1.10), ant-optional (>= 1.10), dh-python, python3-dev (>= 3.6), quilt, bash-completion
 Homepage: https://cassandra.apache.org
 Vcs-Git: https://gitbox.apache.org/repos/asf/cassandra.git
 Vcs-Browser: https://gitbox.apache.org/repos/asf?p=cassandra.git

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: extra
 Maintainer: Eric Evans <eevans@apache.org>
 Uploaders: Sylvain Lebresne <slebresne@apache.org>
-Build-Depends: debhelper (>= 11), java11-runtime | openjdk-11-jdk-headless | java17-runtime | openjdk-17-jdk-headless, ant (>= 1.10), ant-optional (>= 1.10), dh-python, python3-dev (>= 3.6), quilt, bash-completion
+Build-Depends: debhelper (>= 11), java11-jdk | openjdk-11-jdk-headless | java17-jdk | openjdk-17-jdk-headless, ant (>= 1.10), ant-optional (>= 1.10), dh-python, python3-dev (>= 3.6), quilt, bash-completion
 Homepage: https://cassandra.apache.org
 Vcs-Git: https://gitbox.apache.org/repos/asf/cassandra.git
 Vcs-Browser: https://gitbox.apache.org/repos/asf?p=cassandra.git

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: extra
 Maintainer: Eric Evans <eevans@apache.org>
 Uploaders: Sylvain Lebresne <slebresne@apache.org>
-Build-Depends: debhelper (>= 11), openjdk-11-jdk | openjdk-11-jdk-headless | openjdk-17-jdk | openjdk-17-jdk-headless, ant (>= 1.10), ant-optional (>= 1.10), dh-python, python3-dev (>= 3.6), quilt, bash-completion
+Build-Depends: debhelper (>= 11), java11-runtime | openjdk-11-jdk-headless | java17-runtime | openjdk-17-jdk-headless, ant (>= 1.10), ant-optional (>= 1.10), dh-python, python3-dev (>= 3.6), quilt, bash-completion
 Homepage: https://cassandra.apache.org
 Vcs-Git: https://gitbox.apache.org/repos/asf/cassandra.git
 Vcs-Browser: https://gitbox.apache.org/repos/asf?p=cassandra.git
@@ -11,7 +11,7 @@ Standards-Version: 3.8.3
 
 Package: cassandra
 Architecture: all
-Depends: openjdk-11-jre-headless | openjdk-17-jre-headless | openjdk-11-jre | openjdk-17-jre, adduser, python3 (>= 3.6), procps, ${misc:Depends}
+Depends: openjdk-11-jre-headless | openjdk-17-jre-headless | java11-runtime | java17-runtime, adduser, python3 (>= 3.6), procps, ${misc:Depends}
 Recommends: ntp | time-daemon
 Suggests: cassandra-tools
 Conflicts: apache-cassandra1


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CASSANDRA-18844

Instead of using OpenJDK as a dependency, use the virtual packages such as java11-runtime / java17-runtime

eg https://www.linuxtopia.org/online_books/linux_system_administration/debian_linux_guides/debian_linux_faq/ch-pkg_basics.en_007.html

Note for reviewer -  I've been able to test installation of a JDK 11 version of Cassandra but not JDK 17, I've checked the virtual package and it should work. Will try it later tonight my time and see if it works

```
root@2b3021cccbb0:/# apt-cache showpkg java17-runtime
Package: java17-runtime
Versions:

Reverse Depends:
Dependencies:
Provides:
Reverse Provides:
openjdk-17-jre 17.0.7+7-1~deb11u1 (= )
openjdk-17-jre 17.0.6+10-1~deb11u1 (= )