### PR TITLE
CASSANDRA-18841 - Fix InstanceClassloader leak

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -810,7 +810,9 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
     @Override
     public void postStartup()
     {
-        StorageService.instance.doAuthSetup(false);
+        sync(() ->
+            StorageService.instance.doAuthSetup(false)
+        ).run();
     }
 
     private void mkdirs()


### PR DESCRIPTION
By running the `postStartup` logic in a `sync` block, we ensure that any ThreadLocal instances are created on the appropriate, instance-isolated thread. In this case, ThreadLocal objects were holding references to the InstanceClassLoader which created the ThreadLocal's value, thereby preventing the classloader from being collected.