### PR TITLE
CASSANDRA-18742 5.0 - removal of deprecated sstable_compression and chunk_length_kb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -75,12 +75,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -111,10 +111,10 @@ jobs:
   j17_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -182,12 +182,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -246,12 +246,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -281,10 +281,10 @@ jobs:
   j17_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -354,12 +354,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -392,7 +392,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -443,12 +443,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -481,7 +481,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -532,12 +532,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -597,12 +597,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -633,10 +633,10 @@ jobs:
   j17_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -706,12 +706,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -744,7 +744,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -823,12 +823,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -858,10 +858,10 @@ jobs:
   j17_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -931,12 +931,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -966,10 +966,10 @@ jobs:
   j17_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1085,12 +1085,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1120,10 +1120,10 @@ jobs:
   j17_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1217,12 +1217,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1252,10 +1252,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1349,12 +1349,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1388,7 +1388,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1467,12 +1467,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1503,10 +1503,10 @@ jobs:
   j17_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1576,12 +1576,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1614,7 +1614,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1665,12 +1665,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1704,7 +1704,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1783,12 +1783,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1821,7 +1821,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1872,12 +1872,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1907,10 +1907,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1980,12 +1980,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2016,10 +2016,10 @@ jobs:
   j17_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2113,12 +2113,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2148,10 +2148,10 @@ jobs:
   j17_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2267,12 +2267,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2305,7 +2305,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2384,12 +2384,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2420,10 +2420,10 @@ jobs:
   j17_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2493,12 +2493,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2528,10 +2528,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2601,12 +2601,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2640,7 +2640,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2691,12 +2691,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2729,7 +2729,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2780,12 +2780,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2819,7 +2819,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2898,12 +2898,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2936,7 +2936,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3093,12 +3093,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3129,7 +3129,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3178,12 +3178,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3214,10 +3214,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3311,12 +3311,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3350,7 +3350,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3429,12 +3429,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3464,10 +3464,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3537,12 +3537,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3573,7 +3573,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3622,12 +3622,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3661,7 +3661,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3712,12 +3712,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3751,7 +3751,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3830,12 +3830,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3866,10 +3866,10 @@ jobs:
   j11_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3963,12 +3963,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4002,7 +4002,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4081,12 +4081,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4119,7 +4119,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4276,12 +4276,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4311,10 +4311,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4384,12 +4384,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4491,12 +4491,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4529,7 +4529,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4608,12 +4608,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4647,7 +4647,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4698,12 +4698,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4769,12 +4769,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4805,10 +4805,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4902,12 +4902,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4941,7 +4941,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5020,12 +5020,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5124,12 +5124,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5196,12 +5196,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5235,7 +5235,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5286,12 +5286,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5399,12 +5399,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5438,7 +5438,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5517,12 +5517,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5589,12 +5589,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5628,7 +5628,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5679,12 +5679,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5715,10 +5715,10 @@ jobs:
   j17_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5786,12 +5786,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5821,10 +5821,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5918,12 +5918,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5957,7 +5957,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6036,12 +6036,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6075,7 +6075,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6126,12 +6126,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6161,10 +6161,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6234,12 +6234,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6270,10 +6270,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6343,12 +6343,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6382,7 +6382,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6461,12 +6461,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6497,10 +6497,10 @@ jobs:
   j11_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6546,12 +6546,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6582,10 +6582,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6679,12 +6679,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6718,7 +6718,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6769,12 +6769,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6804,10 +6804,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6877,12 +6877,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6949,12 +6949,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6984,7 +6984,7 @@ jobs:
   j17_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -7033,12 +7033,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7068,10 +7068,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7117,12 +7117,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7153,10 +7153,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7226,12 +7226,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7265,7 +7265,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7316,12 +7316,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7355,7 +7355,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7406,12 +7406,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7445,7 +7445,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7496,12 +7496,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7532,10 +7532,10 @@ jobs:
   j17_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7605,12 +7605,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7668,12 +7668,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7703,10 +7703,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7776,12 +7776,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7815,7 +7815,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7894,12 +7894,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7929,10 +7929,10 @@ jobs:
   j17_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8002,12 +8002,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8037,10 +8037,10 @@ jobs:
   j17_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8110,12 +8110,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8148,7 +8148,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8227,12 +8227,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8299,12 +8299,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8337,7 +8337,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8388,12 +8388,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8495,12 +8495,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8534,7 +8534,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8585,12 +8585,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8649,12 +8649,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8685,10 +8685,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8734,12 +8734,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8773,7 +8773,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8852,12 +8852,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8887,10 +8887,10 @@ jobs:
   j17_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8960,12 +8960,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8998,7 +8998,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9077,12 +9077,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9115,7 +9115,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9166,12 +9166,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9201,7 +9201,7 @@ jobs:
   j17_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -9250,12 +9250,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9288,7 +9288,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9339,12 +9339,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9411,12 +9411,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9449,7 +9449,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9500,12 +9500,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9535,10 +9535,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9584,12 +9584,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9623,7 +9623,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9674,12 +9674,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9709,10 +9709,10 @@ jobs:
   j17_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9780,12 +9780,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9815,10 +9815,10 @@ jobs:
   j17_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9912,12 +9912,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9950,7 +9950,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10001,12 +10001,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10039,7 +10039,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10090,12 +10090,12 @@ jobs:
     - CASS_DRIVER_NO_EXTENSIONS: true
     - CASS_DRIVER_NO_CYTHON: true
     - CASSANDRA_SKIP_SYNC: true
-    - DTEST_REPO: https://github.com/apache/cassandra-dtest.git
-    - DTEST_BRANCH: trunk
+    - DTEST_REPO: https://github.com/smiklosovic/cassandra-dtest.git
+    - DTEST_BRANCH: CASSANDRA-18742
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.compress.CQLCompressionTest,org.apache.cassandra.db.guardrails.GuardrailAllowUncompressedTablesTest,org.apache.cassandra.cql3.validation.operations.CreateTest,org.apache.cassandra.cql3.validation.operations.AlterTest,org.apache.cassandra.cql3.validation.miscellaneous.CrcCheckChanceTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10137,6 +10137,12 @@ workflows:
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
+        - j11_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
         - j11_build
     - start_j11_jvm_dtests:
         type: approval
@@ -10198,17 +10204,35 @@ workflows:
         requires:
         - start_j17_unit_tests
         - j11_build
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j11_build
     - start_j11_utests_oa:
         type: approval
     - j11_utests_oa:
         requires:
         - start_j11_utests_oa
         - j11_build
+    - start_j11_utests_oa_repeat:
+        type: approval
+    - j11_utests_oa_repeat:
+        requires:
+        - start_j11_utests_oa_repeat
+        - j11_build
     - start_j17_utests_oa:
         type: approval
     - j17_utests_oa:
         requires:
         - start_j17_utests_oa
+        - j11_build
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
         - j11_build
     - start_j11_utests_long:
         type: approval
@@ -10234,6 +10258,18 @@ workflows:
         requires:
         - start_j17_utests_cdc
         - j11_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j11_build
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
@@ -10246,6 +10282,18 @@ workflows:
         requires:
         - start_j17_utests_compression
         - j11_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j11_build
     - start_j11_utests_trie:
         type: approval
     - j11_utests_trie:
@@ -10257,6 +10305,18 @@ workflows:
     - j17_utests_trie:
         requires:
         - start_j17_utests_trie
+        - j11_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
+        - j11_build
+    - start_j17_utests_trie_repeat:
+        type: approval
+    - j17_utests_trie_repeat:
+        requires:
+        - start_j17_utests_trie_repeat
         - j11_build
     - start_j11_utests_stress:
         type: approval
@@ -10293,6 +10353,18 @@ workflows:
     - j17_utests_system_keyspace_directory:
         requires:
         - start_j17_utests_system_keyspace_directory
+        - j11_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
         - j11_build
     - start_j11_dtest_jars_build:
         type: approval
@@ -10465,6 +10537,15 @@ workflows:
     - j11_utests_oa:
         requires:
         - j11_build
+    - j11_utests_oa_repeat:
+        requires:
+        - j11_build
+    - j17_utests_oa_repeat:
+        requires:
+        - j11_build
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
     - j11_simulator_dtests:
         requires:
         - j11_build
@@ -10498,6 +10579,9 @@ workflows:
     - j17_utests_oa:
         requires:
         - j11_build
+    - j17_unit_tests_repeat:
+        requires:
+        - j11_build
     - start_utests_long:
         type: approval
     - j11_utests_long:
@@ -10518,6 +10602,14 @@ workflows:
         requires:
         - start_utests_cdc
         - j11_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
@@ -10528,6 +10620,14 @@ workflows:
         requires:
         - start_utests_compression
         - j11_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
     - start_utests_trie:
         type: approval
     - j11_utests_trie:
@@ -10535,6 +10635,14 @@ workflows:
         - start_utests_trie
         - j11_build
     - j17_utests_trie:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j11_utests_trie_repeat:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j17_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j11_build
@@ -10564,6 +10672,13 @@ workflows:
         requires:
         - j11_build
     - j17_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - j11_build
+    - j17_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
@@ -10703,6 +10818,12 @@ workflows:
         requires:
         - start_j17_unit_tests
         - j17_build
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j17_build
     - start_j17_jvm_dtests:
         type: approval
     - j17_jvm_dtests:
@@ -10803,6 +10924,12 @@ workflows:
         requires:
         - start_j17_utests_oa
         - j17_build
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
+        - j17_build
     - start_j17_utests_long:
         type: approval
     - j17_utests_long:
@@ -10815,17 +10942,35 @@ workflows:
         requires:
         - start_j17_utests_cdc
         - j17_build
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j17_build
     - start_j17_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_j17_utests_compression
         - j17_build
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j17_build
     - start_j17_utests_trie:
         type: approval
     - j17_utests_trie:
         requires:
         - start_j17_utests_trie
+        - j17_build
+    - start_j17_utests_trie_repeat:
+        type: approval
+    - j17_utests_trie_repeat:
+        requires:
+        - start_j17_utests_trie_repeat
         - j17_build
     - start_j17_utests_stress:
         type: approval
@@ -10845,6 +10990,12 @@ workflows:
         requires:
         - start_j17_utests_system_keyspace_directory
         - j17_build
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
+        - j17_build
   java17_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10856,6 +11007,12 @@ workflows:
         requires:
         - j17_build
     - j17_utests_oa:
+        requires:
+        - j17_build
+    - j17_utests_oa_repeat:
+        requires:
+        - j17_build
+    - j17_unit_tests_repeat:
         requires:
         - j17_build
     - j17_jvm_dtests:
@@ -10936,15 +11093,27 @@ workflows:
         requires:
         - start_utests_cdc
         - j17_build
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j17_build
     - start_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_utests_compression
         - j17_build
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j17_build
     - start_utests_trie:
         type: approval
     - j17_utests_trie:
+        requires:
+        - start_utests_trie
+        - j17_build
+    - j17_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j17_build
@@ -10963,6 +11132,10 @@ workflows:
     - start_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j17_build
+    - j17_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j17_build

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -66,7 +66,7 @@ class Cql3ParsingRuleSet(CqlParsingRuleSet):
             ('class', 'max_threshold', 'tombstone_compaction_interval', 'tombstone_threshold', 'enabled',
              'unchecked_tombstone_compaction', 'only_purge_repaired_tombstones', 'provide_overlapping_tombstones')),
         ('compression', 'compression_parameters',
-            ('sstable_compression', 'chunk_length_kb', 'crc_check_chance')),
+            ('class', 'chunk_length_in_kb', 'enabled', 'min_compress_ratio', 'max_compressed_length')),
         ('caching', None,
             ('rows_per_partition', 'keys')),
     )
@@ -500,7 +500,7 @@ def cf_prop_val_completer(ctxt, cass):
     exist_opts = ctxt.get_binding('propname')
     this_opt = exist_opts[-1]
     if this_opt == 'compression':
-        return ["{'sstable_compression': '"]
+        return ["{'class': '"]
     if this_opt == 'compaction':
         return ["{'class': '"]
     if this_opt == 'caching':
@@ -565,7 +565,7 @@ def cf_prop_val_mapval_completer(ctxt, cass):
             return [Hint('<NONE|ROW|CELL>')]
         return [Hint('<option_value>')]
     elif opt == 'compression':
-        if key == 'sstable_compression':
+        if key == 'class':
             return list(map(escape_value, CqlRuleSet.available_compression_classes))
         return [Hint('<option_value>')]
     elif opt == 'caching':

--- a/pylib/cqlshlib/test/test_keyspace_init.cql
+++ b/pylib/cqlshlib/test/test_keyspace_init.cql
@@ -34,7 +34,7 @@ CREATE TABLE has_all_types (
     uuidcol uuid,
     varcharcol varchar,
     varintcol varint
-) WITH compression = {'sstable_compression':'LZ4Compressor'};
+) WITH compression = {'class':'LZ4Compressor'};
 
 INSERT INTO has_all_types (num, intcol, asciicol, bigintcol, blobcol, booleancol,
                            decimalcol, doublecol, durationcol, floatcol, smallintcol, textcol,

--- a/test/distributed/org/apache/cassandra/distributed/util/PyDtest.java
+++ b/test/distributed/org/apache/cassandra/distributed/util/PyDtest.java
@@ -160,7 +160,7 @@ public class PyDtest
                 query += String.format(" AND CLUSTERING ORDER BY (%s)", clustering);
 
             if (compression != null)
-                query += String.format(" AND compression = { \'sstable_compression\': \'%sCompressor\' }", compression);
+                query += String.format(" AND compression = { \'class\': \'%sCompressor\' }", compression);
             else
                 query += " AND compression = {}";
 

--- a/test/microbench/org/apache/cassandra/test/microbench/CachingBenchTest.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CachingBenchTest.java
@@ -203,7 +203,7 @@ public class CachingBenchTest extends CQLTester
         DatabaseDescriptor.setFileCacheEnabled(cacheEnabled);
         DatabaseDescriptor.setDiskAccessMode(mode);
         alterTable("ALTER TABLE %s WITH compaction = { 'class' :  '" + compactionClass + "'  };");
-        alterTable("ALTER TABLE %s WITH compression = { 'sstable_compression' : '" + compressorClass + "'  };");
+        alterTable("ALTER TABLE %s WITH compression = { 'class' : '" + compressorClass + "'  };");
         ColumnFamilyStore cfs = getCurrentColumnFamilyStore();
         cfs.disableAutoCompaction();
 

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/CrcCheckChanceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/CrcCheckChanceTest.java
@@ -58,9 +58,9 @@ public class CrcCheckChanceTest extends CQLTester
     {
         //Start with crc_check_chance of 99%
         if (newFormat)
-            createTable("CREATE TABLE %s (p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH compression = {'sstable_compression': 'LZ4Compressor'} AND crc_check_chance = 0.99;");
+            createTable("CREATE TABLE %s (p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH compression = {'class': 'LZ4Compressor'} AND crc_check_chance = 0.99;");
         else
-            createTable("CREATE TABLE %s (p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH compression = {'sstable_compression': 'LZ4Compressor', 'crc_check_chance' : 0.99}");
+            createTable("CREATE TABLE %s (p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH compression = {'class': 'LZ4Compressor', 'crc_check_chance' : 0.99}");
 
         execute("CREATE INDEX foo ON %s(v)");
 
@@ -82,7 +82,7 @@ public class CrcCheckChanceTest extends CQLTester
         if (newFormat)
             alterTable("ALTER TABLE %s WITH crc_check_chance = 0.99");
         else
-            alterTable("ALTER TABLE %s WITH compression = {'sstable_compression': 'LZ4Compressor', 'crc_check_chance': 0.99}");
+            alterTable("ALTER TABLE %s WITH compression = {'class': 'LZ4Compressor', 'crc_check_chance': 0.99}");
 
         assertRows(execute("SELECT * FROM %s WHERE p=?", "p1"),
                    row("p1", "k1", "sv1", "v1"),
@@ -134,7 +134,7 @@ public class CrcCheckChanceTest extends CQLTester
         if (newFormat)
             alterTable("ALTER TABLE %s WITH crc_check_chance = 0.5");
         else
-            alterTable("ALTER TABLE %s WITH compression = {'sstable_compression': 'LZ4Compressor', 'crc_check_chance': 0.5}");
+            alterTable("ALTER TABLE %s WITH compression = {'class': 'LZ4Compressor', 'crc_check_chance': 0.5}");
 
         //We should be able to get the new value by accessing directly the schema metadata
         Assert.assertEquals(0.5, cfs.metadata().params.crcCheckChance, 0.0);
@@ -173,7 +173,7 @@ public class CrcCheckChanceTest extends CQLTester
         CompactionManager.instance.disableAutoCompaction();
 
         //Start with crc_check_chance of 99%
-        createTable("CREATE TABLE %s (p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH compression = {'sstable_compression': 'LZ4Compressor', 'crc_check_chance' : 0.99}");
+        createTable("CREATE TABLE %s (p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH compression = {'class': 'LZ4Compressor', 'crc_check_chance' : 0.99}");
 
         ColumnFamilyStore cfs = Keyspace.open(CQLTester.KEYSPACE).getColumnFamilyStore(currentTable());
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -710,17 +710,10 @@ public class AlterTest extends CQLTester
                                         "The 'class' option must not be empty. To disable compression use 'enabled' : false",
                                         "ALTER TABLE %s WITH  compression = { 'class' : ''};");
 
+
         assertAlterTableThrowsException(ConfigurationException.class,
                                         "If the 'enabled' option is set to false no other options must be specified",
                                         "ALTER TABLE %s WITH compression = { 'enabled' : 'false', 'class' : 'SnappyCompressor'};");
-
-        assertAlterTableThrowsException(ConfigurationException.class,
-                                        "The 'sstable_compression' option must not be used if the compression algorithm is already specified by the 'class' option",
-                                        "ALTER TABLE %s WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'class' : 'SnappyCompressor'};");
-
-        assertAlterTableThrowsException(ConfigurationException.class,
-                                        "The 'chunk_length_kb' option must not be used if the chunk length is already specified by the 'chunk_length_in_kb' option",
-                                        "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_kb' : 32 , 'chunk_length_in_kb' : 32 };");
 
         assertAlterTableThrowsException(ConfigurationException.class,
                                         "Invalid negative min_compress_ratio",

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/CreateTest.java
@@ -681,24 +681,16 @@ public class CreateTest extends CQLTester
         assertSchemaOption("compression", map("chunk_length_in_kb", "32", "class", "org.apache.cassandra.io.compress.SnappyCompressor"));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                + " WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'chunk_length_kb' : 32 };");
-        assertSchemaOption("compression", map("chunk_length_in_kb", "32", "class", "org.apache.cassandra.io.compress.SnappyCompressor"));
-
-        createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                + " WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'min_compress_ratio' : 2 };");
+                + " WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : 2 };");
         assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.SnappyCompressor", "min_compress_ratio", "2.0"));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                    + " WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'min_compress_ratio' : 1 };");
+                    + " WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : 1 };");
         assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.SnappyCompressor", "min_compress_ratio", "1.0"));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                    + " WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'min_compress_ratio' : 0 };");
+                    + " WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : 0 };");
         assertSchemaOption("compression", map("chunk_length_in_kb", "16", "class", "org.apache.cassandra.io.compress.SnappyCompressor"));
-
-        createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                + " WITH compression = { 'sstable_compression' : '', 'chunk_length_kb' : 32 };");
-        assertSchemaOption("compression", map("enabled", "false"));
 
         createTable("CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
                 + " WITH compression = { 'enabled' : 'false'};");
@@ -719,14 +711,6 @@ public class CreateTest extends CQLTester
         assertThrowsConfigurationException("If the 'enabled' option is set to false no other options must be specified",
                                            "CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
                                            + " WITH compression = { 'enabled' : 'false', 'chunk_length_in_kb' : 32};");
-
-        assertThrowsConfigurationException("The 'sstable_compression' option must not be used if the compression algorithm is already specified by the 'class' option",
-                                           "CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                                           + " WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'class' : 'SnappyCompressor'};");
-
-        assertThrowsConfigurationException("The 'chunk_length_kb' option must not be used if the chunk length is already specified by the 'chunk_length_in_kb' option",
-                                           "CREATE TABLE %s (a text, b int, c int, primary key (a, b))"
-                                           + " WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_kb' : 32 , 'chunk_length_in_kb' : 32 };");
 
         assertThrowsConfigurationException("chunk_length_in_kb must be a power of 2",
                                            "CREATE TABLE %s (a text, b int, c int, primary key (a, b))"

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailAllowUncompressedTablesTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailAllowUncompressedTablesTest.java
@@ -39,7 +39,7 @@ public class GuardrailAllowUncompressedTablesTest extends GuardrailTester
     {
         setGuardrail(true);
         String table = createTableName();
-        schemaChange(String.format("CREATE TABLE %s.%s (k int primary key, v int) WITH compression={'sstable_compression':''}", KEYSPACE, table));
+        schemaChange(String.format("CREATE TABLE %s.%s (k int primary key, v int) WITH compression={'enabled':false}", KEYSPACE, table));
         TableMetadata tmd = Schema.instance.getTableMetadata(KEYSPACE, table);
         Assert.assertFalse(tmd.params.compression.isEnabled());
     }
@@ -52,7 +52,7 @@ public class GuardrailAllowUncompressedTablesTest extends GuardrailTester
     {
         setGuardrail(false);
         String table = createTableName();
-        assertFails(String.format("CREATE TABLE %s.%s (k int primary key, v int) WITH compression={'sstable_compression':''}", KEYSPACE, table), "Uncompressed table is not allowed");
+        assertFails(String.format("CREATE TABLE %s.%s (k int primary key, v int) WITH compression={'enabled': false}", KEYSPACE, table), "Uncompressed table is not allowed");
     }
 
     @Test
@@ -61,7 +61,7 @@ public class GuardrailAllowUncompressedTablesTest extends GuardrailTester
         setGuardrail(true);
         String table = createTableName();
         schemaChange(String.format("CREATE TABLE %s.%s (k int primary key, v int)", KEYSPACE, table));
-        schemaChange(String.format("ALTER TABLE %s.%s WITH compression = {'sstable_compression': ''}", KEYSPACE, table));
+        schemaChange(String.format("ALTER TABLE %s.%s WITH compression = {'enabled': false}", KEYSPACE, table));
         TableMetadata tmd = Schema.instance.getTableMetadata(KEYSPACE, table);
         Assert.assertFalse(tmd.params.compression.isEnabled());
     }
@@ -72,6 +72,6 @@ public class GuardrailAllowUncompressedTablesTest extends GuardrailTester
         setGuardrail(false);
         String table = createTableName();
         schemaChange(String.format("CREATE TABLE %s.%s (k int primary key, v int)", KEYSPACE, table));
-        assertFails(String.format("ALTER TABLE %s.%s WITH compression = {'sstable_compression': ''}", KEYSPACE, table), "Uncompressed table is not allowed");
+        assertFails(String.format("ALTER TABLE %s.%s WITH compression = {'enabled': false}", KEYSPACE, table), "Uncompressed table is not allowed");
     }
 }

--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
@@ -106,7 +106,7 @@ public class CQLCompressionTest extends CQLTester
     @Test
     public void lz4FlushTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'LZ4Compressor'};");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'class': 'LZ4Compressor'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as LZ4 "fast"
@@ -131,7 +131,7 @@ public class CQLCompressionTest extends CQLTester
     public void lz4hcFlushTest() throws Throwable
     {
         createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = " +
-                    "{'sstable_compression': 'LZ4Compressor', 'lz4_compressor_type': 'high'};");
+                    "{'class': 'LZ4Compressor', 'lz4_compressor_type': 'high'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as LZ4 "fast" mode
@@ -155,7 +155,7 @@ public class CQLCompressionTest extends CQLTester
     @Test
     public void zstdFlushTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'ZstdCompressor'};");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'class': 'ZstdCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as LZ4
@@ -177,7 +177,7 @@ public class CQLCompressionTest extends CQLTester
     @Test
     public void deflateFlushTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'DeflateCompressor'};");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'class': 'DeflateCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as LZ4
@@ -200,7 +200,7 @@ public class CQLCompressionTest extends CQLTester
     public void useNoCompressorOnFlushTest() throws Throwable
     {
         DatabaseDescriptor.setFlushCompression(Config.FlushCompression.none);
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'LZ4Compressor'};");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'class': 'LZ4Compressor'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as Noop compressor
@@ -224,7 +224,7 @@ public class CQLCompressionTest extends CQLTester
     {
         DatabaseDescriptor.setFlushCompression(Config.FlushCompression.table);
 
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'ZstdCompressor'};");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'class': 'ZstdCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as Zstd
@@ -237,7 +237,7 @@ public class CQLCompressionTest extends CQLTester
     @Test
     public void zstdTableFlushTest() throws Throwable
     {
-        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'sstable_compression': 'ZstdCompressor'};");
+        createTable("CREATE TABLE %s (k text PRIMARY KEY, v text) WITH compression = {'class': 'ZstdCompressor'};");
         ColumnFamilyStore store = flushTwice();
 
         // Should flush as LZ4

--- a/tools/cqlstress-example.yaml
+++ b/tools/cqlstress-example.yaml
@@ -44,7 +44,7 @@ table_definition: |
         PRIMARY KEY((name,choice), date, address, dbl, lval, ival, uid)
   ) 
     WITH compaction = { 'class':'LeveledCompactionStrategy' }
-#    AND compression = { 'sstable_compression' : '' }
+#    AND compression = { 'class' : 'LZ4Compressor' }
 #    AND comment='A table of many types to test wide rows'
 
 #

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
@@ -140,7 +140,7 @@ public class SettingsSchema implements Serializable
         //Compression
         b.append(") WITH compression = {");
         if (compression != null)
-            b.append("'sstable_compression' : '").append(compression).append("'");
+            b.append("'class' : '").append(compression).append("'");
 
         b.append("}");
 
@@ -181,7 +181,7 @@ public class SettingsSchema implements Serializable
         //Compression
         b.append(") WITH compression = {");
         if (compression != null)
-            b.append("'sstable_compression' : '").append(compression).append("'");
+            b.append("'class' : '").append(compression).append("'");
 
         b.append("}");
 


### PR DESCRIPTION
Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

