### PR TITLE
CASSANDRA-18737-5.0: Do not create sstable files before registering in txn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -187,7 +187,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -251,7 +251,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -359,7 +359,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -448,7 +448,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -537,7 +537,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -602,7 +602,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -711,7 +711,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -828,7 +828,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -936,7 +936,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1090,7 +1090,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1222,7 +1222,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1354,7 +1354,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1472,7 +1472,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1581,7 +1581,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1670,7 +1670,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1788,7 +1788,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1877,7 +1877,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1985,7 +1985,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2118,7 +2118,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2272,7 +2272,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2389,7 +2389,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2498,7 +2498,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2606,7 +2606,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2696,7 +2696,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2785,7 +2785,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2903,7 +2903,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3098,7 +3098,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3183,7 +3183,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3316,7 +3316,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3434,7 +3434,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3542,7 +3542,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3627,7 +3627,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3717,7 +3717,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3835,7 +3835,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3968,7 +3968,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4086,7 +4086,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4281,7 +4281,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4389,7 +4389,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4496,7 +4496,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4613,7 +4613,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4703,7 +4703,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4774,7 +4774,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4907,7 +4907,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5025,7 +5025,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5129,7 +5129,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5201,7 +5201,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5291,7 +5291,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5404,7 +5404,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5522,7 +5522,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5594,7 +5594,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5684,7 +5684,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5791,7 +5791,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5923,7 +5923,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6041,7 +6041,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6131,7 +6131,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6239,7 +6239,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6348,7 +6348,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6466,7 +6466,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6551,7 +6551,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6684,7 +6684,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6774,7 +6774,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6882,7 +6882,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6954,7 +6954,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7038,7 +7038,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7122,7 +7122,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7231,7 +7231,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7321,7 +7321,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7411,7 +7411,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7501,7 +7501,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7610,7 +7610,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7673,7 +7673,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7781,7 +7781,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7899,7 +7899,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8007,7 +8007,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8115,7 +8115,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8232,7 +8232,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8304,7 +8304,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8393,7 +8393,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8500,7 +8500,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8590,7 +8590,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8654,7 +8654,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8739,7 +8739,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8857,7 +8857,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8965,7 +8965,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9082,7 +9082,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9171,7 +9171,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9255,7 +9255,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9344,7 +9344,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9416,7 +9416,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9505,7 +9505,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9589,7 +9589,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9679,7 +9679,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9785,7 +9785,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9917,7 +9917,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10006,7 +10006,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10095,7 +10095,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest,org.apache.cassandra.io.sstable.SSTableLoaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -80,7 +80,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -111,10 +111,10 @@ jobs:
   j17_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -187,7 +187,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -251,7 +251,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -281,10 +281,10 @@ jobs:
   j17_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -359,7 +359,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -392,7 +392,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -448,7 +448,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -481,7 +481,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -537,7 +537,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -602,7 +602,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -633,10 +633,10 @@ jobs:
   j17_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -711,7 +711,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -744,7 +744,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -828,7 +828,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -858,10 +858,10 @@ jobs:
   j17_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -936,7 +936,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -966,10 +966,10 @@ jobs:
   j17_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1090,7 +1090,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1120,10 +1120,10 @@ jobs:
   j17_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1222,7 +1222,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1252,10 +1252,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1354,7 +1354,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1388,7 +1388,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1472,7 +1472,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1503,10 +1503,10 @@ jobs:
   j17_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1581,7 +1581,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1614,7 +1614,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1670,7 +1670,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1704,7 +1704,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1788,7 +1788,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1821,7 +1821,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1877,7 +1877,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1907,10 +1907,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1985,7 +1985,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2016,10 +2016,10 @@ jobs:
   j17_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2118,7 +2118,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2148,10 +2148,10 @@ jobs:
   j17_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2272,7 +2272,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2305,7 +2305,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2389,7 +2389,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2420,10 +2420,10 @@ jobs:
   j17_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2498,7 +2498,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2528,10 +2528,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2606,7 +2606,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2640,7 +2640,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2696,7 +2696,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2729,7 +2729,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2785,7 +2785,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2819,7 +2819,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2903,7 +2903,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2936,7 +2936,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3098,7 +3098,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3129,7 +3129,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3183,7 +3183,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3214,10 +3214,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3316,7 +3316,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3350,7 +3350,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3434,7 +3434,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3464,10 +3464,10 @@ jobs:
   j11_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3542,7 +3542,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3573,7 +3573,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3627,7 +3627,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3661,7 +3661,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3717,7 +3717,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3751,7 +3751,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3835,7 +3835,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3866,10 +3866,10 @@ jobs:
   j11_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3968,7 +3968,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4002,7 +4002,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4086,7 +4086,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4119,7 +4119,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4281,7 +4281,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4311,10 +4311,10 @@ jobs:
   j11_cqlsh_dtests_py3:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4389,7 +4389,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4496,7 +4496,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4529,7 +4529,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4613,7 +4613,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4647,7 +4647,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4703,7 +4703,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4774,7 +4774,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4805,10 +4805,10 @@ jobs:
   j11_dtests_offheap_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4907,7 +4907,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4941,7 +4941,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5025,7 +5025,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5129,7 +5129,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5201,7 +5201,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5235,7 +5235,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5291,7 +5291,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5404,7 +5404,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5438,7 +5438,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5522,7 +5522,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5594,7 +5594,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5628,7 +5628,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5684,7 +5684,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5715,10 +5715,10 @@ jobs:
   j17_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5791,7 +5791,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5821,10 +5821,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5923,7 +5923,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5957,7 +5957,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6041,7 +6041,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6075,7 +6075,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6131,7 +6131,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6161,10 +6161,10 @@ jobs:
   j11_cqlsh_dtests_py3_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6239,7 +6239,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6270,10 +6270,10 @@ jobs:
   j11_cqlsh_dtests_py311_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6348,7 +6348,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6382,7 +6382,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6466,7 +6466,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6497,10 +6497,10 @@ jobs:
   j11_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6551,7 +6551,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6582,10 +6582,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6684,7 +6684,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6718,7 +6718,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6774,7 +6774,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6804,10 +6804,10 @@ jobs:
   j11_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6882,7 +6882,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6954,7 +6954,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6984,7 +6984,7 @@ jobs:
   j17_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -7038,7 +7038,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7068,10 +7068,10 @@ jobs:
   j11_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7122,7 +7122,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7153,10 +7153,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7231,7 +7231,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7265,7 +7265,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7321,7 +7321,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7355,7 +7355,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7411,7 +7411,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7445,7 +7445,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7501,7 +7501,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7532,10 +7532,10 @@ jobs:
   j17_cqlsh_dtests_py38_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7610,7 +7610,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7673,7 +7673,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7703,10 +7703,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7781,7 +7781,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7815,7 +7815,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7899,7 +7899,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7929,10 +7929,10 @@ jobs:
   j17_cqlsh_dtests_py3_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8007,7 +8007,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8037,10 +8037,10 @@ jobs:
   j17_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8115,7 +8115,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8148,7 +8148,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8232,7 +8232,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8304,7 +8304,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8337,7 +8337,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8393,7 +8393,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8500,7 +8500,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8534,7 +8534,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8590,7 +8590,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8654,7 +8654,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8685,10 +8685,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8739,7 +8739,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8773,7 +8773,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8857,7 +8857,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8887,10 +8887,10 @@ jobs:
   j17_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8965,7 +8965,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8998,7 +8998,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9082,7 +9082,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9115,7 +9115,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9171,7 +9171,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9201,7 +9201,7 @@ jobs:
   j17_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -9255,7 +9255,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9288,7 +9288,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9344,7 +9344,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9416,7 +9416,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9449,7 +9449,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9505,7 +9505,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9535,10 +9535,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9589,7 +9589,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9623,7 +9623,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9679,7 +9679,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9709,10 +9709,10 @@ jobs:
   j17_dtests_offheap:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9785,7 +9785,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9815,10 +9815,10 @@ jobs:
   j17_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9917,7 +9917,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9950,7 +9950,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10006,7 +10006,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10039,7 +10039,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -10095,7 +10095,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.format.bti.PartitionIndexTest,org.apache.cassandra.io.sstable.ScrubTest,org.apache.cassandra.io.sstable.SSTableFlushObserverTest,org.apache.cassandra.db.lifecycle.RealTransactionsTest,org.apache.cassandra.db.SerializationHeaderTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -10137,6 +10137,12 @@ workflows:
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
+        - j11_build
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
         - j11_build
     - start_j11_jvm_dtests:
         type: approval
@@ -10198,17 +10204,35 @@ workflows:
         requires:
         - start_j17_unit_tests
         - j11_build
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j11_build
     - start_j11_utests_oa:
         type: approval
     - j11_utests_oa:
         requires:
         - start_j11_utests_oa
         - j11_build
+    - start_j11_utests_oa_repeat:
+        type: approval
+    - j11_utests_oa_repeat:
+        requires:
+        - start_j11_utests_oa_repeat
+        - j11_build
     - start_j17_utests_oa:
         type: approval
     - j17_utests_oa:
         requires:
         - start_j17_utests_oa
+        - j11_build
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
         - j11_build
     - start_j11_utests_long:
         type: approval
@@ -10234,6 +10258,18 @@ workflows:
         requires:
         - start_j17_utests_cdc
         - j11_build
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j11_build
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
@@ -10246,6 +10282,18 @@ workflows:
         requires:
         - start_j17_utests_compression
         - j11_build
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j11_build
     - start_j11_utests_trie:
         type: approval
     - j11_utests_trie:
@@ -10257,6 +10305,18 @@ workflows:
     - j17_utests_trie:
         requires:
         - start_j17_utests_trie
+        - j11_build
+    - start_j11_utests_trie_repeat:
+        type: approval
+    - j11_utests_trie_repeat:
+        requires:
+        - start_j11_utests_trie_repeat
+        - j11_build
+    - start_j17_utests_trie_repeat:
+        type: approval
+    - j17_utests_trie_repeat:
+        requires:
+        - start_j17_utests_trie_repeat
         - j11_build
     - start_j11_utests_stress:
         type: approval
@@ -10293,6 +10353,18 @@ workflows:
     - j17_utests_system_keyspace_directory:
         requires:
         - start_j17_utests_system_keyspace_directory
+        - j11_build
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
         - j11_build
     - start_j11_dtest_jars_build:
         type: approval
@@ -10465,6 +10537,15 @@ workflows:
     - j11_utests_oa:
         requires:
         - j11_build
+    - j11_utests_oa_repeat:
+        requires:
+        - j11_build
+    - j17_utests_oa_repeat:
+        requires:
+        - j11_build
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
     - j11_simulator_dtests:
         requires:
         - j11_build
@@ -10498,6 +10579,9 @@ workflows:
     - j17_utests_oa:
         requires:
         - j11_build
+    - j17_unit_tests_repeat:
+        requires:
+        - j11_build
     - start_utests_long:
         type: approval
     - j11_utests_long:
@@ -10518,6 +10602,14 @@ workflows:
         requires:
         - start_utests_cdc
         - j11_build
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
@@ -10528,6 +10620,14 @@ workflows:
         requires:
         - start_utests_compression
         - j11_build
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
     - start_utests_trie:
         type: approval
     - j11_utests_trie:
@@ -10535,6 +10635,14 @@ workflows:
         - start_utests_trie
         - j11_build
     - j17_utests_trie:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j11_utests_trie_repeat:
+        requires:
+        - start_utests_trie
+        - j11_build
+    - j17_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j11_build
@@ -10564,6 +10672,13 @@ workflows:
         requires:
         - j11_build
     - j17_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - j11_build
+    - j17_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
@@ -10703,6 +10818,12 @@ workflows:
         requires:
         - start_j17_unit_tests
         - j17_build
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j17_build
     - start_j17_jvm_dtests:
         type: approval
     - j17_jvm_dtests:
@@ -10803,6 +10924,12 @@ workflows:
         requires:
         - start_j17_utests_oa
         - j17_build
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
+        - j17_build
     - start_j17_utests_long:
         type: approval
     - j17_utests_long:
@@ -10815,17 +10942,35 @@ workflows:
         requires:
         - start_j17_utests_cdc
         - j17_build
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j17_build
     - start_j17_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_j17_utests_compression
         - j17_build
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j17_build
     - start_j17_utests_trie:
         type: approval
     - j17_utests_trie:
         requires:
         - start_j17_utests_trie
+        - j17_build
+    - start_j17_utests_trie_repeat:
+        type: approval
+    - j17_utests_trie_repeat:
+        requires:
+        - start_j17_utests_trie_repeat
         - j17_build
     - start_j17_utests_stress:
         type: approval
@@ -10845,6 +10990,12 @@ workflows:
         requires:
         - start_j17_utests_system_keyspace_directory
         - j17_build
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
+        - j17_build
   java17_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10856,6 +11007,12 @@ workflows:
         requires:
         - j17_build
     - j17_utests_oa:
+        requires:
+        - j17_build
+    - j17_utests_oa_repeat:
+        requires:
+        - j17_build
+    - j17_unit_tests_repeat:
         requires:
         - j17_build
     - j17_jvm_dtests:
@@ -10936,15 +11093,27 @@ workflows:
         requires:
         - start_utests_cdc
         - j17_build
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j17_build
     - start_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_utests_compression
         - j17_build
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j17_build
     - start_utests_trie:
         type: approval
     - j17_utests_trie:
+        requires:
+        - start_utests_trie
+        - j17_build
+    - j17_utests_trie_repeat:
         requires:
         - start_utests_trie
         - j17_build
@@ -10963,6 +11132,10 @@ workflows:
     - start_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j17_build
+    - j17_utests_system_keyspace_directory_repeat:
         requires:
         - start_utests_system_keyspace_directory
         - j17_build

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1624,7 +1624,7 @@ public class CompactionManager implements CompactionManagerMBean
                          .setMetadataCollector(new MetadataCollector(cfs.metadata().comparator).sstableLevel(sstable.getSSTableLevel()))
                          .setSerializationHeader(sstable.header)
                          .addDefaultComponents(cfs.indexManager.listIndexGroups())
-                         .addFlushObserversForSecondaryIndexes(cfs.indexManager.listIndexGroups(), txn, cfs.metadata.get())
+                         .setSecondaryIndexGroups(cfs.indexManager.listIndexGroups())
                          .build(txn, cfs);
     }
 
@@ -1664,7 +1664,7 @@ public class CompactionManager implements CompactionManagerMBean
                          .setMetadataCollector(new MetadataCollector(sstables, cfs.metadata().comparator).sstableLevel(minLevel))
                          .setSerializationHeader(SerializationHeader.make(cfs.metadata(), sstables))
                          .addDefaultComponents(cfs.indexManager.listIndexGroups())
-                         .addFlushObserversForSecondaryIndexes(cfs.indexManager.listIndexGroups(), txn, cfs.metadata.get())
+                         .setSecondaryIndexGroups(cfs.indexManager.listIndexGroups())
                          .build(txn, cfs);
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/Upgrader.java
+++ b/src/java/org/apache/cassandra/db/compaction/Upgrader.java
@@ -84,7 +84,7 @@ public class Upgrader
                          .setMetadataCollector(sstableMetadataCollector)
                          .setSerializationHeader(SerializationHeader.make(cfs.metadata(), Sets.newHashSet(sstable)))
                          .addDefaultComponents(cfs.indexManager.listIndexGroups())
-                         .addFlushObserversForSecondaryIndexes(cfs.indexManager.listIndexGroups(), transaction, cfs.metadata.get())
+                         .setSecondaryIndexGroups(cfs.indexManager.listIndexGroups())
                          .build(transaction, cfs);
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedMultiWriter.java
@@ -117,7 +117,7 @@ public class ShardedMultiWriter implements SSTableMultiWriter
                          .setMetadataCollector(metadataCollector)
                          .setSerializationHeader(header)
                          .addDefaultComponents(indexGroups)
-                         .addFlushObserversForSecondaryIndexes(indexGroups, lifecycleNewTracker, cfs.metadata.get())
+                         .setSecondaryIndexGroups(indexGroups)
                          .build(lifecycleNewTracker, cfs);
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
@@ -319,7 +319,7 @@ public abstract class CompactionAwareWriter extends Transactional.AbstractTransa
                          .setTransientSSTable(isTransient)
                          .setRepairedAt(minRepairedAt)
                          .setPendingRepair(pendingRepair)
-                         .addFlushObserversForSecondaryIndexes(cfs.indexManager.listIndexGroups(), txn, cfs.metadata.get())
+                         .setSecondaryIndexGroups(cfs.indexManager.listIndexGroups())
                          .addDefaultComponents(cfs.indexManager.listIndexGroups());
     }
 }

--- a/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressedSequentialWriter.java
@@ -202,7 +202,7 @@ public class CompressedSequentialWriter extends SequentialWriter
         // next chunk should be written right after current + length of the checksum (int)
         chunkOffset += compressedLength + 4;
         if (runPostFlush != null)
-            runPostFlush.run();
+            runPostFlush.accept(getLastFlushOffset());
     }
 
     public CompressionMetadata open(long overrideLength)

--- a/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SimpleSSTableMultiWriter.java
@@ -132,7 +132,7 @@ public class SimpleSSTableMultiWriter implements SSTableMultiWriter
                                             .setMetadataCollector(metadataCollector)
                                             .setSerializationHeader(header)
                                             .addDefaultComponents(indexGroups)
-                                            .addFlushObserversForSecondaryIndexes(indexGroups, lifecycleNewTracker, metadata.get())
+                                            .setSecondaryIndexGroups(indexGroups)
                                             .build(lifecycleNewTracker, owner);
         return new SimpleSSTableMultiWriter(writer, lifecycleNewTracker);
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableWriter.java
@@ -24,15 +24,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.index.Index;
@@ -44,7 +43,6 @@ import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.DataComponent;
 import org.apache.cassandra.io.sstable.format.IndexComponent;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
-import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.io.sstable.format.SortedTableWriter;
 import org.apache.cassandra.io.sstable.format.big.BigFormat.Components;
 import org.apache.cassandra.io.sstable.indexsummary.IndexSummary;
@@ -59,20 +57,19 @@ import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.EstimatedHistogram;
-import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.Throwables;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.cassandra.io.util.FileHandle.Builder.NO_LENGTH_OVERRIDE;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 
-public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
+public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter, BigTableWriter.IndexWriter>
 {
     private static final Logger logger = LoggerFactory.getLogger(BigTableWriter.class);
 
-    private final IndexWriter indexWriter;
     private final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
     private final Map<DecoratedKey, AbstractRowIndexEntry> cachedKeys = new HashMap<>();
     private final boolean shouldMigrateKeyCache;
@@ -80,28 +77,13 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
     public BigTableWriter(Builder builder, LifecycleNewTracker lifecycleNewTracker, SSTable.Owner owner)
     {
         super(builder, lifecycleNewTracker, owner);
-        checkNotNull(builder.getRowIndexEntrySerializer());
-        checkNotNull(builder.getIndexWriter());
 
         this.rowIndexEntrySerializer = builder.getRowIndexEntrySerializer();
-        this.indexWriter = builder.getIndexWriter();
+        checkNotNull(this.rowIndexEntrySerializer);
+
         this.shouldMigrateKeyCache = DatabaseDescriptor.shouldMigrateKeycacheOnCompaction()
                                      && lifecycleNewTracker instanceof ILifecycleTransaction
                                      && !((ILifecycleTransaction) lifecycleNewTracker).isOffline();
-    }
-
-    @Override
-    public void mark()
-    {
-        super.mark();
-        indexWriter.mark();
-    }
-
-    @Override
-    public void resetAndTruncate()
-    {
-        super.resetAndTruncate();
-        indexWriter.resetAndTruncate();
     }
 
     @Override
@@ -145,7 +127,7 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         return entry;
     }
 
-    @SuppressWarnings({"resource", "RedundantSuppression"})
+    @SuppressWarnings({ "resource", "RedundantSuppression" })
     private BigTableReader openInternal(IndexSummaryBuilder.ReadableBoundary boundary, SSTableReader.OpenReason openReason)
     {
         assert boundary == null || (boundary.indexLength > 0 && boundary.dataLength > 0);
@@ -251,16 +233,10 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         return openInternal(null, openReason);
     }
 
-    @Override
-    protected SSTableWriter.TransactionalProxy txnProxy()
-    {
-        return new SSTableWriter.TransactionalProxy(() -> FBUtilities.immutableListWithFilteredNulls(indexWriter, dataWriter));
-    }
-
     /**
      * Encapsulates writing the index and filter for an SSTable. The state of this object is not valid until it has been closed.
      */
-    static class IndexWriter extends SortedTableWriter.AbstractIndexWriter
+    protected static class IndexWriter extends SortedTableWriter.AbstractIndexWriter
     {
         private final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
 
@@ -271,7 +247,7 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         private DecoratedKey first;
         private DecoratedKey last;
 
-        protected IndexWriter(Builder b)
+        protected IndexWriter(Builder b, SequentialWriter dataWriter)
         {
             super(b);
             this.rowIndexEntrySerializer = b.getRowIndexEntrySerializer();
@@ -279,10 +255,8 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
             builder = IndexComponent.fileBuilder(Components.PRIMARY_INDEX, b).withMmappedRegionsCache(b.getMmappedRegionsCache());
             summary = new IndexSummaryBuilder(b.getKeyCount(), b.getTableMetadataRef().getLocal().params.minIndexInterval, Downsampling.BASE_SAMPLING_LEVEL);
             // register listeners to be alerted when the data files are flushed
-            writer.setPostFlushListener(() -> summary.markIndexSynced(writer.getLastFlushOffset()));
-            @SuppressWarnings({"resource", "RedundantSuppression"})
-            SequentialWriter dataWriter = b.getDataWriter();
-            dataWriter.setPostFlushListener(() -> summary.markDataSynced(dataWriter.getLastFlushOffset()));
+            writer.setPostFlushListener(summary::markIndexSynced);
+            dataWriter.setPostFlushListener(summary::markDataSynced);
         }
 
         // finds the last (-offset) decorated key that can be guaranteed to occur fully in the flushed portion of the index file
@@ -316,11 +290,13 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
             summary.maybeAddEntry(key, indexStart, indexEnd, dataEnd);
         }
 
+        @Override
         public void mark()
         {
             mark = writer.mark();
         }
 
+        @Override
         public void resetAndTruncate()
         {
             // we can't un-set the bloom filter addition, but extra keys in there are harmless.
@@ -372,13 +348,17 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         }
     }
 
-    public static class Builder extends SortedTableWriter.Builder<BigFormatPartitionWriter, BigTableWriter, Builder>
+    public static class Builder extends SortedTableWriter.Builder<BigFormatPartitionWriter, IndexWriter, BigTableWriter, Builder>
     {
         private RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
-        private IndexWriter indexWriter;
-        private SequentialWriter dataWriter;
-        private BigFormatPartitionWriter partitionWriter;
         private MmappedRegionsCache mmappedRegionsCache;
+        private OperationType operationType;
+
+        // Writers are expected to be opened only once during construction of the sstable. The following flags are used
+        // to ensure that.
+        private boolean indexWriterOpened;
+        private boolean dataWriterOpened;
+        private boolean partitionWriterOpened;
 
         public Builder(Descriptor descriptor)
         {
@@ -405,30 +385,51 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         }
 
         @Override
-        public SequentialWriter getDataWriter()
+        protected SequentialWriter openDataWriter()
         {
-            return ensuringInBuildInternalContext(dataWriter);
+            checkState(!dataWriterOpened, "Data writer has been already opened.");
+
+            SequentialWriter dataWriter = DataComponent.buildWriter(descriptor,
+                                                                    getTableMetadataRef().getLocal(),
+                                                                    getIOOptions().writerOptions,
+                                                                    getMetadataCollector(),
+                                                                    ensuringInBuildInternalContext(operationType),
+                                                                    getIOOptions().flushCompression);
+            this.dataWriterOpened = true;
+            return dataWriter;
         }
 
         @Override
-        public BigFormatPartitionWriter getPartitionWriter()
+        protected IndexWriter openIndexWriter(SequentialWriter dataWriter)
         {
-            return ensuringInBuildInternalContext(partitionWriter);
+            checkNotNull(dataWriter);
+            checkState(!indexWriterOpened, "Index writer has been already opened.");
+
+            IndexWriter indexWriter = new IndexWriter(this, dataWriter);
+            this.indexWriterOpened = true;
+            return indexWriter;
         }
 
-        public RowIndexEntry.IndexSerializer getRowIndexEntrySerializer()
+        @Override
+        protected BigFormatPartitionWriter openPartitionWriter(SequentialWriter dataWriter, IndexWriter indexWriter)
+        {
+            checkNotNull(dataWriter);
+            checkNotNull(indexWriter);
+            checkState(!partitionWriterOpened, "Partition writer has been already opened.");
+
+            BigFormatPartitionWriter partitionWriter = new BigFormatPartitionWriter(getSerializationHeader(), dataWriter, descriptor.version, getRowIndexEntrySerializer().indexInfoSerializer());
+            this.partitionWriterOpened = true;
+            return partitionWriter;
+        }
+
+        RowIndexEntry.IndexSerializer getRowIndexEntrySerializer()
         {
             return ensuringInBuildInternalContext(rowIndexEntrySerializer);
         }
 
-        public IndexWriter getIndexWriter()
-        {
-            return ensuringInBuildInternalContext(indexWriter);
-        }
-
         private <T> T ensuringInBuildInternalContext(T value)
         {
-            Preconditions.checkState(value != null, "This getter can be used only during the lifetime of the sstable constructor. Do not use it directly.");
+            checkState(value != null, "The requested resource has not been initialized yet.");
             return value;
         }
 
@@ -437,30 +438,24 @@ public class BigTableWriter extends SortedTableWriter<BigFormatPartitionWriter>
         {
             try
             {
-                mmappedRegionsCache = new MmappedRegionsCache();
-                rowIndexEntrySerializer = new RowIndexEntry.Serializer(descriptor.version, getSerializationHeader(), owner != null ? owner.getMetrics() : null);
-                dataWriter = DataComponent.buildWriter(descriptor,
-                                                       getTableMetadataRef().getLocal(),
-                                                       getIOOptions().writerOptions,
-                                                       getMetadataCollector(),
-                                                       lifecycleNewTracker.opType(),
-                                                       getIOOptions().flushCompression);
-                indexWriter = new IndexWriter(this);
-                partitionWriter = new BigFormatPartitionWriter(getSerializationHeader(), dataWriter, descriptor.version, rowIndexEntrySerializer.indexInfoSerializer());
+                this.operationType = lifecycleNewTracker.opType();
+                this.mmappedRegionsCache = new MmappedRegionsCache();
+                this.rowIndexEntrySerializer = new RowIndexEntry.Serializer(descriptor.version, getSerializationHeader(), owner != null ? owner.getMetrics() : null);
                 return new BigTableWriter(this, lifecycleNewTracker, owner);
             }
             catch (RuntimeException | Error ex)
             {
-                Throwables.closeAndAddSuppressed(ex, partitionWriter, indexWriter, dataWriter, mmappedRegionsCache);
+                Throwables.closeNonNullAndAddSuppressed(ex, mmappedRegionsCache);
                 throw ex;
             }
             finally
             {
-                rowIndexEntrySerializer = null;
-                indexWriter = null;
-                dataWriter = null;
-                partitionWriter = null;
-                mmappedRegionsCache = null;
+                this.rowIndexEntrySerializer = null;
+                this.mmappedRegionsCache = null;
+                this.operationType = null;
+                this.partitionWriterOpened = false;
+                this.indexWriterOpened = false;
+                this.dataWriterOpened = false;
             }
         }
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableWriter.java
@@ -23,14 +23,13 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.DeletionTime;
+import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.index.Index;
 import org.apache.cassandra.io.FSReadError;
@@ -50,44 +49,25 @@ import org.apache.cassandra.io.util.MmappedRegionsCache;
 import org.apache.cassandra.io.util.SequentialWriter;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Clock;
-import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.IFilter;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.Throwables;
-import org.apache.cassandra.utils.concurrent.Transactional;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.cassandra.io.util.FileHandle.Builder.NO_LENGTH_OVERRIDE;
 
 /**
  * Writes SSTables in BTI format (see {@link BtiFormat}), which can be read by {@link BtiTableReader}.
  */
 @VisibleForTesting
-public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
+public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter, BtiTableWriter.IndexWriter>
 {
     private static final Logger logger = LoggerFactory.getLogger(BtiTableWriter.class);
-
-    private final BtiFormatPartitionWriter partitionWriter;
-    private final IndexWriter iwriter;
 
     public BtiTableWriter(Builder builder, LifecycleNewTracker lifecycleNewTracker, SSTable.Owner owner)
     {
         super(builder, lifecycleNewTracker, owner);
-        this.iwriter = builder.getIndexWriter();
-        this.partitionWriter = builder.getPartitionWriter();
-    }
-
-    @Override
-    public void mark()
-    {
-        super.mark();
-        iwriter.mark();
-    }
-
-    @Override
-    public void resetAndTruncate()
-    {
-        super.resetAndTruncate();
-        iwriter.resetAndTruncate();
     }
 
     @Override
@@ -97,11 +77,11 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
                                                      finishResult,
                                                      partitionLevelDeletion,
                                                      partitionWriter.getRowIndexBlockCount());
-        iwriter.append(key, entry);
+        indexWriter.append(key, entry);
         return entry;
     }
 
-    @SuppressWarnings({"resource", "RedundantSuppression"})
+    @SuppressWarnings({ "resource", "RedundantSuppression" })
     private BtiTableReader openInternal(OpenReason openReason, boolean isFinal, Supplier<PartitionIndex> partitionIndexSupplier)
     {
         IFilter filter = null;
@@ -118,9 +98,9 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
             builder.setStatsMetadata(statsMetadata());
 
             partitionIndex = partitionIndexSupplier.get();
-            rowIndexFile = iwriter.rowIndexFHBuilder.complete();
+            rowIndexFile = indexWriter.rowIndexFHBuilder.complete();
             dataFile = openDataFile(isFinal ? NO_LENGTH_OVERRIDE : dataWriter.getLastFlushOffset(), builder.getStatsMetadata());
-            filter = iwriter.getFilterCopy();
+            filter = indexWriter.getFilterCopy();
 
             return builder.setPartitionIndex(partitionIndex)
                           .setFirst(partitionIndex.firstKey())
@@ -142,9 +122,9 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
     public void openEarly(Consumer<SSTableReader> callWhenReady)
     {
         long dataLength = dataWriter.position();
-        iwriter.buildPartial(dataLength, partitionIndex ->
+        indexWriter.buildPartial(dataLength, partitionIndex ->
         {
-            iwriter.rowIndexFHBuilder.withLengthOverride(iwriter.rowIndexWriter.getLastFlushOffset());
+            indexWriter.rowIndexFHBuilder.withLengthOverride(indexWriter.rowIndexWriter.getLastFlushOffset());
             BtiTableReader reader = openInternal(OpenReason.EARLY, false, () -> partitionIndex);
             callWhenReady.accept(reader);
         });
@@ -154,10 +134,10 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
     public SSTableReader openFinalEarly()
     {
         // we must ensure the data is completely flushed to disk
-        iwriter.complete(); // This will be called by completedPartitionIndex() below too, but we want it done now to
+        indexWriter.complete(); // This will be called by completedPartitionIndex() below too, but we want it done now to
         // ensure outstanding openEarly actions are not triggered.
         dataWriter.sync();
-        iwriter.rowIndexWriter.sync();
+        indexWriter.rowIndexWriter.sync();
         // Note: Nothing must be written to any of the files after this point, as the chunk cache could pick up and
         // retain a partially-written page.
 
@@ -165,42 +145,20 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
     }
 
     @Override
-    @SuppressWarnings({"resource", "RedundantSuppression"})
+    @SuppressWarnings({ "resource", "RedundantSuppression" })
     protected SSTableReader openFinal(OpenReason openReason)
     {
 
         if (maxDataAge < 0)
             maxDataAge = Clock.Global.currentTimeMillis();
 
-        return openInternal(openReason, true, iwriter::completedPartitionIndex);
-    }
-
-    @Override
-    protected TransactionalProxy txnProxy()
-    {
-        return new TransactionalProxy(() -> FBUtilities.immutableListWithFilteredNulls(iwriter, dataWriter));
-    }
-
-    private class TransactionalProxy extends SortedTableWriter<BtiFormatPartitionWriter>.TransactionalProxy
-    {
-        public TransactionalProxy(Supplier<ImmutableList<Transactional>> transactionals)
-        {
-            super(transactionals);
-        }
-
-        @Override
-        protected Throwable doPostCleanup(Throwable accumulate)
-        {
-            accumulate = Throwables.close(accumulate, partitionWriter);
-            accumulate = super.doPostCleanup(accumulate);
-            return accumulate;
-        }
+        return openInternal(openReason, true, indexWriter::completedPartitionIndex);
     }
 
     /**
      * Encapsulates writing the index and filter for an SSTable. The state of this object is not valid until it has been closed.
      */
-    static class IndexWriter extends SortedTableWriter.AbstractIndexWriter
+    protected static class IndexWriter extends SortedTableWriter.AbstractIndexWriter
     {
         final SequentialWriter rowIndexWriter;
         private final FileHandle.Builder rowIndexFHBuilder;
@@ -211,7 +169,7 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
         private DataPosition riMark;
         private DataPosition piMark;
 
-        IndexWriter(Builder b)
+        IndexWriter(Builder b, SequentialWriter dataWriter)
         {
             super(b);
             rowIndexWriter = new SequentialWriter(descriptor.fileFor(Components.ROW_INDEX), b.getIOOptions().writerOptions);
@@ -220,11 +178,9 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
             partitionIndexFHBuilder = IndexComponent.fileBuilder(Components.PARTITION_INDEX, b).withMmappedRegionsCache(b.getMmappedRegionsCache());
             partitionIndex = new PartitionIndexBuilder(partitionIndexWriter, partitionIndexFHBuilder);
             // register listeners to be alerted when the data files are flushed
-            partitionIndexWriter.setPostFlushListener(() -> partitionIndex.markPartitionIndexSynced(partitionIndexWriter.getLastFlushOffset()));
-            rowIndexWriter.setPostFlushListener(() -> partitionIndex.markRowIndexSynced(rowIndexWriter.getLastFlushOffset()));
-            @SuppressWarnings({"resource", "RedundantSuppression"})
-            SequentialWriter dataWriter = b.getDataWriter();
-            dataWriter.setPostFlushListener(() -> partitionIndex.markDataSynced(dataWriter.getLastFlushOffset()));
+            partitionIndexWriter.setPostFlushListener(partitionIndex::markPartitionIndexSynced);
+            rowIndexWriter.setPostFlushListener(partitionIndex::markRowIndexSynced);
+            dataWriter.setPostFlushListener(partitionIndex::markDataSynced);
         }
 
         public long append(DecoratedKey key, AbstractRowIndexEntry indexEntry) throws IOException
@@ -336,48 +292,18 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
         }
     }
 
-    public static class Builder extends SortedTableWriter.Builder<BtiFormatPartitionWriter, BtiTableWriter, Builder>
+    public static class Builder extends SortedTableWriter.Builder<BtiFormatPartitionWriter, IndexWriter, BtiTableWriter, Builder>
     {
-        private SequentialWriter dataWriter;
-        private BtiFormatPartitionWriter partitionWriter;
-        private IndexWriter indexWriter;
         private MmappedRegionsCache mmappedRegionsCache;
+        private OperationType operationType;
+
+        private boolean dataWriterOpened;
+        private boolean partitionWriterOpened;
+        private boolean indexWriterOpened;
 
         public Builder(Descriptor descriptor)
         {
             super(descriptor);
-        }
-
-        // The following getters for the resources opened by buildInternal method can be only used during the lifetime of
-        // that method - that is, during the construction of the sstable.
-
-        @Override
-        public MmappedRegionsCache getMmappedRegionsCache()
-        {
-            return ensuringInBuildInternalContext(mmappedRegionsCache);
-        }
-
-        @Override
-        public SequentialWriter getDataWriter()
-        {
-            return ensuringInBuildInternalContext(dataWriter);
-        }
-
-        @Override
-        public BtiFormatPartitionWriter getPartitionWriter()
-        {
-            return ensuringInBuildInternalContext(partitionWriter);
-        }
-
-        public IndexWriter getIndexWriter()
-        {
-            return ensuringInBuildInternalContext(indexWriter);
-        }
-
-        private <T> T ensuringInBuildInternalContext(T value)
-        {
-            Preconditions.checkState(value != null, "This getter can be used only during the lifetime of the sstable constructor. Do not use it directly.");
-            return value;
         }
 
         @Override
@@ -390,40 +316,82 @@ public class BtiTableWriter extends SortedTableWriter<BtiFormatPartitionWriter>
             return this;
         }
 
+        // The following getters for the resources opened by buildInternal method can be only used during the lifetime of
+        // that method - that is, during the construction of the sstable.
+
+        @Override
+        public MmappedRegionsCache getMmappedRegionsCache()
+        {
+            return ensuringInBuildInternalContext(mmappedRegionsCache);
+        }
+
+        @Override
+        protected SequentialWriter openDataWriter()
+        {
+            checkState(!dataWriterOpened, "Data writer has been already opened.");
+
+            return DataComponent.buildWriter(descriptor,
+                                             getTableMetadataRef().getLocal(),
+                                             getIOOptions().writerOptions,
+                                             getMetadataCollector(),
+                                             ensuringInBuildInternalContext(operationType),
+                                             getIOOptions().flushCompression);
+        }
+
+        @Override
+        protected IndexWriter openIndexWriter(SequentialWriter dataWriter)
+        {
+            checkNotNull(dataWriter);
+            checkState(!indexWriterOpened, "Index writer has been already opened.");
+
+            IndexWriter indexWriter = new IndexWriter(this, dataWriter);
+            indexWriterOpened = true;
+            return indexWriter;
+        }
+
+        @Override
+        protected BtiFormatPartitionWriter openPartitionWriter(SequentialWriter dataWriter, IndexWriter indexWriter)
+        {
+            checkNotNull(dataWriter);
+            checkNotNull(indexWriter);
+            checkState(!partitionWriterOpened, "Partition writer has been already opened.");
+
+            BtiFormatPartitionWriter partitionWriter = new BtiFormatPartitionWriter(getSerializationHeader(),
+                                                                                    getTableMetadataRef().getLocal().comparator,
+                                                                                    dataWriter,
+                                                                                    indexWriter.rowIndexWriter,
+                                                                                    descriptor.version);
+            partitionWriterOpened = true;
+            return partitionWriter;
+        }
+
+        private <T> T ensuringInBuildInternalContext(T value)
+        {
+            checkState(value != null, "The requested resource has not been initialized yet.");
+            return value;
+        }
+
         @Override
         protected BtiTableWriter buildInternal(LifecycleNewTracker lifecycleNewTracker, Owner owner)
         {
             try
             {
-                mmappedRegionsCache = new MmappedRegionsCache();
-                dataWriter = DataComponent.buildWriter(descriptor,
-                                                       getTableMetadataRef().getLocal(),
-                                                       getIOOptions().writerOptions,
-                                                       getMetadataCollector(),
-                                                       lifecycleNewTracker.opType(),
-                                                       getIOOptions().flushCompression);
-
-                indexWriter = new IndexWriter(this);
-                partitionWriter = new BtiFormatPartitionWriter(getSerializationHeader(),
-                                                               getTableMetadataRef().getLocal().comparator,
-                                                               dataWriter,
-                                                               indexWriter.rowIndexWriter,
-                                                               descriptor.version);
-
+                this.mmappedRegionsCache = new MmappedRegionsCache();
+                this.operationType = lifecycleNewTracker.opType();
 
                 return new BtiTableWriter(this, lifecycleNewTracker, owner);
             }
             catch (RuntimeException | Error ex)
             {
-                Throwables.closeAndAddSuppressed(ex, partitionWriter, indexWriter, dataWriter, mmappedRegionsCache);
+                Throwables.closeAndAddSuppressed(ex, mmappedRegionsCache);
                 throw ex;
             }
             finally
             {
-                partitionWriter = null;
-                indexWriter = null;
-                dataWriter = null;
                 mmappedRegionsCache = null;
+                partitionWriterOpened = false;
+                indexWriterOpened = false;
+                dataWriterOpened = false;
             }
         }
     }

--- a/src/java/org/apache/cassandra/io/util/SequentialWriter.java
+++ b/src/java/org/apache/cassandra/io/util/SequentialWriter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
+import java.util.function.LongConsumer;
 
 import org.apache.cassandra.io.FSReadError;
 import org.apache.cassandra.io.FSWriteError;
@@ -60,7 +61,7 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
 
     protected long lastFlushOffset;
 
-    protected Runnable runPostFlush;
+    protected LongConsumer runPostFlush;
 
     private final TransactionalProxy txnProxy = txnProxy();
 
@@ -229,7 +230,7 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
         resetBuffer();
     }
 
-    public void setPostFlushListener(Runnable runPostFlush)
+    public void setPostFlushListener(LongConsumer runPostFlush)
     {
         assert this.runPostFlush == null;
         this.runPostFlush = runPostFlush;
@@ -252,7 +253,7 @@ public class SequentialWriter extends BufferedDataOutputStreamPlus implements Tr
             throw new FSWriteError(e, getPath());
         }
         if (runPostFlush != null)
-            runPostFlush.run();
+            runPostFlush.accept(getLastFlushOffset());
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/SerializationHeaderTest.java
@@ -100,7 +100,6 @@ public class SerializationHeaderTest
                                                              .setTableMetadataRef(TableMetadataRef.forOfflineTools(schema))
                                                              .setKeyCount(1)
                                                              .setSerializationHeader(header)
-                                                             .setFlushObservers(Collections.emptyList())
                                                              .setMetadataCollector(new MetadataCollector(schema.comparator))
                                                              .addDefaultComponents(Collections.emptySet())
                                                              .build(txn, null))

--- a/test/unit/org/apache/cassandra/db/lifecycle/RealTransactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/RealTransactionsTest.java
@@ -163,7 +163,7 @@ public class RealTransactionsTest extends SchemaLoader
                 rewriter.switchWriter(desc.getFormat().getWriterFactory().builder(desc)
                                           .setTableMetadataRef(metadata)
                                           .setSerializationHeader(SerializationHeader.make(cfs.metadata(), txn.originals()))
-                                          .addFlushObserversForSecondaryIndexes(cfs.indexManager.listIndexGroups(), txn, metadata.get())
+                                          .setSecondaryIndexGroups(cfs.indexManager.listIndexGroups())
                                           .setMetadataCollector(new MetadataCollector(cfs.metadata().comparator))
                                           .addDefaultComponents(cfs.indexManager.listIndexGroups())
                                           .build(txn, cfs));

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableFlushObserverTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableFlushObserverTest.java
@@ -23,12 +23,16 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -50,6 +54,7 @@ import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.EncodingStats;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.index.Index;
 import org.apache.cassandra.io.FSWriteError;
 import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -60,102 +65,169 @@ import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
+import org.apache.cassandra.utils.concurrent.Transactional.AbstractTransactional.State;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SSTableFlushObserverTest
 {
+
+    private TableMetadata cfm;
+    private File directory;
+    private SSTableFormat<?, ?> sstableFormat;
+    private static Supplier<SSTableId> idGen;
+
     @BeforeClass
     public static void initDD()
     {
         DatabaseDescriptor.daemonInitialization();
         CommitLog.instance.start();
+        idGen = SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty());
     }
 
     private static final String KS_NAME = "test";
     private static final String CF_NAME = "flush_observer";
 
-    @Test
-    public void testFlushObserver() throws Exception
+    @Before
+    public void setUp() throws Exception
     {
-        TableMetadata cfm =
-        TableMetadata.builder(KS_NAME, CF_NAME)
+        cfm = TableMetadata.builder(KS_NAME, CF_NAME)
                      .addPartitionKeyColumn("id", UTF8Type.instance)
                      .addRegularColumn("first_name", UTF8Type.instance)
                      .addRegularColumn("age", Int32Type.instance)
                      .addRegularColumn("height", LongType.instance)
                      .build();
-
-        LifecycleTransaction transaction = LifecycleTransaction.offline(OperationType.COMPACTION);
-        FlushObserver observer = new FlushObserver();
-
         String sstableDirectory = DatabaseDescriptor.getAllDataFileLocations()[0];
-        File directory = new File(sstableDirectory + File.pathSeparator() + KS_NAME + File.pathSeparator() + CF_NAME);
+        directory = new File(sstableDirectory + File.pathSeparator() + KS_NAME + File.pathSeparator() + CF_NAME);
         directory.deleteOnExit();
 
         if (!directory.exists() && !directory.tryCreateDirectories())
             throw new FSWriteError(new IOException("failed to create tmp directory"), directory.absolutePath());
 
-        SSTableFormat<?, ?> sstableFormat = DatabaseDescriptor.getSelectedSSTableFormat();
-        Descriptor descriptor = new Descriptor(sstableFormat.getLatestVersion(),
-                                               directory,
-                                               cfm.keyspace,
-                                               cfm.name,
-                                               new SequenceBasedSSTableId(0));
+        sstableFormat = DatabaseDescriptor.getSelectedSSTableFormat();
+    }
 
-        SSTableWriter writer = descriptor.getFormat().getWriterFactory().builder(descriptor)
-                                         .setKeyCount(10)
-                                         .setTableMetadataRef(TableMetadataRef.forOfflineTools(cfm))
-                                         .setMetadataCollector(new MetadataCollector(cfm.comparator).sstableLevel(0))
-                                         .setSerializationHeader(new SerializationHeader(true, cfm, cfm.regularAndStaticColumns(), EncodingStats.NO_STATS))
-                                         .setFlushObservers(Collections.singletonList(observer))
-                                         .addDefaultComponents(Collections.emptySet())
-                                         .build(transaction, null);
-
-        SSTableReader reader;
-        Multimap<ByteBuffer, Cell<?>> expected = ArrayListMultimap.create();
-
-        try
+    @Test
+    public void testFlushObserver() throws Exception
+    {
+        try (LifecycleTransaction transaction = LifecycleTransaction.offline(OperationType.COMPACTION))
         {
-            final long now = System.currentTimeMillis();
+            FlushObserver observer = new FlushObserver();
 
-            ByteBuffer key = UTF8Type.instance.fromString("key1");
-            expected.putAll(key, Arrays.asList(BufferCell.live(getColumn(cfm, "age"), now, Int32Type.instance.decompose(27)),
-                                               BufferCell.live(getColumn(cfm, "first_name"), now, UTF8Type.instance.fromString("jack")),
-                                               BufferCell.live(getColumn(cfm, "height"), now, LongType.instance.decompose(183L))));
+            Descriptor descriptor = new Descriptor(sstableFormat.getLatestVersion(),
+                                                   directory,
+                                                   cfm.keyspace,
+                                                   cfm.name,
+                                                   idGen.get());
+            Index.Group indexGroup = mock(Index.Group.class);
+            when(indexGroup.getFlushObserver(any(), any(), any())).thenReturn(observer);
+            SSTableWriter.Builder<?, ?> writerBuilder = descriptor.getFormat().getWriterFactory().builder(descriptor)
+                                                                  .setKeyCount(10)
+                                                                  .setTableMetadataRef(TableMetadataRef.forOfflineTools(cfm))
+                                                                  .setMetadataCollector(new MetadataCollector(cfm.comparator).sstableLevel(0))
+                                                                  .setSerializationHeader(new SerializationHeader(true, cfm, cfm.regularAndStaticColumns(), EncodingStats.NO_STATS))
+                                                                  .setSecondaryIndexGroups(Collections.singleton(indexGroup))
+                                                                  .addDefaultComponents(Collections.emptySet());
+            assertThat(observer.beginCalled).isFalse();
+            assertThat(observer.isComplete).isFalse();
 
-            writer.append(new RowIterator(cfm, key.duplicate(), Collections.singletonList(buildRow(expected.get(key)))));
+            SSTableWriter writer = writerBuilder.build(transaction, null);
 
-            key = UTF8Type.instance.fromString("key2");
-            expected.putAll(key, Arrays.asList(BufferCell.live(getColumn(cfm, "age"), now, Int32Type.instance.decompose(30)),
-                                               BufferCell.live(getColumn(cfm, "first_name"), now, UTF8Type.instance.fromString("jim")),
-                                               BufferCell.live(getColumn(cfm, "height"), now, LongType.instance.decompose(180L))));
+            assertThat(observer.beginCalled).isTrue();
+            assertThat(observer.isComplete).isFalse();
 
-            writer.append(new RowIterator(cfm, key, Collections.singletonList(buildRow(expected.get(key)))));
+            SSTableReader reader;
+            Multimap<ByteBuffer, Cell<?>> expected = ArrayListMultimap.create();
 
-            key = UTF8Type.instance.fromString("key3");
-            expected.putAll(key, Arrays.asList(BufferCell.live(getColumn(cfm, "age"), now, Int32Type.instance.decompose(30)),
-                                               BufferCell.live(getColumn(cfm, "first_name"), now, UTF8Type.instance.fromString("ken")),
-                                               BufferCell.live(getColumn(cfm, "height"), now, LongType.instance.decompose(178L))));
+            try
+            {
+                final long now = System.currentTimeMillis();
 
-            writer.append(new RowIterator(cfm, key, Collections.singletonList(buildRow(expected.get(key)))));
+                ByteBuffer key = UTF8Type.instance.fromString("key1");
+                expected.putAll(key, Arrays.asList(BufferCell.live(getColumn(cfm, "age"), now, Int32Type.instance.decompose(27)),
+                                                   BufferCell.live(getColumn(cfm, "first_name"), now, UTF8Type.instance.fromString("jack")),
+                                                   BufferCell.live(getColumn(cfm, "height"), now, LongType.instance.decompose(183L))));
 
-            reader = writer.finish(true);
+                writer.append(new RowIterator(cfm, key.duplicate(), Collections.singletonList(buildRow(expected.get(key)))));
+
+                key = UTF8Type.instance.fromString("key2");
+                expected.putAll(key, Arrays.asList(BufferCell.live(getColumn(cfm, "age"), now, Int32Type.instance.decompose(30)),
+                                                   BufferCell.live(getColumn(cfm, "first_name"), now, UTF8Type.instance.fromString("jim")),
+                                                   BufferCell.live(getColumn(cfm, "height"), now, LongType.instance.decompose(180L))));
+
+                writer.append(new RowIterator(cfm, key, Collections.singletonList(buildRow(expected.get(key)))));
+
+                key = UTF8Type.instance.fromString("key3");
+                expected.putAll(key, Arrays.asList(BufferCell.live(getColumn(cfm, "age"), now, Int32Type.instance.decompose(30)),
+                                                   BufferCell.live(getColumn(cfm, "first_name"), now, UTF8Type.instance.fromString("ken")),
+                                                   BufferCell.live(getColumn(cfm, "height"), now, LongType.instance.decompose(178L))));
+
+                writer.append(new RowIterator(cfm, key, Collections.singletonList(buildRow(expected.get(key)))));
+
+                reader = writer.finish(true);
+            }
+            finally
+            {
+                FileUtils.closeQuietly(writer);
+            }
+
+            Assert.assertTrue(observer.isComplete);
+            Assert.assertEquals(expected.size(), observer.rows.size());
+
+            for (Triple<ByteBuffer, Long, Long> e : observer.rows.keySet())
+            {
+                ByteBuffer key = e.getLeft();
+                long indexPosition = e.getRight();
+
+                DecoratedKey indexKey = reader.keyAtPositionFromSecondaryIndex(indexPosition);
+                Assert.assertEquals(0, UTF8Type.instance.compare(key, indexKey.getKey()));
+                Assert.assertEquals(expected.get(key), observer.rows.get(e));
+            }
         }
-        finally
+    }
+
+    @Test
+    public void testFailedInitialization() throws Exception
+    {
+        try (LifecycleTransaction transaction = LifecycleTransaction.offline(OperationType.COMPACTION))
         {
-            FileUtils.closeQuietly(writer);
-        }
+            FlushObserver observer1 = new FlushObserver();
+            FlushObserver observer2 = new FlushObserver();
+            Index.Group indexGroup1 = mock(Index.Group.class);
+            Index.Group indexGroup2 = mock(Index.Group.class);
+            when(indexGroup1.getFlushObserver(any(), any(), any())).thenReturn(observer1);
+            when(indexGroup2.getFlushObserver(any(), any(), any())).thenReturn(observer2);
+            observer2.failOnBegin = true;
 
-        Assert.assertTrue(observer.isComplete);
-        Assert.assertEquals(expected.size(), observer.rows.size());
+            Descriptor descriptor = new Descriptor(sstableFormat.getLatestVersion(),
+                                                   directory,
+                                                   cfm.keyspace,
+                                                   cfm.name,
+                                                   idGen.get());
+            assertThatRuntimeException().isThrownBy(() -> descriptor.getFormat().getWriterFactory().builder(descriptor)
+                                                                    .setKeyCount(10)
+                                                                    .setTableMetadataRef(TableMetadataRef.forOfflineTools(cfm))
+                                                                    .setMetadataCollector(new MetadataCollector(cfm.comparator).sstableLevel(0))
+                                                                    .setSerializationHeader(new SerializationHeader(true, cfm, cfm.regularAndStaticColumns(), EncodingStats.NO_STATS))
+                                                                    .setSecondaryIndexGroups(List.of(indexGroup1, indexGroup2))
+                                                                    .addDefaultComponents(Collections.emptySet())
+                                                                    .build(transaction, null)
+            ).withMessage("Failed to initialize");
 
-        for (Triple<ByteBuffer, Long, Long> e : observer.rows.keySet())
-        {
-            ByteBuffer key = e.getLeft();
-            long indexPosition = e.getRight();
+            assertThat(observer1.beginCalled).isTrue();
+            assertThat(observer1.isComplete).isFalse();
+            assertThat(observer1.abortCalled).isTrue();
 
-            DecoratedKey indexKey = reader.keyAtPositionFromSecondaryIndex(indexPosition);
-            Assert.assertEquals(0, UTF8Type.instance.compare(key, indexKey.getKey()));
-            Assert.assertEquals(expected.get(key), observer.rows.get(e));
+            assertThat(observer2.beginCalled).isTrue();
+            assertThat(observer2.isComplete).isFalse();
+            assertThat(observer2.abortCalled).isFalse();
+
+            assertThat(transaction.state()).isEqualTo(State.IN_PROGRESS);
+            assertThat(transaction.originals()).isEmpty();
         }
     }
 
@@ -190,10 +262,16 @@ public class SSTableFlushObserverTest
 
         private Triple<ByteBuffer, Long, Long> currentKey;
         private boolean isComplete;
+        private boolean beginCalled;
+        private boolean failOnBegin;
+        private boolean abortCalled;
 
         @Override
         public void begin()
         {
+            beginCalled = true;
+            if (failOnBegin)
+                throw new RuntimeException("Failed to initialize");
         }
 
         @Override
@@ -219,6 +297,12 @@ public class SSTableFlushObserverTest
         public void staticRow(Row staticRow)
         {
             staticRow.forEach((c) -> staticRows.put(currentKey, (Cell<?>) c));
+        }
+
+        @Override
+        public void abort(Throwable accumulate)
+        {
+            abortCalled = true;
         }
     }
 

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTestBase.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTestBase.java
@@ -163,7 +163,7 @@ public class SSTableWriterTestBase extends SchemaLoader
                    .setPendingRepair(pendingRepair)
                    .setTransientSSTable(isTransient)
                    .setSerializationHeader(new SerializationHeader(true, cfs.metadata(), cfs.metadata().regularAndStaticColumns(), EncodingStats.NO_STATS))
-                   .addFlushObserversForSecondaryIndexes(cfs.indexManager.listIndexGroups(), txn, cfs.metadata.get())
+                   .setSecondaryIndexGroups(cfs.indexManager.listIndexGroups())
                    .setMetadataCollector(new MetadataCollector(cfs.metadata().comparator))
                    .addDefaultComponents(cfs.indexManager.listIndexGroups())
                    .build(txn, cfs);

--- a/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/ScrubTest.java
@@ -839,7 +839,6 @@ public class ScrubTest
                                          .setTableMetadataRef(cfs.metadata)
                                          .setMetadataCollector(collector)
                                          .setSerializationHeader(header)
-                                         .setFlushObservers(Collections.emptyList())
                                          .addDefaultComponents(Collections.emptySet())
                                          .build(txn, cfs);
 

--- a/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/bti/PartitionIndexTest.java
@@ -429,7 +429,7 @@ public class PartitionIndexTest
                  PartitionIndexBuilder builder = new PartitionIndexBuilder(writer, fhBuilder)
             )
             {
-                writer.setPostFlushListener(() -> builder.markPartitionIndexSynced(writer.getLastFlushOffset()));
+                writer.setPostFlushListener(builder::markPartitionIndexSynced);
                 for (int i = 0; i < COUNT; i++)
                 {
                     DecoratedKey key = generateRandomLengthKey();
@@ -506,7 +506,7 @@ public class PartitionIndexTest
                     for (i = 0; i < 3; ++i)
                         builder.addEntry(list.get(i), i);
 
-                    writer.setPostFlushListener(() -> builder.markPartitionIndexSynced(writer.getLastFlushOffset()));
+                    writer.setPostFlushListener(builder::markPartitionIndexSynced);
                     AtomicInteger callCount = new AtomicInteger();
 
                     final int addedSize = i;
@@ -669,7 +669,7 @@ public class PartitionIndexTest
                  PartitionIndexBuilder builder = new PartitionIndexBuilder(writer, fhBuilder)
             )
             {
-                writer.setPostFlushListener(() -> builder.markPartitionIndexSynced(writer.getLastFlushOffset()));
+                writer.setPostFlushListener(builder::markPartitionIndexSynced);
                 for (int i = 0; i < COUNT; i++)
                 {
                     DecoratedKey key = generateRandomKey();
@@ -708,7 +708,7 @@ public class PartitionIndexTest
              PartitionIndexBuilder builder = new PartitionIndexBuilder(writer, fhBuilder)
         )
         {
-            writer.setPostFlushListener(() -> builder.markPartitionIndexSynced(writer.getLastFlushOffset()));
+            writer.setPostFlushListener(builder::markPartitionIndexSynced);
             for (int i = 0; i < 1000; i++)
             {
                 DecoratedKey key = generateRandomKey();


### PR DESCRIPTION
Refactoring prevents the situation where some sstable components, like data or index, are created before the new sstable is registered with lifecycle transaction, which leads to a problem such that there is a short time when incomplete sstable components are present. At the same time, no transaction file is created, which leads to the possibility that the sstable can be recognized as completed by various transaction-aware listers.
