### PR TITLE
Enable Direct-IO feature for CommitLog files using Java native API's.

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -589,9 +589,14 @@ commitlog_segment_size: 32MiB
 #     parameters:
 #         -
 
-# Configure commitlog disk access mode preferred order:direct_io, mmap, standard.
-# Default access mode is mmap. Direct I/O uses minimum page size to flush to disk.
-commitlog_disk_access_mode : mmap
+# CommitLog segments can use mmap (default) and direct (new) I/O modes to flush
+# the data to disk. Direct I/O is a new feature that minimizes cache effects by
+# using user space buffers. This helps in transferring data from/to disk at high
+# speed. Java enabled support for Direct-I/O feature from version 10 onwards.
+#   Refer: https://bugs.openjdk.org/browse/JDK-8164900
+# Direct-I/O is not enabled yet for compressed and encrypted based segments and
+# for replay (reading) commitlog files.
+commitlog_disk_access_mode_for_write: mmap
 
 # Compression to apply to SSTables as they flush for compressed tables.
 # Note that tables without compression enabled do not respect this flag.

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -589,6 +589,10 @@ commitlog_segment_size: 32MiB
 #     parameters:
 #         -
 
+# Configure commitlog disk access mode preferred order:direct_io, mmap, standard.
+# Default access mode is mmap. Direct I/O uses minimum page size to flush to disk.
+commitlog_disk_access_mode : mmap
+
 # Compression to apply to SSTables as they flush for compressed tables.
 # Note that tables without compression enabled do not respect this flag.
 #
@@ -2111,5 +2115,3 @@ drop_compact_storage_enabled: false
 #
 storage_compatibility_mode: CASSANDRA_4
 
-# Enable Direct I/O feature for Commitlog files. Java-11 forces minimum alignement to 4K and minimum disk write to 4K.
-direct_io_for_commitlog_enabled: true

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2114,4 +2114,3 @@ drop_compact_storage_enabled: false
 #   a stable cluster. If a node from a previous version was started by accident we won't any longer toggle behaviors as when UPGRADING.
 #
 storage_compatibility_mode: CASSANDRA_4
-

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2111,5 +2111,5 @@ drop_compact_storage_enabled: false
 #
 storage_compatibility_mode: CASSANDRA_4
 
-# Enable Direct IO feature for Commitlog files. Java-11 forces minimum alignement to 4K and minimum disk write to 4K.
-use_directio_for_commitlog: false
+# Enable Direct I/O feature for Commitlog files. Java-11 forces minimum alignement to 4K and minimum disk write to 4K.
+direct_io_for_commitlog_enabled: true

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2110,3 +2110,6 @@ drop_compact_storage_enabled: false
 #   a stable cluster. If a node from a previous version was started by accident we won't any longer toggle behaviors as when UPGRADING.
 #
 storage_compatibility_mode: CASSANDRA_4
+
+# Enable Direct IO feature for Commitlog files. Java-11 forces minimum alignement to 4K and minimum disk write to 4K.
+use_directio_for_commitlog: false

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -589,14 +589,15 @@ commitlog_segment_size: 32MiB
 #     parameters:
 #         -
 
-# CommitLog segments can use mmap (default) and direct (new) I/O modes to flush
-# the data to disk. Direct I/O is a new feature that minimizes cache effects by
-# using user space buffers. This helps in transferring data from/to disk at high
-# speed. Java enabled support for Direct-I/O feature from version 10 onwards.
-#   Refer: https://bugs.openjdk.org/browse/JDK-8164900
-# Direct-I/O is not enabled yet for compressed and encrypted based segments and
+# CommitLog segments can use legacy (default), direct (new) and 'auto' (optimized
+# configuration) I/O modes to flush the data to disk. Direct I/O is a new feature
+# that minimizes cache effects by using user space buffers. This helps in
+# transferring data from/to disk at high speed. Java enabled support for
+# Direct-I/O feature from version 10 # onwards.
+# Refer: https://bugs.openjdk.org/browse/JDK-8164900
+# The same is not enabled yet for compressed and encrypted based segments and
 # for replay (reading) commitlog files.
-commitlog_disk_access_mode_for_write: mmap
+# commitlog_disk_access_mode: legacy
 
 # Compression to apply to SSTables as they flush for compressed tables.
 # Note that tables without compression enabled do not respect this flag.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -390,8 +390,7 @@ public class Config
     public ParameterizedClass commitlog_compression;
     public FlushCompression flush_compression = FlushCompression.fast;
     public int commitlog_max_compression_buffers_in_pool = 3;
-    public boolean direct_io_for_commitlog_enabled = false;
-    public CommitLogDiskAccessMode commitlog_disk_access_mode = CommitLogDiskAccessMode.mmap;
+    public DiskAccessMode commitlog_disk_access_mode_for_write = DiskAccessMode.mmap;
     @Replaces(oldName = "periodic_commitlog_sync_lag_block_in_ms", converter = Converters.MILLIS_DURATION_INT, deprecated = true)
     public DurationSpec.IntMillisecondsBound periodic_commitlog_sync_lag_block;
     public TransparentDataEncryptionOptions transparent_data_encryption_options = new TransparentDataEncryptionOptions();
@@ -1149,13 +1148,14 @@ public class Config
         mmap,
         mmap_index_only,
         standard,
+        direct,
     }
 
     public enum CommitLogDiskAccessMode
     {
         standard,
         mmap,
-        direct_io,
+        direct,
     }
 
     public enum MemtableAllocationType

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -390,7 +390,7 @@ public class Config
     public ParameterizedClass commitlog_compression;
     public FlushCompression flush_compression = FlushCompression.fast;
     public int commitlog_max_compression_buffers_in_pool = 3;
-    public boolean use_directio_for_commitlog = false;
+    public boolean direct_io_for_commitlog_enabled = false;
     @Replaces(oldName = "periodic_commitlog_sync_lag_block_in_ms", converter = Converters.MILLIS_DURATION_INT, deprecated = true)
     public DurationSpec.IntMillisecondsBound periodic_commitlog_sync_lag_block;
     public TransparentDataEncryptionOptions transparent_data_encryption_options = new TransparentDataEncryptionOptions();

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -391,6 +391,7 @@ public class Config
     public FlushCompression flush_compression = FlushCompression.fast;
     public int commitlog_max_compression_buffers_in_pool = 3;
     public boolean direct_io_for_commitlog_enabled = false;
+    public CommitLogDiskAccessMode commitlog_disk_access_mode = CommitLogDiskAccessMode.mmap;
     @Replaces(oldName = "periodic_commitlog_sync_lag_block_in_ms", converter = Converters.MILLIS_DURATION_INT, deprecated = true)
     public DurationSpec.IntMillisecondsBound periodic_commitlog_sync_lag_block;
     public TransparentDataEncryptionOptions transparent_data_encryption_options = new TransparentDataEncryptionOptions();
@@ -1148,6 +1149,13 @@ public class Config
         mmap,
         mmap_index_only,
         standard,
+    }
+
+    public enum CommitLogDiskAccessMode
+    {
+        standard,
+        mmap,
+        direct_io,
     }
 
     public enum MemtableAllocationType

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -390,6 +390,7 @@ public class Config
     public ParameterizedClass commitlog_compression;
     public FlushCompression flush_compression = FlushCompression.fast;
     public int commitlog_max_compression_buffers_in_pool = 3;
+    public boolean use_directio_for_commitlog = false;
     @Replaces(oldName = "periodic_commitlog_sync_lag_block_in_ms", converter = Converters.MILLIS_DURATION_INT, deprecated = true)
     public DurationSpec.IntMillisecondsBound periodic_commitlog_sync_lag_block;
     public TransparentDataEncryptionOptions transparent_data_encryption_options = new TransparentDataEncryptionOptions();

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -390,7 +390,7 @@ public class Config
     public ParameterizedClass commitlog_compression;
     public FlushCompression flush_compression = FlushCompression.fast;
     public int commitlog_max_compression_buffers_in_pool = 3;
-    public DiskAccessMode commitlog_disk_access_mode_for_write = DiskAccessMode.mmap;
+    public DiskAccessMode commitlog_disk_access_mode = DiskAccessMode.legacy;
     @Replaces(oldName = "periodic_commitlog_sync_lag_block_in_ms", converter = Converters.MILLIS_DURATION_INT, deprecated = true)
     public DurationSpec.IntMillisecondsBound periodic_commitlog_sync_lag_block;
     public TransparentDataEncryptionOptions transparent_data_encryption_options = new TransparentDataEncryptionOptions();
@@ -1148,14 +1148,8 @@ public class Config
         mmap,
         mmap_index_only,
         standard,
-        direct,
-    }
-
-    public enum CommitLogDiskAccessMode
-    {
-        standard,
-        mmap,
-        direct,
+        legacy,
+        direct // Direct-I/O is enabled for commitlog disk only.
     }
 
     public enum MemtableAllocationType

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2649,6 +2649,11 @@ public class DatabaseDescriptor
         conf.commitlog_segment_size = new DataStorageSpec.IntMebibytesBound(sizeMebibytes);
     }
 
+    public static boolean getDirectIOStatus()
+    {
+        return conf.use_directio_for_commitlog;
+    }
+
     public static String getSavedCachesLocation()
     {
         return conf.saved_caches_directory;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -513,21 +513,30 @@ public class DatabaseDescriptor
 
         // Only mmap & Direct-I/O access modes are supported. Standard access mode is preassumed if Compressed or Encrypted segment is used.
         // This ensures default behavior is unchanged.
-        if  (conf.commitlog_disk_access_mode_for_write != Config.DiskAccessMode.mmap
-             && conf.commitlog_disk_access_mode_for_write != Config.DiskAccessMode.direct)
+        if  (conf.commitlog_disk_access_mode != Config.DiskAccessMode.auto
+             && conf.commitlog_disk_access_mode != Config.DiskAccessMode.legacy
+             && conf.commitlog_disk_access_mode != Config.DiskAccessMode.direct)
         {
-            throw new ConfigurationException(String.format("Commitlog access mode '%s' is not supported. Supported modes are '%s' and '%s'", conf.commitlog_disk_access_mode_for_write,
-                                                                              Config.DiskAccessMode.mmap, Config.DiskAccessMode.direct));
-        } else {
-            Config.DiskAccessMode current_disk_access_mode = conf.commitlog_disk_access_mode_for_write;
+            throw new ConfigurationException(String.format("Commitlog access mode '%s' is not supported. Supported modes are '%s', '%s' and '%s'",
+                                                            conf.commitlog_disk_access_mode, Config.DiskAccessMode.auto,
+                                                            Config.DiskAccessMode.legacy, Config.DiskAccessMode.direct));
+        }
+        else
+        {
+            Config.DiskAccessMode current_disk_access_mode = conf.commitlog_disk_access_mode;
+
+            if (current_disk_access_mode == Config.DiskAccessMode.auto)
+            {
+                current_disk_access_mode = conf.disk_optimization_strategy == Config.DiskOptimizationStrategy.ssd ? Config.DiskAccessMode.direct
+                                                                                                                    : Config.DiskAccessMode.legacy;
+                // This is necessary for other functions to get the new mode determined through auto.
+                conf.commitlog_disk_access_mode = current_disk_access_mode;
+                logger.info("DiskAccessMode 'auto' determined to be '{}' for Commitlog disk", current_disk_access_mode);
+            }
 
             if (getCommitLogCompression() != null || (getEncryptionContext() != null && getEncryptionContext().isEnabled()))
             {
-                if (current_disk_access_mode == Config.DiskAccessMode.mmap)
-                {
-                    current_disk_access_mode = Config.DiskAccessMode.standard;
-                }
-                else if (current_disk_access_mode == Config.DiskAccessMode.direct)
+                if (current_disk_access_mode == Config.DiskAccessMode.direct)
                 {
                     // Compressed and Encrypted segments are not yet supported with Direct-I/O feature.
                     throw new ConfigurationException("Direct I/O does not support Compressed or Encrypted segment yet.");
@@ -549,6 +558,10 @@ public class DatabaseDescriptor
             conf.disk_access_mode = Config.DiskAccessMode.standard;
             indexAccessMode = Config.DiskAccessMode.mmap;
             logger.info("DiskAccessMode is {}, indexAccessMode is {}", conf.disk_access_mode, indexAccessMode);
+        }
+        else if (conf.disk_access_mode == Config.DiskAccessMode.direct || conf.disk_access_mode == Config.DiskAccessMode.legacy)
+        {
+            throw new ConfigurationException(String.format("DiskAccessMode '%s' and '%s' are not supported", Config.DiskAccessMode.direct, Config.DiskAccessMode.legacy));
         }
         else
         {
@@ -2680,7 +2693,7 @@ public class DatabaseDescriptor
      */
     public static Config.DiskAccessMode getCommitLogDiskAccessMode()
     {
-        return conf.commitlog_disk_access_mode_for_write;
+        return conf.commitlog_disk_access_mode;
     }
 
     public static boolean isCommitLogUsingDirectIO()
@@ -2690,7 +2703,7 @@ public class DatabaseDescriptor
 
     public static void setCommitLogDiskAccessMode(Config.DiskAccessMode new_mode)
     {
-        conf.commitlog_disk_access_mode_for_write = new_mode;
+        conf.commitlog_disk_access_mode = new_mode;
     }
 
     public static String getSavedCachesLocation()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2649,9 +2649,12 @@ public class DatabaseDescriptor
         conf.commitlog_segment_size = new DataStorageSpec.IntMebibytesBound(sizeMebibytes);
     }
 
-    public static boolean getDirectIOStatus()
+    /**
+     * Return user configured input for Commitlog files.
+     */
+    public static boolean getDirectIOForCommitlogEnabled()
     {
-        return conf.use_directio_for_commitlog;
+        return conf.direct_io_for_commitlog_enabled;
     }
 
     public static String getSavedCachesLocation()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2696,11 +2696,6 @@ public class DatabaseDescriptor
         return conf.commitlog_disk_access_mode;
     }
 
-    public static boolean isCommitLogUsingDirectIO()
-    {
-        return getCommitLogDiskAccessMode() == Config.DiskAccessMode.direct;
-    }
-
     public static void setCommitLogDiskAccessMode(Config.DiskAccessMode new_mode)
     {
         conf.commitlog_disk_access_mode = new_mode;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -2650,11 +2650,21 @@ public class DatabaseDescriptor
     }
 
     /**
-     * Return user configured input for Commitlog files.
+     * Return commitlog disk access mode.
      */
-    public static boolean getDirectIOForCommitlogEnabled()
+    public static Config.CommitLogDiskAccessMode getCommitLogDiskAccessMode()
     {
-        return conf.direct_io_for_commitlog_enabled;
+        return conf.commitlog_disk_access_mode;
+    }
+
+    public static boolean isCommitLogUsingDirectIO()
+    {
+        return getCommitLogDiskAccessMode() == Config.CommitLogDiskAccessMode.direct_io;
+    }
+
+    public static void setCommitLogDiskAccessMode(Config.CommitLogDiskAccessMode new_mode)
+    {
+        conf.commitlog_disk_access_mode = new_mode;
     }
 
     public static String getSavedCachesLocation()

--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogSegmentManager.java
@@ -117,8 +117,9 @@ public abstract class AbstractCommitLogSegmentManager
                                     ? BufferType.ON_HEAP
                                     : commitLog.configuration.getCompressor().preferredBufferType();
 
-        // Identify minimum block size used for Direct-I/O. allocateDirect does not return from aligned space.
-        // To avoid write errors additional block size is requested and next aligned it minimum block size.
+        // The direct buffer must be aligned with the file system block size. We cannot enforce that during
+        // allocation, but we can get an aligned slice from the allocated buffer. The buffer must be oversized by the
+        // alignment unit to make it possible.
         int minimumAllowedAlign = !commitLog.configuration.isDirectIOEnabled()
                                   ? 0 : CommitLogSegment.getDirectIOMinimumAlignement(storageDirectory, "CommitLog-DirectIO-Test.log");
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -130,9 +130,7 @@ public class CommitLog implements CommitLogMBean
         // register metrics
         metrics.attach(executor, segmentManager);
 
-	if (configuration.isDirectIOEnabled()) {
-          logger.info("Direct-IO feature enabled for Commitlog files.");
-	}
+        logger.info("Direct I/O feature for Commitlog files is : " + configuration.isDirectIOEnabled() + ".");
     }
 
     /**
@@ -638,7 +636,7 @@ public class CommitLog implements CommitLogMBean
             this.compressorClass = compressorClass;
             this.compressor = compressorClass != null ? CompressionParams.createCompressor(compressorClass) : null;
             this.encryptionContext = encryptionContext;
-            this.useDirectIO = DatabaseDescriptor.getDirectIOStatus();
+            this.useDirectIO = DatabaseDescriptor.getDirectIOForCommitlogEnabled();
         }
 
         /**

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -72,7 +72,7 @@ import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
  */
 public class CommitLog implements CommitLogMBean
 {
-    private static final Logger logger = LoggerFactory.getLogger(CommitLog.class);
+    public static final Logger logger = LoggerFactory.getLogger(CommitLog.class);
 
     public static final CommitLog instance = CommitLog.construct();
 
@@ -129,6 +129,10 @@ public class CommitLog implements CommitLogMBean
 
         // register metrics
         metrics.attach(executor, segmentManager);
+
+	if (configuration.isDirectIOEnabled()) {
+          logger.info("Direct-IO feature enabled for Commitlog files.");
+	}
     }
 
     /**
@@ -609,6 +613,7 @@ public class CommitLog implements CommitLogMBean
 
     public static final class Configuration
     {
+        private final boolean useDirectIO;
         /**
          * The compressor class.
          */
@@ -629,6 +634,7 @@ public class CommitLog implements CommitLogMBean
             this.compressorClass = compressorClass;
             this.compressor = compressorClass != null ? CompressionParams.createCompressor(compressorClass) : null;
             this.encryptionContext = encryptionContext;
+            this.useDirectIO = DatabaseDescriptor.getDirectIOStatus();
         }
 
         /**
@@ -683,6 +689,15 @@ public class CommitLog implements CommitLogMBean
         public EncryptionContext getEncryptionContext()
         {
             return encryptionContext;
+        }
+
+        /**
+         * Returns DirectIO/non-buffer IO status
+         * @return DirectIO/non-buffer IO status
+         */
+        public boolean isDirectIOEnabled()
+        {
+            return useDirectIO;
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -613,7 +613,11 @@ public class CommitLog implements CommitLogMBean
 
     public static final class Configuration
     {
+        /**
+         * Flag used to shows user configured Direct-IO status.
+         */
         private final boolean useDirectIO;
+
         /**
          * The compressor class.
          */

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -131,25 +131,6 @@ public class CommitLog implements CommitLogMBean
 
         // register metrics
         metrics.attach(executor, segmentManager);
-
-        String diskMode = " ";
-
-        switch (DatabaseDescriptor.getCommitLogDiskAccessMode())
-        {
-            case standard:
-                diskMode = "Standard (buffered)";
-                break;
-            case mmap:
-                diskMode = "MMap(memory mmaped)";
-                break;
-            case direct_io:
-                diskMode = "Direct (non-buffered)";
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown commitlog disk access mode type: " + DatabaseDescriptor.getCommitLogDiskAccessMode());
-        }
-
-	logger.info("Using " + diskMode + " I/O for CommitLog files.");
     }
 
     /**
@@ -634,7 +615,7 @@ public class CommitLog implements CommitLogMBean
         /**
          * Flag used to shows user configured Direct-IO status.
          */
-        private final Config.CommitLogDiskAccessMode diskAccessMode;
+        private final Config.DiskAccessMode diskAccessMode;
 
         /**
          * The compressor class.
@@ -652,7 +633,7 @@ public class CommitLog implements CommitLogMBean
         private EncryptionContext encryptionContext;
 
         public Configuration(ParameterizedClass compressorClass, EncryptionContext encryptionContext,
-                             Config.CommitLogDiskAccessMode diskAccessMode)
+                             Config.DiskAccessMode diskAccessMode)
         {
             this.compressorClass = compressorClass;
             this.compressor = compressorClass != null ? CompressionParams.createCompressor(compressorClass) : null;
@@ -720,25 +701,16 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isDirectIOEnabled()
         {
-            return diskAccessMode == Config.CommitLogDiskAccessMode.direct_io;
-        }
-
-        /**
-         * Returns MMAP used for CommitLog IO.
-         * @return MMAP used for CommitLog IO
-         */
-        public boolean isMMAPEnabled()
-        {
-            return diskAccessMode == Config.CommitLogDiskAccessMode.mmap;
+            return diskAccessMode == Config.DiskAccessMode.direct;
         }
 
         /**
          * Returns Standard or buffered I/O used for CommitLog IO.
          * @return Standard or buffered I/O used for CommitLog IO
          */
-        public boolean isBufferedIOEnabled()
+        public boolean isStandardModeEnable()
         {
-            return diskAccessMode == Config.CommitLogDiskAccessMode.standard;
+            return diskAccessMode == Config.DiskAccessMode.standard;
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -73,7 +73,7 @@ import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
  */
 public class CommitLog implements CommitLogMBean
 {
-    public static final Logger logger = LoggerFactory.getLogger(CommitLog.class);
+    private static final Logger logger = LoggerFactory.getLogger(CommitLog.class);
 
     public static final CommitLog instance = CommitLog.construct();
 
@@ -634,7 +634,7 @@ public class CommitLog implements CommitLogMBean
         /**
          * Flag used to shows user configured Direct-IO status.
          */
-        private final Config.CommitLogDiskAccessMode diskMode;
+        private final Config.CommitLogDiskAccessMode diskAccessMode;
 
         /**
          * The compressor class.
@@ -657,7 +657,7 @@ public class CommitLog implements CommitLogMBean
             this.compressorClass = compressorClass;
             this.compressor = compressorClass != null ? CompressionParams.createCompressor(compressorClass) : null;
             this.encryptionContext = encryptionContext;
-            this.diskMode = diskAccessMode;
+            this.diskAccessMode = diskAccessMode;
         }
 
         /**
@@ -720,7 +720,7 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isDirectIOEnabled()
         {
-            return diskMode == Config.CommitLogDiskAccessMode.direct_io;
+            return diskAccessMode == Config.CommitLogDiskAccessMode.direct_io;
         }
 
         /**
@@ -729,7 +729,7 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isMMAPEnabled()
         {
-            return diskMode == Config.CommitLogDiskAccessMode.mmap;
+            return diskAccessMode == Config.CommitLogDiskAccessMode.mmap;
         }
 
         /**
@@ -738,7 +738,7 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isBufferedIOEnabled()
         {
-            return diskMode == Config.CommitLogDiskAccessMode.standard;
+            return diskAccessMode == Config.CommitLogDiskAccessMode.standard;
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -720,7 +720,7 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isDirectIOEnabled()
         {
-            return diskMode == Config.CommitLogDiskAccessMode.direct_io ;
+            return diskMode == Config.CommitLogDiskAccessMode.direct_io;
         }
 
         /**
@@ -729,7 +729,7 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isMMAPEnabled()
         {
-            return diskMode == Config.CommitLogDiskAccessMode.mmap ;
+            return diskMode == Config.CommitLogDiskAccessMode.mmap;
         }
 
         /**
@@ -738,7 +738,7 @@ public class CommitLog implements CommitLogMBean
          */
         public boolean isBufferedIOEnabled()
         {
-            return diskMode == Config.CommitLogDiskAccessMode.standard ;
+            return diskMode == Config.CommitLogDiskAccessMode.standard;
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -206,12 +206,6 @@ public abstract class CommitLogSegment
         lastSyncedOffset = lastMarkerOffset = buffer.position();
         allocatePosition.set(lastSyncedOffset + SYNC_MARKER_SIZE);
         headerWritten = true;
-
-        // Testing shows writing initial bytes takes some time for Direct I/O. During peak load,
-        // it is better to make "COMMIT-LOG-ALLOCATOR" thread to write these few bytes of each
-        // file and this helps syncer thread to speedup the flush activity.
-        if (CommitLog.instance.configuration.isDirectIOEnabled())
-            flush(0, lastSyncedOffset);
     }
 
     /**
@@ -737,7 +731,7 @@ public abstract class CommitLogSegment
         if (minimumDirectIOAlignement != 0)
             return minimumDirectIOAlignement;
 
-        File testFile = new File(storageDirectory, "directio_test_blocksize.log");
+        File testFile = new File(storageDirectory, fileName);
         try
         {
             FileChannel channel = FileChannel.open(testFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE, ExtendedOpenOption.DIRECT);

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegment.java
@@ -139,8 +139,8 @@ public abstract class CommitLogSegment
         Configuration config = commitLog.configuration;
         CommitLogSegment segment = config.useEncryption() ? new EncryptedSegment(commitLog, manager)
                                                           : config.useCompression() ? new CompressedSegment(commitLog, manager)
-                                                                                    : ! config.isDirectIOEnabled() ? new MemoryMappedSegment(commitLog, manager)
-                                                                                                                   : new DirectIOSegment(commitLog, manager);
+                                                                                    : config.isDirectIOEnabled() ? new DirectIOSegment(commitLog, manager)
+                                                                                                                 : new MemoryMappedSegment(commitLog, manager);
         segment.writeLogHeader();
         return segment;
     }
@@ -178,7 +178,7 @@ public abstract class CommitLogSegment
         try
         {
             if(commitLog.configuration.isDirectIOEnabled())
-                channel = FileChannel.open(logFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE,ExtendedOpenOption.DIRECT);
+                channel = FileChannel.open(logFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE, ExtendedOpenOption.DIRECT);
             else
                 channel = FileChannel.open(logFile.toPath(), StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE);
             fd = NativeLibrary.getfd(channel);

--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -31,7 +31,7 @@ import org.apache.cassandra.io.FSWriteError;
  */
 public class DirectIOSegment extends CommitLogSegment
 {
-    ByteBuffer original;
+    private ByteBuffer original;
 
     // Needed to track number of bytes written to disk in multiple of page size.
     long lastWritten = 0;
@@ -56,6 +56,7 @@ public class DirectIOSegment extends CommitLogSegment
         int segmentSize = DatabaseDescriptor.getCommitLogSegmentSize();
 
         original =  manager.getBufferPool().createBuffer();
+        assert original != null : String.format("Direct ByteBuffer allocation failed for DirectIOSegment");
 
         // May get previously used buffer and zero it out to now. Direct I/O writes additional bytes during flush
         // operation.
@@ -70,6 +71,16 @@ public class DirectIOSegment extends CommitLogSegment
         assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumDirectIOAlignement) == 0 : String.format("Limit should be aligned to %d page size", minimumDirectIOAlignement);
 
         return alignedBuffer;
+    }
+
+    @Override
+    void writeLogHeader()
+    {
+        super.writeLogHeader();
+        // Testing shows writing initial bytes takes some time for Direct I/O. During peak load,
+        // it is better to make "COMMIT-LOG-ALLOCATOR" thread to write these few bytes of each
+        // file and this helps syncer thread to speedup the flush activity.
+        flush(0, lastSyncedOffset);
     }
 
     @Override
@@ -91,39 +102,38 @@ public class DirectIOSegment extends CommitLogSegment
     @Override
     protected void flush(int startMarker, int nextMarker)
     {
-
         try
         {
-            // lastSyncedOffset is synced to disk. Align lastSyncedOffset to start of 4K page
-            // and nextMarker to end of 4K page to avoid write errors.
-            int filePosition = lastSyncedOffset;
+            // lastSyncedOffset is synced to disk. Align lastSyncedOffset to start of its block
+            // and nextMarker to end of its block to avoid write errors.
+            int flushPosition = lastSyncedOffset;
             ByteBuffer duplicate = buffer.duplicate();
 
             // Aligned file position if not aligned to start of 4K page.
-            if (filePosition % minimumDirectIOAlignement != 0)
+            if (flushPosition % minimumDirectIOAlignement != 0)
             {
-                filePosition = filePosition & ~(minimumDirectIOAlignement -1);
-                channel.position(filePosition);
+                flushPosition = flushPosition & ~(minimumDirectIOAlignement -1);
+                channel.position(flushPosition);
             }
-            duplicate.position(filePosition);
+            duplicate.position(flushPosition);
 
-            int flushSizeInBytes = nextMarker;
+            int flushLimit = nextMarker;
 
-            // Align last byte to end of 4K page.
-            if (flushSizeInBytes % minimumDirectIOAlignement != 0)
-                flushSizeInBytes = (flushSizeInBytes + minimumDirectIOAlignement) & ~(minimumDirectIOAlignement -1);
+            // Align last byte to end of block.
+            if (flushLimit % minimumDirectIOAlignement != 0)
+                flushLimit = (flushLimit + minimumDirectIOAlignement) & ~(minimumDirectIOAlignement -1);
 
-            duplicate.limit(flushSizeInBytes);
+            duplicate.limit(flushLimit);
 
             channel.write(duplicate);
 
             // Direct I/O always writes flushes in block size and writes more than the flush size.
-            // File size on disk will always multiple of page size and taking this into account
-            // helps testcases to pass.
-            if (flushSizeInBytes > lastWritten)
+            // File size on disk will always multiple of block size and taking this into account
+            // helps testcases to pass. Avoid counting same block more than once.
+            if (flushLimit > lastWritten)
             {
-                manager.addSize(flushSizeInBytes - lastWritten);
-                lastWritten = flushSizeInBytes;
+                manager.addSize(flushLimit - lastWritten);
+                lastWritten = flushLimit;
             }
         }
         catch (IOException e)

--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.commitlog;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.util.FileUtils;
+
+/*
+ * Direct-IO segment. Allocates ByteBuffer using ByteBuffer.allocateDirect and align
+ * ByteBuffer.position, ByteBuffer.limit and FileChannel.position to page size (4K).
+ * Java-11 forces minimum page size to be written to disk with Direct-IO.
+ */
+public class DirectIOSegment extends CommitLogSegment
+{
+    ByteBuffer original;
+    static int minimumAllowedAlign;
+
+    /**
+     * Constructs a new segment file.
+     *
+     * @param commitLog the commit log it will be used with.
+     */
+    DirectIOSegment(CommitLog commitLog, AbstractCommitLogSegmentManager manager)
+    {
+        super(commitLog, manager);
+
+        // mark the initial sync marker as uninitialised
+        int firstSync = buffer.position();
+        buffer.putInt(firstSync + 0, 0);
+        buffer.putInt(firstSync + 4, 0);
+
+        // Testing shows writing initial bytes takes some time. During peak load, it helps
+        // lot and Syncer thread can actually do flush activity. Making this initial
+        // slow operation to be executed by Allocator thread here.
+        int oldLastSyncedOffset=lastSyncedOffset;
+        // 8 bytes are written above.
+        lastSyncedOffset=8;
+        flush(0,lastSyncedOffset);
+        lastSyncedOffset = oldLastSyncedOffset;
+    }
+
+    ByteBuffer createBuffer(CommitLog commitLog)
+    {
+        if (minimumAllowedAlign ==0)
+        {
+            try
+            {
+                minimumAllowedAlign = (int)Files.getFileStore(logFile.toPath()).getBlockSize();
+            }
+            catch (IOException e)
+            {
+                throw new FSWriteError(e, logFile);
+            }
+        }
+
+        int cl_size = DatabaseDescriptor.getCommitLogSegmentSize();
+        original = ByteBuffer.allocateDirect(cl_size + minimumAllowedAlign);
+
+        ByteBuffer alignedBuffer = original.alignedSlice(minimumAllowedAlign);
+        assert alignedBuffer.limit() >= cl_size : String.format("Bytebuffer slicing failed to get required buffer size (required=%d,current size=%d", cl_size, alignedBuffer.limit());
+
+        assert alignedBuffer.alignmentOffset(0, minimumAllowedAlign) ==0 : "Index 0 should be aligned to 4K page size";
+        assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumAllowedAlign) ==0 : "Limit should be aligned to 4K page size" ;
+
+        manager.addSize(cl_size);
+
+        return alignedBuffer;
+    }
+
+    @Override
+    void write(int startMarker, int nextMarker)
+    {
+        // if there's room in the discard section to write an empty header,
+        // zero out the next sync marker so replayer can cleanly exit
+        if (nextMarker <= buffer.capacity() - SYNC_MARKER_SIZE)
+        {
+            buffer.putInt(nextMarker, 0);
+            buffer.putInt(nextMarker + 4, 0);
+        }
+
+        // write previous sync marker to point to next sync marker
+        // we don't chain the crcs here to ensure this method is idempotent if it fails
+        writeSyncMarker(id, buffer, startMarker, startMarker, nextMarker);
+    }
+
+    @Override
+    protected void flush(int startMarker, int nextMarker)
+    {
+
+        try
+        {
+            // lastSyncedOffset is synced to disk. Align lastSyncedOffset to start of 4K page
+            // and nextMarker to end of 4K page to avoid write errors.
+            long filePosition = lastSyncedOffset;
+            ByteBuffer duplicate = buffer.duplicate();
+
+            // Aligned file position if not aligned to start of 4K page.
+            if (filePosition % minimumAllowedAlign != 0 )
+            {
+                filePosition = filePosition & ~(minimumAllowedAlign -1);
+                channel.position(filePosition);
+            }
+            duplicate.position((int)filePosition);
+
+            int flushSizeInBytes = nextMarker;
+
+            // Align last byte to end of 4K page.
+            if (flushSizeInBytes % minimumAllowedAlign !=0)
+                flushSizeInBytes = (flushSizeInBytes+minimumAllowedAlign) & ~(minimumAllowedAlign -1);
+
+            duplicate.limit(flushSizeInBytes);
+
+            channel.write(duplicate);
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
+    }
+
+    @Override
+    public long onDiskSize()
+    {
+        return DatabaseDescriptor.getCommitLogSegmentSize();
+    }
+
+    @Override
+    protected void internalClose()
+    {
+        FileUtils.clean(original);
+        super.internalClose();
+    }
+}

--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -52,16 +52,16 @@ public class DirectIOSegment extends CommitLogSegment
         // Testing shows writing initial bytes takes some time. During peak load, it helps
         // lot and Syncer thread can actually do flush activity. Making this initial
         // slow operation to be executed by Allocator thread here.
-        int oldLastSyncedOffset=lastSyncedOffset;
+        int oldLastSyncedOffset = lastSyncedOffset;
         // 8 bytes are written above.
-        lastSyncedOffset=8;
-        flush(0,lastSyncedOffset);
+        lastSyncedOffset = 8;
+        flush(0, lastSyncedOffset);
         lastSyncedOffset = oldLastSyncedOffset;
     }
 
     ByteBuffer createBuffer(CommitLog commitLog)
     {
-        if (minimumAllowedAlign ==0)
+        if (minimumAllowedAlign == 0)
         {
             try
             {
@@ -79,8 +79,8 @@ public class DirectIOSegment extends CommitLogSegment
         ByteBuffer alignedBuffer = original.alignedSlice(minimumAllowedAlign);
         assert alignedBuffer.limit() >= cl_size : String.format("Bytebuffer slicing failed to get required buffer size (required=%d,current size=%d", cl_size, alignedBuffer.limit());
 
-        assert alignedBuffer.alignmentOffset(0, minimumAllowedAlign) ==0 : "Index 0 should be aligned to 4K page size";
-        assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumAllowedAlign) ==0 : "Limit should be aligned to 4K page size" ;
+        assert alignedBuffer.alignmentOffset(0, minimumAllowedAlign) == 0 : "Index 0 should be aligned to 4K page size";
+        assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumAllowedAlign) == 0 : "Limit should be aligned to 4K page size" ;
 
         manager.addSize(cl_size);
 

--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -35,6 +35,9 @@ public class DirectIOSegment extends CommitLogSegment
     ByteBuffer original;
     static int minimumAllowedAlign;
 
+    // Needed to track number of bytes written to disk in multiple of page size.
+    int lastWritten = 0;
+
     /**
      * Constructs a new segment file.
      *
@@ -82,8 +85,6 @@ public class DirectIOSegment extends CommitLogSegment
         assert alignedBuffer.alignmentOffset(0, minimumAllowedAlign) == 0 : "Index 0 should be aligned to 4K page size";
         assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumAllowedAlign) == 0 : "Limit should be aligned to 4K page size" ;
 
-        manager.addSize(cl_size);
-
         return alignedBuffer;
     }
 
@@ -113,6 +114,7 @@ public class DirectIOSegment extends CommitLogSegment
             // and nextMarker to end of 4K page to avoid write errors.
             long filePosition = lastSyncedOffset;
             ByteBuffer duplicate = buffer.duplicate();
+            long file_old_position = channel.position();
 
             // Aligned file position if not aligned to start of 4K page.
             if (filePosition % minimumAllowedAlign != 0 )
@@ -126,11 +128,19 @@ public class DirectIOSegment extends CommitLogSegment
 
             // Align last byte to end of 4K page.
             if (flushSizeInBytes % minimumAllowedAlign !=0)
-                flushSizeInBytes = (flushSizeInBytes+minimumAllowedAlign) & ~(minimumAllowedAlign -1);
+                flushSizeInBytes = (flushSizeInBytes + minimumAllowedAlign) & ~(minimumAllowedAlign -1);
 
             duplicate.limit(flushSizeInBytes);
 
             channel.write(duplicate);
+
+            // Direct I/O always writes flushes in block size and writes more than the flush size.
+            // File size on disk will always multiple of page size and taking this into account
+            // helps testcases to pass.
+            if (flushSizeInBytes > lastWritten) {
+                manager.addSize(flushSizeInBytes - lastWritten);
+                lastWritten = (int)flushSizeInBytes;
+            }
         }
         catch (IOException e)
         {
@@ -141,7 +151,7 @@ public class DirectIOSegment extends CommitLogSegment
     @Override
     public long onDiskSize()
     {
-        return DatabaseDescriptor.getCommitLogSegmentSize();
+        return lastWritten ;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -82,8 +82,8 @@ public class DirectIOSegment extends CommitLogSegment
         ByteBuffer alignedBuffer = original.alignedSlice(minimumAllowedAlign);
         assert alignedBuffer.limit() >= segmentSize : String.format("Bytebuffer slicing failed to get required buffer size (required=%d,current size=%d", segmentSize, alignedBuffer.limit());
 
-        assert alignedBuffer.alignmentOffset(0, minimumAllowedAlign) == 0 : "Index 0 should be aligned to 4K page size";
-        assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumAllowedAlign) == 0 : "Limit should be aligned to 4K page size" ;
+        assert alignedBuffer.alignmentOffset(0, minimumAllowedAlign) == 0 : String.format("Index 0 should be aligned to %d page size.", minimumAllowedAlign);
+        assert alignedBuffer.alignmentOffset(alignedBuffer.limit(), minimumAllowedAlign) == 0 : String.format("Limit should be aligned to %d page size", minimumAllowedAlign);
 
         return alignedBuffer;
     }
@@ -116,7 +116,7 @@ public class DirectIOSegment extends CommitLogSegment
             ByteBuffer duplicate = buffer.duplicate();
 
             // Aligned file position if not aligned to start of 4K page.
-            if (filePosition % minimumAllowedAlign != 0 )
+            if (filePosition % minimumAllowedAlign != 0)
             {
                 filePosition = filePosition & ~(minimumAllowedAlign -1);
                 channel.position(filePosition);
@@ -126,7 +126,7 @@ public class DirectIOSegment extends CommitLogSegment
             int flushSizeInBytes = nextMarker;
 
             // Align last byte to end of 4K page.
-            if (flushSizeInBytes % minimumAllowedAlign !=0)
+            if (flushSizeInBytes % minimumAllowedAlign != 0)
                 flushSizeInBytes = (flushSizeInBytes + minimumAllowedAlign) & ~(minimumAllowedAlign -1);
 
             duplicate.limit(flushSizeInBytes);
@@ -136,7 +136,8 @@ public class DirectIOSegment extends CommitLogSegment
             // Direct I/O always writes flushes in block size and writes more than the flush size.
             // File size on disk will always multiple of page size and taking this into account
             // helps testcases to pass.
-            if (flushSizeInBytes > lastWritten) {
+            if (flushSizeInBytes > lastWritten)
+            {
                 manager.addSize(flushSizeInBytes - lastWritten);
                 lastWritten = flushSizeInBytes;
             }

--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -8,6 +8,7 @@ memtable_allocation_type: offheap_objects
 commitlog_sync: batch
 commitlog_segment_size: 5MiB
 commitlog_directory: build/test/cassandra/commitlog
+direct_io_for_commitlog_enabled: true
 # commitlog_compression:
 # - class_name: LZ4Compressor
 cdc_raw_directory: build/test/cassandra/cdc_raw

--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -8,7 +8,7 @@ memtable_allocation_type: offheap_objects
 commitlog_sync: batch
 commitlog_segment_size: 5MiB
 commitlog_directory: build/test/cassandra/commitlog
-direct_io_for_commitlog_enabled: true
+commitlog_disk_access_mode : mmap
 # commitlog_compression:
 # - class_name: LZ4Compressor
 cdc_raw_directory: build/test/cassandra/cdc_raw

--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -8,7 +8,6 @@ memtable_allocation_type: offheap_objects
 commitlog_sync: batch
 commitlog_segment_size: 5MiB
 commitlog_directory: build/test/cassandra/commitlog
-commitlog_disk_access_mode : mmap
 # commitlog_compression:
 # - class_name: LZ4Compressor
 cdc_raw_directory: build/test/cassandra/cdc_raw

--- a/test/long/org/apache/cassandra/db/commitlog/BatchCommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/BatchCommitLogStressTest.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.security.EncryptionContext;
 @RunWith(Parameterized.class)
 public class BatchCommitLogStressTest extends CommitLogStressTest
 {
-    public BatchCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
+    public BatchCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode accessMode)
     {
         super(commitLogCompression, encryptionContext, accessMode);
         DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.batch);

--- a/test/long/org/apache/cassandra/db/commitlog/BatchCommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/BatchCommitLogStressTest.java
@@ -29,9 +29,9 @@ import org.apache.cassandra.security.EncryptionContext;
 @RunWith(Parameterized.class)
 public class BatchCommitLogStressTest extends CommitLogStressTest
 {
-    public BatchCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext)
+    public BatchCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
     {
-        super(commitLogCompression, encryptionContext);
+        super(commitLogCompression, encryptionContext, accessMode);
         DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.batch);
     }
 }

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -95,7 +95,7 @@ public abstract class CommitLogStressTest
     private CommitLogPosition discardedPos;
     private long totalBytesWritten = 0;
 
-    public CommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
+    public CommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode accessMode)
     {
         DatabaseDescriptor.setCommitLogCompression(commitLogCompression);
         DatabaseDescriptor.setEncryptionContext(encryptionContext);
@@ -143,14 +143,13 @@ public abstract class CommitLogStressTest
     @Parameters()
     public static Collection<Object[]> buildParameterizedVariants()
     {
-        //{null, EncryptionContextGenerator.createDisabledContext(), Config.CommitLogDiskAccessMode.direct_io}}); // No compression, no encryption
         return Arrays.asList(new Object[][]{
-        {null, EncryptionContextGenerator.createDisabledContext(), Config.CommitLogDiskAccessMode.mmap}, // No compression, no encryption, mmap
-        {null, EncryptionContextGenerator.createDisabledContext(), Config.CommitLogDiskAccessMode.direct_io}, // Direct-IO
-        {null, EncryptionContextGenerator.createContext(true), Config.CommitLogDiskAccessMode.standard},
-        { new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.CommitLogDiskAccessMode.standard},
-        { new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.CommitLogDiskAccessMode.standard},
-        { new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.CommitLogDiskAccessMode.standard}});
+        {null, EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap}, // No compression, no encryption, mmap
+        {null, EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.direct}, // Use Direct-I/O (non-buffered) feature.
+        {null, EncryptionContextGenerator.createContext(true), Config.DiskAccessMode.mmap},
+        { new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap},
+        { new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap},
+        { new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap}});
     }
 
     @Test

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -194,8 +194,9 @@ public abstract class CommitLogStressTest
     }
 
     private void testLog(CommitLog commitLog) throws IOException, InterruptedException {
-        System.out.format("\nTesting commit log size %.0fmb, compressor: %s, encryption enabled: %b, direct I/O enabled: %b, sync %s%s%s\n",
+        System.out.format("\nTesting commit log size %.0fmb, disk mode: %s, compressor: %s, encryption enabled: %b, direct I/O enabled: %b, sync %s%s%s\n",
                            mb(DatabaseDescriptor.getCommitLogSegmentSize()),
+                           DatabaseDescriptor.getCommitLogDiskAccessMode(),
                            commitLog.configuration.getCompressorName(),
                            commitLog.configuration.useEncryption(),
                            commitLog.configuration.isDirectIOEnabled(),
@@ -263,7 +264,8 @@ public abstract class CommitLogStressTest
                 Assert.fail("Failed to delete " + f);
 
         if (hash == reader.hash && cells == reader.cells)
-            System.out.format("Test success. compressor = %s, encryption enabled = %b, direct I/O = %b; discarded = %d, skipped = %d; IO speed(total bytes=%.2fmb, rate=%.2fmb/sec)\n",
+            System.out.format("Test success. disk mode = %s, compressor = %s, encryption enabled = %b, direct I/O = %b; discarded = %d, skipped = %d; IO speed(total bytes=%.2fmb, rate=%.2fmb/sec)\n",
+                              DatabaseDescriptor.getCommitLogDiskAccessMode(),
                               commitLog.configuration.getCompressorName(),
                               commitLog.configuration.useEncryption(),
                               commitLog.configuration.isDirectIOEnabled(),
@@ -271,7 +273,8 @@ public abstract class CommitLogStressTest
                               mb(totalBytesWritten), mb(totalBytesWritten)/runTimeMs*1000);
         else
         {
-            System.out.format("Test failed (compressor = %s, encryption enabled = %b, direct I/O = %b). Cells %d, expected %d, diff %d; discarded = %d, skipped = %d -  hash %d expected %d.\n",
+            System.out.format("Test failed (disk mode = %s, compressor = %s, encryption enabled = %b, direct I/O = %b). Cells %d, expected %d, diff %d; discarded = %d, skipped = %d -  hash %d expected %d.\n",
+                              DatabaseDescriptor.getCommitLogDiskAccessMode(),
                               commitLog.configuration.getCompressorName(),
                               commitLog.configuration.useEncryption(),
                               commitLog.configuration.isDirectIOEnabled(),

--- a/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/CommitLogStressTest.java
@@ -144,12 +144,12 @@ public abstract class CommitLogStressTest
     public static Collection<Object[]> buildParameterizedVariants()
     {
         return Arrays.asList(new Object[][]{
-        {null, EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap}, // No compression, no encryption, mmap
+        {null, EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.legacy}, // No compression, no encryption, legacy
         {null, EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.direct}, // Use Direct-I/O (non-buffered) feature.
-        {null, EncryptionContextGenerator.createContext(true), Config.DiskAccessMode.mmap},
-        { new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap},
-        { new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap},
-        { new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.mmap}});
+        {null, EncryptionContextGenerator.createContext(true), Config.DiskAccessMode.legacy},
+        { new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.legacy},
+        { new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.legacy},
+        { new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext(), Config.DiskAccessMode.legacy}});
     }
 
     @Test
@@ -194,7 +194,7 @@ public abstract class CommitLogStressTest
     }
 
     private void testLog(CommitLog commitLog) throws IOException, InterruptedException {
-        System.out.format("\nTesting commit log size %.0fmb, compressor: %s, encryption enabled: %b, Direct I/O enabled: %b, sync %s%s%s\n",
+        System.out.format("\nTesting commit log size %.0fmb, compressor: %s, encryption enabled: %b, direct I/O enabled: %b, sync %s%s%s\n",
                            mb(DatabaseDescriptor.getCommitLogSegmentSize()),
                            commitLog.configuration.getCompressorName(),
                            commitLog.configuration.useEncryption(),

--- a/test/long/org/apache/cassandra/db/commitlog/GroupCommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/GroupCommitLogStressTest.java
@@ -29,9 +29,9 @@ import org.apache.cassandra.security.EncryptionContext;
 @RunWith(Parameterized.class)
 public class GroupCommitLogStressTest extends CommitLogStressTest
 {
-    public GroupCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext)
+    public GroupCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
     {
-        super(commitLogCompression, encryptionContext);
+        super(commitLogCompression, encryptionContext, accessMode);
         DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.group);
         DatabaseDescriptor.setCommitLogSyncGroupWindow(1);
     }

--- a/test/long/org/apache/cassandra/db/commitlog/GroupCommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/GroupCommitLogStressTest.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.security.EncryptionContext;
 @RunWith(Parameterized.class)
 public class GroupCommitLogStressTest extends CommitLogStressTest
 {
-    public GroupCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
+    public GroupCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode accessMode)
     {
         super(commitLogCompression, encryptionContext, accessMode);
         DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.group);

--- a/test/long/org/apache/cassandra/db/commitlog/PeriodicCommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/PeriodicCommitLogStressTest.java
@@ -29,9 +29,9 @@ import org.apache.cassandra.security.EncryptionContext;
 @RunWith(Parameterized.class)
 public class PeriodicCommitLogStressTest extends CommitLogStressTest
 {
-    public PeriodicCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext)
+    public PeriodicCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
     {
-        super(commitLogCompression, encryptionContext);
+        super(commitLogCompression, encryptionContext, accessMode);
         DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.periodic);
         DatabaseDescriptor.setCommitLogSyncPeriod(30);
     }

--- a/test/long/org/apache/cassandra/db/commitlog/PeriodicCommitLogStressTest.java
+++ b/test/long/org/apache/cassandra/db/commitlog/PeriodicCommitLogStressTest.java
@@ -29,7 +29,7 @@ import org.apache.cassandra.security.EncryptionContext;
 @RunWith(Parameterized.class)
 public class PeriodicCommitLogStressTest extends CommitLogStressTest
 {
-    public PeriodicCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.CommitLogDiskAccessMode accessMode)
+    public PeriodicCommitLogStressTest(ParameterizedClass commitLogCompression, EncryptionContext encryptionContext, Config.DiskAccessMode accessMode)
     {
         super(commitLogCompression, encryptionContext, accessMode);
         DatabaseDescriptor.setCommitLogSync(Config.CommitLogSync.periodic);


### PR DESCRIPTION
Enable Direct-IO feature for CommitLog files using Java native API's.

Cassandra by default uses memory mapped segments for commitlog files. This implementation is unable to scale on large core count machines for heavy insert type workload(s). This PR proposes Direct-IO feature for Commitlog files to improve the write speed. This feature known to provide larger bandwidth for IO activity. Java version 11 supports this feature by providing new API's.





