### PR TITLE
Measure repair state caches by memory retention

### DIFF
--- a/src/java/org/apache/cassandra/cache/IMeasurableMemory.java
+++ b/src/java/org/apache/cassandra/cache/IMeasurableMemory.java
@@ -21,6 +21,11 @@ package org.apache.cassandra.cache;
  */
 
 
+import org.apache.cassandra.utils.Shared;
+
+import static org.apache.cassandra.utils.Shared.Recursive.INTERFACES;
+
+@Shared(inner = INTERFACES)
 public interface IMeasurableMemory
 {
     /**

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -859,7 +859,11 @@ public class Config
     public volatile Map<StartupCheckType, Map<String, Object>> startup_checks = new HashMap<>();
 
     public volatile DurationSpec.LongNanosecondsBound repair_state_expires = new DurationSpec.LongNanosecondsBound("3d");
-    public volatile int repair_state_size = 100_000;
+
+    // Only one of repair_state_size and repair_state_heap_size should be set
+    @Deprecated
+    public volatile Integer repair_state_size = null;
+    public volatile DataStorageSpec.IntBytesBound repair_state_heap_size = new DataStorageSpec.IntBytesBound(5, DataStorageSpec.DataStorageUnit.MEBIBYTES);
 
     /**
      * The variants of paxos implementation and semantics supported by Cassandra.

--- a/src/java/org/apache/cassandra/dht/Range.java
+++ b/src/java/org/apache/cassandra/dht/Range.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.ObjectUtils;
 
 import org.apache.cassandra.db.PartitionPosition;
+import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.Pair;
 
 /**
@@ -39,6 +40,8 @@ import org.apache.cassandra.utils.Pair;
 public class Range<T extends RingPosition<T>> extends AbstractBounds<T> implements Comparable<Range<T>>, Serializable
 {
     public static final long serialVersionUID = 1L;
+
+    public static final long EMPTY_SIZE = ObjectSizes.measure(new Range<>(new Murmur3Partitioner.LongToken(Long.MIN_VALUE), new Murmur3Partitioner.LongToken(Long.MIN_VALUE)));
 
     public Range(T left, T right)
     {

--- a/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
+++ b/src/java/org/apache/cassandra/locator/InetAddressAndPort.java
@@ -30,6 +30,10 @@ import java.util.regex.Pattern;
 import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.cache.IMeasurableMemory;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -37,6 +41,7 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.FastByteOperations;
+import org.apache.cassandra.utils.ObjectSizes;
 
 /**
  * A class to replace the usage of InetAddress to identify hosts in the cluster.
@@ -52,8 +57,9 @@ import org.apache.cassandra.utils.FastByteOperations;
  *
  */
 @SuppressWarnings("UnstableApiUsage")
-public final class InetAddressAndPort extends InetSocketAddress implements Comparable<InetAddressAndPort>, Serializable
+public final class InetAddressAndPort extends InetSocketAddress implements Comparable<InetAddressAndPort>, Serializable, IMeasurableMemory
 {
+    private static final Logger logger = LoggerFactory.getLogger(InetAddressAndPort.class);
     private static final long serialVersionUID = 0;
 
     //Store these here to avoid requiring DatabaseDescriptor to be loaded. DatabaseDescriptor will set
@@ -63,6 +69,46 @@ public final class InetAddressAndPort extends InetSocketAddress implements Compa
     static volatile int defaultPort = 7000;
 
     public final byte[] addressBytes;
+
+    private static final long INET_ADDRESS_AND_PORT_SIZE;
+    private static final long INET_ADDRESS_IPV4_SIZE;
+    private static final long INET_ADDRESS_IPV6_SIZE;
+    static
+    {
+        try
+        {
+            INET_ADDRESS_AND_PORT_SIZE = ObjectSizes.measure(InetAddressAndPort.getByAddress(new byte[4]));
+            // Use measureDeep because InetSocketAddress uses a singular reference to a InetSocketAddressHolder, which should be
+            // counted as part of the retained size.
+            INET_ADDRESS_IPV4_SIZE = ObjectSizes.measureDeep(InetAddress.getByAddress(new byte[4]));
+            INET_ADDRESS_IPV6_SIZE = ObjectSizes.measureDeep(InetAddress.getByAddress(new byte[16]));
+        }
+        catch (UnknownHostException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public long unsharedHeapSize()
+    {
+        long addressSize;
+        if (this.getAddress() instanceof Inet4Address)
+            addressSize = INET_ADDRESS_IPV4_SIZE;
+        else if (this.getAddress() instanceof Inet6Address)
+            addressSize = INET_ADDRESS_IPV6_SIZE;
+        else
+        {
+            logger.warn("Unexpected family for address {}; accounting for memory assuming IPv4", this.getAddress());
+            addressSize = INET_ADDRESS_IPV4_SIZE;
+        }
+
+        // Skip the measurement of InetAddress.hostname, because InetAddress.getHostName will reverse-resolve IP addresses
+        // that are missing hostnames against DNS, and we don't want to block here. There's no API to check whether or not
+        // an address has been reverse-resolved, so we can't do this safely.
+
+        return INET_ADDRESS_AND_PORT_SIZE + addressSize + ObjectSizes.sizeOfArray(addressBytes);
+    }
 
     private InetAddressAndPort(InetAddress address, byte[] addressBytes, int port)
     {

--- a/src/java/org/apache/cassandra/repair/NormalRepairTask.java
+++ b/src/java/org/apache/cassandra/repair/NormalRepairTask.java
@@ -21,24 +21,24 @@ import java.util.List;
 
 import org.apache.cassandra.concurrent.ExecutorPlus;
 import org.apache.cassandra.repair.messages.RepairOption;
+import org.apache.cassandra.repair.state.CoordinatorState;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Future;
 
 public class NormalRepairTask extends AbstractRepairTask
 {
-    private final TimeUUID parentSession;
     private final List<CommonRange> commonRanges;
     private final String[] cfnames;
 
-    protected NormalRepairTask(RepairOption options,
+    protected NormalRepairTask(CoordinatorState coordinator,
+                               RepairOption options,
                                String keyspace,
                                RepairNotifier notifier,
                                TimeUUID parentSession,
                                List<CommonRange> commonRanges,
                                String[] cfnames)
     {
-        super(options, keyspace, notifier);
-        this.parentSession = parentSession;
+        super(coordinator, options, keyspace, notifier);
         this.commonRanges = commonRanges;
         this.cfnames = cfnames;
     }
@@ -52,6 +52,6 @@ public class NormalRepairTask extends AbstractRepairTask
     @Override
     public Future<CoordinatedRepairResult> performUnsafe(ExecutorPlus executor)
     {
-        return runRepair(parentSession, false, executor, commonRanges, cfnames);
+        return runRepair(false, executor, commonRanges, cfnames);
     }
 }

--- a/src/java/org/apache/cassandra/repair/state/Completable.java
+++ b/src/java/org/apache/cassandra/repair/state/Completable.java
@@ -19,7 +19,9 @@ package org.apache.cassandra.repair.state;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.cassandra.cache.IMeasurableMemory;
 import org.apache.cassandra.utils.Clock;
+import org.apache.cassandra.utils.ObjectSizes;
 
 public interface Completable<I>
 {
@@ -64,8 +66,16 @@ public interface Completable<I>
         return r.message;
     }
 
-    class Result
+    class Result implements IMeasurableMemory
     {
+        private static final long EMPTY_SIZE = ObjectSizes.measure(new Result(Kind.SUCCESS, ""));
+
+        @Override
+        public long unsharedHeapSize()
+        {
+            return EMPTY_SIZE + ObjectSizes.sizeOf(message);
+        }
+
         public enum Kind
         {SUCCESS, SKIPPED, FAILURE}
 

--- a/src/java/org/apache/cassandra/repair/state/CoordinatorState.java
+++ b/src/java/org/apache/cassandra/repair/state/CoordinatorState.java
@@ -18,22 +18,29 @@
 package org.apache.cassandra.repair.state;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.CommonRange;
 import org.apache.cassandra.repair.RepairRunnable;
 import org.apache.cassandra.repair.messages.RepairOption;
+import org.apache.cassandra.repair.RepairParallelism;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.streaming.PreviewKind;
+import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.TimeUUID;
 
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 
-public class CoordinatorState extends AbstractState<CoordinatorState.State, TimeUUID>
+public class CoordinatorState extends AbstractState<CoordinatorState.State, TimeUUID> implements WeightedHierarchy.Root
 {
     public enum State
     {
@@ -52,6 +59,11 @@ public class CoordinatorState extends AbstractState<CoordinatorState.State, Time
 
     // API to split function calls for phase changes from getting the state
     public final Phase phase = new Phase();
+
+    private static final long EMPTY_SIZE = ObjectSizes.measure(new CoordinatorState(0, "", new RepairOption(RepairParallelism.SEQUENTIAL, false, false, false,
+                                                                                                                          8, Collections.emptyList(), false, false, false, PreviewKind.NONE, false, false, false, false)));
+
+    private final AtomicLong nestedStateRetainedSize = new AtomicLong(0);
 
     public CoordinatorState(int cmd, String keyspace, RepairOption options)
     {
@@ -73,6 +85,7 @@ public class CoordinatorState extends AbstractState<CoordinatorState.State, Time
 
     public void register(SessionState state)
     {
+        onNestedStateRegistration(state);
         sessions.put(state.id, state);
     }
 
@@ -112,6 +125,39 @@ public class CoordinatorState extends AbstractState<CoordinatorState.State, Time
         if (neighborsAndRanges == null)
             return null;
         return neighborsAndRanges.filterCommonRanges(keyspace, getColumnFamilyNames());
+    }
+
+    @Override
+    public long independentRetainedSize()
+    {
+        long size = EMPTY_SIZE;
+        size += ObjectSizes.sizeOf(keyspace);
+        size += options.unsharedHeapSize();
+
+        // Excludes sessions, since those are measured by nestedStateRetainedSize and accounted on registration of nested
+        // SessionState and JobState. Also excludes columnFamilies, since those are referenced by Keyspace, which is long-lived
+        // as a referent from Schema.
+
+        size += neighborsAndRanges == null ? 0 : neighborsAndRanges.unsharedHeapSize();
+        return size;
+    }
+
+    @Override
+    public WeightedHierarchy.Root root()
+    {
+        return this;
+    }
+
+    @Override
+    public AtomicLong totalNestedRetainedSize()
+    {
+        return nestedStateRetainedSize;
+    }
+
+    @Override
+    public void onRetainedSizeUpdate()
+    {
+        ActiveRepairService.instance.onUpdate(this);
     }
 
     public final class Phase extends BaseSkipPhase

--- a/src/java/org/apache/cassandra/repair/state/JobState.java
+++ b/src/java/org/apache/cassandra/repair/state/JobState.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.repair.state;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 
@@ -24,8 +25,11 @@ import com.google.common.collect.ImmutableSet;
 
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.RepairJobDesc;
+import org.apache.cassandra.utils.ObjectSizes;
 
-public class JobState extends AbstractState<JobState.State, UUID>
+import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
+
+public class JobState extends AbstractState<JobState.State, UUID> implements WeightedHierarchy.Node
 {
     public enum State
     {
@@ -40,6 +44,8 @@ public class JobState extends AbstractState<JobState.State, UUID>
 
     public final Phase phase = new Phase();
 
+    private static final long EMPTY_SIZE = ObjectSizes.measure(new JobState(new RepairJobDesc(nextTimeUUID(), nextTimeUUID(), "", "", Collections.emptySet()), ImmutableSet.of()));
+
     public JobState(RepairJobDesc desc, ImmutableSet<InetAddressAndPort> endpoints)
     {
         super(desc.determanisticId(), State.class);
@@ -50,6 +56,13 @@ public class JobState extends AbstractState<JobState.State, UUID>
     public Set<InetAddressAndPort> getParticipants()
     {
         return endpoints;
+    }
+
+    @Override
+    public long independentRetainedSize()
+    {
+        // Excludes endpoints because these are already referenced by parent SessionState's CommonRange
+        return EMPTY_SIZE + desc.unsharedHeapSize();
     }
 
     public final class Phase extends BasePhase

--- a/src/java/org/apache/cassandra/repair/state/WeightedHierarchy.java
+++ b/src/java/org/apache/cassandra/repair/state/WeightedHierarchy.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.repair.state;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.cassandra.cache.IMeasurableMemory;
+
+/**
+ * A pattern for tracking the weight of a hierarchy of references. Registered objects are treated as though they are
+ * immutable, and are only measured on registration.
+ *
+ * Internal nodes must maintain a reference to the root, in order to notify it of any new registrations that may impact
+ * the total weight of the hierarchy.
+ */
+class WeightedHierarchy
+{
+    interface Node
+    {
+        // How much does this object retain without any of its nested state
+        long independentRetainedSize();
+    }
+
+    interface InternalNode extends Node
+    {
+        Root root();
+
+        default void onNestedStateRegistration(Node nested)
+        {
+            Root root = root();
+            root.totalNestedRetainedSize().addAndGet(nested.independentRetainedSize());
+            root.onRetainedSizeUpdate();
+        }
+    }
+
+    interface Root extends InternalNode, IMeasurableMemory
+    {
+        AtomicLong totalNestedRetainedSize();
+
+        default long unsharedHeapSize()
+        {
+            return totalNestedRetainedSize().get() + independentRetainedSize();
+        }
+
+        void onRetainedSizeUpdate();
+    }
+}

--- a/src/java/org/apache/cassandra/schema/TableId.java
+++ b/src/java/org/apache/cassandra/schema/TableId.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ObjectSizes;
 
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 
@@ -38,6 +39,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class TableId
 {
+    public static final long EMPTY_SIZE = ObjectSizes.measure(fromUUID(new UUID(0L, 0L)));
+
     // TODO: should this be a TimeUUID?
     private final UUID id;
 

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -34,17 +34,23 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.common.primitives.Ints;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.cassandra.concurrent.ExecutorPlus;
+import org.apache.cassandra.concurrent.ImmediateExecutor;
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DataStorageSpec;
 import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.EndpointsByRange;
 import org.apache.cassandra.locator.EndpointsForRange;
@@ -173,9 +179,9 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
 
     private final ConcurrentMap<TimeUUID, ParentRepairSession> parentRepairSessions = new ConcurrentHashMap<>();
     // map of top level repair id (parent repair id) -> state
-    private final Cache<TimeUUID, CoordinatorState> repairs;
+    final Cache<TimeUUID, CoordinatorState> repairs;
     // map of top level repair id (parent repair id) -> participate state
-    private final Cache<TimeUUID, ParticipateState> participates;
+    final Cache<TimeUUID, ParticipateState> participates;
 
     private volatile ScheduledFuture<?> irCleanup;
 
@@ -209,8 +215,7 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
 
     private final IFailureDetector failureDetector;
     private final Gossiper gossiper;
-    private final Cache<Integer, Pair<ParentRepairStatus, List<String>>> repairStatusByCmd;
-
+    private final com.google.common.cache.Cache<Integer, Pair<ParentRepairStatus, List<String>>> repairStatusByCmd;
     public final ExecutorPlus snapshotExecutor = executorFactory().configurePooled("RepairSnapshotExecutor", 1)
                                                                   .withKeepAlive(1, TimeUnit.HOURS)
                                                                   .build();
@@ -230,16 +235,64 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
                                              .build();
 
         DurationSpec.LongNanosecondsBound duration = getRepairStateExpires();
-        int numElements = getRepairStateSize();
-        logger.info("Storing repair state for {} or for {} elements", duration, numElements);
-        repairs = CacheBuilder.newBuilder()
+        DataStorageSpec.IntBytesBound maxRetainedSize = getRepairStateHeapSize();
+        Integer numElements = getRepairStateSize();
+        if (numElements != null)
+        {
+            logger.info("Storing repair state for {} or for {} cached elements", duration, numElements);
+            repairs = Caffeine.newBuilder()
                               .expireAfterWrite(duration.quantity(), duration.unit())
                               .maximumSize(numElements)
+                              .executor(ImmediateExecutor.INSTANCE)
                               .build();
-        participates = CacheBuilder.newBuilder()
+            participates = Caffeine.newBuilder()
                                    .expireAfterWrite(duration.quantity(), duration.unit())
                                    .maximumSize(numElements)
+                                   .executor(ImmediateExecutor.INSTANCE)
                                    .build();
+        }
+        else if (maxRetainedSize != null)
+        {
+            logger.info("Storing repair state for {} or for {} retained size", duration, maxRetainedSize);
+            repairs = Caffeine.newBuilder()
+                              .expireAfterWrite(duration.quantity(), duration.unit())
+                              .weigher(new Weigher<TimeUUID, CoordinatorState>()
+                              {
+                                  @Override
+                                  public int weigh(TimeUUID id, CoordinatorState coordinatorState)
+                                  {
+                                      // REVIEW: This addition is unchecked - I was planning to not check memory accounting
+                                      // additions into long because the maximum before overflow is ~thousands of PB, but
+                                      // I check any casts into ints (4GB). Is that a reasonable policy?
+
+                                      long retained = coordinatorState.totalNestedRetainedSize().get() + coordinatorState.independentRetainedSize();
+                                      int clamped = Ints.saturatedCast(retained);
+                                      return Math.max(1, clamped);
+                                  }
+                              })
+                              .maximumWeight(maxRetainedSize.toBytes())
+                              .executor(ImmediateExecutor.INSTANCE)
+                              .build();
+            participates = Caffeine.newBuilder()
+                                   .expireAfterWrite(duration.quantity(), duration.unit())
+                                   .weigher(new Weigher<TimeUUID, ParticipateState>()
+                                   {
+                                       @Override
+                                       public int weigh(TimeUUID id, ParticipateState participateState)
+                                       {
+                                           long retained = participateState.totalNestedRetainedSize().get() + participateState.independentRetainedSize();
+                                           int clamped = Ints.saturatedCast(retained);
+                                           return Math.max(1, clamped);
+                                       }
+                                   })
+                                   .maximumWeight(maxRetainedSize.toBytes())
+                                   .executor(ImmediateExecutor.INSTANCE)
+                                   .build();
+        }
+        else
+        {
+            throw new ConfigurationException("Expected repair state cache to be configured by number of elements or heap size, got neither", true);
+        }
 
         MBeanWrapper.instance.registerMBean(this, MBEAN_NAME);
     }
@@ -266,6 +319,17 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         if (irCleanup != null)
             irCleanup.cancel(false);
         consistent.local.stop();
+    }
+
+    // Caches only weigh elements on insertion and not on mutation, so need to explicitly handle updates by re-inserting
+    public void onUpdate(CoordinatorState coordinatorState)
+    {
+        repairs.put(coordinatorState.id, coordinatorState);
+    }
+
+    public void onUpdate(ParticipateState participateState)
+    {
+        participates.put(participateState.id, participateState);
     }
 
     @Override
@@ -376,7 +440,7 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
      *
      * @return Future for asynchronous call or null if there is no need to repair
      */
-    public RepairSession submitRepairSession(TimeUUID parentRepairSession,
+    public RepairSession submitRepairSession(CoordinatorState coordinator,
                                              CommonRange range,
                                              String keyspace,
                                              RepairParallelism parallelismDegree,
@@ -398,10 +462,10 @@ public class ActiveRepairService implements IEndpointStateChangeSubscriber, IFai
         if (cfnames.length == 0)
             return null;
 
-        final RepairSession session = new RepairSession(parentRepairSession, range, keyspace,
+        final RepairSession session = new RepairSession(coordinator, range, keyspace,
                                                         parallelismDegree, isIncremental, pullRepair,
                                                         previewKind, optimiseStreams, repairPaxos, paxosOnly, cfnames);
-        repairs.getIfPresent(parentRepairSession).register(session.state);
+        repairs.getIfPresent(coordinator.id).register(session.state);
 
         sessions.put(session.getId(), session);
         // register listeners

--- a/src/java/org/apache/cassandra/utils/ObjectSizes.java
+++ b/src/java/org/apache/cassandra/utils/ObjectSizes.java
@@ -20,8 +20,11 @@
 package org.apache.cassandra.utils;
 
 import java.nio.ByteBuffer;
+import java.util.UUID;
 
 import org.github.jamm.MemoryLayoutSpecification;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
 import org.github.jamm.MemoryMeter;
 
 /**
@@ -37,6 +40,8 @@ public class ObjectSizes
     private static final long EMPTY_STRING_SIZE = measure("");
 
     private static final long DIRECT_BUFFER_HEAP_SIZE = measure(ByteBuffer.allocateDirect(0));
+
+    private static final long UUID_SIZE = measure(new UUID(0L, 0L));
 
     /**
      * Memory a byte array consumes
@@ -202,6 +207,13 @@ public class ObjectSizes
             return 0;
 
         return EMPTY_STRING_SIZE + sizeOfArray(str.length(), Character.BYTES);
+    }
+
+    public static long sizeOf(Range<Token> range)
+    {
+        if (range == null)
+            return 0;
+        return Range.EMPTY_SIZE + range.left.getHeapSize() + range.right.getHeapSize();
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/TimeUUID.java
+++ b/src/java/org/apache/cassandra/utils/TimeUUID.java
@@ -81,7 +81,7 @@ public class TimeUUID implements Serializable, Comparable<TimeUUID>
      */
     private static final long MIN_CLOCK_SEQ_AND_NODE = 0x8080808080808080L;
     private static final long MAX_CLOCK_SEQ_AND_NODE = 0x7f7f7f7f7f7f7f7fL;
-
+    public static final long TIMEUUID_SIZE = ObjectSizes.measureDeep(new TimeUUID(10, 10));
 
     final long uuidTimestamp, lsb;
 

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorRefTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorRefTest.java
@@ -66,6 +66,7 @@ public class DatabaseDescriptorRefTest
     "org.apache.cassandra.auth.IInternodeAuthenticator",
     "org.apache.cassandra.auth.IAuthenticator",
     "org.apache.cassandra.auth.IAuthorizer",
+    "org.apache.cassandra.cache.IMeasurableMemory",
     "org.apache.cassandra.auth.IRoleManager",
     "org.apache.cassandra.auth.INetworkAuthorizer",
     "org.apache.cassandra.config.DatabaseDescriptor",

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -815,4 +815,27 @@ public class DatabaseDescriptorTest
     {
         DatabaseDescriptor.setDefaultKeyspaceRF(0);
     }
+
+    @Test
+    public void testRepairStateCacheConfiguration()
+    {
+        Config original = DatabaseDescriptor.getRawConfig();
+
+        Config conf = new Config();
+        DatabaseDescriptor.setConfig(conf);
+
+        // Defaults
+        Assert.assertNotNull(DatabaseDescriptor.getRepairStateHeapSize());
+        Assert.assertNull(DatabaseDescriptor.getRepairStateSize());
+
+        // Handle existing config with repair_state_size already set, should ignore the default for repair_state_heap_size
+        conf = new Config();
+        conf.repair_state_size = 99;
+        DatabaseDescriptor.setConfig(conf);
+        DatabaseDescriptor.applyRepairStateSizingValidations();
+        Assert.assertNull(DatabaseDescriptor.getRepairStateHeapSize());
+        Assert.assertNotNull(DatabaseDescriptor.getRepairStateSize());
+
+        DatabaseDescriptor.setConfig(original);
+    }
 }

--- a/test/unit/org/apache/cassandra/db/virtual/LocalRepairTablesTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/LocalRepairTablesTest.java
@@ -55,6 +55,8 @@ import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TimeUUID;
 
+import static org.apache.cassandra.repair.RepairSessionTest.coordinator;
+
 public class LocalRepairTablesTest extends CQLTester
 {
     private static final String KS_NAME = "vts";
@@ -298,7 +300,7 @@ public class LocalRepairTablesTest extends CQLTester
     private static SessionState session()
     {
         CoordinatorState parent = coordinator();
-        SessionState state = new SessionState(parent.id, REPAIR_KS, new String[]{ REPAIR_TABLE }, COMMON_RANGE);
+        SessionState state = new SessionState(parent, REPAIR_KS, new String[]{ REPAIR_TABLE }, COMMON_RANGE);
         parent.register(state);
         return state;
     }
@@ -306,7 +308,7 @@ public class LocalRepairTablesTest extends CQLTester
     private static JobState job()
     {
         SessionState session = session();
-        JobState state = new JobState(new RepairJobDesc(session.parentRepairSession, session.id, session.keyspace, session.cfnames[0], session.commonRange.ranges), session.commonRange.endpoints);
+        JobState state = new JobState(new RepairJobDesc(session.id, session.id, session.keyspace, session.cfnames[0], session.commonRange.ranges), session.commonRange.endpoints);
         session.register(state);
         return state;
     }

--- a/test/unit/org/apache/cassandra/service/ActiveRepairServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/ActiveRepairServiceTest.java
@@ -34,8 +34,20 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.repair.CommonRange;
+import org.apache.cassandra.repair.RepairJobDesc;
+import org.apache.cassandra.repair.RepairParallelism;
+import org.apache.cassandra.repair.messages.PrepareMessage;
+import org.apache.cassandra.repair.state.CoordinatorState;
+import org.apache.cassandra.repair.state.JobState;
+import org.apache.cassandra.repair.state.ParticipateState;
+import org.apache.cassandra.repair.state.SessionState;
+import org.apache.cassandra.repair.state.ValidationState;
+import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Condition;
 import org.junit.Assert;
@@ -485,5 +497,70 @@ public class ActiveRepairServiceTest
             blocked.awaitUninterruptibly(TASK_SECONDS, TimeUnit.SECONDS);
             complete.countDown();
         }
+    }
+
+    @Test
+    public void expectedCoordinatorStateSizes()
+    {
+        String keyspace = "ks";
+        Set<String> tables = new HashSet<>();
+        tables.add("tbl0");
+        tables.add("tbl1");
+        Collection<Range<Token>> range = new HashSet<>();
+        range.add(new Range<>(new Murmur3Partitioner.LongToken(Long.MIN_VALUE), new Murmur3Partitioner.LongToken(Long.MAX_VALUE)));
+        RepairOption options = new RepairOption(RepairParallelism.SEQUENTIAL, false, false, false,
+                                                8, range, false, false, false, PreviewKind.NONE, false,
+                                                false, false, false);
+        CoordinatorState coordinatorState = new CoordinatorState(0, keyspace, options);
+        ActiveRepairService.instance.register(coordinatorState);
+        long initialCoordinatorStateSize = 272;
+        Assert.assertEquals(initialCoordinatorStateSize, coordinatorState.unsharedHeapSize());
+        Assert.assertEquals(initialCoordinatorStateSize, ActiveRepairService.instance.repairs.policy().eviction().get().weightedSize().getAsLong());
+
+        Set<InetAddressAndPort> endpoints = new HashSet<>();
+        endpoints.add(FBUtilities.getBroadcastAddressAndPort());
+        CommonRange commonRange = new CommonRange(endpoints, new HashSet<>(), range);
+        SessionState sessionState = new SessionState(coordinatorState, keyspace, tables.toArray(new String[0]), commonRange);
+        coordinatorState.register(sessionState);
+        long sessionStateSize = 472L;
+        long expectedSize = initialCoordinatorStateSize + sessionStateSize;
+        Assert.assertEquals(expectedSize, coordinatorState.unsharedHeapSize());
+        Assert.assertEquals(expectedSize, ActiveRepairService.instance.repairs.policy().eviction().get().weightedSize().getAsLong());
+
+        RepairJobDesc desc = new RepairJobDesc(coordinatorState.id, sessionState.id, keyspace, tables.stream().findAny().get(), range);
+        JobState jobState = new JobState(desc, ImmutableSet.copyOf(endpoints));
+        sessionState.register(jobState);
+        long jobStateSize = 336L;
+        expectedSize = initialCoordinatorStateSize + sessionStateSize + jobStateSize;
+        Assert.assertEquals(expectedSize, coordinatorState.unsharedHeapSize());
+        Assert.assertEquals(expectedSize, ActiveRepairService.instance.repairs.policy().eviction().get().weightedSize().getAsLong());
+    }
+
+    @Test
+    public void expectedParticipateStateSizes()
+    {
+        TimeUUID parentRepairSession = nextTimeUUID();
+        List<TableId> tableIds = new ArrayList<>();
+        tableIds.add(TableId.generate());
+        tableIds.add(TableId.generate());
+        tableIds.add(TableId.generate());
+        Collection<Range<Token>> range = new HashSet<>();
+        range.add(new Range<>(new Murmur3Partitioner.LongToken(Long.MIN_VALUE), new Murmur3Partitioner.LongToken(Long.MAX_VALUE)));
+        PrepareMessage prepareMessage = new PrepareMessage(parentRepairSession, tableIds, range, false, 1, false, PreviewKind.NONE);
+        InetAddressAndPort initiator = FBUtilities.getBroadcastAddressAndPort();
+        ParticipateState participateState = new ParticipateState(initiator, prepareMessage);
+        ActiveRepairService.instance.register(participateState);
+        long initialParticipateStateSize = 312;
+        Assert.assertEquals(initialParticipateStateSize, participateState.unsharedHeapSize());
+        Assert.assertEquals(initialParticipateStateSize, ActiveRepairService.instance.participates.policy().eviction().get().weightedSize().getAsLong());
+
+        String keyspace = "ks";
+        RepairJobDesc desc = new RepairJobDesc(parentRepairSession, participateState.id, keyspace, tableIds.stream().findAny().get().toString(), range);
+        ValidationState validationState = new ValidationState(desc, FBUtilities.getBroadcastAddressAndPort());
+        participateState.register(validationState);
+        long validationStateSize = 72L;
+        long expectedSize = initialParticipateStateSize + validationStateSize;
+        Assert.assertEquals(expectedSize, participateState.unsharedHeapSize());
+        Assert.assertEquals(expectedSize, ActiveRepairService.instance.participates.policy().eviction().get().weightedSize().getAsLong());
     }
 }


### PR DESCRIPTION
CASSANDRA-18904

This PR is for 4.1, which slightly differs from trunk due to the exclusion of CASSANDRA-18816 on 4.1. See #2804 for the trunk PR.