### PR TITLE
CASSANDRA-18933 Correct comment for nc SSTable format

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormat.java
@@ -349,7 +349,7 @@ public class BigFormat extends AbstractSSTableFormat<BigTableReader, BigTableWri
 
         // na (4.0-rc1): uncompressed chunks, pending repair session, isTransient, checksummed sstable metadata file, new Bloomfilter format
         // nb (4.0.0): originating host id
-        // nc (4.1): improved min/max, partition level deletion presence marker, key range (CASSANDRA-18134)
+        // nc (5.0): improved min/max, partition level deletion presence marker, key range (CASSANDRA-18134)
         // oa (5.0): Long deletionTime to prevent TTL overflow
         //           token space coverage
         //


### PR DESCRIPTION
In [CASSANDRA-18134 ](https://issues.apache.org/jira/browse/CASSANDRA-18134), the
`nc` SSTable format was introduced. The patch was merged into `5.0+`, however the
comment in source incorrectly mentions that the format was added to version `4.1`.

[CASSANDRA-18933](https://issues.apache.org/jira/browse/CASSANDRA-18933)

cassandra-5.0 cherry-pick