### PR TITLE
[CASSANDRA-18968] StartupClusterConnectivityChecker fails on upgrade from 3.X

### DIFF
--- a/src/java/org/apache/cassandra/net/StartupClusterConnectivityChecker.java
+++ b/src/java/org/apache/cassandra/net/StartupClusterConnectivityChecker.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -36,11 +37,9 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
-import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.FBUtilities;
@@ -55,7 +54,6 @@ public class StartupClusterConnectivityChecker
 
     private final boolean blockForRemoteDcs;
     private final long timeoutNanos;
-    private final Gossiper gossiper;
 
     public static StartupClusterConnectivityChecker create(long timeoutSecs, boolean blockForRemoteDcs)
     {
@@ -63,15 +61,14 @@ public class StartupClusterConnectivityChecker
             logger.warn("setting the block-for-peers timeout (in seconds) to {} might be a bit excessive, but using it nonetheless", timeoutSecs);
         long timeoutNanos = TimeUnit.SECONDS.toNanos(timeoutSecs);
 
-        return new StartupClusterConnectivityChecker(timeoutNanos, blockForRemoteDcs, Gossiper.instance);
+        return new StartupClusterConnectivityChecker(timeoutNanos, blockForRemoteDcs);
     }
 
     @VisibleForTesting
-    StartupClusterConnectivityChecker(long timeoutNanos, boolean blockForRemoteDcs, Gossiper gossiper)
+    StartupClusterConnectivityChecker(long timeoutNanos, boolean blockForRemoteDcs)
     {
         this.blockForRemoteDcs = blockForRemoteDcs;
         this.timeoutNanos = timeoutNanos;
-        this.gossiper = gossiper;
     }
 
     /**
@@ -80,7 +77,8 @@ public class StartupClusterConnectivityChecker
      * @return true if the requested percentage of peers are marked ALIVE in gossip and have their connections opened;
      * else false.
      */
-    public boolean execute(Set<InetAddressAndPort> peers, Function<InetAddressAndPort, String> getDatacenterSource)
+    public boolean execute(Set<InetAddressAndPort> peers, Function<InetAddressAndPort, String> getDatacenterSource,
+                           Predicate<CassandraVersion> isUpgradingFromLowerVersionThan)
     {
         if (peers == null || this.timeoutNanos < 0)
             return true;
@@ -88,7 +86,7 @@ public class StartupClusterConnectivityChecker
         // Check if there are any nodes which we know are running a version prior to 4.0.
         // We use this intead of Gossiper::hasMajorVersion3Nodes because in the absence of version information for a peer
         // we still prefer to run the startup connectivity check.
-        if (gossiper.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_4_0))
+        if (isUpgradingFromLowerVersionThan.test(CassandraVersion.CASSANDRA_4_0))
         {
             logger.debug("Skipping startup connectivity check as some nodes may be running Cassandra version 3 or older " +
                         "which does not support connectivity checking.");

--- a/src/java/org/apache/cassandra/net/StartupClusterConnectivityChecker.java
+++ b/src/java/org/apache/cassandra/net/StartupClusterConnectivityChecker.java
@@ -89,7 +89,7 @@ public class StartupClusterConnectivityChecker
         if (isUpgradingFromLowerVersionThan.test(CassandraVersion.CASSANDRA_4_0))
         {
             logger.debug("Skipping startup connectivity check as some nodes may be running Cassandra version 3 or older " +
-                        "which does not support connectivity checking.");
+                         "which does not support connectivity checking.");
             return true;
         }
 

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -667,7 +667,8 @@ public class CassandraDaemon
     {
         StartupClusterConnectivityChecker connectivityChecker = StartupClusterConnectivityChecker.create(DatabaseDescriptor.getBlockForPeersTimeoutInSeconds(),
                                                                                                          DatabaseDescriptor.getBlockForPeersInRemoteDatacenters());
-        connectivityChecker.execute(Gossiper.instance.getEndpoints(), DatabaseDescriptor.getEndpointSnitch()::getDatacenter);
+        connectivityChecker.execute(Gossiper.instance.getEndpoints(), DatabaseDescriptor.getEndpointSnitch()::getDatacenter,
+                                    Gossiper.instance::isUpgradingFromVersionLowerThan);
 
         // check to see if transports may start else return without starting.  This is needed when in survey mode or
         // when bootstrap has not completed.

--- a/test/unit/org/apache/cassandra/net/StartupClusterConnectivityCheckerTest.java
+++ b/test/unit/org/apache/cassandra/net/StartupClusterConnectivityCheckerTest.java
@@ -40,8 +40,6 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.FBUtilities;
 
-import static org.mockito.Mockito.mock;
-
 public class StartupClusterConnectivityCheckerTest
 {
     private StartupClusterConnectivityChecker localQuorumConnectivityChecker;
@@ -70,14 +68,17 @@ public class StartupClusterConnectivityCheckerTest
         return null;
     }
 
-    private static class MockIsUpgradingFromVersionLowerThan implements Predicate<CassandraVersion> {
+    private static class MockIsUpgradingFromVersionLowerThan implements Predicate<CassandraVersion>
+    {
         CassandraVersion clusterVersion;
-        MockIsUpgradingFromVersionLowerThan(CassandraVersion clusterVersion) {
+        MockIsUpgradingFromVersionLowerThan(CassandraVersion clusterVersion)
+        {
             this.clusterVersion = clusterVersion;
         }
         @Override
-        public boolean test(CassandraVersion other) {
-            return this.clusterVersion.compareTo(other) < 0;
+        public boolean test(CassandraVersion other)
+        {
+            return clusterVersion.compareTo(other) < 0;
         }
     }
 


### PR DESCRIPTION
Cassandra versions prior to Cassandra 4 do not support the PING_REQ message type which causes the StartupConnectivityChecker::execute method to fail.
This commit changes the behavior of the StartupConnectivityChecker::execute method to only run a connectivity check if there are no nodes which are running a version prior to Cassandra 4.

patch by Isaac Reath ([ireath@bloomberg.net](mailto:ireath@bloomberg.net)); reviewed by Paulo Motta for [CASSANDRA-18968](https://issues.apache.org/jira/browse/CASSANDRA-18968)

This can be reproduced by starting a Cassandra 4 or greater node where at least one peer is running Cassandra 3 or older. In this scenario you should see:
```WARN [main] 2023-10-27 15:58:22,234 StartupClusterConnectivityChecker.java:183 - Timed out after 10002 milliseconds, was waiting for remaining peers to connect: {dc1=[X.Y.Z.W, A.B.C.D]}.```

After applying this patch, instead you should see:
```Skipping startup connectivity check as some nodes may be running Cassandra version 3 or older which does not support connectivity checking.```