### PR TITLE
Move format-specific sstable options into the format configuration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Move format-specific sstable options into the format configuration(CASSANDRA-18533)
  * Add ELAPSED command to cqlsh (CASSANDRA-18861)
  * Add the ability to disable bulk loading of SSTables (CASSANDRA-18781)
  * Clean up obsolete functions and simplify cql_version handling in cqlsh (CASSANDRA-18787)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1025,8 +1025,15 @@ snapshot_links_per_second: 0
 # The default format is "big", the legacy SSTable format in use since Cassandra 3.0.
 # Cassandra versions 5.0 and later also support the trie-indexed "bti" format,
 # which offers better performance.
+# The format define the different sstable format option, where the format name can be
+# user custom type and the value is some key-value pair that used to define the sstable
+# format options, like row_index_granularity.
 #sstable:
 #  selected_format: big
+#  format:
+#    big:
+#      row_index_granularity: 4KiB
+#      column_index_cache_size: 2KiB
 
 # Granularity of the collation index of rows within a partition.
 # Applies to both BIG and BTI SSTable formats. In both formats,
@@ -1038,11 +1045,11 @@ snapshot_links_per_second: 0
 # large rows, or a very large number of rows per partition are
 # present, it is recommended to increase the index granularity
 # or switch to the BTI SSTable format.
-#
+# The original name of this configuration is colum_index_size.
 # Leave undefined to use a default suitable for the SSTable format
 # in use (64 KiB for BIG, 16KiB for BTI).
 # Min unit: KiB
-# column_index_size: 4KiB
+# row_index_granularity: 4KiB
 
 # Per sstable indexed key cache entries (the collation index in memory
 # mentioned above) exceeding this size will not be held on heap.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -315,7 +315,8 @@ public class Config
 
     /* if the size of columns or super-columns are more than this, indexing will kick in */
     @Replaces(oldName = "column_index_size_in_kb", converter = Converters.KIBIBYTES_DATASTORAGE, deprecated = true)
-    public volatile DataStorageSpec.IntKibibytesBound column_index_size;
+    @Replaces(oldName = "column_index_size", converter = Converters.KIBIBYTES_DATASTORAGE, deprecated = true)
+    public volatile DataStorageSpec.IntKibibytesBound row_index_granularity;
     @Replaces(oldName = "column_index_cache_size_in_kb", converter = Converters.KIBIBYTES_DATASTORAGE, deprecated = true)
     public volatile DataStorageSpec.IntKibibytesBound column_index_cache_size = new DataStorageSpec.IntKibibytesBound("2KiB");
     @Replaces(oldName = "batch_size_warn_threshold_in_kb", converter = Converters.KIBIBYTES_DATASTORAGE, deprecated = true)

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -3112,6 +3112,11 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         return indexManager.getBuiltIndexNames();
     }
 
+    public  SSTableFormat<?, ?> getSSTableFormat()
+    {
+        return metadata().getSSTableFormat();
+    }
+
     @Override
     public int getUnleveledSSTables()
     {

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -1438,7 +1438,7 @@ public class CompactionManager implements CompactionManagerMBean, ICompactionMan
         List<SSTableReader> finished;
 
         long nowInSec = FBUtilities.nowInSeconds();
-        try (SSTableRewriter writer = SSTableRewriter.construct(cfs, txn, false, sstable.maxDataAge);
+        try (SSTableRewriter writer = SSTableRewriter.construct(cfs, sstable.descriptor.getFormat(), txn, false, sstable.maxDataAge);
              ISSTableScanner scanner = cleanupStrategy.getScanner(sstable);
              CompactionController controller = new CompactionController(cfs, txn.originals(), getDefaultGcBefore(cfs, nowInSec));
              Refs<SSTableReader> refs = Refs.ref(Collections.singleton(sstable));
@@ -1778,10 +1778,11 @@ public class CompactionManager implements CompactionManagerMBean, ICompactionMan
         }
 
         CompactionStrategyManager strategy = cfs.getCompactionStrategyManager();
+        SSTableFormat<?, ?> format = DatabaseDescriptor.getSelectedSSTableFormat();
         try (SharedTxn sharedTxn = new SharedTxn(txn);
-             SSTableRewriter fullWriter = SSTableRewriter.constructWithoutEarlyOpening(sharedTxn, false, groupMaxDataAge);
-             SSTableRewriter transWriter = SSTableRewriter.constructWithoutEarlyOpening(sharedTxn, false, groupMaxDataAge);
-             SSTableRewriter unrepairedWriter = SSTableRewriter.constructWithoutEarlyOpening(sharedTxn, false, groupMaxDataAge);
+             SSTableRewriter fullWriter = SSTableRewriter.constructWithoutEarlyOpening(sharedTxn, format, false, groupMaxDataAge);
+             SSTableRewriter transWriter = SSTableRewriter.constructWithoutEarlyOpening(sharedTxn,  format, false, groupMaxDataAge);
+             SSTableRewriter unrepairedWriter = SSTableRewriter.constructWithoutEarlyOpening(sharedTxn, format, false, groupMaxDataAge);
 
              AbstractCompactionStrategy.ScannerList scanners = strategy.getScanners(txn.originals());
              CompactionController controller = new CompactionController(cfs, sstableAsSet, getDefaultGcBefore(cfs, nowInSec));

--- a/src/java/org/apache/cassandra/db/compaction/Upgrader.java
+++ b/src/java/org/apache/cassandra/db/compaction/Upgrader.java
@@ -92,7 +92,7 @@ public class Upgrader
     {
         outputHandler.output("Upgrading " + sstable);
         long nowInSec = FBUtilities.nowInSeconds();
-        try (SSTableRewriter writer = SSTableRewriter.construct(cfs, transaction, keepOriginals, CompactionTask.getMaxDataAge(transaction.originals()));
+        try (SSTableRewriter writer = SSTableRewriter.construct(cfs, sstable.descriptor.getFormat(), transaction, keepOriginals, CompactionTask.getMaxDataAge(transaction.originals()));
              AbstractCompactionStrategy.ScannerList scanners = strategyManager.getScanners(transaction.originals());
              CompactionIterator iter = new CompactionIterator(transaction.opType(), scanners.scanners, controller, nowInSec, nextTimeUUID()))
         {

--- a/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/CompactionAwareWriter.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,7 @@ public abstract class CompactionAwareWriter extends Transactional.AbstractTransa
 
         estimatedTotalKeys = SSTableReader.getApproximateKeyCount(nonExpiredSSTables);
         maxAge = CompactionTask.getMaxDataAge(nonExpiredSSTables);
-        sstableWriter = SSTableRewriter.construct(cfs, txn, keepOriginals, maxAge);
+        sstableWriter = SSTableRewriter.construct(cfs, cfs.getSSTableFormat(), txn, keepOriginals, maxAge);
         minRepairedAt = CompactionTask.getMinRepairedAt(nonExpiredSSTables);
         pendingRepair = CompactionTask.getPendingRepair(nonExpiredSSTables);
         isTransient = CompactionTask.getIsTransient(nonExpiredSSTables);

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -168,7 +168,7 @@ public class Expression
                 break;
         }
 
-        assert operator != null;
+        assert operator != null || context.isNotIndexed() : "Cannot use '" + op + "' operator with indexed " + context.getColumnName() + " column";;
 
         return this;
     }

--- a/src/java/org/apache/cassandra/io/sstable/IndexInfo.java
+++ b/src/java/org/apache/cassandra/io/sstable/IndexInfo.java
@@ -35,7 +35,7 @@ import org.apache.cassandra.utils.ObjectSizes;
 
 /**
  * {@code IndexInfo} is embedded in the indexed version of {@link RowIndexEntry}.
- * Each instance roughly covers a range of {@link org.apache.cassandra.config.Config#column_index_size column_index_size} KiB
+ * Each instance roughly covers a range of {@link org.apache.cassandra.config.Config#row_index_granularity column_index_size} KiB
  * and contains the first and last clustering value (or slice bound), its offset in the data file and width in the data file.
  * <p>
  * Each {@code IndexInfo} object is serialized as follows.

--- a/src/java/org/apache/cassandra/io/sstable/format/AbstractSSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/AbstractSSTableFormat.java
@@ -32,6 +32,33 @@ public abstract class AbstractSSTableFormat<R extends SSTableReader, W extends S
         this.options = options;
     }
 
+    public enum Option
+    {
+        // TODO add other configurations in the future
+        ROW_INDEX_GRANULARITY("row_index_granularity"),
+        COLUMN_INDEX_CACHE_SIZE("column_index_cache_size"),
+        INDEX_SUMMARY_CAPACITY("index_summary_capacity"),
+        INDEX_SUMMARY_RESIZE_INTERVAL("index_summary_resize_interval"),
+        SSTABLE_PREEMPTIVE_OPEN_INTERVAL("sstable_preemptive_open_interval");
+
+        private String name;
+        Option(String name)
+        {
+            this.name = name;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+    }
+
+    @Override
+    public Map<String, String> options()
+    {
+        return options;
+    }
+
     @Override
     public final String name()
     {

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableFormat.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
+import org.apache.cassandra.config.DataStorageSpec;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
@@ -30,6 +31,7 @@ import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.io.sstable.AbstractRowIndexEntry;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.Descriptor;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
 import org.apache.cassandra.io.sstable.IScrubber;
 import org.apache.cassandra.io.sstable.MetricsProviders;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -45,9 +47,12 @@ import org.apache.cassandra.utils.Pair;
 public interface SSTableFormat<R extends SSTableReader, W extends SSTableWriter>
 {
     String name();
+    Map<String, String> options();
 
     Version getLatestVersion();
     Version getVersion(String version);
+
+    Object getSSTableFormatValue(Option option);
 
     SSTableWriterFactory<W, ?> getWriterFactory();
 

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableScrubber.java
@@ -184,7 +184,7 @@ public abstract class SortedTableScrubber<R extends SSTableReaderWithFilter> imp
     {
         List<SSTableReader> finished = new ArrayList<>();
         outputHandler.output("Scrubbing %s (%s)", sstable, FBUtilities.prettyPrintMemory(dataFile.length()));
-        try (SSTableRewriter writer = SSTableRewriter.construct(cfs, transaction, false, sstable.maxDataAge);
+        try (SSTableRewriter writer = SSTableRewriter.construct(cfs, sstable.descriptor.getFormat(), transaction, false, sstable.maxDataAge);
              Refs<SSTableReader> refs = Refs.ref(Collections.singleton(sstable)))
         {
             StatsMetadata metadata = sstable.getSSTableMetadata();

--- a/src/java/org/apache/cassandra/io/sstable/format/Version.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/Version.java
@@ -17,6 +17,8 @@
  */
 package org.apache.cassandra.io.sstable.format;
 
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
+
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -59,7 +61,7 @@ public abstract class Version
     public abstract boolean hasIsTransient();
 
     public abstract boolean hasMetadataChecksum();
-    
+
     /**
      * This format raises the legacy int year 2038 limit to 2106 by using an uint instead
      */
@@ -126,6 +128,11 @@ public abstract class Version
     public String toFormatAndVersionString()
     {
         return format.name() + '-' + version;
+    }
+
+    public Object getSSTableFormatValue(Option option)
+    {
+        return format.getSSTableFormatValue(option);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigFormatPartitionWriter.java
@@ -27,12 +27,12 @@ import java.util.List;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.io.ISerializer;
 import org.apache.cassandra.io.sstable.IndexInfo;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
 import org.apache.cassandra.io.sstable.format.SortedTablePartitionWriter;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -70,7 +70,12 @@ public class BigFormatPartitionWriter extends SortedTablePartitionWriter
                              Version version,
                              ISerializer<IndexInfo> indexInfoSerializer)
     {
-        this(header, writer, version, indexInfoSerializer, DatabaseDescriptor.getColumnIndexCacheSize(), DatabaseDescriptor.getColumnIndexSize(DEFAULT_GRANULARITY));
+        this(header,
+             writer,
+             version,
+             indexInfoSerializer,
+             (int)version.getSSTableFormatValue(Option.COLUMN_INDEX_CACHE_SIZE),
+             (int)version.getSSTableFormatValue(Option.ROW_INDEX_GRANULARITY));
     }
 
     BigFormatPartitionWriter(SerializationHeader header,

--- a/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/RowIndexEntry.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.ISerializer;
 import org.apache.cassandra.io.sstable.AbstractRowIndexEntry;
 import org.apache.cassandra.io.sstable.IndexInfo;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.sstable.format.big.BigFormat.Components;
 import org.apache.cassandra.io.util.DataInputPlus;
@@ -83,7 +84,7 @@ import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
  *     samples</i> (list of {@link IndexInfo} objects) and those who don't.
  *     For each <i>portion</i> of data for a single partition in the data file,
  *     an index sample is created. The size of that <i>portion</i> is defined
- *     by {@link org.apache.cassandra.config.Config#column_index_size}.
+ *     by {@link org.apache.cassandra.config.Config#row_index_granularity}.
  * </p>
  * <p>
  *     Index entries with less than 2 index samples, will just store the
@@ -357,7 +358,7 @@ public class RowIndexEntry extends AbstractRowIndexEntry
 
                 int indexedPartSize = size - serializedSize(deletionTime, headerLength, columnsIndexCount, version);
 
-                if (size <= DatabaseDescriptor.getColumnIndexCacheSize())
+                if (size <= (int)version.getSSTableFormatValue(Option.COLUMN_INDEX_CACHE_SIZE))
                 {
                     return new IndexedEntry(position, in, deletionTime, headerLength, columnsIndexCount,
                                             idxInfoSerializer, indexedPartSize, version);

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormatPartitionWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormatPartitionWriter.java
@@ -20,10 +20,10 @@ package org.apache.cassandra.io.sstable.format.bti;
 
 import java.io.IOException;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ClusteringComparator;
 import org.apache.cassandra.db.SerializationHeader;
 import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
 import org.apache.cassandra.io.sstable.format.SortedTablePartitionWriter;
 import org.apache.cassandra.io.sstable.format.Version;
 import org.apache.cassandra.io.sstable.format.bti.RowIndexReader.IndexInfo;
@@ -33,7 +33,7 @@ import org.apache.cassandra.io.util.SequentialWriter;
  * Partition writer used by {@link BtiTableWriter}.
  * <p>
  * Writes all passed data to the given SequentialWriter and if necessary builds a RowIndex by constructing an entry
- * for each row within a partition that follows {@link org.apache.cassandra.config.Config#column_index_size} of written
+ * for each row within a partition that follows {@link org.apache.cassandra.config.Config#row_index_granularity} of written
  * data.
  */
 class BtiFormatPartitionWriter extends SortedTablePartitionWriter
@@ -49,7 +49,7 @@ class BtiFormatPartitionWriter extends SortedTablePartitionWriter
                              SequentialWriter rowIndexWriter,
                              Version version)
     {
-        this(header, comparator, dataWriter, rowIndexWriter, version, DatabaseDescriptor.getColumnIndexSize(DEFAULT_GRANULARITY));
+        this(header, comparator, dataWriter, rowIndexWriter, version, (int)version.getSSTableFormatValue(Option.ROW_INDEX_GRANULARITY));
     }
 
 

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -375,6 +376,12 @@ public class TableMetadata implements SchemaElement
                 return otherColumns.hasNext() ? otherColumns.next() : endOfData();
             }
         };
+    }
+
+    public SSTableFormat<?, ?> getSSTableFormat()
+    {
+        //TODO make table level
+        return DatabaseDescriptor.getSelectedSSTableFormat();
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -6611,16 +6611,17 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @Override
     public int getColumnIndexSizeInKiB()
     {
-        return DatabaseDescriptor.getColumnIndexSizeInKiB();
+        return DatabaseDescriptor.getRowIndexGranularityInKiB();
     }
 
+    //todo we should support set the sstable format option value like: nodetool set sstable-format option value
     @Override
     public void setColumnIndexSizeInKiB(int columnIndexSizeInKiB)
     {
-        int oldValueInKiB = DatabaseDescriptor.getColumnIndexSizeInKiB();
+        int oldValueInKiB = DatabaseDescriptor.getRowIndexGranularityInKiB();
         try
         {
-            DatabaseDescriptor.setColumnIndexSizeInKiB(columnIndexSizeInKiB);
+            DatabaseDescriptor.setRowIndexGranularityInKiB(columnIndexSizeInKiB);
         }
         catch (ConfigurationException e)
         {
@@ -6634,8 +6635,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     @Override
     public void setColumnIndexSize(int columnIndexSizeInKB)
     {
-        int oldValueInKiB = DatabaseDescriptor.getColumnIndexSizeInKiB();
-        DatabaseDescriptor.setColumnIndexSizeInKiB(columnIndexSizeInKB);
+        int oldValueInKiB = DatabaseDescriptor.getRowIndexGranularityInKiB();
+        DatabaseDescriptor.setRowIndexGranularityInKiB(columnIndexSizeInKB);
         logger.info("Updated column_index_size to {} KiB (was {} KiB)", columnIndexSizeInKB, oldValueInKiB);
     }
 

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -987,12 +987,14 @@ public interface StorageServiceMBean extends NotificationEmitter
      * Returns the granularity of the collation index of rows within a partition.
      * -1 stands for the SSTable format's default.
      **/
+    //TODO rename or deprecated in the future
     public int getColumnIndexSizeInKiB();
 
     /**
      * Sets the granularity of the collation index of rows within a partition.
      * Use -1 to select the SSTable format's default.
      **/
+    //TODO rename or deprecated in the future
     public void setColumnIndexSizeInKiB(int columnIndexSizeInKiB);
 
     /**

--- a/src/java/org/apache/cassandra/tools/nodetool/SetColumnIndexSize.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetColumnIndexSize.java
@@ -33,6 +33,8 @@ public class SetColumnIndexSize extends NodeToolCmd
     @Override
     protected void execute(NodeProbe probe)
     {
+        //TODO we may change the nodetool name in the future as we change the column_index_size to row_index_granularity
+        // see CASSANDRA-18533 for more detail
         probe.setColumnIndexSize(columnIndexSizeInKiB);
     }
 }

--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -19,7 +19,7 @@ storage_port: 7012
 ssl_storage_port: 17012
 start_native_transport: true
 native_transport_port: 9042
-column_index_size: 4KiB
+row_index_granularity: 4KiB
 saved_caches_directory: build/test/cassandra/saved_caches
 data_file_directories:
     - build/test/cassandra/data
@@ -65,6 +65,13 @@ local_read_size_warn_threshold: 4096KiB
 local_read_size_fail_threshold: 8192KiB
 row_index_read_size_warn_threshold: 4096KiB
 row_index_read_size_fail_threshold: 8192KiB
+
+sstable:
+    selected_format: big
+    format:
+        big:
+           row_index_granularity: 4KiB
+           column_index_cache_size: 2KiB
 
 memtable:
     configurations:

--- a/test/distributed/org/apache/cassandra/distributed/test/thresholds/RowIndexSizeWarningTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/thresholds/RowIndexSizeWarningTest.java
@@ -47,7 +47,7 @@ public class RowIndexSizeWarningTest extends AbstractClientSizeWarning
 
             // hack to force multiple index entries
             DatabaseDescriptor.setColumnIndexCacheSize(1 << 20);
-            DatabaseDescriptor.setColumnIndexSizeInKiB(0);
+            DatabaseDescriptor.setRowIndexGranularityInKiB(0);
         }));
     }
 

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorTest.java
@@ -288,22 +288,22 @@ public class DatabaseDescriptorTest
 
         try
         {
-            DatabaseDescriptor.setColumnIndexSizeInKiB(-5);
+            DatabaseDescriptor.setRowIndexGranularityInKiB(-5);
             fail("Should have received a IllegalArgumentException column_index_size = -5");
         }
         catch (IllegalArgumentException ignored) { }
-        Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize(0));
+        Assert.assertEquals(4096, DatabaseDescriptor.getRowIndexGranularity(0));
 
         try
         {
-            DatabaseDescriptor.setColumnIndexSizeInKiB(2 * 1024 * 1024);
+            DatabaseDescriptor.setRowIndexGranularityInKiB(2 * 1024 * 1024);
             fail("Should have received a ConfigurationException column_index_size = 2GiB");
         }
         catch (ConfigurationException ignored) { }
-        Assert.assertEquals(4096, DatabaseDescriptor.getColumnIndexSize(0));
+        Assert.assertEquals(4096, DatabaseDescriptor.getRowIndexGranularity(0));
 
-        DatabaseDescriptor.setColumnIndexSizeInKiB(-1);  // set undefined
-        Assert.assertEquals(8192, DatabaseDescriptor.getColumnIndexSize(8192));
+        DatabaseDescriptor.setRowIndexGranularityInKiB(-1);  // set undefined
+        Assert.assertEquals(8192, DatabaseDescriptor.getRowIndexGranularity(8192));
 
         try
         {

--- a/test/unit/org/apache/cassandra/config/LoadOldYAMLBackwardCompatibilityTest.java
+++ b/test/unit/org/apache/cassandra/config/LoadOldYAMLBackwardCompatibilityTest.java
@@ -20,12 +20,14 @@ package org.apache.cassandra.config;
 
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -70,7 +72,7 @@ public class LoadOldYAMLBackwardCompatibilityTest
         assertEquals(new DurationSpec.IntMillisecondsBound(300000), config.internode_streaming_tcp_user_timeout);
         assertEquals(new DataStorageSpec.IntMebibytesBound(16), config.native_transport_max_frame_size);
         assertEquals(new DataStorageSpec.IntMebibytesBound(256), config.max_value_size);
-        assertEquals(new DataStorageSpec.IntKibibytesBound(4), config.column_index_size);
+        assertEquals(new DataStorageSpec.IntKibibytesBound(4), config.row_index_granularity);
         assertEquals(new DataStorageSpec.IntKibibytesBound(2), config.column_index_cache_size);
         assertEquals(new DataStorageSpec.IntKibibytesBound(5), config.batch_size_warn_threshold);
         assertEquals(new DataRateSpec.LongBytesPerSecondBound(64, DataRateSpec.DataRateUnit.MEBIBYTES_PER_SECOND), config.compaction_throughput);
@@ -128,5 +130,11 @@ public class LoadOldYAMLBackwardCompatibilityTest
         assertEquals(new DurationSpec.IntSecondsBound(0), config.row_cache_save_period);
         assertEquals(new DurationSpec.IntSecondsBound(2, TimeUnit.HOURS), config.counter_cache_save_period);
         assertEquals(new DurationSpec.IntSecondsBound(35), config.cache_load_timeout);
+
+        // sstable format, see test's config cassandra.yaml
+        assertNotNull(config.sstable);
+        // big by default
+        assertEquals("big", config.sstable.selected_format);
+        assertEquals(ImmutableMap.of("row_index_granularity", "4KiB", "column_index_cache_size", "2KiB"), config.sstable.format.get("big"));
     }
 }

--- a/test/unit/org/apache/cassandra/config/ParseAndConvertUnitsTest.java
+++ b/test/unit/org/apache/cassandra/config/ParseAndConvertUnitsTest.java
@@ -17,11 +17,13 @@
  */
 package org.apache.cassandra.config;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.apache.cassandra.config.DataStorageSpec.DataStorageUnit.MEBIBYTES;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class ParseAndConvertUnitsTest
@@ -88,7 +90,7 @@ public class ParseAndConvertUnitsTest
         assertEquals(new DataStorageSpec.IntBytesBound(536870912), config.internode_application_receive_queue_reserve_global_capacity);
         assertEquals(new DataStorageSpec.IntMebibytesBound(16), config.native_transport_max_frame_size);
         assertEquals(new DataStorageSpec.IntMebibytesBound(256), config.max_value_size);
-        assertEquals(new DataStorageSpec.IntKibibytesBound(4), config.column_index_size);
+        assertEquals(new DataStorageSpec.IntKibibytesBound(4), config.row_index_granularity);
         assertEquals(new DataStorageSpec.IntKibibytesBound(2), config.column_index_cache_size);
         assertEquals(new DataStorageSpec.IntKibibytesBound(5), config.batch_size_warn_threshold);
         assertEquals(new DataStorageSpec.IntKibibytesBound(50), config.batch_size_fail_threshold);
@@ -114,5 +116,11 @@ public class ParseAndConvertUnitsTest
         assertEquals(new DataRateSpec.LongBytesPerSecondBound(0), config.compaction_throughput);
         assertEquals(new DataRateSpec.LongBytesPerSecondBound(23841858, DataRateSpec.DataRateUnit.MEBIBYTES_PER_SECOND), config.stream_throughput_outbound);
         assertEquals(new DataRateSpec.LongBytesPerSecondBound(24, DataRateSpec.DataRateUnit.MEBIBYTES_PER_SECOND), config.inter_dc_stream_throughput_outbound);
+
+        // sstable format, see test's config cassandra.yaml
+        assertNotNull(config.sstable);
+        // big by default
+        assertEquals("big", config.sstable.selected_format);
+        assertEquals(ImmutableMap.of("row_index_granularity", "4KiB", "column_index_cache_size", "2KiB"), config.sstable.format.get("big"));
     }
 }

--- a/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
+++ b/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 
@@ -371,8 +372,8 @@ public class YamlConfigurationLoaderTest
         .hasRootCauseMessage("Invalid data storage: value must be non-negative");
 
         // KIBIBYTES_DATASTORAGE
-        assertThat(from("column_index_size_in_kb", "42").column_index_size.toKibibytes()).isEqualTo(42);
-        assertThatThrownBy(() -> from("column_index_size_in_kb", -2).column_index_size.toKibibytes())
+        assertThat(from("column_index_size_in_kb", "42").row_index_granularity.toKibibytes()).isEqualTo(42);
+        assertThatThrownBy(() -> from("column_index_size_in_kb", -2).row_index_granularity.toKibibytes())
         .hasRootCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Invalid data storage: value must be non-negative");
 

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/SSTablesIteratedTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/SSTablesIteratedTest.java
@@ -374,7 +374,7 @@ public class SSTablesIteratedTest extends CQLTester
     private void testDeletionOnIndexedSSTableDESC(boolean deleteWithRange) throws Throwable
     {
         // reduce the column index size so that columns get indexed during flush
-        DatabaseDescriptor.setColumnIndexSizeInKiB(1);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(1);
 
         createTable("CREATE TABLE %s (id int, col int, val text, PRIMARY KEY (id, col)) WITH CLUSTERING ORDER BY (col DESC)");
 
@@ -422,7 +422,7 @@ public class SSTablesIteratedTest extends CQLTester
     private void testDeletionOnIndexedSSTableASC(boolean deleteWithRange) throws Throwable
     {
         // reduce the column index size so that columns get indexed during flush
-        DatabaseDescriptor.setColumnIndexSizeInKiB(1);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(1);
 
         createTable("CREATE TABLE %s (id int, col int, val text, PRIMARY KEY (id, col)) WITH CLUSTERING ORDER BY (col ASC)");
 
@@ -477,7 +477,7 @@ public class SSTablesIteratedTest extends CQLTester
     private void testDeletionOnOverlappingIndexedSSTable(boolean deleteWithRange) throws Throwable
     {
         // reduce the column index size so that columns get indexed during flush
-        DatabaseDescriptor.setColumnIndexSizeInKiB(1);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(1);
 
         createTable("CREATE TABLE %s (id int, col int, val1 text, val2 text, PRIMARY KEY (id, col)) WITH CLUSTERING ORDER BY (col ASC)");
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsCQLTest.java
@@ -408,14 +408,14 @@ public class CompactionsCQLTest extends CQLTester
     {
         // write enough data to make sure we use an IndexedReader when doing a read, and make sure it fails when reading a corrupt row deletion
         DatabaseDescriptor.setCorruptedTombstoneStrategy(Config.CorruptedTombstoneStrategy.exception);
-        int maxSizePre = DatabaseDescriptor.getColumnIndexSizeInKiB();
-        DatabaseDescriptor.setColumnIndexSizeInKiB(1024);
+        int maxSizePre = DatabaseDescriptor.getRowIndexGranularityInKiB();
+        DatabaseDescriptor.setRowIndexGranularityInKiB(1024);
         prepareWide();
         RowUpdateBuilder.deleteRowAt(getCurrentColumnFamilyStore().metadata(), System.currentTimeMillis() * 1000, -1, 22, 33).apply();
         flush();
         readAndValidate(true);
         readAndValidate(false);
-        DatabaseDescriptor.setColumnIndexSizeInKiB(maxSizePre);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(maxSizePre);
     }
 
     @Test
@@ -423,8 +423,8 @@ public class CompactionsCQLTest extends CQLTester
     {
         // write enough data to make sure we use an IndexedReader when doing a read, and make sure it fails when reading a corrupt standard tombstone
         DatabaseDescriptor.setCorruptedTombstoneStrategy(Config.CorruptedTombstoneStrategy.exception);
-        int maxSizePre = DatabaseDescriptor.getColumnIndexSizeInKiB();
-        DatabaseDescriptor.setColumnIndexSizeInKiB(1024);
+        int maxSizePre = DatabaseDescriptor.getRowIndexGranularityInKiB();
+        DatabaseDescriptor.setRowIndexGranularityInKiB(1024);
         prepareWide();
 
         Assertions.assertThatThrownBy(() -> {
@@ -435,7 +435,7 @@ public class CompactionsCQLTest extends CQLTester
         }).isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("out of range");
 
-        DatabaseDescriptor.setColumnIndexSizeInKiB(maxSizePre);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(maxSizePre);
     }
 
     @Test
@@ -443,8 +443,8 @@ public class CompactionsCQLTest extends CQLTester
     {
         // write enough data to make sure we use an IndexedReader when doing a read, and make sure it fails when reading a corrupt range tombstone
         DatabaseDescriptor.setCorruptedTombstoneStrategy(Config.CorruptedTombstoneStrategy.exception);
-        final int maxSizePreKiB = DatabaseDescriptor.getColumnIndexSizeInKiB();
-        DatabaseDescriptor.setColumnIndexSizeInKiB(1024);
+        final int maxSizePreKiB = DatabaseDescriptor.getRowIndexGranularityInKiB();
+        DatabaseDescriptor.setRowIndexGranularityInKiB(1024);
 
         String cfsName = "invalid_range_tombstone_reader";
         prepareWide(cfsName);
@@ -468,7 +468,7 @@ public class CompactionsCQLTest extends CQLTester
 
         readAndValidate(true, cfs);
         readAndValidate(false, cfs);
-        DatabaseDescriptor.setColumnIndexSizeInKiB(maxSizePreKiB);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(maxSizePreKiB);
     }
 
 

--- a/test/unit/org/apache/cassandra/db/lifecycle/RealTransactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/RealTransactionsTest.java
@@ -151,7 +151,7 @@ public class RealTransactionsTest extends SchemaLoader
         long nowInSec = FBUtilities.nowInSeconds();
         try (CompactionController controller = new CompactionController(cfs, txn.originals(), cfs.gcBefore(FBUtilities.nowInSeconds())))
         {
-            try (SSTableRewriter rewriter = SSTableRewriter.constructKeepingOriginals(txn, false, 1000);
+            try (SSTableRewriter rewriter = SSTableRewriter.constructKeepingOriginals(txn, txn.originals().iterator().next().descriptor.getFormat(), false, 1000);
                  AbstractCompactionStrategy.ScannerList scanners = cfs.getCompactionStrategyManager().getScanners(txn.originals());
                  CompactionIterator ci = new CompactionIterator(txn.opType(), scanners.scanners, controller, nowInSec, txn.opId())
             )

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableRewriterTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.apache.cassandra.io.sstable.format.SSTableFormat;
 import org.junit.Test;
 
 import org.apache.cassandra.UpdateBuilder;
@@ -98,7 +99,7 @@ public class SSTableRewriterTest extends SSTableWriterTestBase
         long nowInSec = FBUtilities.nowInSeconds();
         try (AbstractCompactionStrategy.ScannerList scanners = cfs.getCompactionStrategyManager().getScanners(sstables);
              LifecycleTransaction txn = cfs.getTracker().tryModify(sstables, OperationType.UNKNOWN);
-             SSTableRewriter writer = SSTableRewriter.constructKeepingOriginals(txn, false, 1000);
+             SSTableRewriter writer = SSTableRewriter.constructKeepingOriginals(txn, sstables.iterator().next().descriptor.getFormat(),false, 1000);
              CompactionController controller = new CompactionController(cfs, sstables, cfs.gcBefore(nowInSec));
              CompactionIterator ci = new CompactionIterator(COMPACTION, scanners.scanners, controller, nowInSec, nextTimeUUID()))
         {
@@ -804,10 +805,11 @@ public class SSTableRewriterTest extends SSTableWriterTestBase
         Set<SSTableReader> sstables = Sets.newHashSet(s);
         assertEquals(1, sstables.size());
         long nowInSec = FBUtilities.nowInSeconds();
+        SSTableFormat<?, ?> format = sstables.iterator().next().descriptor.getFormat();
         try (AbstractCompactionStrategy.ScannerList scanners = cfs.getCompactionStrategyManager().getScanners(sstables);
              LifecycleTransaction txn = cfs.getTracker().tryModify(sstables, OperationType.UNKNOWN);
-             SSTableRewriter writer = SSTableRewriter.constructWithoutEarlyOpening(txn, false, 1000);
-             SSTableRewriter writer2 = SSTableRewriter.constructWithoutEarlyOpening(txn, false, 1000);
+             SSTableRewriter writer = SSTableRewriter.constructWithoutEarlyOpening(txn, format, false, 1000);
+             SSTableRewriter writer2 = SSTableRewriter.constructWithoutEarlyOpening(txn, format, false, 1000);
              CompactionController controller = new CompactionController(cfs, sstables, cfs.gcBefore(nowInSec));
              CompactionIterator ci = new CompactionIterator(COMPACTION, scanners.scanners, controller, nowInSec, nextTimeUUID())
              )

--- a/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
@@ -119,7 +119,7 @@ public class VerifyTest
     {
         CompressionParams compressionParameters = CompressionParams.snappy(32768);
         DatabaseDescriptor.daemonInitialization();
-        DatabaseDescriptor.setColumnIndexSizeInKiB(0);
+        DatabaseDescriptor.setRowIndexGranularityInKiB(0);
 
         loadSchema();
         createKeyspace(KEYSPACE,

--- a/test/unit/org/apache/cassandra/io/sstable/format/big/RowIndexEntryTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/format/big/RowIndexEntryTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.primitives.Ints;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -421,7 +422,7 @@ public class RowIndexEntryTest extends CQLTester
                 }
 
                 // if we hit the column index size that we have to index after, go ahead and index it.
-                if (currentPosition() - startPosition >= DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY))
+                if (currentPosition() - startPosition >= (int)version.getSSTableFormatValue(Option.ROW_INDEX_GRANULARITY))
                     addIndexBlock();
 
             }
@@ -463,7 +464,7 @@ public class RowIndexEntryTest extends CQLTester
         assertEquals(buffer.getLength(), serializer.serializedSize(simple));
 
         // write enough rows to ensure we get a few column index entries
-        for (int i = 0; i <= DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY) / 4; i++)
+        for (int i = 0; i <= DatabaseDescriptor.getRowIndexGranularity(BigFormatPartitionWriter.DEFAULT_GRANULARITY) / 4; i++)
             execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, String.valueOf(i), i);
 
         ImmutableBTreePartition partition = Util.getOnlyPartitionUnfiltered(Util.cmd(cfs).build());

--- a/test/unit/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryManagerTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/indexsummary/IndexSummaryManagerTest.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+import org.apache.cassandra.io.sstable.format.AbstractSSTableFormat.Option;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -556,15 +557,19 @@ public class IndexSummaryManagerTest<R extends SSTableReader & IndexSummarySuppo
         // resize interval
         manager.setResizeIntervalInMinutes(-1);
         assertEquals(-1, DatabaseDescriptor.getIndexSummaryResizeIntervalInMinutes());
+        assertEquals(-1, (int)DatabaseDescriptor.getSelectedSSTableFormat().getSSTableFormatValue(Option.INDEX_SUMMARY_RESIZE_INTERVAL));
         assertNull(manager.getTimeToNextResize(TimeUnit.MINUTES));
+
 
         manager.setResizeIntervalInMinutes(10);
         assertEquals(10, manager.getResizeIntervalInMinutes());
         assertEquals(10, DatabaseDescriptor.getIndexSummaryResizeIntervalInMinutes());
+        assertEquals(10, (int)DatabaseDescriptor.getSelectedSSTableFormat().getSSTableFormatValue(Option.INDEX_SUMMARY_RESIZE_INTERVAL));
         assertEquals(10, manager.getTimeToNextResize(TimeUnit.MINUTES), 1);
         manager.setResizeIntervalInMinutes(15);
         assertEquals(15, manager.getResizeIntervalInMinutes());
         assertEquals(15, DatabaseDescriptor.getIndexSummaryResizeIntervalInMinutes());
+        assertEquals(15, (int)DatabaseDescriptor.getSelectedSSTableFormat().getSSTableFormatValue(Option.INDEX_SUMMARY_RESIZE_INTERVAL));
         assertEquals(15, manager.getTimeToNextResize(TimeUnit.MINUTES), 2);
 
         // memory pool capacity

--- a/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
+++ b/test/unit/org/apache/cassandra/streaming/StreamingTransferTest.java
@@ -342,13 +342,13 @@ public class StreamingTransferTest
 
         // add columns of size slightly less than column_index_size to force insert column index
         updates.clustering(1)
-                .add("val", ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY) - 64]))
+                .add("val", ByteBuffer.wrap(new byte[DatabaseDescriptor.getRowIndexGranularity(BigFormatPartitionWriter.DEFAULT_GRANULARITY) - 64]))
                 .build()
                 .apply();
 
         updates = new RowUpdateBuilder(cfs.metadata(), FBUtilities.timestampMicros(), key);
         updates.clustering(6)
-                .add("val", ByteBuffer.wrap(new byte[DatabaseDescriptor.getColumnIndexSize(BigFormatPartitionWriter.DEFAULT_GRANULARITY)]))
+                .add("val", ByteBuffer.wrap(new byte[DatabaseDescriptor.getRowIndexGranularity(BigFormatPartitionWriter.DEFAULT_GRANULARITY)]))
                 .build()
                 .apply();
 

--- a/test/unit/org/apache/cassandra/tools/JMXCompatabilityTest.java
+++ b/test/unit/org/apache/cassandra/tools/JMXCompatabilityTest.java
@@ -73,7 +73,7 @@ public class JMXCompatabilityTest extends CQLTester
     public static void setup() throws Exception
     {
         DatabaseDescriptor.daemonInitialization();
-        DatabaseDescriptor.setColumnIndexSizeInKiB(0); // make sure the column index is created
+        DatabaseDescriptor.setRowIndexGranularityInKiB(0); // make sure the column index is created
 
         startJMXServer();
         // as of CASSANDRA-18816 the instance is lazy loaded only once instance() is called, which isn't true from this code path (but is from CassandraDaemon)


### PR DESCRIPTION

```
Move format-specific sstable options into the format configuration

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-18533

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra18533](https://issues.apache.org/jira/browse/CASSANDRA-18533)

