### PR TITLE
CASSANDRA-18757: UnifiedCompactionTask is incorrectly setting keepOriginals

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
@@ -43,7 +43,7 @@ public class UnifiedCompactionTask extends CompactionTask
                                  long gcBefore,
                                  ShardManager shardManager)
     {
-        super(cfs, txn, gcBefore, strategy.getController().getIgnoreOverlapsInExpirationCheck());
+        super(cfs, txn, gcBefore);
         this.controller = strategy.getController();
         this.shardManager = shardManager;
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -224,14 +224,98 @@ public class CompactionControllerTest extends SchemaLoader
     condition = "Thread.currentThread().getName().equals(\"compaction1\")",
     action = "org.apache.cassandra.db.compaction.CompactionControllerTest.incrementOverlapRefreshCounter();")
     })
-    public void testIgnoreOverlaps() throws Exception
+    public void testIgnoreOverlapsTrue() throws Exception
     {
+        resetCounters();
         testOverlapIterator(true);
+    }
+
+    @Test
+    @BMRules(rules = {
+    @BMRule(name = "Pause compaction",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "INVOKE getCompactionAwareWriter",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.createCompactionControllerLatch.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.compaction2FinishLatch);"),
+    @BMRule(name = "Check overlaps",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "INVOKE finish",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.compaction1RefreshLatch.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.refreshCheckLatch);"),
+    @BMRule(name = "Increment overlap refresh counter",
+    targetClass = "ColumnFamilyStore",
+    targetMethod = "getAndReferenceOverlappingLiveSSTables",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.incrementOverlapRefreshCounter();")
+    })
+    public void testIgnoreOverlapsFalse() throws Exception
+    {
         resetCounters();
         testOverlapIterator(false);
-        resetCounters();
+    }
 
+    @Test
+    @BMRules(rules = {
+    @BMRule(name = "Pause compaction",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "INVOKE getCompactionAwareWriter",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.createCompactionControllerLatch.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.compaction2FinishLatch);"),
+    @BMRule(name = "Check overlaps",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "INVOKE finish",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.compaction1RefreshLatch.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.refreshCheckLatch);"),
+    @BMRule(name = "Increment overlap refresh counter",
+    targetClass = "ColumnFamilyStore",
+    targetMethod = "getAndReferenceOverlappingLiveSSTables",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.incrementOverlapRefreshCounter();")
+    })
+    public void testIgnoreOverlapsUCSTrue() throws Exception
+    {
+        resetCounters();
         testOverlapIteratorUCS(true);
+    }
+
+    @Test
+    @BMRules(rules = {
+    @BMRule(name = "Pause compaction",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "INVOKE getCompactionAwareWriter",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.createCompactionControllerLatch.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.compaction2FinishLatch);"),
+    @BMRule(name = "Check overlaps",
+    targetClass = "CompactionTask",
+    targetMethod = "runMayThrow",
+    targetLocation = "INVOKE finish",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.compaction1RefreshLatch.countDown();" +
+             "com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly" +
+             "(org.apache.cassandra.db.compaction.CompactionControllerTest.refreshCheckLatch);"),
+    @BMRule(name = "Increment overlap refresh counter",
+    targetClass = "ColumnFamilyStore",
+    targetMethod = "getAndReferenceOverlappingLiveSSTables",
+    condition = "Thread.currentThread().getName().equals(\"compaction1\")",
+    action = "org.apache.cassandra.db.compaction.CompactionControllerTest.incrementOverlapRefreshCounter();")
+    })
+    public void testIgnoreOverlapsUCSFalse() throws Exception
+    {
         resetCounters();
         testOverlapIteratorUCS(false);
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -227,12 +227,22 @@ public class CompactionControllerTest extends SchemaLoader
     public void testIgnoreOverlaps() throws Exception
     {
         testOverlapIterator(true);
+        resetCounters();
+        testOverlapIterator(false);
+        resetCounters();
+
+        testOverlapIteratorUCS(true);
+        resetCounters();
+        testOverlapIteratorUCS(false);
+    }
+
+    private void resetCounters()
+    {
         overlapRefreshCounter = 0;
         compaction2FinishLatch = new CountDownLatch(1);
         createCompactionControllerLatch = new CountDownLatch(1);
         compaction1RefreshLatch = new CountDownLatch(1);
         refreshCheckLatch = new CountDownLatch(1);
-        testOverlapIterator(false);
     }
 
     public void testOverlapIterator(boolean ignoreOverlaps) throws Exception
@@ -271,6 +281,87 @@ public class CompactionControllerTest extends SchemaLoader
         twcs.startup();
 
         CompactionTask task = (CompactionTask)twcs.getUserDefinedTask(sstables, 0);
+        assertFalse(task.keepOriginals);
+
+        assertNotNull(task);
+        assertEquals(1, Iterables.size(task.transaction.originals()));
+
+        //start a compaction for the first sstable (compaction1)
+        //the overlap iterator should contain sstable2
+        //this compaction will be paused by the BMRule
+        Thread t = new Thread(() -> {
+            task.execute(null);
+        });
+
+        //start a compaction for the second sstable (compaction2)
+        //the overlap iterator should contain sstable1
+        //this compaction should complete as normal
+        Thread t2 = new Thread(() -> {
+            Uninterruptibles.awaitUninterruptibly(createCompactionControllerLatch);
+            assertEquals(1, overlapRefreshCounter);
+            CompactionManager.instance.forceUserDefinedCompaction(sstable2);
+
+            //after compaction2 is finished, wait 1 minute and then resume compaction1 (this gives enough time for the overlapIterator to be refreshed)
+            //after resuming, the overlap iterator for compaction1 should be updated to include the new sstable created by compaction2,
+            //and it should not contain sstable2
+            try
+            {
+                TimeUnit.MINUTES.sleep(1);
+            }
+            catch (InterruptedException e)
+            {
+                throw new RuntimeException(e);
+            }
+            compaction2FinishLatch.countDown();
+        });
+
+        t.setName("compaction1");
+        t.start();
+        t2.start();
+
+        compaction1RefreshLatch.await();
+        //at this point, the overlap iterator for compaction1 should be refreshed
+
+        //verify that the overlap iterator for compaction1 is refreshed twice, (once during the constructor, and again after compaction2 finishes)
+        assertEquals(2, overlapRefreshCounter);
+
+        refreshCheckLatch.countDown();
+        t.join();
+    }
+
+    public void testOverlapIteratorUCS(boolean ignoreOverlaps) throws Exception
+    {
+
+        Keyspace keyspace = Keyspace.open(KEYSPACE);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF1);
+        cfs.truncateBlocking();
+        cfs.disableAutoCompaction();
+
+        //create 2 overlapping sstables
+        DecoratedKey key = Util.dk("k1");
+        long timestamp1 = FBUtilities.timestampMicros();
+        long timestamp2 = timestamp1 - 5;
+        applyMutation(cfs.metadata(), key, timestamp1);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        assertEquals(cfs.getLiveSSTables().size(), 1);
+        Set<SSTableReader> sstables = cfs.getLiveSSTables();
+
+        applyMutation(cfs.metadata(), key, timestamp2);
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        assertEquals(cfs.getLiveSSTables().size(), 2);
+        String sstable2 = cfs.getLiveSSTables().iterator().next().getFilename();
+
+        CassandraRelevantProperties.ALLOW_UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION.setBoolean(true);
+        Map<String, String> options = new HashMap<>();
+        options.put(TimeWindowCompactionStrategyOptions.UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_KEY, Boolean.toString(ignoreOverlaps));
+        UnifiedCompactionStrategy ucs = new UnifiedCompactionStrategy(cfs, options);
+        for (SSTableReader sstable : cfs.getLiveSSTables())
+            ucs.addSSTable(sstable);
+
+        ucs.startup();
+
+        CompactionTask task = (CompactionTask)ucs.getUserDefinedTask(sstables, 0);
+        assertFalse(task.keepOriginals);
 
         assertNotNull(task);
         assertEquals(1, Iterables.size(task.transaction.originals()));

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
@@ -36,8 +36,6 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.cql3.statements.schema.CreateTableStatement;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.SystemKeyspace;
-import org.apache.cassandra.db.compaction.unified.Controller;
-import org.apache.cassandra.db.compaction.unified.UnifiedCompactionTask;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.KeyspaceParams;
@@ -47,7 +45,6 @@ import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Transactional;
-import org.mockito.Mockito;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.service.ActiveRepairService.UNREPAIRED_SSTABLE;
@@ -238,31 +235,5 @@ public class CompactionTaskTest
         //major compact without range/pk specified 
         CompactionTasks compactionTasks = cfs.getCompactionStrategyManager().getMaximalTasks(Integer.MAX_VALUE, false, OperationType.MAJOR_COMPACTION);
         Assert.assertTrue(compactionTasks.stream().allMatch(task -> task.compactionType.equals(OperationType.MAJOR_COMPACTION)));
-    }
-
-    @Test
-    public void testUnifiedCompactionTaskIgnoreOverlaps()
-    {
-        QueryProcessor.executeInternal("INSERT INTO ks.tbl (k, v) VALUES (1, 1);");
-        QueryProcessor.executeInternal("INSERT INTO ks.tbl (k, v) VALUES (2, 2);");
-        Util.flush(cfs);
-        Set<SSTableReader> sstables = cfs.getLiveSSTables();
-        Assert.assertEquals(1, sstables.size());
-
-        UnifiedCompactionStrategy strat = Mockito.mock(UnifiedCompactionStrategy.class);
-        ShardManager shardManager = Mockito.mock(ShardManager.class);
-        Controller controller = Mockito.mock(Controller.class);
-
-        Mockito.when(strat.getController()).thenReturn(controller);
-        try (LifecycleTransaction txn = cfs.getTracker().tryModify(sstables, OperationType.COMPACTION))
-        {
-            Mockito.when(controller.getIgnoreOverlapsInExpirationCheck()).thenReturn(false);
-            UnifiedCompactionTask task = new UnifiedCompactionTask(cfs, strat, txn, 0, shardManager);
-            Assert.assertFalse(task.keepOriginals);
-
-            Mockito.when(controller.getIgnoreOverlapsInExpirationCheck()).thenReturn(true);
-            UnifiedCompactionTask task2 = new UnifiedCompactionTask(cfs, strat, txn, 0, shardManager);
-            Assert.assertFalse(task2.keepOriginals);
-        }
     }
 }


### PR DESCRIPTION
Fixed bug where UnifiedCompactionTask constructor was calling the wrong base constructor of CompactionTask.

patch by Ethan Brown; reviewed by Branimir Lambov for CASSANDRA-18757

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

[CASSANDRA-18757](https://issues.apache.org/jira/browse/CASSANDRA-18757)

