### PR TITLE
CASSANDRA-19015 Nodetool 'tablestats' formatting uses inconsistent significant digits

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
@@ -51,7 +51,7 @@ public class StatsTable
     public double localWriteLatencyMs;
     public Object pendingFlushes;
     public Object bloomFilterFalsePositives;
-    public Object bloomFilterFalseRatio;
+    public double bloomFilterFalseRatio;
     public String bloomFilterSpaceUsed;
     public boolean bloomFilterOffHeapUsed = false;
     public String bloomFilterOffHeapMemoryUsed;

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
@@ -37,7 +37,7 @@ public class StatsTable
     public String spaceUsedBySnapshotsTotal;
     public boolean offHeapUsed = false;
     public String offHeapMemoryUsedTotal;
-    public Object sstableCompressionRatio;
+    public double sstableCompressionRatio;
     public Object numberOfPartitionsEstimate;
     public Object memtableCellCount;
     public String memtableDataSize;

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTableComparator.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTableComparator.java
@@ -326,8 +326,8 @@ public class StatsTableComparator implements Comparator<StatsTable>
         }
         else if (sortKey.equals("sstable_compression_ratio"))
         {
-            result = compareDoubles((Double) stx.sstableCompressionRatio,
-                                    (Double) sty.sstableCompressionRatio);
+            result = compareDoubles(stx.sstableCompressionRatio,
+                                    sty.sstableCompressionRatio);
         }
         else if (sortKey.equals("sstable_count"))
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTableComparator.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTableComparator.java
@@ -139,8 +139,8 @@ public class StatsTableComparator implements Comparator<StatsTable>
         }
         else if (sortKey.equals("bloom_filter_false_ratio"))
         {
-            result = compareDoubles((Double) stx.bloomFilterFalseRatio,
-                                    (Double) sty.bloomFilterFalseRatio);
+            result = compareDoubles(stx.bloomFilterFalseRatio,
+                                    sty.bloomFilterFalseRatio);
         }
         else if (sortKey.equals("bloom_filter_off_heap_memory_used"))
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -314,7 +314,7 @@ public class TableStatsHolder implements StatsHolder
                 statsTable.bytesUnrepaired = bytesUnrepaired != null ? bytesUnrepaired : 0;
                 statsTable.bytesPendingRepair = bytesPendingRepair != null ? bytesPendingRepair : 0;
 
-                statsTable.sstableCompressionRatio = probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio");
+                statsTable.sstableCompressionRatio = toDouble(probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio"));
                 Object estimatedPartitionCount = probe.getColumnFamilyMetric(keyspaceName, tableName, "EstimatedPartitionCount");
                 if (Long.valueOf(-1L).equals(estimatedPartitionCount))
                 {
@@ -388,6 +388,15 @@ public class TableStatsHolder implements StatsHolder
                 statsKeyspace.tables.add(statsTable);
             }
             keyspaces.add(statsKeyspace);
+        }
+    }
+
+    private double toDouble(Object valueObj) {
+        if (valueObj instanceof Number)
+        {
+            return ((Number) valueObj).doubleValue();
+        } else {
+            return Double.NaN;
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -274,6 +274,7 @@ public class TableStatsHolder implements StatsHolder
                 Long bytesUnrepaired = null;
                 Long bytesPendingRepair = null;
                 Double sstableCompressionRatio = null;
+                Double bloomFilterFalseRatio = null;
 
                 try
                 {
@@ -287,6 +288,7 @@ public class TableStatsHolder implements StatsHolder
                     bytesUnrepaired = (Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BytesUnrepaired");
                     bytesPendingRepair = (Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BytesPendingRepair");
                     sstableCompressionRatio = (Double) probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio");
+                    bloomFilterFalseRatio = (Double) probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio");
                 }
                 catch (RuntimeException e)
                 {
@@ -350,7 +352,7 @@ public class TableStatsHolder implements StatsHolder
 
                 statsTable.bloomFilterFalsePositives = probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives");
 
-                statsTable.bloomFilterFalseRatio = toDouble(probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio"));
+                statsTable.bloomFilterFalseRatio = bloomFilterFalseRatio != null ? bloomFilterFalseRatio : Double.NaN;
                 statsTable.bloomFilterSpaceUsed = format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable);
 
                 if (bloomFilterOffHeapSize != null)
@@ -391,15 +393,6 @@ public class TableStatsHolder implements StatsHolder
                 statsKeyspace.tables.add(statsTable);
             }
             keyspaces.add(statsKeyspace);
-        }
-    }
-
-    private double toDouble(Object valueObj) {
-        if (valueObj instanceof Number)
-        {
-            return ((Number) valueObj).doubleValue();
-        } else {
-            return Double.NaN;
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -273,6 +273,7 @@ public class TableStatsHolder implements StatsHolder
                 Long bytesRepaired = null;
                 Long bytesUnrepaired = null;
                 Long bytesPendingRepair = null;
+                Double sstableCompressionRatio = null;
 
                 try
                 {
@@ -285,6 +286,7 @@ public class TableStatsHolder implements StatsHolder
                     bytesRepaired = (Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BytesRepaired");
                     bytesUnrepaired = (Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BytesUnrepaired");
                     bytesPendingRepair = (Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BytesPendingRepair");
+                    sstableCompressionRatio = (Double) probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio");
                 }
                 catch (RuntimeException e)
                 {
@@ -314,7 +316,7 @@ public class TableStatsHolder implements StatsHolder
                 statsTable.bytesUnrepaired = bytesUnrepaired != null ? bytesUnrepaired : 0;
                 statsTable.bytesPendingRepair = bytesPendingRepair != null ? bytesPendingRepair : 0;
 
-                statsTable.sstableCompressionRatio = toDouble(probe.getColumnFamilyMetric(keyspaceName, tableName, "CompressionRatio"));
+                statsTable.sstableCompressionRatio = sstableCompressionRatio != null ? sstableCompressionRatio : Double.NaN;
                 Object estimatedPartitionCount = probe.getColumnFamilyMetric(keyspaceName, tableName, "EstimatedPartitionCount");
                 if (Long.valueOf(-1L).equals(estimatedPartitionCount))
                 {
@@ -347,6 +349,7 @@ public class TableStatsHolder implements StatsHolder
                 statsTable.pendingFlushes = probe.getColumnFamilyMetric(keyspaceName, tableName, "PendingFlushes");
 
                 statsTable.bloomFilterFalsePositives = probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives");
+
                 statsTable.bloomFilterFalseRatio = toDouble(probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio"));
                 statsTable.bloomFilterSpaceUsed = format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable);
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -347,7 +347,7 @@ public class TableStatsHolder implements StatsHolder
                 statsTable.pendingFlushes = probe.getColumnFamilyMetric(keyspaceName, tableName, "PendingFlushes");
 
                 statsTable.bloomFilterFalsePositives = probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterFalsePositives");
-                statsTable.bloomFilterFalseRatio = probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio");
+                statsTable.bloomFilterFalseRatio = toDouble(probe.getColumnFamilyMetric(keyspaceName, tableName, "RecentBloomFilterFalseRatio"));
                 statsTable.bloomFilterSpaceUsed = format((Long) probe.getColumnFamilyMetric(keyspaceName, tableName, "BloomFilterDiskSpaceUsed"), humanReadable);
 
                 if (bloomFilterOffHeapSize != null)

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -139,9 +139,11 @@ public class TableStatsPrinter<T extends StatsHolder>
             out.println(indent + "Compacted partition minimum bytes: " + table.compactedPartitionMinimumBytes);
             out.println(indent + "Compacted partition maximum bytes: " + table.compactedPartitionMaximumBytes);
             out.println(indent + "Compacted partition mean bytes: " + table.compactedPartitionMeanBytes);
-            out.println(indent + "Average live cells per slice (last five minutes): " + table.averageLiveCellsPerSliceLastFiveMinutes);
+            out.println(indent + "Average live cells per slice (last five minutes): " +
+                        FBUtilities.prettyPrintAverage(table.averageLiveCellsPerSliceLastFiveMinutes));
             out.println(indent + "Maximum live cells per slice (last five minutes): " + table.maximumLiveCellsPerSliceLastFiveMinutes);
-            out.println(indent + "Average tombstones per slice (last five minutes): " + table.averageTombstonesPerSliceLastFiveMinutes);
+            out.println(indent + "Average tombstones per slice (last five minutes): " +
+                        FBUtilities.prettyPrintAverage(table.averageTombstonesPerSliceLastFiveMinutes));
             out.println(indent + "Maximum tombstones per slice (last five minutes): " + table.maximumTombstonesPerSliceLastFiveMinutes);
             out.println(indent + "Droppable tombstone ratio: " + FBUtilities.prettyPrintRatio(table.droppableTombstoneRatio));
             if (table.isInCorrectLocation != null)

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -62,9 +62,9 @@ public class TableStatsPrinter<T extends StatsHolder>
                 // print each keyspace's information
                 out.println("Keyspace: " + keyspace.name);
                 out.println("\tRead Count: " + keyspace.readCount);
-                out.println("\tRead Latency: " + keyspace.readLatency() + " ms");
+                out.println("\tRead Latency: " + FBUtilities.prettyPrintLatency(keyspace.readLatency()));
                 out.println("\tWrite Count: " + keyspace.writeCount);
-                out.println("\tWrite Latency: " + keyspace.writeLatency() + " ms");
+                out.println("\tWrite Latency: " + FBUtilities.prettyPrintLatency(keyspace.writeLatency()));
                 out.println("\tPending Flushes: " + keyspace.pendingFlushes);
 
                 // print each table's information
@@ -112,9 +112,9 @@ public class TableStatsPrinter<T extends StatsHolder>
             out.println(indent + "Memtable switch count: " + table.memtableSwitchCount);
             out.println(indent + "Speculative retries: " + table.speculativeRetries);
             out.println(indent + "Local read count: " + table.localReadCount);
-            out.printf(indent + "Local read latency: %01.3f ms%n", table.localReadLatencyMs);
+            out.println(indent + "Local read latency: " + FBUtilities.prettyPrintLatency(table.localReadLatencyMs));
             out.println(indent + "Local write count: " + table.localWriteCount);
-            out.printf(indent + "Local write latency: %01.3f ms%n", table.localWriteLatencyMs);
+            out.println(indent + "Local write latency: " + FBUtilities.prettyPrintLatency(table.localWriteLatencyMs));
 
             out.printf(indent + "Local read/write ratio: %01.5f%n", table.localReadWriteRatio);
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -102,7 +102,7 @@ public class TableStatsPrinter<T extends StatsHolder>
 
             if (table.offHeapUsed)
                 out.println(indent + "Off heap memory used (total): " + table.offHeapMemoryUsedTotal);
-            out.printf(indent + "SSTable Compression Ratio: %01.5f%n", table.sstableCompressionRatio);
+            out.println(indent + "SSTable Compression Ratio: " + FBUtilities.prettyPrintRatio(table.sstableCompressionRatio));
             out.println(indent + "Number of partitions (estimate): " + table.numberOfPartitionsEstimate);
             out.println(indent + "Memtable cell count: " + table.memtableCellCount);
             out.println(indent + "Memtable data size: " + table.memtableDataSize);
@@ -116,7 +116,7 @@ public class TableStatsPrinter<T extends StatsHolder>
             out.println(indent + "Local write count: " + table.localWriteCount);
             out.println(indent + "Local write latency: " + FBUtilities.prettyPrintLatency(table.localWriteLatencyMs));
 
-            out.printf(indent + "Local read/write ratio: %01.5f%n", table.localReadWriteRatio);
+            out.println(indent + "Local read/write ratio: " + FBUtilities.prettyPrintRatio(table.localReadWriteRatio));
 
             out.println(indent + "Pending flushes: " + table.pendingFlushes);
             out.println(indent + "Percent repaired: " + table.percentRepaired);
@@ -126,7 +126,7 @@ public class TableStatsPrinter<T extends StatsHolder>
             out.println(indent +"Bytes pending repair: " + FBUtilities.prettyPrintMemory(table.bytesPendingRepair));
 
             out.println(indent + "Bloom filter false positives: " + table.bloomFilterFalsePositives);
-            out.printf(indent + "Bloom filter false ratio: %01.5f%n", table.bloomFilterFalseRatio);
+            out.println(indent + "Bloom filter false ratio: " + FBUtilities.prettyPrintRatio(table.bloomFilterFalseRatio));
             out.println(indent + "Bloom filter space used: " + table.bloomFilterSpaceUsed);
 
             if (table.bloomFilterOffHeapUsed)
@@ -143,7 +143,7 @@ public class TableStatsPrinter<T extends StatsHolder>
             out.println(indent + "Maximum live cells per slice (last five minutes): " + table.maximumLiveCellsPerSliceLastFiveMinutes);
             out.println(indent + "Average tombstones per slice (last five minutes): " + table.averageTombstonesPerSliceLastFiveMinutes);
             out.println(indent + "Maximum tombstones per slice (last five minutes): " + table.maximumTombstonesPerSliceLastFiveMinutes);
-            out.printf(indent + "Droppable tombstone ratio: %01.5f%n", table.droppableTombstoneRatio);
+            out.println(indent + "Droppable tombstone ratio: " + FBUtilities.prettyPrintRatio(table.droppableTombstoneRatio));
             if (table.isInCorrectLocation != null)
                 out.println(indent + "SSTables in correct location: " + table.isInCorrectLocation);
             if (table.topSizePartitions != null && !table.topSizePartitions.isEmpty())

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -899,17 +899,13 @@ public class FBUtilities
     }
 
     /**
-     * Formats an average value for display, rounds it to one or two decimal places.
-     * For example, "100500.0", "1.5", "0.05", "0.0", "NaN".
+     * Formats an average value for display, rounds it to two decimal places.
+     * For example, "100500.00", "1.50", "0.05", "0.00", "NaN".
      * @param average   Average value to print.
      */
     public static String prettyPrintAverage(double average)
     {
-        if (average == (long) average || average * 10 == (long) (average * 10)) {
-            return String.format("%.1f", average);
-        } else {
-            return String.format("%.2f", average);
-        }
+        return String.format("%.2f", average);
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -866,6 +866,18 @@ public class FBUtilities
     }
 
     /**
+     * Formats a latency value in milliseconds for display, appending an "ms" suffix.
+     * The formatted output is rounded to three decimal places.
+     * For example, "5000.000 ms", "100.000 ms", "0.050 ms", "0.000 ms", "NaN ms".
+     * Note: This method does not handle negative values or infinite values specially.
+     * @param latency   Latency in milliseconds to print.
+     */
+    public static String prettyPrintLatency(double latency)
+    {
+        return String.format("%.3f ms", latency);
+    }
+
+    /**
      * Convert the given size in bytes to a human-readable value using binary (i.e. 2^10-based) modifiers.
      * For example, 1.000KiB, 2.100GiB etc., up to 8.000 EiB.
      * @param size      Number to convert.

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -885,16 +885,30 @@ public class FBUtilities
     {
         if (ratioObj instanceof Number)
         {
+            double ratio;
             if (ratioObj instanceof Float || ratioObj instanceof Double)
             {
-                double ratio = (Double) ratioObj;
-                return String.format("%.3f", ratio);
+                ratio = (Double) ratioObj;
             } else {
-                double ratio = ((Integer) ratioObj).doubleValue();
-                return String.format("%.3f", ratio);
+                ratio = ((Integer) ratioObj).doubleValue();
             }
+            return String.format("%.3f", ratio);
         } else {
             return String.format("NaN");
+        }
+    }
+
+    /**
+     * Formats an average value for display, rounds it to one or two decimal places.
+     * For example, "100500.0", "1.5", "0.05", "0.0", "NaN".
+     * @param average   Average value to print.
+     */
+    public static String prettyPrintAverage(double average)
+    {
+        if (average == (long) average || average * 10 == (long) (average * 10)) {
+            return String.format("%.1f", average);
+        } else {
+            return String.format("%.2f", average);
         }
     }
 

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -869,12 +869,33 @@ public class FBUtilities
      * Formats a latency value in milliseconds for display, appending an "ms" suffix.
      * The formatted output is rounded to three decimal places.
      * For example, "5000.000 ms", "100.000 ms", "0.050 ms", "0.000 ms", "NaN ms".
-     * Note: This method does not handle negative values or infinite values specially.
      * @param latency   Latency in milliseconds to print.
      */
     public static String prettyPrintLatency(double latency)
     {
         return String.format("%.3f ms", latency);
+    }
+
+    /**
+     * Formats a ratio value for display, rounds it to three decimal places.
+     * For example, "10.000", "1.000", "0.050", "0.001", "0.000", "NaN".
+     * @param ratioObj   Ratio to print.
+     */
+    public static String prettyPrintRatio(Object ratioObj)
+    {
+        if (ratioObj instanceof Number)
+        {
+            if (ratioObj instanceof Float || ratioObj instanceof Double)
+            {
+                double ratio = (Double) ratioObj;
+                return String.format("%.3f", ratio);
+            } else {
+                double ratio = ((Integer) ratioObj).doubleValue();
+                return String.format("%.3f", ratio);
+            }
+        } else {
+            return String.format("NaN");
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -879,17 +879,10 @@ public class FBUtilities
     /**
      * Formats a ratio value for display, rounds it to three decimal places.
      * For example, "10.000", "1.000", "0.050", "0.001", "0.000", "NaN".
-     * @param ratioObj   Ratio to print.
+     * @param ratio   Ratio to print.
      */
-    public static String prettyPrintRatio(Object ratioObj)
+    public static String prettyPrintRatio(double ratio)
     {
-        double ratio;
-        if (ratioObj instanceof Number)
-        {
-            ratio = ((Number) ratioObj).doubleValue();
-        } else {
-            ratio = Double.NaN;
-        }
         return String.format("%.3f", ratio);
     }
 

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -883,19 +883,14 @@ public class FBUtilities
      */
     public static String prettyPrintRatio(Object ratioObj)
     {
+        double ratio;
         if (ratioObj instanceof Number)
         {
-            double ratio;
-            if (ratioObj instanceof Float || ratioObj instanceof Double)
-            {
-                ratio = (Double) ratioObj;
-            } else {
-                ratio = ((Integer) ratioObj).doubleValue();
-            }
-            return String.format("%.3f", ratio);
+            ratio = ((Number) ratioObj).doubleValue();
         } else {
-            return String.format("NaN");
+            ratio = Double.NaN;
         }
+        return String.format("%.3f", ratio);
     }
 
     /**

--- a/test/unit/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinterTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinterTest.java
@@ -43,7 +43,7 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tSpace used (live): 0\n" +
         "\tSpace used (total): 9001\n" +
         "\tSpace used by snapshots (total): 1111\n" +
-        "\tSSTable Compression Ratio: 0.68000\n" +
+        "\tSSTable Compression Ratio: 0.680\n" +
         "\tNumber of partitions (estimate): 111111\n" +
         "\tMemtable cell count: 111\n" +
         "\tMemtable data size: 0\n" +
@@ -53,23 +53,23 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tLocal read latency: 2.000 ms\n" +
         "\tLocal write count: 5\n" +
         "\tLocal write latency: 0.050 ms\n" +
-        "\tLocal read/write ratio: 0.00000\n" +
+        "\tLocal read/write ratio: 0.000\n" +
         "\tPending flushes: 11111\n" +
         "\tPercent repaired: 100.0\n" +
         "\tBytes repaired: 0B\n" +
         "\tBytes unrepaired: 0B\n" +
         "\tBytes pending repair: 0B\n" +
         "\tBloom filter false positives: 30\n" +
-        "\tBloom filter false ratio: 0.40000\n" +
+        "\tBloom filter false ratio: 0.400\n" +
         "\tBloom filter space used: 789\n" +
         "\tCompacted partition minimum bytes: 2\n" +
         "\tCompacted partition maximum bytes: 60\n" +
         "\tCompacted partition mean bytes: 6\n" +
-        "\tAverage live cells per slice (last five minutes): 6.0\n" +
+        "\tAverage live cells per slice (last five minutes): 6.00\n" +
         "\tMaximum live cells per slice (last five minutes): 6\n" +
-        "\tAverage tombstones per slice (last five minutes): 5.0\n" +
+        "\tAverage tombstones per slice (last five minutes): 5.00\n" +
         "\tMaximum tombstones per slice (last five minutes): 1\n" +
-        "\tDroppable tombstone ratio: 0.00000\n" +
+        "\tDroppable tombstone ratio: 0.000\n" +
         "\n";
 
     public static final String expectedDefaultTable2Output =
@@ -81,7 +81,7 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tSpace used (total): 1024\n" +
         "\tSpace used by snapshots (total): 222\n" +
         "\tOff heap memory used (total): 314159367\n" +
-        "\tSSTable Compression Ratio: 0.68000\n" +
+        "\tSSTable Compression Ratio: 0.680\n" +
         "\tNumber of partitions (estimate): 22222\n" +
         "\tMemtable cell count: 22\n" +
         "\tMemtable data size: 900\n" +
@@ -92,14 +92,14 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tLocal read latency: 3.000 ms\n" +
         "\tLocal write count: 4\n" +
         "\tLocal write latency: 0.000 ms\n" +
-        "\tLocal read/write ratio: 0.00000\n" +
+        "\tLocal read/write ratio: 0.000\n" +
         "\tPending flushes: 222222\n" +
         "\tPercent repaired: 99.9\n" +
         "\tBytes repaired: 0B\n" +
         "\tBytes unrepaired: 0B\n" +
         "\tBytes pending repair: 0B\n" +
         "\tBloom filter false positives: 600\n" +
-        "\tBloom filter false ratio: 0.01000\n" +
+        "\tBloom filter false ratio: 0.010\n" +
         "\tBloom filter space used: 161718\n" +
         "\tBloom filter off heap memory used: 98\n" +
         "\tIndex summary off heap memory used: 1\n" +
@@ -109,9 +109,9 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tCompacted partition mean bytes: 4\n" +
         "\tAverage live cells per slice (last five minutes): 4.01\n" +
         "\tMaximum live cells per slice (last five minutes): 5\n" +
-        "\tAverage tombstones per slice (last five minutes): 4.001\n" +
+        "\tAverage tombstones per slice (last five minutes): 4.00\n" +
         "\tMaximum tombstones per slice (last five minutes): 2\n" +
-        "\tDroppable tombstone ratio: 0.22222\n" +
+        "\tDroppable tombstone ratio: 0.222\n" +
         "\n";
 
     public static final String expectedDefaultTable3Output =
@@ -122,7 +122,7 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tSpace used (live): 0\n" +
         "\tSpace used (total): 512\n" +
         "\tSpace used by snapshots (total): 0\n" +
-        "\tSSTable Compression Ratio: 0.32000\n" +
+        "\tSSTable Compression Ratio: 0.320\n" +
         "\tNumber of partitions (estimate): 3333\n" +
         "\tMemtable cell count: 333333\n" +
         "\tMemtable data size: 1999\n" +
@@ -132,23 +132,23 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tLocal read latency: 4.000 ms\n" +
         "\tLocal write count: 3\n" +
         "\tLocal write latency: NaN ms\n" +
-        "\tLocal read/write ratio: 0.00000\n" +
+        "\tLocal read/write ratio: 0.000\n" +
         "\tPending flushes: 333\n" +
         "\tPercent repaired: 99.8\n" +
         "\tBytes repaired: 0B\n" +
         "\tBytes unrepaired: 0B\n" +
         "\tBytes pending repair: 0B\n" +
         "\tBloom filter false positives: 20\n" +
-        "\tBloom filter false ratio: 0.50000\n" +
+        "\tBloom filter false ratio: 0.500\n" +
         "\tBloom filter space used: 456\n" +
         "\tCompacted partition minimum bytes: 2\n" +
         "\tCompacted partition maximum bytes: 50\n" +
         "\tCompacted partition mean bytes: 5\n" +
-        "\tAverage live cells per slice (last five minutes): 0.0\n" +
+        "\tAverage live cells per slice (last five minutes): 0.00\n" +
         "\tMaximum live cells per slice (last five minutes): 5\n" +
         "\tAverage tombstones per slice (last five minutes): NaN\n" +
         "\tMaximum tombstones per slice (last five minutes): 3\n" +
-        "\tDroppable tombstone ratio: 0.33333\n" +
+        "\tDroppable tombstone ratio: 0.333\n" +
         "\n";
 
     public static final String expectedDefaultTable4Output =
@@ -160,7 +160,7 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tSpace used (total): 256\n" +
         "\tSpace used by snapshots (total): 44\n" +
         "\tOff heap memory used (total): 441213818\n" +
-        "\tSSTable Compression Ratio: 0.95000\n" +
+        "\tSSTable Compression Ratio: 0.950\n" +
         "\tNumber of partitions (estimate): 444\n" +
         "\tMemtable cell count: 4\n" +
         "\tMemtable data size: 3000\n" +
@@ -171,14 +171,14 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tLocal read latency: NaN ms\n" +
         "\tLocal write count: 2\n" +
         "\tLocal write latency: 2.000 ms\n" +
-        "\tLocal read/write ratio: 0.00000\n" +
+        "\tLocal read/write ratio: 0.000\n" +
         "\tPending flushes: 4444\n" +
         "\tPercent repaired: 50.0\n" +
         "\tBytes repaired: 0B\n" +
         "\tBytes unrepaired: 0B\n" +
         "\tBytes pending repair: 0B\n" +
         "\tBloom filter false positives: 500\n" +
-        "\tBloom filter false ratio: 0.02000\n" +
+        "\tBloom filter false ratio: 0.020\n" +
         "\tBloom filter space used: 131415\n" +
         "\tBloom filter off heap memory used: 299792458\n" +
         "\tIndex summary off heap memory used: 2\n" +
@@ -188,9 +188,9 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tCompacted partition mean bytes: 4\n" +
         "\tAverage live cells per slice (last five minutes): NaN\n" +
         "\tMaximum live cells per slice (last five minutes): 3\n" +
-        "\tAverage tombstones per slice (last five minutes): 0.0\n" +
+        "\tAverage tombstones per slice (last five minutes): 0.00\n" +
         "\tMaximum tombstones per slice (last five minutes): 3\n" +
-        "\tDroppable tombstone ratio: 0.44444\n" +
+        "\tDroppable tombstone ratio: 0.444\n" +
         "\n";
 
     public static final String expectedDefaultTable5Output =
@@ -201,7 +201,7 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tSpace used (live): 55555\n" +
         "\tSpace used (total): 64\n" +
         "\tSpace used by snapshots (total): 55555\n" +
-        "\tSSTable Compression Ratio: 0.99000\n" +
+        "\tSSTable Compression Ratio: 0.990\n" +
         "\tNumber of partitions (estimate): 55\n" +
         "\tMemtable cell count: 55555\n" +
         "\tMemtable data size: 20000\n" +
@@ -211,23 +211,23 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tLocal read latency: 0.000 ms\n" +
         "\tLocal write count: 1\n" +
         "\tLocal write latency: 1.000 ms\n" +
-        "\tLocal read/write ratio: 0.00000\n" +
+        "\tLocal read/write ratio: 0.000\n" +
         "\tPending flushes: 5\n" +
         "\tPercent repaired: 93.0\n" +
         "\tBytes repaired: 0B\n" +
         "\tBytes unrepaired: 0B\n" +
         "\tBytes pending repair: 0B\n" +
         "\tBloom filter false positives: 10\n" +
-        "\tBloom filter false ratio: 0.60000\n" +
+        "\tBloom filter false ratio: 0.600\n" +
         "\tBloom filter space used: 123\n" +
         "\tCompacted partition minimum bytes: 3\n" +
         "\tCompacted partition maximum bytes: 40\n" +
         "\tCompacted partition mean bytes: 4\n" +
-        "\tAverage live cells per slice (last five minutes): 4.0\n" +
+        "\tAverage live cells per slice (last five minutes): 4.00\n" +
         "\tMaximum live cells per slice (last five minutes): 3\n" +
         "\tAverage tombstones per slice (last five minutes): 4.01\n" +
         "\tMaximum tombstones per slice (last five minutes): 5\n" +
-        "\tDroppable tombstone ratio: 0.55556\n" +
+        "\tDroppable tombstone ratio: 0.556\n" +
         "\n";
 
     public static final String expectedDefaultTable6Output =
@@ -239,7 +239,7 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tSpace used (total): 0\n" +
         "\tSpace used by snapshots (total): 0\n" +
         "\tOff heap memory used (total): 162470810\n" +
-        "\tSSTable Compression Ratio: 0.68000\n" +
+        "\tSSTable Compression Ratio: 0.680\n" +
         "\tNumber of partitions (estimate): 6\n" +
         "\tMemtable cell count: 6666\n" +
         "\tMemtable data size: 1000000\n" +
@@ -250,14 +250,14 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tLocal read latency: 1.000 ms\n" +
         "\tLocal write count: 0\n" +
         "\tLocal write latency: 0.500 ms\n" +
-        "\tLocal read/write ratio: 0.00000\n" +
+        "\tLocal read/write ratio: 0.000\n" +
         "\tPending flushes: 66\n" +
         "\tPercent repaired: 0.0\n" +
         "\tBytes repaired: 0B\n" +
         "\tBytes unrepaired: 0B\n" +
         "\tBytes pending repair: 0B\n" +
         "\tBloom filter false positives: 400\n" +
-        "\tBloom filter false ratio: 0.03000\n" +
+        "\tBloom filter false ratio: 0.030\n" +
         "\tBloom filter space used: 101112\n" +
         "\tBloom filter off heap memory used: 667408\n" +
         "\tIndex summary off heap memory used: 3\n" +
@@ -265,11 +265,11 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tCompacted partition minimum bytes: 6\n" +
         "\tCompacted partition maximum bytes: 20\n" +
         "\tCompacted partition mean bytes: 3\n" +
-        "\tAverage live cells per slice (last five minutes): 5.0\n" +
+        "\tAverage live cells per slice (last five minutes): 5.00\n" +
         "\tMaximum live cells per slice (last five minutes): 2\n" +
-        "\tAverage tombstones per slice (last five minutes): 6.0\n" +
+        "\tAverage tombstones per slice (last five minutes): 6.00\n" +
         "\tMaximum tombstones per slice (last five minutes): 6\n" +
-        "\tDroppable tombstone ratio: 0.66667\n" +
+        "\tDroppable tombstone ratio: 0.667\n" +
         "\n";
 
     /**
@@ -282,9 +282,9 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "----------------\n" +
         "Keyspace: keyspace1\n" +
         "\tRead Count: 3\n" +
-        "\tRead Latency: 0.0 ms\n" +
+        "\tRead Latency: 0.000 ms\n" +
         "\tWrite Count: 12\n" +
-        "\tWrite Latency: 0.0 ms\n" +
+        "\tWrite Latency: 0.000 ms\n" +
         "\tPending Flushes: 233666\n" +
         String.format(duplicateTabs(expectedDefaultTable1Output), "table1") +
         String.format(duplicateTabs(expectedDefaultTable2Output), "table2") +
@@ -292,16 +292,16 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "----------------\n" +
         "Keyspace: keyspace2\n" +
         "\tRead Count: 7\n" +
-        "\tRead Latency: 0.0 ms\n" +
+        "\tRead Latency: 0.000 ms\n" +
         "\tWrite Count: 3\n" +
-        "\tWrite Latency: 0.0 ms\n" +
+        "\tWrite Latency: 0.000 ms\n" +
         "\tPending Flushes: 4449\n" +
         String.format(duplicateTabs(expectedDefaultTable4Output), "table4") +
         String.format(duplicateTabs(expectedDefaultTable5Output), "table5") +
         "----------------\n" +
         "Keyspace: keyspace3\n" +
         "\tRead Count: 5\n" +
-        "\tRead Latency: 0.0 ms\n" +
+        "\tRead Latency: 0.000 ms\n" +
         "\tWrite Count: 0\n" +
         "\tWrite Latency: NaN ms\n" +
         "\tPending Flushes: 66\n" +

--- a/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
+++ b/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
@@ -375,4 +375,17 @@ public class FBUtilitiesTest
         Assert.assertEquals("NaN ms", FBUtilities.prettyPrintLatency(Double.NaN));
         Assert.assertEquals("Infinity ms", FBUtilities.prettyPrintLatency(Double.POSITIVE_INFINITY));
     }
+
+    @Test
+    public void testPrettyPrintRatio()
+    {
+        Assert.assertEquals("10.000", FBUtilities.prettyPrintRatio(10));
+        Assert.assertEquals("1.000", FBUtilities.prettyPrintRatio(1));
+        Assert.assertEquals("0.050", FBUtilities.prettyPrintRatio(0.05));
+        Assert.assertEquals("0.001", FBUtilities.prettyPrintRatio(0.0005));
+        Assert.assertEquals("0.000", FBUtilities.prettyPrintRatio(0.0004));
+        Assert.assertEquals("NaN", FBUtilities.prettyPrintRatio(Double.NaN));
+        Assert.assertEquals("NaN", FBUtilities.prettyPrintRatio(null));
+        Assert.assertEquals("Infinity", FBUtilities.prettyPrintRatio(Double.POSITIVE_INFINITY));
+    }
 }

--- a/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
+++ b/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
@@ -385,7 +385,6 @@ public class FBUtilitiesTest
         Assert.assertEquals("0.001", FBUtilities.prettyPrintRatio(0.0005));
         Assert.assertEquals("0.000", FBUtilities.prettyPrintRatio(0.0004));
         Assert.assertEquals("NaN", FBUtilities.prettyPrintRatio(Double.NaN));
-        Assert.assertEquals("NaN", FBUtilities.prettyPrintRatio(null));
         Assert.assertEquals("Infinity", FBUtilities.prettyPrintRatio(Double.POSITIVE_INFINITY));
     }
 

--- a/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
+++ b/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
@@ -388,4 +388,15 @@ public class FBUtilitiesTest
         Assert.assertEquals("NaN", FBUtilities.prettyPrintRatio(null));
         Assert.assertEquals("Infinity", FBUtilities.prettyPrintRatio(Double.POSITIVE_INFINITY));
     }
+
+    @Test
+    public void testPrettyPrintAverage()
+    {
+        Assert.assertEquals("100500.0", FBUtilities.prettyPrintAverage(100500));
+        Assert.assertEquals("1.5", FBUtilities.prettyPrintAverage(1.5));
+        Assert.assertEquals("0.05", FBUtilities.prettyPrintAverage(0.05));
+        Assert.assertEquals("0.0", FBUtilities.prettyPrintAverage(0.00));
+        Assert.assertEquals("NaN", FBUtilities.prettyPrintAverage(Double.NaN));
+        Assert.assertEquals("Infinity", FBUtilities.prettyPrintAverage(Double.POSITIVE_INFINITY));
+    }
 }

--- a/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
+++ b/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
@@ -392,10 +392,10 @@ public class FBUtilitiesTest
     @Test
     public void testPrettyPrintAverage()
     {
-        Assert.assertEquals("100500.0", FBUtilities.prettyPrintAverage(100500));
-        Assert.assertEquals("1.5", FBUtilities.prettyPrintAverage(1.5));
+        Assert.assertEquals("100500.00", FBUtilities.prettyPrintAverage(100500));
+        Assert.assertEquals("1.50", FBUtilities.prettyPrintAverage(1.5));
         Assert.assertEquals("0.05", FBUtilities.prettyPrintAverage(0.05));
-        Assert.assertEquals("0.0", FBUtilities.prettyPrintAverage(0.00));
+        Assert.assertEquals("0.00", FBUtilities.prettyPrintAverage(0.00));
         Assert.assertEquals("NaN", FBUtilities.prettyPrintAverage(Double.NaN));
         Assert.assertEquals("Infinity", FBUtilities.prettyPrintAverage(Double.POSITIVE_INFINITY));
     }

--- a/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
+++ b/test/unit/org/apache/cassandra/utils/FBUtilitiesTest.java
@@ -363,4 +363,16 @@ public class FBUtilitiesTest
             Assert.assertEquals(value, FBUtilities.parseHumanReadable(vDec, sep, unit), getDelta(value));
         }
     }
+
+    @Test
+    public void testPrettyPrintLatency()
+    {
+        Assert.assertEquals("5000.000 ms", FBUtilities.prettyPrintLatency(5000));
+        Assert.assertEquals("100.000 ms", FBUtilities.prettyPrintLatency(100));
+        Assert.assertEquals("0.050 ms", FBUtilities.prettyPrintLatency(0.05));
+        Assert.assertEquals("0.001 ms", FBUtilities.prettyPrintLatency(0.0005));
+        Assert.assertEquals("0.000 ms", FBUtilities.prettyPrintLatency(0.0004));
+        Assert.assertEquals("NaN ms", FBUtilities.prettyPrintLatency(Double.NaN));
+        Assert.assertEquals("Infinity ms", FBUtilities.prettyPrintLatency(Double.POSITIVE_INFINITY));
+    }
 }


### PR DESCRIPTION
### Before
Nodetool reports milliseconds (ms) with anywhere from 3 to 15 significant digits.  Ratios use five or sixteen decimal places.  Averages use 1 or 13 decimal places.
Example:
```bash
Keyspace: system
        Read Count: 18
        Read Latency: 5.364611111111111 ms
        Write Count: 22
        Write Latency: 0.6970454545454545 ms
        Pending Flushes: 0
                Table: IndexInfo
...
                SSTable Compression Ratio: 1.14583
...
                Local read count: 1
                Local read latency: 17.084 ms
                Local write count: 1
                Local write latency: 1.916 ms
                Local read/write ratio: 1.00000
...
                Bloom filter false ratio: 0.00000
...
                Average live cells per slice (last five minutes): 1.0
                Maximum live cells per slice (last five minutes): 1
                Average tombstones per slice (last five minutes): 1.0
                Maximum tombstones per slice (last five minutes): 1
                Droppable tombstone ratio: 0.00000
```

### After
Milliseconds use 3 decimal places 
Ratios use 3 decimal places (tenths of a percent)
Averages use 2 decimal places
Example:
```bash
Keyspace: system
        Read Count: 18
        Read Latency: 5.084 ms
        Write Count: 22
        Write Latency: 0.566 ms
        Pending Flushes: 0
                Table: IndexInfo
...
                SSTable Compression Ratio: 1.146
...
                Local read count: 1
                Local read latency: 14.237 ms
                Local write count: 1
                Local write latency: 0.770 ms
                Local read/write ratio: 1.000
...
                Bloom filter false ratio: 0.000
...
                Average live cells per slice (last five minutes): 61.43
                Maximum live cells per slice (last five minutes): 72
                Average tombstones per slice (last five minutes): 1.00
                Maximum tombstones per slice (last five minutes): 1
                Droppable tombstone ratio: 0.000
```

### How to reproduce
`nodetool tablestats`

### Tests
`ant testsome -Dtest.name=org.apache.cassandra.utils.FBUtilitiesTest`
`ant testsome -Dtest.name=org.apache.cassandra.tools.nodetool.stats.TableStatsPrinterTest`
`ant testsome -Dtest.name=org.apache.cassandra.tools.nodetool.TableStatsTest`

patch by @zaaath; reviewed by @smiklosovic for [CASSANDRA-19015](https://issues.apache.org/jira/browse/CASSANDRA-19015)