### PR TITLE
CASSANDRA-18824: Backport CASSANDRA-16418 to 3.x

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -452,12 +452,15 @@ public class CompactionManager implements CompactionManagerMBean
     public AllSSTableOpStatus performCleanup(final ColumnFamilyStore cfStore, int jobs) throws InterruptedException, ExecutionException
     {
         assert !cfStore.isIndex();
-        Keyspace keyspace = cfStore.keyspace;
-        if (!StorageService.instance.isJoined())
+
+        if (nodeHasPendingRangesForKeyspace(cfStore))
         {
-            logger.info("Cleanup cannot run before a node has joined the ring");
+            logger.info("Cleanup cannot run while node has pending ranges for keyspace {} table {}, wait for node addition/decommission to complete and try again", cfStore.keyspace.getName(), cfStore.getTableName());
             return AllSSTableOpStatus.ABORTED;
         }
+
+        Keyspace keyspace = cfStore.keyspace;
+
         // if local ranges is empty, it means no data should remain
         final Collection<Range<Token>> ranges = StorageService.instance.getLocalRanges(keyspace.getName());
         final boolean hasIndexes = cfStore.indexManager.hasIndexes();
@@ -497,6 +500,11 @@ public class CompactionManager implements CompactionManagerMBean
                 doCleanupOne(cfStore, txn, cleanupStrategy, ranges, hasIndexes);
             }
         }, jobs, OperationType.CLEANUP);
+    }
+
+    private boolean nodeHasPendingRangesForKeyspace(ColumnFamilyStore cfs)
+    {
+        return !StorageService.instance.getTokenMetadata().getPendingRanges(cfs.keyspace.getName(), FBUtilities.getBroadcastAddress()).isEmpty();
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2996,6 +2996,9 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         if (Schema.isLocalSystemKeyspace(keyspaceName))
             throw new RuntimeException("Cleanup of the system keyspace is neither necessary nor wise");
 
+        if (tokenMetadata.getPendingRanges(keyspaceName, FBUtilities.getBroadcastAddress()).size() > 0)
+            throw new RuntimeException("Node is involved in cluster membership changes. Not safe to run cleanup.");
+
         CompactionManager.AllSSTableOpStatus status = CompactionManager.AllSSTableOpStatus.SUCCESSFUL;
         for (ColumnFamilyStore cfStore : getValidColumnFamilies(false, false, keyspaceName, tables))
         {

--- a/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/action/GossipHelper.java
@@ -52,6 +52,22 @@ public class GossipHelper
         };
     }
 
+    public static InstanceAction statusToDecommission(IInvokableInstance newNode)
+    {
+        return (instance) ->
+        {
+            changeGossipState(instance,
+                              newNode,
+                              Arrays.asList(tokens(newNode),
+                                            statusLeaving(newNode)));
+        };
+    }
+
+    public static VersionedApplicationState statusLeaving(IInvokableInstance instance)
+    {
+        return versionedToken(instance, ApplicationState.STATUS, (partitioner, tokens) -> new VersionedValue.VersionedValueFactory(partitioner).leaving(tokens));
+    }
+
     public static void withProperty(String prop, String value, Runnable r)
     {
         String before = System.getProperty(prop);

--- a/test/distributed/org/apache/cassandra/distributed/test/CleanupFailureTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/CleanupFailureTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.IInstanceConfig;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.NodeToolResult;
+import org.apache.cassandra.distributed.shared.NetworkTopology;
+
+import static org.apache.cassandra.distributed.action.GossipHelper.statusToBootstrap;
+import static org.apache.cassandra.distributed.action.GossipHelper.statusToDecommission;
+import static org.apache.cassandra.distributed.action.GossipHelper.withProperty;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.apache.cassandra.distributed.api.TokenSupplier.evenlyDistributedTokens;
+import static org.junit.Assert.assertEquals;
+
+public class CleanupFailureTest extends TestBaseImpl
+{
+    @Test
+    public void cleanupDuringDecommissionTest() throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(2)
+                                        .withTokenSupplier(evenlyDistributedTokens(2))
+                                        .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(2, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK, GOSSIP))
+                                        .start())
+        {
+            IInvokableInstance nodeToDecommission = cluster.get(1);
+            IInvokableInstance nodeToRemainInCluster = cluster.get(2);
+
+            // Start decomission on nodeToDecommission
+            cluster.forEach(statusToDecommission(nodeToDecommission));
+
+            // Add data to cluster while node is decomissioning
+            int numRows = 100;
+            createKeyspaceWithTable(cluster, 1);
+            insertData(cluster, 1, numRows, ConsistencyLevel.ONE);
+
+            // Check data before cleanup on nodeToRemainInCluster
+            assertEquals(100, nodeToRemainInCluster.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+
+            // Run cleanup on nodeToRemainInCluster
+            NodeToolResult result = nodeToRemainInCluster.nodetoolResult("cleanup");
+            result.asserts().failure();
+            result.asserts().stderrContains("Node is involved in cluster membership changes. Not safe to run cleanup.");
+
+            // Check data after cleanup on nodeToRemainInCluster
+            assertEquals(100, nodeToRemainInCluster.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+        }
+    }
+
+    @Test
+    public void cleanupDuringBootstrapTest() throws Throwable
+    {
+        int originalNodeCount = 1;
+        int expandedNodeCount = originalNodeCount + 1;
+
+        try (Cluster cluster = builder().withNodes(originalNodeCount)
+                                        .withTokenSupplier(evenlyDistributedTokens(expandedNodeCount))
+                                        .withNodeIdTopology(NetworkTopology.singleDcNetworkTopology(expandedNodeCount, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK, GOSSIP))
+                                        .start())
+        {
+            IInstanceConfig config = cluster.newInstanceConfig();
+            IInvokableInstance bootstrappingNode = cluster.bootstrap(config);
+            withProperty("cassandra.join_ring", "false",
+                         () -> bootstrappingNode.startup(cluster));
+
+            // Start decomission on bootstrappingNode
+            cluster.forEach(statusToBootstrap(bootstrappingNode));
+
+            // Add data to cluster while node is bootstrapping
+            int numRows = 100;
+            createKeyspaceWithTable(cluster, 2);
+            insertData(cluster, 1, numRows, ConsistencyLevel.ONE);
+
+            // Check data before cleanup on bootstrappingNode
+            assertEquals(numRows, bootstrappingNode.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+
+            // Run cleanup on bootstrappingNode
+            NodeToolResult result = bootstrappingNode.nodetoolResult("cleanup");
+            result.asserts().stderrContains("Node is involved in cluster membership changes. Not safe to run cleanup.");
+
+            // Check data after cleanup on bootstrappingNode
+            assertEquals(numRows, bootstrappingNode.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+        }
+    }
+
+    private void createKeyspaceWithTable(Cluster cluster, int rf)
+    {
+        cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': " + rf + "};");
+        cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+    }
+
+    private void insertData(Cluster cluster, int node, int numberOfRows, ConsistencyLevel cl)
+    {
+        for (int i = 0; i < numberOfRows; i++)
+        {
+            cluster.coordinator(node).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)", cl, i, i, i);
+        }
+        cluster.forEach(c -> c.flush(KEYSPACE));
+    }
+}

--- a/test/unit/org/apache/cassandra/db/CleanupTest.java
+++ b/test/unit/org/apache/cassandra/db/CleanupTest.java
@@ -41,6 +41,11 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.ColumnDefinition;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.locator.AbstractReplicationStrategy;
+import org.apache.cassandra.locator.IEndpointSnitch;
+import org.apache.cassandra.locator.PendingRangeMaps;
+import org.apache.cassandra.locator.PropertyFileSnitch;
+import org.apache.cassandra.locator.SimpleStrategy;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.cql3.Operator;
 import org.apache.cassandra.db.compaction.CompactionManager;
@@ -116,9 +121,11 @@ public class CleanupTest
     }
 
     @Test
-    public void testCleanup() throws ExecutionException, InterruptedException
+    public void testCleanup() throws ExecutionException, InterruptedException, UnknownHostException
     {
-        StorageService.instance.getTokenMetadata().clearUnsafe();
+        TokenMetadata tmd = StorageService.instance.getTokenMetadata();
+        tmd.clearUnsafe();
+        tmd.updateNormalToken(token(new byte[]{ 50 }), InetAddress.getByName("127.0.0.1"));
 
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD1);
@@ -330,6 +337,43 @@ public class CleanupTest
             assertEquals(testCase.getKey(), CompactionManager.needsCleanup(ssTable, testCase.getValue()));
         }
     }
+
+    @Test
+    public void testCleanupIsAbortedWhenNodeHasPendingRanges() throws ExecutionException, InterruptedException, UnknownHostException
+    {
+        // given
+        StorageService.instance.getTokenMetadata().clearUnsafe();
+
+        Keyspace keyspace = Keyspace.open(KEYSPACE1);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_STANDARD1);
+
+        fillCF(cfs, "val", LOOPS);
+        assertEquals(LOOPS, Util.getAll(Util.cmd(cfs).build()).size());
+
+        Range<Token> range = range(new BytesToken(new byte[]{0}), new BytesToken(new byte[]{1}));
+        givenPendingRange(cfs, range);
+
+        // when
+        CompactionManager.AllSSTableOpStatus status = CompactionManager.instance.performCleanup(cfs, 2);
+
+        // then
+        assertEquals("cleanup should be aborted", CompactionManager.AllSSTableOpStatus.ABORTED, status);
+    }
+
+    private void givenPendingRange(ColumnFamilyStore cfs, Range<Token> range) throws UnknownHostException
+    {
+        StorageService.instance.getTokenMetadata().calculatePendingRanges(createStrategy(cfs.keyspace.getName()), cfs.keyspace.getName());
+        PendingRangeMaps ranges = StorageService.instance.getTokenMetadata().getPendingRanges(cfs.keyspace.getName());
+        ranges.addPendingRange(range, InetAddress.getByName("127.0.0.1"));
+    }
+
+    private AbstractReplicationStrategy createStrategy(String keyspace)
+    {
+        IEndpointSnitch snitch = new PropertyFileSnitch();
+        DatabaseDescriptor.setEndpointSnitch(snitch);
+        return new SimpleStrategy(keyspace, new TokenMetadata(), DatabaseDescriptor.getEndpointSnitch(), Collections.emptyMap());
+    }
+
     private static BytesToken token(byte ... value)
     {
         return new BytesToken(value);


### PR DESCRIPTION
When a node is decommissioned, it triggers data transfer to other nodes.
During this transfer process, receiving nodes temporarily hold token ranges in a pending state.
However, the current cleanup process doesn't account for these pending ranges when calculating token ownership,
leading to inadvertent cleanup of data already stored in SSTables.
To address this issue, this patch introduces two changes.
Firstly, it backports CASSANDRA-16418, introducing a preventive check in `StorageService#forceKeyspaceCleanup`.
This check disallows the initiation of cleanup when a node contains any pending ranges for the requested keyspace.
Secondly, it reintroduces a similar condition to test for the existence of pending ranges in `CompactionManager#performCleanup`.
This ensures the safety of this API as well.

https://issues.apache.org/jira/browse/CASSANDRA-18824

