### PR TITLE
CASSANDRA-18839: Catch SSLHandshakeExceptions exceptions

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1550,7 +1550,7 @@ client_encryption_options:
   # optional: true
   # Set keystore and keystore_password to valid keystores if enabled is true
   keystore: conf/.keystore
-  # keystore_password: cassandra
+  #keystore_password: cassandra
   # Configure the way Cassandra creates SSL contexts.
   # To use PEM-based key material, see org.apache.cassandra.security.PEMBasedSslContextFactory
   # ssl_context_factory:

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1543,14 +1543,14 @@ server_encryption_options:
 # auth set require_client_auth=true. Restart all nodes
 client_encryption_options:
   # Enable client-to-server encryption
-  enabled: true
+  enabled: false
   # When set to true, encrypted and unencrypted connections are allowed on the native_transport_port
   # This should _only be true_ while in unencrypted or transitional operation
   # optional defaults to true when enabled is false, and false when enabled is true.
-  optional: false
+  # optional: true
   # Set keystore and keystore_password to valid keystores if enabled is true
-  keystore: /home/gfx/Documents/cassandra/test/conf/cassandra_ssl_test.keystore
-  keystore_password: cassandra
+  keystore: conf/.keystore
+  # keystore_password: cassandra
   # Configure the way Cassandra creates SSL contexts.
   # To use PEM-based key material, see org.apache.cassandra.security.PEMBasedSslContextFactory
   # ssl_context_factory:

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1543,14 +1543,14 @@ server_encryption_options:
 # auth set require_client_auth=true. Restart all nodes
 client_encryption_options:
   # Enable client-to-server encryption
-  enabled: false
+  enabled: true
   # When set to true, encrypted and unencrypted connections are allowed on the native_transport_port
   # This should _only be true_ while in unencrypted or transitional operation
   # optional defaults to true when enabled is false, and false when enabled is true.
-  # optional: true
+  optional: false
   # Set keystore and keystore_password to valid keystores if enabled is true
-  keystore: conf/.keystore
-  #keystore_password: cassandra
+  keystore: /home/gfx/Documents/cassandra/test/conf/cassandra_ssl_test.keystore
+  keystore_password: cassandra
   # Configure the way Cassandra creates SSL contexts.
   # To use PEM-based key material, see org.apache.cassandra.security.PEMBasedSslContextFactory
   # ssl_context_factory:

--- a/src/java/org/apache/cassandra/metrics/ClientMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/ClientMetrics.java
@@ -49,6 +49,7 @@ public final class ClientMetrics
     private Meter requestDispatched;
 
     private Meter protocolException;
+    private Meter sslHandshakeException;
     private Meter unknownException;
 
     private ClientMetrics()
@@ -84,6 +85,11 @@ public final class ClientMetrics
     public void markProtocolException()
     {
         protocolException.mark();
+    }
+
+    public void markSslHandshakeException()
+    {
+        sslHandshakeException.mark();
     }
 
     public void markUnknownException()
@@ -124,6 +130,7 @@ public final class ClientMetrics
         requestDispatched = registerMeter("RequestDispatched");
 
         protocolException = registerMeter("ProtocolException");
+        sslHandshakeException = registerMeter("SslHandshakeException");
         unknownException = registerMeter("UnknownException");
 
         initialized = true;

--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -137,7 +137,7 @@ public class ExceptionHandlers
         }
         else if (Throwables.anyCauseMatches(cause, t -> t instanceof SSLException))
         {
-            // logger.warn("SSLException in client networking with peer {} {}", clientAddress, cause.getMessage());
+            ClientMetrics.instance.markSslHandshakeException();
             NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.MINUTES, "SSLException in client networking with peer {} {}", clientAddress, cause.getMessage());
         }
         else

--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -23,8 +23,6 @@ import java.net.SocketAddress;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLException;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 
@@ -93,13 +91,6 @@ public class ExceptionHandlers
                     JVMStabilityInspector.inspectThrowable(cause);
                 }
             }
-
-            if (Throwables.anyCauseMatches(cause, t -> t instanceof SSLException))
-            {
-                logger.warn("SSLException in client networking with peer {}", ctx.channel().remoteAddress(), cause);
-                return;
-            }
-            
             if (DatabaseDescriptor.getClientErrorReportingExclusions().contains(ctx.channel().remoteAddress()))
             {
                 // Sometimes it is desirable to ignore exceptions from specific IPs; such as when security scans are

--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -91,6 +91,7 @@ public class ExceptionHandlers
                     JVMStabilityInspector.inspectThrowable(cause);
                 }
             }
+            
             if (DatabaseDescriptor.getClientErrorReportingExclusions().contains(ctx.channel().remoteAddress()))
             {
                 // Sometimes it is desirable to ignore exceptions from specific IPs; such as when security scans are

--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -23,6 +23,8 @@ import java.net.SocketAddress;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLException;
+
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 
@@ -90,6 +92,12 @@ public class ExceptionHandlers
                     payload.release();
                     JVMStabilityInspector.inspectThrowable(cause);
                 }
+            }
+
+            if (Throwables.anyCauseMatches(cause, t -> t instanceof SSLException))
+            {
+                logger.warn("SSLException in client networking with peer {}", ctx.channel().remoteAddress(), cause);
+                return;
             }
             
             if (DatabaseDescriptor.getClientErrorReportingExclusions().contains(ctx.channel().remoteAddress()))

--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -23,6 +23,8 @@ import java.net.SocketAddress;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLException;
+
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 
@@ -100,7 +102,7 @@ public class ExceptionHandlers
                 logger.debug("Excluding client exception for {}; address contained in client_error_reporting_exclusions", ctx.channel().remoteAddress(), cause);
                 return;
             }
-            logClientNetworkingExceptions(cause);
+            logClientNetworkingExceptions(cause, ctx.channel().remoteAddress());
         }
 
         private static boolean isFatal(Throwable cause)
@@ -110,7 +112,7 @@ public class ExceptionHandlers
         }
     }
 
-    static void logClientNetworkingExceptions(Throwable cause)
+    static void logClientNetworkingExceptions(Throwable cause, SocketAddress clientAddress)
     {
         if (Throwables.anyCauseMatches(cause, t -> t instanceof ProtocolException))
         {
@@ -132,6 +134,11 @@ public class ExceptionHandlers
         {
             ClientMetrics.instance.markUnknownException();
             logger.trace("Native exception in client networking", cause);
+        }
+        else if (Throwables.anyCauseMatches(cause, t -> t instanceof SSLException))
+        {
+            // logger.warn("SSLException in client networking with peer {} {}", clientAddress, cause.getMessage());
+            NoSpamLogger.log(logger, NoSpamLogger.Level.WARN, 1, TimeUnit.MINUTES, "SSLException in client networking with peer {} {}", clientAddress, cause.getMessage());
         }
         else
         {

--- a/src/java/org/apache/cassandra/transport/PreV5Handlers.java
+++ b/src/java/org/apache/cassandra/transport/PreV5Handlers.java
@@ -330,14 +330,8 @@ public class PreV5Handlers
                 logger.debug("Excluding client exception for {}; address contained in client_error_reporting_exclusions", ctx.channel().remoteAddress(), cause);
                 return;
             }
-
-            if (Throwables.anyCauseMatches(cause, t -> t instanceof SSLException))
-            {
-                logger.warn("SSLException in client networking with peer {} {}", ctx.channel().remoteAddress(), cause.getMessage());
-                return;
-            }
             
-            ExceptionHandlers.logClientNetworkingExceptions(cause);
+            ExceptionHandlers.logClientNetworkingExceptions(cause, ctx.channel().remoteAddress());
             JVMStabilityInspector.inspectThrowable(cause);
         }
 


### PR DESCRIPTION
This patch prevents `SSLExceptions` from flooding the log with the stack trace. Addresses [CASSANDRA-18839](https://issues.apache.org/jira/browse/CASSANDRA-19015?filter=-3).