### PR TITLE
CASSANDRA-19110 convert deprecated apt-key command to new method on deb systems

### DIFF
--- a/doc/modules/cassandra/examples/BASH/add_repo_keys.sh
+++ b/doc/modules/cassandra/examples/BASH/add_repo_keys.sh
@@ -1,1 +1,2 @@
-$ curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
+# Make sure /etc/apt/keyrings exists on your system.
+$ curl https://downloads.apache.org/cassandra/KEYS | sudo gpg --dearmor -o /etc/apt/keyrings/cassandra-archive-keyring.gpg

--- a/doc/modules/cassandra/examples/BASH/get_deb_package.sh
+++ b/doc/modules/cassandra/examples/BASH/get_deb_package.sh
@@ -1,2 +1,2 @@
-$ echo "deb https://debian.cassandra.apache.org 42x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
-deb https://debian.cassandra.apache.org 42x main
+$ echo "deb [signed-by=/etc/apt/keyrings/cassandra-archive-keyring.gpg] https://debian.cassandra.apache.org 42x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+deb [signed-by=/etc/apt/keyrings/cassandra-archive-keyring.gpg] https://debian.cassandra.apache.org 42x main


### PR DESCRIPTION
Hi,

I've updated the 2 shell scripts that generates the output for Debian based systems.
since `apt-key` is deprecated and getting removed soon then I suggest on moving to the "new" way with `gpg --dearmor` method and pointing the apt source to the new file.

I've pointed the source of the gpg key to `/etc/apt/keyrings` because `/usr/share/keyrings/` is also getting converted.
On Ubuntu 22.04 a default folder `/etc/apt/keyrings` is created but not on `20.04` hence my comment in that shell script.

There are no output of `gpg --dearmor` so I have not updated [add_repo_keys.result](https://github.com/apache/cassandra/blob/trunk/doc/modules/cassandra/examples/RESULTS/add_repo_keys.result)

I've also updated the `deb` line in [get_deb_packages.sh](https://github.com/apache/cassandra/blob/trunk/doc/modules/cassandra/examples/BASH/get_deb_package.sh) to use signed gpg key since `apt` is starting to require keys like that.

