### PR TITLE
CASSANDRA-18875 upgrade Jackson to 2.15.3 and snakeyaml to 2.1

### DIFF
--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -427,27 +427,27 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.2.2</version>
+        <version>2.15.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.13.2</version>
+        <version>2.15.3</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -469,7 +469,7 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.26</version>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
+++ b/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
@@ -197,7 +197,7 @@ public class YamlConfigurationLoader implements ConfigurationLoader
 
     private static void verifyReplacements(Map<Class<?>, Map<String, Replacement>> replacements, byte[] configBytes)
     {
-        LoaderOptions loaderOptions = new LoaderOptions();
+        LoaderOptions loaderOptions = getDefaultLoaderOptions();
         loaderOptions.setAllowDuplicateKeys(ALLOW_DUPLICATE_CONFIG_KEYS.getBoolean());
         Yaml rawYaml = new Yaml(loaderOptions);
 
@@ -260,7 +260,7 @@ public class YamlConfigurationLoader implements ConfigurationLoader
 
     private static Composer getDefaultComposer(Node node)
     {
-        return new Composer(new ParserImpl(null), new Resolver(), new LoaderOptions())
+        return new Composer(new ParserImpl(null), new Resolver(), getDefaultLoaderOptions())
         {
             @Override
             public Node getSingleNode()
@@ -275,7 +275,7 @@ public class YamlConfigurationLoader implements ConfigurationLoader
     {
         CustomConstructor(Class<?> theRoot, ClassLoader classLoader)
         {
-            super(theRoot, classLoader, new LoaderOptions());
+            super(theRoot, classLoader, getDefaultLoaderOptions());
 
             TypeDescription seedDesc = new TypeDescription(ParameterizedClass.class);
             seedDesc.putMapPropertyType("parameters", String.class, String.class);
@@ -425,6 +425,13 @@ public class YamlConfigurationLoader implements ConfigurationLoader
             if (!deprecationWarnings.isEmpty())
                 logger.warn("{} parameters have been deprecated. They have new names and/or value format; For more information, please refer to NEWS.txt", deprecationWarnings);
         }
+    }
+
+    public static LoaderOptions getDefaultLoaderOptions()
+    {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(64 * 1024 * 1024); // 64 MiB
+        return loaderOptions;
     }
 }
 

--- a/src/java/org/apache/cassandra/tools/JMXTool.java
+++ b/src/java/org/apache/cassandra/tools/JMXTool.java
@@ -71,6 +71,8 @@ import io.airlift.airline.Option;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.utils.JsonUtils;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -163,7 +165,7 @@ public class JMXTool
             {
                 void dump(OutputStream output, Map<String, Info> map) throws IOException
                 {
-                    Representer representer = new Representer();
+                    Representer representer = new Representer(new DumperOptions());
                     representer.addClassTag(Info.class, Tag.MAP); // avoid the auto added tag
                     Yaml yaml = new Yaml(representer);
                     yaml.dump(map, new OutputStreamWriter(output));
@@ -394,6 +396,7 @@ public class JMXTool
 
             public CustomConstructor()
             {
+                super(new LoaderOptions());
                 this.rootTag = new Tag(ROOT);
                 this.addTypeDescription(INFO_TYPE);
             }

--- a/src/java/org/apache/cassandra/tools/JMXTool.java
+++ b/src/java/org/apache/cassandra/tools/JMXTool.java
@@ -396,7 +396,7 @@ public class JMXTool
 
             public CustomConstructor()
             {
-                super(new LoaderOptions());
+                super(getLoaderOptions());
                 this.rootTag = new Tag(ROOT);
                 this.addTypeDescription(INFO_TYPE);
             }
@@ -418,6 +418,13 @@ public class JMXTool
                 {
                     return super.constructObject(node);
                 }
+            }
+
+            private static LoaderOptions getLoaderOptions()
+            {
+                LoaderOptions loaderOptions = new LoaderOptions();
+                loaderOptions.setCodePointLimit(64 * 1024 * 1024); // 64 MiB
+                return loaderOptions;
             }
         }
     }

--- a/src/java/org/apache/cassandra/tools/JMXTool.java
+++ b/src/java/org/apache/cassandra/tools/JMXTool.java
@@ -68,11 +68,11 @@ import io.airlift.airline.Command;
 import io.airlift.airline.Help;
 import io.airlift.airline.HelpOption;
 import io.airlift.airline.Option;
+import org.apache.cassandra.config.YamlConfigurationLoader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileInputStreamPlus;
 import org.apache.cassandra.utils.JsonUtils;
 import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -396,7 +396,7 @@ public class JMXTool
 
             public CustomConstructor()
             {
-                super(getLoaderOptions());
+                super(YamlConfigurationLoader.getDefaultLoaderOptions());
                 this.rootTag = new Tag(ROOT);
                 this.addTypeDescription(INFO_TYPE);
             }
@@ -418,13 +418,6 @@ public class JMXTool
                 {
                     return super.constructObject(node);
                 }
-            }
-
-            private static LoaderOptions getLoaderOptions()
-            {
-                LoaderOptions loaderOptions = new LoaderOptions();
-                loaderOptions.setCodePointLimit(64 * 1024 * 1024); // 64 MiB
-                return loaderOptions;
             }
         }
     }

--- a/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
@@ -56,6 +56,7 @@ import org.apache.cassandra.stress.report.Timer;
 import org.apache.cassandra.stress.settings.*;
 import org.apache.cassandra.stress.util.JavaDriverClient;
 import org.apache.cassandra.stress.util.ResultLogger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -809,7 +810,7 @@ public class StressProfile implements Serializable
     {
         try
         {
-            Constructor constructor = new Constructor(StressYaml.class);
+            Constructor constructor = new Constructor(StressYaml.class, new LoaderOptions());
 
             Yaml yaml = new Yaml(constructor);
 

--- a/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
@@ -37,6 +37,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.AlreadyExistsException;
 import org.antlr.runtime.RecognitionException;
+import org.apache.cassandra.config.YamlConfigurationLoader;
 import org.apache.cassandra.cql3.CQLFragmentParser;
 import org.apache.cassandra.cql3.CqlParser;
 import org.apache.cassandra.cql3.statements.ModificationStatement;
@@ -56,7 +57,6 @@ import org.apache.cassandra.stress.report.Timer;
 import org.apache.cassandra.stress.settings.*;
 import org.apache.cassandra.stress.util.JavaDriverClient;
 import org.apache.cassandra.stress.util.ResultLogger;
-import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -810,7 +810,7 @@ public class StressProfile implements Serializable
     {
         try
         {
-            Constructor constructor = new Constructor(StressYaml.class, new LoaderOptions());
+            Constructor constructor = new Constructor(StressYaml.class, YamlConfigurationLoader.getDefaultLoaderOptions());
 
             Yaml yaml = new Yaml(constructor);
 


### PR DESCRIPTION
[CASSANDRA-18875](https://issues.apache.org/jira/browse/CASSANDRA-18875)

This PR upgrades to the latest release of Jackson [2.15.3](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15), and upgrades snakeyaml to [2.1](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes) to match that version of Jackson.

The only compile-time breaking change is that some snakeyaml classes had overloaded constructors removed, so we now need to pass default Options objects.
