### PR TITLE
CASSANDRA-19014 Resolved repair_admin summarize-pending command issue

### DIFF
--- a/src/java/org/apache/cassandra/repair/consistent/admin/PendingStats.java
+++ b/src/java/org/apache/cassandra/repair/consistent/admin/PendingStats.java
@@ -78,9 +78,10 @@ public class PendingStats
         Map<String, Object> values = new HashMap<>();
         values.put(COMPOSITE_NAMES[0], keyspace);
         values.put(COMPOSITE_NAMES[1], table);
-        values.put(COMPOSITE_NAMES[2], pending.toComposite());
-        values.put(COMPOSITE_NAMES[3], finalized.toComposite());
-        values.put(COMPOSITE_NAMES[4], failed.toComposite());
+        values.put(COMPOSITE_NAMES[2], total.toComposite());
+        values.put(COMPOSITE_NAMES[3], pending.toComposite());
+        values.put(COMPOSITE_NAMES[4], finalized.toComposite());
+        values.put(COMPOSITE_NAMES[5], failed.toComposite());
         try
         {
             return new CompositeDataSupport(COMPOSITE_TYPE, values);

--- a/test/distributed/org/apache/cassandra/distributed/test/IncRepairAdminTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/IncRepairAdminTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.UUIDGen;
 
+import static java.util.Arrays.stream;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.repair.consistent.ConsistentSession.State.REPAIRING;
@@ -50,6 +51,27 @@ import static org.junit.Assert.assertTrue;
 
 public class IncRepairAdminTest extends TestBaseImpl
 {
+    @Test
+    public void testRepairAdminSummarizePending() throws IOException
+    {
+        try (Cluster cluster = init(Cluster.build(1)
+                                           .withConfig(config -> config.with(GOSSIP).with(NETWORK))
+                                           .start()))
+        {
+            // given a cluster with a table
+            cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (k INT PRIMARY KEY, v INT)");
+            // when running repair_admin summarize-pending
+            NodeToolResult res = cluster.get(1).nodetoolResult("repair_admin", "summarize-pending");
+            // then the table info should be present in the output
+            res.asserts().success();
+            String outputLine = stream(res.getStdout().split("\n"))
+                    .filter(l -> l.contains(KEYSPACE) && l.contains("tbl"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("should find tbl table in output of repair_admin summarize-pending"));
+            assertTrue("should contain information about zero pending bytes", outputLine.contains("0 bytes (0 sstables / 0 sessions)"));
+        }
+    }
+
     @Test
     public void testManualSessionFail() throws IOException
     {


### PR DESCRIPTION
[CASSANDRA-19014](https://issues.apache.org/jira/browse/CASSANDRA-19014)

Fixed a bug causing the `OpenDataException` being thrown when executing the `repair_admin summarize-pending` command. This patch addresses the problem by including a missing composite in `PendingStats.toComposite`, ensuring proper data conversion.

