### PR TITLE
Docs - fix image not found error

### DIFF
--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_conceptual.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_conceptual.adoc
@@ -30,7 +30,7 @@ underlined. Relationships between entities are represented as diamonds,
 and the connectors between the relationship and each entity show the
 multiplicity of the connection.
 
-image::data-modeling_hotel_erd.png[image]
+image::data_modeling_hotel_erd.png[image]
 
 Obviously, in the real world, there would be many more considerations
 and much more complexity. For example, hotel rates are notoriously

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_logical.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_logical.adoc
@@ -34,7 +34,7 @@ informative way to visualize the relationships between queries and
 tables in your designs. This figure shows the Chebotko notation for a
 logical data model.
 
-image::cassandra:developing/data-modeling/data-modeling_chebotko_logical.png[image]
+image::cassandra:developing/data-modeling/data_modeling_chebotko_logical.png[image]
 
 Each table is shown with its title and a list of columns. Primary key
 columns are identified via symbols such as *K* for partition key columns
@@ -51,7 +51,7 @@ dedicated tables for rooms or amenities, as you had in the relational
 design. This is because the workflow didn't identify any queries
 requiring this direct access.
 
-image::cassandra:developing/data-modeling/data-modeling_hotel_logical.png[image]
+image::cassandra:developing/data-modeling/data_modeling_hotel_logical.png[image]
 
 Let's explore the details of each of these tables.
 
@@ -127,7 +127,7 @@ shows a logical data model for reservations. You'll notice that these
 tables represent a denormalized design; the same data appears in
 multiple tables, with differing keys.
 
-image::cassandra:developing/data-modeling/data-modeling_reservation_logical.png[image]
+image::cassandra:developing/data-modeling/data_modeling_reservation_logical.png[image]
 
 In order to satisfy Q6, the `reservations_by_guest` table can be used to
 look up the reservation by guest name. You could envision query Q7 being

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_physical.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_physical.adoc
@@ -19,7 +19,7 @@ notation for physical data models. To draw physical models, you need to
 be able to add the typing information for each column. This figure shows
 the addition of a type for each column in a sample table.
 
-image::cassandra:developing/data-modeling/data-modeling_chebotko_physical.png[image]
+image::cassandra:developing/data-modeling/data_modeling_chebotko_physical.png[image]
 
 The figure includes a designation of the keyspace containing each table
 and visual cues for columns represented using collections and
@@ -61,7 +61,7 @@ As you work to create physical representations of various tables in the
 logical hotel data model, you use the same approach. The resulting
 design is shown in this figure:
 
-image::cassandra:developing/data-modeling/data-modeling_hotel_physical.png[image]
+image::cassandra:developing/data-modeling/data_modeling_hotel_physical.png[image]
 
 Note that the `address` type is also included in the design. It is
 designated with an asterisk to denote that it is a user-defined type,
@@ -86,7 +86,7 @@ first iteration of your physical data model design, assume you're going
 to manage this denormalization manually. Note that this design could be
 revised to use Cassandra's (experimental) materialized view feature.
 
-image::cassandra:developing/data-modeling/data-modeling_reservation_physical.png[image]
+image::cassandra:developing/data-modeling/data_modeling_reservation_physical.png[image]
 
 Note that the `address` type is reproduced in this keyspace and
 `guest_id` is modeled as a `uuid` type in all of the tables.

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_queries.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_queries.adoc
@@ -53,7 +53,7 @@ to obtain detailed description of the hotel. The act of booking a room
 creates a reservation record that may be accessed by the guest and hotel
 staff at a later time through various additional queries.
 
-image::cassandra:developing/data-modeling/data-modeling_hotel_queries.png[image]
+image::cassandra:developing/data-modeling/data_modeling_hotel_queries.png[image]
 
 _Material adapted from Cassandra, The Definitive Guide. Published by
 O'Reilly Media, Inc. Copyright © 2020 Jeff Carpenter, Eben Hewitt. All

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_rdbms.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_rdbms.adoc
@@ -12,7 +12,7 @@ relationships from the conceptual model of hotels-to-points of interest,
 rooms-to-amenities, rooms-to-availability, and guests-to-rooms (via a
 reservation).
 
-image::data-modeling_hotel_relational.png[image]
+image::data_modeling_hotel_relational.png[image]
 
 == Design Differences Between RDBMS and Cassandra
 

--- a/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_refining.adoc
+++ b/doc/modules/cassandra/pages/developing/data-modeling/data-modeling_refining.adoc
@@ -188,7 +188,7 @@ the original design is shown in the figure below. While the `month`
 column is partially duplicative of the `date`, it provides a nice way of
 grouping related data in a partition that will not get too large.
 
-image::data-modeling_hotel_bucketing.png[image]
+image::data_modeling_hotel_bucketing.png[image]
 
 If you really felt strongly about preserving a wide partition design,
 you could instead add the `room_id` to the partition key, so that each


### PR DESCRIPTION
```
I want to edit the links of images related to the Data Modeling pages.
```
<img width="1107" alt="Screen Shot 2023-12-09 at 21 44 19" src="https://github.com/apache/cassandra/assets/56917374/73179257-3d7d-42a7-b151-1ad90f8c0a84">
