### PR TITLE
Skip version check if an endpoint is dead state

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0-beta2
+ * Skip version check if an endpoint is dead state (CASSANDRA-19187)
  * Fix resource cleanup after SAI query timeouts (CASSANDRA-19177)
  * Suppress CVE-2023-6481 (CASSANDRA-19184)
 Merged from 4.1:

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -233,13 +233,17 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
 
         // Check the release version of all the peers it heard of. Not necessary the peer that it has/had contacted with.
         boolean allHostsHaveKnownVersion = true;
-        for (InetAddressAndPort host : endpointStateMap.keySet())
+        for (Entry<InetAddressAndPort, EndpointState> entry : endpointStateMap.entrySet())
         {
+            InetAddressAndPort host = entry.getKey();
             if (justRemovedEndpoints.containsKey(host))
                 continue;
 
-            CassandraVersion version = getReleaseVersion(host);
+            // if it is dead state, we skip the version check
+            if (isDeadState(entry.getValue()))
+                continue;
 
+            CassandraVersion version = getReleaseVersion(host);
             //Raced with changes to gossip state, wait until next iteration
             if (version == null)
                 allHostsHaveKnownVersion = false;

--- a/src/java/org/apache/cassandra/utils/ExpiringMemoizingSupplier.java
+++ b/src/java/org/apache/cassandra/utils/ExpiringMemoizingSupplier.java
@@ -102,7 +102,7 @@ public class ExpiringMemoizingSupplier<T> implements Supplier<T>
             this.value = value;
         }
 
-        abstract boolean canMemoize();
+        public abstract boolean canMemoize();
 
         public T value()
         {

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -164,30 +164,20 @@ public class GossiperTest
     @Test
     public void testAssassinatedNodeWillNotContributeToVersionCalculation() throws Exception
     {
-        Gossiper.instance.start(0);
+        int initialNodeCount = 3;
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, initialNodeCount);
+        for (int i = 0; i < initialNodeCount; i++)
+        {
+            Gossiper.instance.injectApplicationState(hosts.get(i), ApplicationState.RELEASE_VERSION, new VersionedValue.VersionedValueFactory(null).releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
+        }
+        Gossiper.instance.start(1);
         Gossiper.instance.expireUpgradeFromVersion();
-
-        VersionedValue.VersionedValueFactory factory = new VersionedValue.VersionedValueFactory(null);
-        EndpointState es = new EndpointState(new HeartBeatState((int) ((System.currentTimeMillis() + 60000) / 1000), 1234));
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
-        Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.1"), es);
-        Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.1"));
-
-
-        es = new EndpointState(new HeartBeatState((int) ((System.currentTimeMillis() + 60000) / 1000), 1234));
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
-        Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.2"), es);
-        Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.2"));
-
-        es = new EndpointState(new HeartBeatState((int) ((System.currentTimeMillis() + 60000) / 1000), 1234));
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
-        Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.3"), es);
-        Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.3"));
 
         // assassinate a non-existing node
         Gossiper.instance.assassinateEndpoint("127.0.0.4");
 
         assertTrue(Gossiper.instance.endpointStateMap.containsKey(InetAddressAndPort.getByName("127.0.0.4")));
+        assertNull(Gossiper.instance.upgradeFromVersionSupplier.get().value());
         assertTrue(Gossiper.instance.upgradeFromVersionSupplier.get().canMemoize());
         assertFalse(Gossiper.instance.hasMajorVersion3Nodes());
         assertFalse(Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_3_4));

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -188,7 +188,7 @@ public class GossiperTest
         Gossiper.instance.assassinateEndpoint("127.0.0.4");
 
         assertTrue(Gossiper.instance.endpointStateMap.containsKey(InetAddressAndPort.getByName("127.0.0.4")));
-        assertNull(Gossiper.instance.upgradeFromVersionSupplier.get().value());
+        assertTrue(Gossiper.instance.upgradeFromVersionSupplier.get().canMemoize());
         assertFalse(Gossiper.instance.hasMajorVersion3Nodes());
         assertFalse(Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_3_4));
     }

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -187,7 +187,7 @@ public class GossiperTest
         // assassinate a non-existing node
         Gossiper.instance.assassinateEndpoint("127.0.0.4");
 
-        assertEquals(4, Gossiper.instance.endpointStateMap.size());
+        assertTrue(Gossiper.instance.endpointStateMap.containsKey(InetAddressAndPort.getByName("127.0.0.4")));
         assertNull(Gossiper.instance.upgradeFromVersionSupplier.get().value());
         assertFalse(Gossiper.instance.hasMajorVersion3Nodes());
         assertFalse(Gossiper.instance.isUpgradingFromVersionLowerThan(CassandraVersion.CASSANDRA_3_4));


### PR DESCRIPTION
Skip version check if an endpoint is dead state
If the dead / left node is not skipped, sometimes a such node will cause the upgradeFromVersionSupplier to not able to return memoized data. Which will lead to thread serialization because all of them need to acquire the lock first.