### PR TITLE
CASSANDRA-18879 Fix datetime_from_utc_to_local in cqlshlib

### DIFF
--- a/pylib/cqlshlib/tracing.py
+++ b/pylib/cqlshlib/tracing.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
-import time
+from datetime import datetime, timezone
 
 from cassandra.query import QueryTrace, TraceUnavailable
 from cqlshlib.displaying import MAGENTA
@@ -85,6 +84,8 @@ def total_micro_seconds(td):
 
 
 def datetime_from_utc_to_local(utc_datetime):
-    now_timestamp = time.time()
-    offset = datetime.fromtimestamp(now_timestamp) - datetime.utcfromtimestamp(now_timestamp)
-    return utc_datetime + offset
+    """
+    Convert a naive UTC datetime to the local timezone.
+    This is necessary because the driver always returns naive datetime objects.
+    """
+    return utc_datetime.replace(tzinfo=timezone.utc).astimezone()


### PR DESCRIPTION
CASSANDRA-18879

UTC offsets for a timezone can change over time. The current `datetime_from_utc_to_local` doesn't handle daylight savings, and uses the current UTC offset for timezones that may have had a different UTC offset in the past (see comments from [1]).

Also, the UTC datetime objects obtained from the Datastax Python driver are naive (see [2]). Thus, to convert them to the local timezone, we need to make them UTC "aware" objects first (using `replace()`) before calling `astimezone()` (see [3]).

[1] https://stackoverflow.com/a/19238551/9523462
[2] https://docs.datastax.com/en/developer/python-driver/3.28/dates_and_times/#read-path
[3] https://docs.python.org/3/library/datetime.html#datetime.datetime.astimezone