### PR TITLE
4.0 Updated the OWASP plugin to 9.0.5 and refactored dependency checks

### DIFF
--- a/.build/build-owasp.xml
+++ b/.build/build-owasp.xml
@@ -100,97 +100,11 @@
         </dependency-check>
     </target>
 
-    <target name="-resolve-latest-nightly-build" unless="nightly.build.dir">
-        <property name="nightly.version" value="4.0"/>
-        <property name="nightlies.url"
-                  value="https://nightlies.apache.org/cassandra/cassandra-${nightly.version}/Cassandra-${nightly.version}-artifacts"/>
-        <exec executable="curl" failonerror="true" failifexecutionfails="true" logerror="true">
-            <arg value="-s"/>
-            <arg value="${nightlies.url}/?C=M;O=D"/>
-            <redirector outputproperty="last.build.number">
-                <outputfilterchain>
-                    <linecontainsregexp regexp="href=&quot;([0-9]+./)&quot;"/>
-                    <replaceregex byline="true" pattern=".*href=&quot;([0-9]+)/&quot;.*" replace="\1"/>
-                    <headfilter lines="1"/>
-                </outputfilterchain>
-            </redirector>
-        </exec>
-        <echo message="last.build.number=${last.build.number}"/>
-
-        <property name="last.build.url"
-                  value="${nightlies.url}/${last.build.number}/Cassandra-${nightly.version}-artifacts/jdk=jdk_1.8_latest,label=cassandra/build"/>
-        <exec executable="curl" failonerror="true" failifexecutionfails="true" logerror="true">
-            <arg value="-s"/>
-            <arg value="${last.build.url}/"/>
-            <redirector outputproperty="last.build.name">
-                <outputfilterchain>
-                    <linecontainsregexp regexp="-bin\.tar\.gz"/>
-                    <replaceregex byline="true" pattern=".*href=&quot;([^&quot;]+)&quot;.*" replace="\1"/>
-                    <headfilter lines="1"/>
-                </outputfilterchain>
-            </redirector>
-        </exec>
-        <property name="last.build.artifact.url" value="${last.build.url}/${last.build.name}"/>
-        <echo message="last.build.artifact.url=${last.build.artifact.url}"/>
-    </target>
-
-    <target name="-maybe-fetch-latest-nightly-build" depends="-resolve-latest-nightly-build" unless="nightly.build.dir">
-        <property name="cassandra.nightlies.dir" value="${tmp.dir}/cassandra-nightlies"/>
-        <property name="nightly.build.dir" value="${cassandra.nightlies.dir}/${nightly.version}/${last.build.number}"/>
-        <condition property="nightly.build.dir.exists">
-            <available file="${nightly.build.dir}" type="dir"/>
-        </condition>
-        <antcall target="-fetch-latest-nightly-build" unless:set="nightly.build.dir.exists" inheritall="true"
-                 inheritrefs="true"/>
-    </target>
-
-    <target name="-fetch-latest-nightly-build">
-        <dirname property="nightly.build.parent.dir" file="${nightly.build.dir}"/>
-        <delete dir="${nightly.build.parent.dir}" includeemptydirs="true" failonerror="false"/>
-        <mkdir dir="${nightly.build.dir}"/>
-        <get src="${last.build.artifact.url}" dest="${nightly.build.dir}/cassandra.tar.gz" verbose="true"/>
-        <gunzip src="${nightly.build.dir}/cassandra.tar.gz" dest="${nightly.build.dir}/cassandra.tar"/>
-        <delete file="${nightly.build.dir}/cassandra.tar.gz"/>
-        <untar src="${nightly.build.dir}/cassandra.tar" dest="${nightly.build.dir}/" allowfilestoescapedest="false"
-               stripabsolutepathspec="2"/>
-        <delete file="${nightly.build.dir}/cassandra.tar"/>
-        <exec executable="bash" failifexecutionfails="true" failonerror="true" logerror="true"
-              dir="${nightly.build.dir}">
-            <arg value="-c"/>
-            <arg value="mv apache-cassandra-*/* .; rm -rf apache-cassandra-*"/>
-        </exec>
-    </target>
-
-    <target name="-determine-dependency-changes">
-        <get src="https://raw.githubusercontent.com/apache/cassandra/cassandra-4.0/build.xml" retries="3"
-             dest="${tmp.dir}/cassandra-4.0-build.xml" verbose="true"/>
-        <condition property="dependencies-changed" value="true">
-            <not>
-                <filesmatch file1="${tmp.dir}/cassandra-4.0-build.xml" file2="build.xml"/>
-            </not>
-        </condition>
-        <delete file="${tmp.dir}/cassandra-4.0-build.xml"/>
-        <echo if:set="dependencies-changed" message="Dependencies changed compared to the last nightly build"/>
-    </target>
-
-    <target name="dependency-check-full" depends="resolver-dist-lib">
+    <target name="dependency-check" depends="resolver-dist-lib">
         <fileset dir="lib" id="dependencies_to_check">
             <include name="**/*.jar"/>
         </fileset>
         <antcall target="-run-owasp-scan" inheritrefs="true" inheritall="true"/>
-    </target>
-
-    <target name="-dependency-check" depends="-maybe-fetch-latest-nightly-build,resolver-dist-lib">
-        <fileset id="dependencies_to_check" dir="${build.lib}" includes="**/**">
-            <present present="srconly" targetdir="${nightly.build.dir}/lib"/>
-        </fileset>
-        <echo message="New or changed dependencies: ${toString:dependencies_to_check}"/>
-        <antcall target="-run-owasp-scan" inheritrefs="true" inheritall="true"/>
-    </target>
-
-    <target name="dependency-check" depends="-determine-dependency-changes">
-        <antcall target="-dependency-check" inheritall="true" inheritrefs="true" if:set="dependencies-changed"/>
-        <echo unless:set="dependencies-changed" message="No dependency changes detected"/>
     </target>
 
 </project>

--- a/.build/build-owasp.xml
+++ b/.build/build-owasp.xml
@@ -16,30 +16,50 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project basedir="." name="apache-cassandra-owasp-tasks">
-    <property name="dependency-check.version" value="8.3.1"/>
-    <property name="dependency-check.home" value="${build.dir}/dependency-check-ant-${dependency-check.version}"/>
+<project basedir="." name="apache-cassandra-owasp-tasks"
+         xmlns:unless="ant:unless"
+         xmlns:if="ant:if">
+    <property name="dependency-check.version" value="9.0.5"/>
+    <property name="dependency-check.home" value="${tmp.dir}/dependency-check-ant-${dependency-check.version}"/>
+    <property name="dependency-check.archive.dir" value="${local.repository}/org/owasp/dependency-check-ant/${dependency-check.version}"/>
+    <property name="dependency-check.archive.name" value="dependency-check-ant-${dependency-check.version}-release.zip"/>
+    <property name="dependency-check.report.dir" value="${build.dir}/owasp"/>
 
-    <condition property="is.dependency.check.jar">
-        <available file="${dependency-check.home}/dependency-check-ant/dependency-check-ant.jar" type="file" />
+    <condition property="dependency-check-ant.archive.present">
+        <available file="${dependency-check.archive.dir}/${dependency-check.archive.name}" type="file" />
     </condition>
 
-    <target name="dependency-check-download"
-            depends="build"
+    <target name="-dependency-check-download"
             description="Fetch OWASP Dependency checker"
-            unless="is.dependency.check.jar">
+            unless="dependency-check-ant.archive.present">
 
-        <echo>Downloading OWASP Dependency checks ...</echo>
-
-        <mkdir dir="${dependency-check.home}"/>
-
-        <get src="https://github.com/jeremylong/DependencyCheck/releases/download/v${dependency-check.version}/dependency-check-ant-${dependency-check.version}-release.zip"
-             dest="${dependency-check.home}/dependency-check-ant-${dependency-check.version}-release.zip"/>
-
-        <unzip src="${dependency-check.home}/dependency-check-ant-${dependency-check.version}-release.zip" dest="${dependency-check.home}"/>
+        <mkdir dir="${dependency-check.archive.dir}"/>
+        <get src="https://github.com/jeremylong/DependencyCheck/releases/download/v${dependency-check.version}/${dependency-check.archive.name}"
+             dest="${dependency-check.archive.dir}/${dependency-check.archive.name}" retries="3"/>
     </target>
 
-    <target name="dependency-check" description="Dependency-Check Analysis" depends="dependency-check-download,resolver-dist-lib">
+    <target name="-dependency-check-init" depends="-dependency-check-download">
+        <delete dir="${dependency-check.home}" includeemptydirs="true" failonerror="false"/>
+        <mkdir dir="${dependency-check.home}"/>
+        <unzip src="${dependency-check.archive.dir}/${dependency-check.archive.name}" dest="${dependency-check.home}"/>
+    </target>
+
+    <target name="-run-owasp-scan" description="Dependency-Check Analysis"
+            depends="-dependency-check-init,resolver-dist-lib">
+        <fail unless:set="nvd.api.key">
+            Please set the nvd.api.key property to your NVD API key. It is recommended to put that property into your
+            ~/.ant/build.properties file. You can get your API key from https://nvd.nist.gov/developers/request-an-api-key
+        </fail>
+
+        <echo unless:set="nvd.data.dir">
+            Since the NVD database is pretty large, you should consider storing it in some persistent location to reuse
+            it between builds. You can do that by setting the nvd.data.dir property to a directory of your choice,
+            such as ~/.cache/ant/owasp/database for Linux or ~/Library/Caches/Ant/owasp/database for MacOS.
+            Putting that property into your ~/.ant/build.properties file is recommended.
+        </echo>
+
+        <property name="nvd.data.dir" value="${tmp.dir}/owasp/database"/>
+        <property name="nvd.validity.hours" value="4"/>
 
         <path id="dependency-check.path">
             <fileset dir="${dependency-check.home}/dependency-check-ant/lib">
@@ -52,35 +72,125 @@
         </taskdef>
 
         <!--
-            default value for cveValidForHours is 4 after which sync is done again
-
-            skipping using two specific caches at the end is solving (1)
+            default value for nvdValidForHours is 4 after which sync is done again
 
             failBuildOnCVSS is by default 11 so build would never fail,
-            the table categorising vulnerabilities is here (2), so by setting
+            the table categorising vulnerabilities is here (1), so by setting
             "failBuildOnCVSS" to 1, we will fail the build on any CVE found
             if it is not suppressed already dependency-check-suppressions.xml
 
             If a vendor provides no details about a vulnerability,
             NVD will score that vulnerability as 10.0 (the highest rating translating to critical).
 
-            (1) https://github.com/jeremylong/DependencyCheck/issues/2166
-            (2) https://nvd.nist.gov/vuln-metrics/cvss
+            (1) https://nvd.nist.gov/vuln-metrics/cvss
         -->
         <dependency-check projectname="Apache Cassandra"
-                          reportoutputdirectory="${basedir}/build"
-                          reportformat="HTML"
+                          nvdApiKey="${nvd.api.key}"
+                          reportoutputdirectory="${dependency-check.report.dir}"
+                          reportformat="ALL"
                           prettyPrint="true"
-                          cveValidForHours="1"
-                          centralAnalyzerUseCache="false"
-                          nodeAuditAnalyzerUseCache="false"
+                          nvdValidForHours="${nvd.validity.hours}"
+                          centralAnalyzerUseCache="true"
+                          nodeAuditAnalyzerUseCache="true"
                           failBuildOnCVSS="1"
                           assemblyAnalyzerEnabled="false"
-                          dataDirectory="${dependency-check.home}/data"
+                          dataDirectory="${nvd.data.dir}"
                           suppressionFile="${basedir}/.build/dependency-check-suppressions.xml">
-            <fileset dir="lib">
-                <include name="**/*.jar"/>
-            </fileset>
+            <fileset refid="dependencies_to_check"/>
         </dependency-check>
     </target>
+
+    <target name="-resolve-latest-nightly-build" unless="nightly.build.dir">
+        <property name="nightly.version" value="4.0"/>
+        <property name="nightlies.url"
+                  value="https://nightlies.apache.org/cassandra/cassandra-${nightly.version}/Cassandra-${nightly.version}-artifacts"/>
+        <exec executable="curl" failonerror="true" failifexecutionfails="true" logerror="true">
+            <arg value="-s"/>
+            <arg value="${nightlies.url}/?C=M;O=D"/>
+            <redirector outputproperty="last.build.number">
+                <outputfilterchain>
+                    <linecontainsregexp regexp="href=&quot;([0-9]+./)&quot;"/>
+                    <replaceregex byline="true" pattern=".*href=&quot;([0-9]+)/&quot;.*" replace="\1"/>
+                    <headfilter lines="1"/>
+                </outputfilterchain>
+            </redirector>
+        </exec>
+        <echo message="last.build.number=${last.build.number}"/>
+
+        <property name="last.build.url"
+                  value="${nightlies.url}/${last.build.number}/Cassandra-${nightly.version}-artifacts/jdk=jdk_1.8_latest,label=cassandra/build"/>
+        <exec executable="curl" failonerror="true" failifexecutionfails="true" logerror="true">
+            <arg value="-s"/>
+            <arg value="${last.build.url}/"/>
+            <redirector outputproperty="last.build.name">
+                <outputfilterchain>
+                    <linecontainsregexp regexp="-bin\.tar\.gz"/>
+                    <replaceregex byline="true" pattern=".*href=&quot;([^&quot;]+)&quot;.*" replace="\1"/>
+                    <headfilter lines="1"/>
+                </outputfilterchain>
+            </redirector>
+        </exec>
+        <property name="last.build.artifact.url" value="${last.build.url}/${last.build.name}"/>
+        <echo message="last.build.artifact.url=${last.build.artifact.url}"/>
+    </target>
+
+    <target name="-maybe-fetch-latest-nightly-build" depends="-resolve-latest-nightly-build" unless="nightly.build.dir">
+        <property name="cassandra.nightlies.dir" value="${tmp.dir}/cassandra-nightlies"/>
+        <property name="nightly.build.dir" value="${cassandra.nightlies.dir}/${nightly.version}/${last.build.number}"/>
+        <condition property="nightly.build.dir.exists">
+            <available file="${nightly.build.dir}" type="dir"/>
+        </condition>
+        <antcall target="-fetch-latest-nightly-build" unless:set="nightly.build.dir.exists" inheritall="true"
+                 inheritrefs="true"/>
+    </target>
+
+    <target name="-fetch-latest-nightly-build">
+        <dirname property="nightly.build.parent.dir" file="${nightly.build.dir}"/>
+        <delete dir="${nightly.build.parent.dir}" includeemptydirs="true" failonerror="false"/>
+        <mkdir dir="${nightly.build.dir}"/>
+        <get src="${last.build.artifact.url}" dest="${nightly.build.dir}/cassandra.tar.gz" verbose="true"/>
+        <gunzip src="${nightly.build.dir}/cassandra.tar.gz" dest="${nightly.build.dir}/cassandra.tar"/>
+        <delete file="${nightly.build.dir}/cassandra.tar.gz"/>
+        <untar src="${nightly.build.dir}/cassandra.tar" dest="${nightly.build.dir}/" allowfilestoescapedest="false"
+               stripabsolutepathspec="2"/>
+        <delete file="${nightly.build.dir}/cassandra.tar"/>
+        <exec executable="bash" failifexecutionfails="true" failonerror="true" logerror="true"
+              dir="${nightly.build.dir}">
+            <arg value="-c"/>
+            <arg value="mv apache-cassandra-*/* .; rm -rf apache-cassandra-*"/>
+        </exec>
+    </target>
+
+    <target name="-determine-dependency-changes">
+        <get src="https://raw.githubusercontent.com/apache/cassandra/cassandra-4.0/build.xml" retries="3"
+             dest="${tmp.dir}/cassandra-4.0-build.xml" verbose="true"/>
+        <condition property="dependencies-changed" value="true">
+            <not>
+                <filesmatch file1="${tmp.dir}/cassandra-4.0-build.xml" file2="build.xml"/>
+            </not>
+        </condition>
+        <delete file="${tmp.dir}/cassandra-4.0-build.xml"/>
+        <echo if:set="dependencies-changed" message="Dependencies changed compared to the last nightly build"/>
+    </target>
+
+    <target name="dependency-check-full" depends="resolver-dist-lib">
+        <fileset dir="lib" id="dependencies_to_check">
+            <include name="**/*.jar"/>
+        </fileset>
+        <antcall target="-run-owasp-scan" inheritrefs="true" inheritall="true"/>
+    </target>
+
+    <target name="-dependency-check" depends="-maybe-fetch-latest-nightly-build,resolver-dist-lib">
+        <fileset id="dependencies_to_check" dir="${build.lib}" includes="**/**">
+            <present present="srconly" targetdir="${nightly.build.dir}/lib"/>
+        </fileset>
+        <echo message="New or changed dependencies: ${toString:dependencies_to_check}"/>
+        <antcall target="-run-owasp-scan" inheritrefs="true" inheritall="true"/>
+    </target>
+
+    <target name="dependency-check" depends="-determine-dependency-changes">
+        <antcall target="-dependency-check" inheritall="true" inheritrefs="true" if:set="dependencies-changed"/>
+        <echo unless:set="dependencies-changed" message="No dependency changes detected"/>
+    </target>
+
 </project>

--- a/.build/dependency-check-suppressions.xml
+++ b/.build/dependency-check-suppressions.xml
@@ -23,17 +23,13 @@
     <suppress>
         <!--  https://issues.apache.org/jira/browse/CASSANDRA-17907 -->
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2023-2251</cve>
+        <cve>CVE-2022-1471</cve>
         <cve>CVE-2022-25857</cve>
         <cve>CVE-2022-38749</cve>
         <cve>CVE-2022-38750</cve>
         <cve>CVE-2022-38751</cve>
         <cve>CVE-2022-38752</cve>
         <cve>CVE-2022-41854</cve>
-        <cve>CVE-2022-1471</cve>
-        <cve>CVE-2022-3064</cve>
-        <cve>CVE-2021-4235</cve>
-        <cve>CVE-2017-18640</cve>
     </suppress>
     <suppress>
         <!-- not applicable https://nvd.nist.gov/vuln/detail/CVE-2020-8908 -->
@@ -52,7 +48,6 @@
         <cve>CVE-2021-43797</cve>
         <cve>CVE-2022-24823</cve>
         <cve>CVE-2022-41881</cve>
-        <cve>CVE-2022-41915</cve>
         <cve>CVE-2023-34462</cve>
         <cve>CVE-2023-44487</cve>
     </suppress>

--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,7 @@
     <property environment="env"/>
     <property file="build.properties" />
     <property file="build.properties.default" />
+    <property file="${user.home}/.ant/build.properties"/>
     <property name="debuglevel" value="source,lines,vars"/>
 
     <!-- default version and SCM information -->


### PR DESCRIPTION
Configured OWASP database to use caching and NVD key. Properties can be configured in ~/.ant/build.properties and defined both the key and the storage location

Allow for incremental dependency checking so that for pre-commit we can check only the modified/added dependencies and not fail the build because a new CVE appeared

The user can specify -Dnightly.build.dir=... to provide its own reference distribution against which the dependencies should be compared in incremental mode

Don't check dependencies if build.xml was not changed (to be implemented differently on the newer branches)
