### PR TITLE
[CASSANDRA-18999][5.0] Gossiper::hasMajorVersion3Nodes returns true when a cluster is upgrading patch version without Cassandra 3 nodes.

### DIFF
--- a/src/java/org/apache/cassandra/gms/EndpointState.java
+++ b/src/java/org/apache/cassandra/gms/EndpointState.java
@@ -129,47 +129,6 @@ public class EndpointState
         }
     }
 
-    void removeMajorVersion3LegacyApplicationStates()
-    {
-        while (hasLegacyFields())
-        {
-            Map<ApplicationState, VersionedValue> orig = applicationState.get();
-            Map<ApplicationState, VersionedValue> updatedStates = filterMajorVersion3LegacyApplicationStates(orig);
-            // avoid updating if no state is removed
-            if (orig.size() == updatedStates.size()
-                || applicationState.compareAndSet(orig, updatedStates))
-                return;
-        }
-    }
-
-    private boolean hasLegacyFields()
-    {
-        Set<ApplicationState> statesPresent = applicationState.get().keySet();
-        if (statesPresent.isEmpty())
-            return false;
-        return (statesPresent.contains(ApplicationState.STATUS) && statesPresent.contains(ApplicationState.STATUS_WITH_PORT))
-               || (statesPresent.contains(ApplicationState.INTERNAL_IP) && statesPresent.contains(ApplicationState.INTERNAL_ADDRESS_AND_PORT))
-               || (statesPresent.contains(ApplicationState.RPC_ADDRESS) && statesPresent.contains(ApplicationState.NATIVE_ADDRESS_AND_PORT));
-    }
-
-    private static Map<ApplicationState, VersionedValue> filterMajorVersion3LegacyApplicationStates(Map<ApplicationState, VersionedValue> states)
-    {
-        return states.entrySet().stream().filter(entry -> {
-                // Filter out pre-4.0 versions of data for more complete 4.0 versions
-                switch (entry.getKey())
-                {
-                    case INTERNAL_IP:
-                        return !states.containsKey(ApplicationState.INTERNAL_ADDRESS_AND_PORT);
-                    case STATUS:
-                        return !states.containsKey(ApplicationState.STATUS_WITH_PORT);
-                    case RPC_ADDRESS:
-                        return !states.containsKey(ApplicationState.NATIVE_ADDRESS_AND_PORT);
-                    default:
-                        return true;
-                }
-            }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
     /* getters and setters */
     /**
      * @return System.nanoTime() when state was updated last time.

--- a/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
+++ b/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
@@ -124,10 +124,9 @@ public final class TraceKeyspace
         Row.SimpleBuilder rb = builder.row();
         rb.ttl(ttl)
           .add("client", client)
-          .add("coordinator", FBUtilities.getBroadcastAddressAndPort().getAddress());
-        if (!Gossiper.instance.hasMajorVersion3Nodes())
-            rb.add("coordinator_port", FBUtilities.getBroadcastAddressAndPort().getPort());
-        rb.add("request", request)
+          .add("coordinator", FBUtilities.getBroadcastAddressAndPort().getAddress())
+          .add("coordinator_port", FBUtilities.getBroadcastAddressAndPort().getPort())
+          .add("request", request)
           .add("started_at", new Date(startedAt))
           .add("command", command)
           .appendAll("parameters", parameters);
@@ -151,10 +150,9 @@ public final class TraceKeyspace
                                               .ttl(ttl);
 
         rowBuilder.add("activity", message)
-                  .add("source", FBUtilities.getBroadcastAddressAndPort().getAddress());
-        if (!Gossiper.instance.hasMajorVersion3Nodes())
-            rowBuilder.add("source_port", FBUtilities.getBroadcastAddressAndPort().getPort());
-        rowBuilder.add("thread", threadName);
+                  .add("source", FBUtilities.getBroadcastAddressAndPort().getAddress())
+                  .add("source_port", FBUtilities.getBroadcastAddressAndPort().getPort())
+                  .add("thread", threadName);
 
         if (elapsed >= 0)
             rowBuilder.add("source_elapsed", elapsed);

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -1082,7 +1082,7 @@ public class Util
 
     /**
      * Setups Gossiper to mimic the upgrade behaviour when {@link Gossiper#isUpgradingFromVersionLowerThan(CassandraVersion)}
-     * or {@link Gossiper#hasMajorVersion3Nodes()} is called.
+     * is called.
      */
     public static void setUpgradeFromVersion(String version)
     {

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -121,47 +121,6 @@ public class GossiperTest
     }
 
     @Test
-    public void testHasVersion3Nodes() throws Exception
-    {
-        Gossiper.instance.start(0);
-        Gossiper.instance.expireUpgradeFromVersion();
-
-        VersionedValue.VersionedValueFactory factory = new VersionedValue.VersionedValueFactory(null);
-        EndpointState es = new EndpointState((HeartBeatState) null);
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion(CURRENT_VERSION.toString()));
-        Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.1"), es);
-        Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.1"));
-
-
-        es = new EndpointState((HeartBeatState) null);
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion("3.11.3"));
-        Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.2"), es);
-        Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.2"));
-
-        es = new EndpointState((HeartBeatState) null);
-        es.addApplicationState(ApplicationState.RELEASE_VERSION, factory.releaseVersion("3.0.0"));
-        Gossiper.instance.endpointStateMap.put(InetAddressAndPort.getByName("127.0.0.3"), es);
-        Gossiper.instance.liveEndpoints.add(InetAddressAndPort.getByName("127.0.0.3"));
-
-        assertFalse(Gossiper.instance.upgradeFromVersionSupplier.get().value().compareTo(new CassandraVersion("3.0")) < 0);
-        assertTrue(Gossiper.instance.upgradeFromVersionSupplier.get().value().compareTo(new CassandraVersion("3.1")) < 0);
-        assertTrue(Gossiper.instance.hasMajorVersion3Nodes());
-
-        Gossiper.instance.endpointStateMap.remove(InetAddressAndPort.getByName("127.0.0.3"));
-        Gossiper.instance.liveEndpoints.remove(InetAddressAndPort.getByName("127.0.0.3"));
-
-        assertFalse(Gossiper.instance.upgradeFromVersionSupplier.get().value().compareTo(new CassandraVersion("3.0")) < 0);
-        assertFalse(Gossiper.instance.upgradeFromVersionSupplier.get().value().compareTo(new CassandraVersion("3.1")) < 0);
-        assertTrue(Gossiper.instance.upgradeFromVersionSupplier.get().value().compareTo(new CassandraVersion("3.12")) < 0);
-        assertTrue(Gossiper.instance.hasMajorVersion3Nodes());
-
-        Gossiper.instance.endpointStateMap.remove(InetAddressAndPort.getByName("127.0.0.2"));
-        Gossiper.instance.liveEndpoints.remove(InetAddressAndPort.getByName("127.0.0.2"));
-
-        assertEquals(SystemKeyspace.CURRENT_VERSION, Gossiper.instance.upgradeFromVersionSupplier.get().value());
-    }
-
-    @Test
     public void testLargeGenerationJump() throws UnknownHostException, InterruptedException
     {
         Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);


### PR DESCRIPTION
Per the conversation in CASSANDRA-18999, this PR removes `Gossiper#hasMajorVersion3Nodes` for Cassandra 5.0 as we do not support upgrades from 3.x -> 5.0. This PR also removes all references to `Gossiper#hasMajorVersion3Nodes` and cleans up any additional dead code that this creates (mostly that in `EndpointState`). 