### PR TITLE
Remove unused import

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/ReadRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ReadRepairTest.java
@@ -55,7 +55,6 @@ import org.apache.cassandra.distributed.api.TokenSupplier;
 import org.apache.cassandra.distributed.shared.NetworkTopology;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.locator.ReplicaPlan;
-import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.reads.repair.BlockingReadRepair;
 import org.apache.cassandra.service.reads.repair.ReadRepairStrategy;
 import org.apache.cassandra.utils.concurrent.Condition;


### PR DESCRIPTION
`ant artifacts` fails on the current `cep-15-accord` branch:

```
$ ant artifacts
...
checkstyle-test:
[checkstyle] Running Checkstyle 10.12.1 on 2088 files
[checkstyle] [ERROR] /cassandra/test/distributed/org/apache/cassandra/distributed/test/ReadRepairTest.java:58:8: Unused import - org.apache.cassandra.service.accord.AccordService. [UnusedImports]

BUILD FAILED
/cassandra/build.xml:561: The following error occurred while executing this line:
/cassandra/.build/build-checkstyle.xml:57: Got 1 errors and 0 warnings.

Total time: 39 seconds
```

Importing the class `org.apache.cassandra.service.accord.AccordService` is introduced in f04d9ec1d626213074e9153866e440dafe86408e but the line using that class is removed in 38f355ce7f7d5b4f5ed07744283336bc110d6372.