### PR TITLE
CASSANDRA-18824-trunk: Backport CASSANDRA-16418 to 3.x

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupDuringRangeMovementTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ring/CleanupDuringRangeMovementTest.java
@@ -36,14 +36,13 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.tcm.transformations.PrepareJoin;
 import org.apache.cassandra.tcm.transformations.PrepareLeave;
 
-import static org.apache.cassandra.distributed.shared.ClusterUtils.decommission;
-import static org.apache.cassandra.distributed.shared.ClusterUtils.pauseBeforeCommit;
-import static org.apache.cassandra.distributed.shared.ClusterUtils.unpauseCommits;
-import static org.apache.cassandra.distributed.test.ring.BootstrapTest.populateExistingTable;
-import static org.junit.Assert.assertEquals;
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.apache.cassandra.distributed.api.TokenSupplier.evenlyDistributedTokens;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.decommission;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.pauseBeforeCommit;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.unpauseCommits;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CleanupDuringRangeMovementTest extends TestBaseImpl
@@ -65,8 +64,7 @@ public class CleanupDuringRangeMovementTest extends TestBaseImpl
             // Create table before starting decommission as at the moment schema changes are not permitted
             // while range movements are in-flight. Additionally, pausing the CMS instance to block the
             // leave sequence from completing would also block the commit of the schema transformation
-            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
-            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+            createKeyspaceWithTable(cluster, 1);
 
             // Prime the CMS node to pause before the finish leave event is committed
             Callable<?> pending = pauseBeforeCommit(cmsInstance, (e) -> e instanceof PrepareLeave.FinishLeave);
@@ -75,19 +73,19 @@ public class CleanupDuringRangeMovementTest extends TestBaseImpl
             pending.call();
 
             // Add data to cluster while node is decomissioning
-            int NUM_ROWS = 100;
-            populateExistingTable(cluster, 0, NUM_ROWS, 2, ConsistencyLevel.ONE);
+            int numRows = 100;
+            insertData(cluster, 2, numRows, ConsistencyLevel.ONE);
             cluster.forEach(c -> c.flush(KEYSPACE));
 
             // Check data before cleanup on nodeToRemainInCluster
-            assertEquals(NUM_ROWS, nodeToRemainInCluster.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+            assertEquals(numRows, nodeToRemainInCluster.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
 
             // Run cleanup on nodeToRemainInCluster
             NodeToolResult result = nodeToRemainInCluster.nodetoolResult("cleanup");
             result.asserts().success();
 
             // Check data after cleanup on nodeToRemainInCluster
-            assertEquals(NUM_ROWS, nodeToRemainInCluster.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+            assertEquals(numRows, nodeToRemainInCluster.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
 
             unpauseCommits(cmsInstance);
             assertTrue(decomFuture.get());
@@ -110,8 +108,7 @@ public class CleanupDuringRangeMovementTest extends TestBaseImpl
             // Create table before starting bootstrap as at the moment schema changes are not permitted
             // while range movements are in-flight. Additionally, pausing the CMS instance to block the
             // leave sequence from completing would also block the commit of the schema transformation
-            cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};");
-            cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+            createKeyspaceWithTable(cluster, 2);
 
             IInvokableInstance cmsInstance = cluster.get(1);
             IInstanceConfig config = cluster.newInstanceConfig()
@@ -125,21 +122,36 @@ public class CleanupDuringRangeMovementTest extends TestBaseImpl
             pending.call();
 
             // Add data to cluster while node is bootstrapping
-            int NUM_ROWS = 100;
-            populateExistingTable(cluster, 0, NUM_ROWS, 1, ConsistencyLevel.ONE);
+            int numRows = 100;
+            insertData(cluster, 1, numRows, ConsistencyLevel.ONE);
             cluster.forEach(c -> c.flush(KEYSPACE));
 
             // Check data before cleanup on bootstrappingNode
-            assertEquals(NUM_ROWS, bootstrappingNode.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+            assertEquals(numRows, bootstrappingNode.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
 
             // Run cleanup on bootstrappingNode
             NodeToolResult result = bootstrappingNode.nodetoolResult("cleanup");
             result.asserts().success();
 
             // Check data after cleanup on bootstrappingNode
-            assertEquals(NUM_ROWS, bootstrappingNode.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
+            assertEquals(numRows, bootstrappingNode.executeInternal("SELECT * FROM " + KEYSPACE + ".tbl").length);
             unpauseCommits(cmsInstance);
             bootstrapFuture.get();
         }
+    }
+
+    private void createKeyspaceWithTable(Cluster cluster, int rf)
+    {
+        cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': " + rf + "};");
+        cluster.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
+    }
+
+    private void insertData(Cluster cluster, int node, int numberOfRows, ConsistencyLevel cl)
+    {
+        for (int i = 0; i < numberOfRows; i++)
+        {
+            cluster.coordinator(node).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (?, ?, ?)", cl, i, i, i);
+        }
+        cluster.forEach(c -> c.flush(KEYSPACE));
     }
 }


### PR DESCRIPTION
When a node is decommissioned, it triggers data transfer to other nodes. During this transfer process, receiving nodes temporarily hold token ranges in a pending state. However, the current cleanup process doesn't account for these pending ranges when calculating token ownership, leading to inadvertent cleanup of data already stored in SSTables. To address this issue, this patch introduces two changes. Firstly, it backports CASSANDRA-16418, introducing a preventive check in `StorageService#forceKeyspaceCleanup`. This check disallows the initiation of cleanup when a node contains any pending ranges for the requested keyspace. Secondly, it reintroduces a similar condition to test for the existence of pending ranges in `CompactionManager#performCleanup`. This ensures the safety of this API as well.

patch by Szymon Miezal; reviewed by TBD for CASSANDRA-18824

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

