### PR TITLE
CASSANDRA-19104/2 Default to human-readable in `nodetool tablestats`

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
@@ -36,10 +36,10 @@ public class TableStats extends NodeToolCmd
     @Option(name = "-i", description = "Ignore the list of tables and display the remaining tables")
     private boolean ignore = false;
 
-    @Option(title = "human_readable",
-            name = {"-H", "--human-readable"},
-            description = "Display bytes in human readable form, i.e. KiB, MiB, GiB, TiB")
-    private boolean humanReadable = false;
+    @Option(title = "no_human_readable",
+            name = {"--no-human-readable"},
+            description = "Disable displaying bytes in human readable form, i.e. KiB, MiB, GiB, TiB")
+    private boolean noHumanReadable = false;
 
     @Option(title = "format",
             name = {"-F", "--format"},
@@ -98,7 +98,7 @@ public class TableStats extends NodeToolCmd
             throw new IllegalArgumentException("argument for top must be a positive integer.");
         }
 
-        StatsHolder holder = new TableStatsHolder(probe, humanReadable, ignore, tableNames, sortKey, top, locationCheck);
+        StatsHolder holder = new TableStatsHolder(probe, !noHumanReadable, ignore, tableNames, sortKey, top, locationCheck);
         // print out the keyspace and table statistics
         StatsPrinter printer = TableStatsPrinter.from(outputFormat, !sortKey.isEmpty());
         printer.print(holder, probe.output().out);

--- a/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
@@ -38,7 +38,7 @@ public class TableStats extends NodeToolCmd
 
     @Option(title = "no_human_readable",
             name = {"--no-human-readable"},
-            description = "Disable displaying bytes in human readable form, i.e. KiB, MiB, GiB, TiB")
+            description = "Disable displaying bytes in human readable form")
     private boolean noHumanReadable = false;
 
     @Option(title = "format",

--- a/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
@@ -160,12 +160,12 @@ public class TableStatsTest extends CQLTester
     }
 
     @Test
-    public void testHumanReadableArg()
+    public void testNoHumanReadableArg()
     {
-        Arrays.asList("-H", "--human-readable").forEach(arg -> {
+        Arrays.asList("--no-human-readable").forEach(arg -> {
             ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", arg);
             tool.assertOnCleanExit();
-            assertThat(tool.getStdout()).contains(" KiB");
+            assertThat(tool.getStdout()).doesNotContain(" KiB");
         });
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
@@ -61,26 +61,27 @@ public class TableStatsTest extends CQLTester
                         "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
                         "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
                         "                [(-u <username> | --username <username>)] tablestats\n" +
-                        "                [(-F <format> | --format <format>)] [(-H | --human-readable)] [-i]\n" +
-                        "                [(-l | --sstable-location-check)] [(-s <sort_key> | --sort <sort_key>)]\n" +
-                        "                [(-t <top> | --top <top>)] [--] [<keyspace.table>...]\n" +
-                        "\n" + 
+                        "                [(-F <format> | --format <format>)] [-i]\n" +
+                        "                [(-l | --sstable-location-check)] [--no-human-readable]\n" +
+                        "                [(-s <sort_key> | --sort <sort_key>)] [(-t <top> | --top <top>)] [--]\n" +
+                        "                [<keyspace.table>...]\n" +
+                        "\n" +
                         "OPTIONS\n" +
                         "        -F <format>, --format <format>\n" +
                         "            Output format (json, yaml)\n" + 
-                        "\n" + 
+                        "\n" +
                         "        -h <host>, --host <host>\n" + 
                         "            Node hostname or ip address\n" + 
-                        "\n" + 
-                        "        -H, --human-readable\n" + 
-                        "            Display bytes in human readable form, i.e. KiB, MiB, GiB, TiB\n" + 
-                        "\n" + 
+                        "\n" +
                         "        -i\n" + 
                         "            Ignore the list of tables and display the remaining tables\n" +
                         "\n" +
                         "        -l, --sstable-location-check\n" +
                         "            Check whether or not the SSTables are in the correct location.\n" +
-                        "\n" + 
+                        "\n" +
+                        "        --no-human-readable\n" +
+                        "            Disable displaying bytes in human readable form\n" +
+                        "\n" +
                         "        -p <port>, --port <port>\n" + 
                         "            Remote jmx agent port number\n" + 
                         "\n" + 


### PR DESCRIPTION
Default to human-readable in `nodetool tablestats`. See a discussion on the topic in the dev mailing list [dev@cassandra.apache.org](https://lists.apache.org/thread/mlp715kxho5b6f1ql9omlzmmnh4qfby9)

### Before
`nodetool tablestats` doesn't use the human-readable formatting by default (with KiB/MiB/GiB units), instead it outputs data size values as is. In order to switch to the human-readable output, `--human-readable` or `--H` CLI flag is required.

### After
`nodetool tablestats` uses the human-readable format by default. For backward compatibility `--no-human-readable` flag can be used to disable it.

### How to reproduce
```bash
nodetool tablestats
```
and
```bash
nodetool tablestats --no-human-readable
```

Tests
```bash
ant testsome -Dtest.name=org.apache.cassandra.tools.nodetool.TableStatsTest
ant testsome -Dtest.name=org.apache.cassandra.tools.nodetool.stats.TableStatsPrinterTest
```

patch by @zaaath; reviewed by ??? for [CASSANDRA-19104](https://issues.apache.org/jira/browse/CASSANDRA-19104)