### PR TITLE
CASSANDRA-19107 Revert unnecessary read lock acquisition when reading ring version in TokenMetadata introduced in CASSANDRA-16286

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0.12
+ * Revert unnecessary read lock acquisition when reading ring version in TokenMetadata introduced in CASSANDRA-16286 (CASSANDRA-19107)
  * Support max SSTable size in sorted CQLSSTableWriter (CASSANDRA-18941)
  * Fix nodetool repair_admin summarize-pending command to not throw exception (CASSANDRA-19014)
  * Fix cassandra-stress in simplenative mode with prepared statements (CASSANDRA-18744)

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -111,7 +111,7 @@ public class TokenMetadata
 
     // signals replication strategies that nodes have joined or left the ring and they need to recompute ownership
     @GuardedBy("lock")
-    private long ringVersion = 0;
+    private volatile long ringVersion = 0;
 
     public TokenMetadata()
     {
@@ -1372,16 +1372,7 @@ public class TokenMetadata
 
     public long getRingVersion()
     {
-        lock.readLock().lock();
-
-        try
-        {
-            return ringVersion;
-        }
-        finally
-        {
-            lock.readLock().unlock();
-        }
+        return ringVersion;
     }
 
     public void invalidateCachedRings()

--- a/test/unit/org/apache/cassandra/locator/TokenMetadataTest.java
+++ b/test/unit/org/apache/cassandra/locator/TokenMetadataTest.java
@@ -79,7 +79,7 @@ public class TokenMetadataTest
 
         ExecutorService pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() + 1);
         
-        int invalidations = 1024;
+        int invalidations = 2048;
         
         for (int i = 0; i < invalidations; i++)
             pool.execute(() -> tmd.invalidateCachedRings());


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by Francisco Guerrero for CASSANDRA-19107