### PR TITLE
CASSANDRA-19107 Revert unnecessary read lock acquisition when reading ring version in TokenMetadata introduced in CASSANDRA-16286

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Merged from 4.1:
  * Memoize Cassandra verion and add a backoff interval for failed schema pulls (CASSANDRA-18902)
  * Fix StackOverflowError on ALTER after many previous schema changes (CASSANDRA-19166)
 Merged from 4.0:
+ * Revert unnecessary read lock acquisition when reading ring version in TokenMetadata introduced in CASSANDRA-16286 (CASSANDRA-19107)
 Merged from 3.11:
 Merged from 3.0:
 

--- a/src/java/org/apache/cassandra/locator/TokenMetadata.java
+++ b/src/java/org/apache/cassandra/locator/TokenMetadata.java
@@ -113,7 +113,7 @@ public class TokenMetadata
 
     // signals replication strategies that nodes have joined or left the ring and they need to recompute ownership
     @GuardedBy("lock")
-    private long ringVersion = 0;
+    private volatile long ringVersion = 0;
 
     public TokenMetadata()
     {
@@ -1387,16 +1387,7 @@ public class TokenMetadata
 
     public long getRingVersion()
     {
-        lock.readLock().lock();
-
-        try
-        {
-            return ringVersion;
-        }
-        finally
-        {
-            lock.readLock().unlock();
-        }
+        return ringVersion;
     }
 
     public void invalidateCachedRings()

--- a/test/unit/org/apache/cassandra/locator/TokenMetadataTest.java
+++ b/test/unit/org/apache/cassandra/locator/TokenMetadataTest.java
@@ -88,7 +88,7 @@ public class TokenMetadataTest
 
         ExecutorService pool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() + 1);
         
-        int invalidations = 1024;
+        int invalidations = 2048;
         
         for (int i = 0; i < invalidations; i++)
             pool.execute(() -> tmd.invalidateCachedRings());


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by Francisco Guerrero for CASSANDRA-19107