### PR TITLE
CASSANDRA-19263: Fix tcm startup ExceptionInInitializerError when upgrade from 5.0-beta1 to trunk

### DIFF
--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -226,6 +226,8 @@ public class MessagingService extends MessagingServiceMBeanImpl implements Messa
 
         public static final Version CURRENT;
 
+        private static final Logger logger = LoggerFactory.getLogger(Version.class);
+
         static
         {
              if (DatabaseDescriptor.getStorageCompatibilityMode().isBefore(5))

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -277,6 +277,10 @@ public class CassandraDaemon
         {
             exitOrFail(e.returnCode, e.getMessage(), e.getCause());
         }
+        catch (Exception | Error e)
+        {
+            throw new AssertionError("Can't initialize cluster metadata service. Maybe for incompatibility issues and you can try upgrade strategies");
+        }
 
         QueryProcessor.registerStatementInvalidatingListener();
 


### PR DESCRIPTION
- more details in the [CASSANDRA-19263](https://issues.apache.org/jira/browse/CASSANDRA-19263)