### PR TITLE
CASSANDRA-19268 Add a new compressor to accelerate compress/decompress operations using Intel® IAA, an integrated hardware accelerator

### DIFF
--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -380,5 +380,9 @@
       <groupId>com.vdurmont</groupId>
       <artifactId>semver4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.intel.qpl</groupId>
+      <artifactId>qpl-java</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -1231,6 +1231,11 @@
         <artifactId>semver4j</artifactId>
         <version>3.1.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.intel.qpl</groupId>
+        <artifactId>qpl-java</artifactId>
+        <version>1.0.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/README.asc
+++ b/README.asc
@@ -16,6 +16,38 @@ Requirements
 - Java: see supported versions in build.xml (search for property "java.supported").
 - Python: for `cqlsh`, see `bin/cqlsh` (search for function "is_supported_version").
 
+Enabling Intel® In-Memory Analytics Accelerator (Intel® IAA)
+------------------------------------------------------------
+QPLCompressor is a custom compressor, which enables Cassandra to perform compress/decompress operations using Intel® In-Memory Analytics Accelerator (Intel® IAA) & Intel® Query Processing Library (Intel® QPL).For more information about the Intel® In-Memory Analytics Accelerator, refer to the https://cdrdv2.intel.com/v1/dl/getContent/721858[IAA spec] on the https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html[Intel® 64 and IA-32 Architectures Software Developer Manuals] page.
+
+Prerequisites to use QPLCompressor
+----------------------------------
+. https://github.com/intel/qpl[Intel® QPL] library - To build, follow https://intel.github.io/qpl/documentation/get_started_docs/installation.html[Installation].
+. https://github.com/intel/qpl-java[Intel® qpl-java] library -To build, follow https://github.com/intel/qpl-java#steps-to-build-and-run-tests[steps to build] under Readme.
+. Java >= 11.
+
+Configuring QPLCompressor
+-------------------------
+----
+cqlsh> CREATE KEYSPACE schema1
+       WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+cqlsh> USE schema1;
+cqlsh:Schema1> CREATE TABLE users (
+                 user_id varchar PRIMARY KEY,
+                 first varchar,
+                 last varchar,
+                 age int
+               ) WITH compression = {'class': 'QPLCompressor'};
+----
+
+QPLCompressor supports followings advanced options:
+
+
+* execution_path(default hardware): Specifies whether operation should be executed on the IAA hardware or emulated in software. There are three options: hardware, software and auto.
+                                    For information on execution path, please refer https://intel.github.io/qpl/documentation/introduction_docs/introduction.html#execution-paths[here].
+                                    Warning: auto implementation is in progress.
+* compressor_level(default 1): User can set any of these https://intel.github.io/qpl/documentation/dev_ref_docs/c_ref/c_common_definitions.html?highlight=compression_level#c.qpl_compression_levels[supported] compression levels.
+* retry_count(default 0): This option determines how long QPLCompressor should retry compress/decompress operations if IAA queues are busy.
 
 Getting started
 ---------------

--- a/README.asc
+++ b/README.asc
@@ -16,38 +16,6 @@ Requirements
 - Java: see supported versions in build.xml (search for property "java.supported").
 - Python: for `cqlsh`, see `bin/cqlsh` (search for function "is_supported_version").
 
-Enabling Intel® In-Memory Analytics Accelerator (Intel® IAA)
-------------------------------------------------------------
-QPLCompressor is a custom compressor, which enables Cassandra to perform compress/decompress operations using Intel® In-Memory Analytics Accelerator (Intel® IAA) & Intel® Query Processing Library (Intel® QPL).For more information about the Intel® In-Memory Analytics Accelerator, refer to the https://cdrdv2.intel.com/v1/dl/getContent/721858[IAA spec] on the https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html[Intel® 64 and IA-32 Architectures Software Developer Manuals] page.
-
-Prerequisites to use QPLCompressor
-----------------------------------
-. https://github.com/intel/qpl[Intel® QPL] library - To build, follow https://intel.github.io/qpl/documentation/get_started_docs/installation.html[Installation].
-. https://github.com/intel/qpl-java[Intel® qpl-java] library -To build, follow https://github.com/intel/qpl-java#steps-to-build-and-run-tests[steps to build] under Readme.
-. Java >= 11.
-
-Configuring QPLCompressor
--------------------------
-----
-cqlsh> CREATE KEYSPACE schema1
-       WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
-cqlsh> USE schema1;
-cqlsh:Schema1> CREATE TABLE users (
-                 user_id varchar PRIMARY KEY,
-                 first varchar,
-                 last varchar,
-                 age int
-               ) WITH compression = {'class': 'QPLCompressor'};
-----
-
-QPLCompressor supports followings advanced options:
-
-
-* execution_path(default hardware): Specifies whether operation should be executed on the IAA hardware or emulated in software. There are three options: hardware, software and auto.
-                                    For information on execution path, please refer https://intel.github.io/qpl/documentation/introduction_docs/introduction.html#execution-paths[here].
-                                    Warning: auto implementation is in progress.
-* compressor_level(default 1): User can set any of these https://intel.github.io/qpl/documentation/dev_ref_docs/c_ref/c_common_definitions.html?highlight=compression_level#c.qpl_compression_levels[supported] compression levels.
-* retry_count(default 0): This option determines how long QPLCompressor should retry compress/decompress operations if IAA queues are busy.
 
 Getting started
 ---------------

--- a/src/java/org/apache/cassandra/io/compress/QPLCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/QPLCompressor.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.intel.qpl.QPLException;
+import com.intel.qpl.QPLUtils;
+import io.netty.util.concurrent.FastThreadLocal;
+import org.apache.cassandra.exceptions.ConfigurationException;
+
+public class QPLCompressor implements ICompressor {
+    private static final Logger logger = LoggerFactory.getLogger(QPLCompressor.class);
+    private static final Set<String> VALID_EXECUTION_PATH = new HashSet<>(Arrays.asList("auto", "hardware", "software"));
+    private static final Map<String, QPLUtils.ExecutionPaths> executionPathMap = createMap();
+
+    public static final String DEFAULT_EXECUTION_PATH = "hardware";
+    public static final int DEFAULT_COMPRESSION_LEVEL = 1;
+    public static final int DEFAULT_RETRY_COUNT = 0;
+
+    //If hardware path is not available then redirect it to software path
+    public static final String REDIRECT_EXECUTION_PATH = "software";
+
+    //Configurable parameters name
+    public static final String QPL_EXECUTION_PATH = "execution_path";
+    public static final String QPL_COMPRESSOR_LEVEL = "compressor_level";
+    public static final String QPL_RETRY_COUNT = "retry_count";
+
+    private final Set<Uses> recommendedUses;
+
+    public int initialCompressedBufferLength(int chunkLength) {
+      if (chunkLength <= 0) {
+        return 0;
+      }
+      return com.intel.qpl.QPLCompressor.maxCompressedLength(chunkLength);
+    }
+
+    public static QPLCompressor create(Map<String, String> options) {
+        return new QPLCompressor(options);
+    }
+
+    @VisibleForTesting
+    String executionPath;
+    @VisibleForTesting
+    Integer compressionLevel;
+    @VisibleForTesting
+    Integer retryCount;
+    private final FastThreadLocal<com.intel.qpl.QPLCompressor> reusableCompressor;
+
+    private QPLCompressor(Map<String, String> options) {
+        this.executionPath = validateExecutionPath(options.get(QPL_EXECUTION_PATH));
+        this.compressionLevel = validateCompressionLevel(options.get(QPL_COMPRESSOR_LEVEL), this.executionPath);
+        this.retryCount = validateRetryCount(options.get(QPL_RETRY_COUNT));
+        reusableCompressor = new FastThreadLocal<>() {
+            @Override
+            protected com.intel.qpl.QPLCompressor initialValue() {
+                return new com.intel.qpl.QPLCompressor(executionPathMap.get(executionPath),compressionLevel,retryCount);
+            }
+        };
+
+        recommendedUses = ImmutableSet.of(Uses.GENERAL);
+        logger.trace("Creating QPLCompressor with execution path {}  and compression level {} add retry_count {}.", this.executionPath, this.compressionLevel, this.retryCount);
+    }
+
+    public int uncompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset) throws IOException {
+        try {
+            if (inputLength > 0) {
+                return reusableCompressor.get().decompress(input, inputOffset, inputLength, output, outputOffset, output.length - outputOffset);
+            }
+        } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException |
+                 IllegalStateException | QPLException e) {
+          throw new IOException(e);
+        }
+        return 0;
+    }
+
+    public void compress(ByteBuffer input, ByteBuffer output) throws IOException {
+        try {
+            if (input.hasRemaining()) {
+                reusableCompressor.get().compress(input,output);
+            }
+        } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException |
+                 IllegalStateException | QPLException e) {
+          throw new IOException(e);
+        }
+    }
+
+    public void uncompress(ByteBuffer input, ByteBuffer output) throws IOException {
+        try {
+            if (input.hasRemaining()) {
+                reusableCompressor.get().decompress(input,output);
+            }
+        } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException |
+                 IllegalStateException | QPLException e) {
+          throw new IOException(e);
+        }
+    }
+
+    public BufferType preferredBufferType() {
+        return BufferType.OFF_HEAP;
+    }
+
+    public boolean supports(BufferType bufferType) {
+        return bufferType == BufferType.OFF_HEAP;
+    }
+
+    public Set<String> supportedOptions() {
+        return new HashSet<>(Arrays.asList(QPL_EXECUTION_PATH, QPL_COMPRESSOR_LEVEL, QPL_RETRY_COUNT));
+    }
+
+    @Override
+    public Set<Uses> recommendedUses() {
+        return recommendedUses;
+    }
+
+    public static String validateExecutionPath(String executionPath) throws ConfigurationException {
+        String validExecPath;
+        if (executionPath == null) {
+            //if hardware path is not available then set it to software path.
+            executionPath = DEFAULT_EXECUTION_PATH;
+            validExecPath = com.intel.qpl.QPLCompressor.getValidExecutionPath(executionPathMap.get(executionPath)).name();
+            if (!QPLUtils.ExecutionPaths.QPL_PATH_HARDWARE.name().equalsIgnoreCase(validExecPath)) {
+                logger.warn("The execution path 'hardware' is not available hence default it to software.");
+                executionPath = REDIRECT_EXECUTION_PATH;
+            }
+            return executionPath;
+        }
+
+
+        if (!VALID_EXECUTION_PATH.contains(executionPath)) {
+            throw new ConfigurationException(String.format("Invalid execution path '%s' specified for QPLCompressor parameter '%s'. "
+                                                           + "Valid options are %s.", executionPath, QPL_EXECUTION_PATH,
+                                                           VALID_EXECUTION_PATH));
+        } else {
+             validExecPath = com.intel.qpl.QPLCompressor.getValidExecutionPath(executionPathMap.get(executionPath)).name();
+            if (!validExecPath.equalsIgnoreCase(executionPathMap.get(executionPath).name())) {
+                logger.warn("The execution path '{}' is not available hence default it to software.", executionPath);
+                executionPath = REDIRECT_EXECUTION_PATH;
+            }
+            return executionPath;
+        }
+    }
+
+    public static int validateCompressionLevel(String compressionLevel, String execPath) throws ConfigurationException {
+        if (compressionLevel == null)
+            return DEFAULT_COMPRESSION_LEVEL;
+
+        ConfigurationException ex = new ConfigurationException("Invalid value [" + compressionLevel + "] for parameter '"
+                                                               + QPL_COMPRESSOR_LEVEL + "'.");
+
+        int level;
+        try {
+            level = Integer.parseInt(compressionLevel);
+            if (level < 0)
+                throw ex;
+        } catch (NumberFormatException e) {
+            throw ex;
+        }
+
+        int validLevel = com.intel.qpl.QPLCompressor.getValidCompressionLevel(executionPathMap.get(execPath), level);
+        if (level != validLevel) {
+            logger.warn("The compression level '{}' is not supported for {} execution path hence its default to {}.", level, execPath, validLevel);
+        }
+        return validLevel;
+    }
+
+    public static int validateRetryCount(String retryCount) throws ConfigurationException {
+        if (retryCount == null)
+            return DEFAULT_RETRY_COUNT;
+
+        ConfigurationException ex = new ConfigurationException("Invalid value [" + retryCount + "] for parameter '"
+                                                               + QPL_RETRY_COUNT + "'. Value must be >= 0.");
+
+        int count;
+        try {
+            count = Integer.parseInt(retryCount);
+            if (count < 0) {
+                throw ex;
+            }
+        } catch (NumberFormatException e) {
+            throw ex;
+        }
+
+        return count;
+    }
+
+    private static Map<String, QPLUtils.ExecutionPaths> createMap() {
+        return ImmutableMap.of("auto", QPLUtils.ExecutionPaths.QPL_PATH_AUTO, "hardware", QPLUtils.ExecutionPaths.QPL_PATH_HARDWARE, "software", QPLUtils.ExecutionPaths.QPL_PATH_SOFTWARE);
+    }
+}

--- a/src/java/org/apache/cassandra/schema/CompressionParams.java
+++ b/src/java/org/apache/cassandra/schema/CompressionParams.java
@@ -178,6 +178,19 @@ public final class CompressionParams
         return new CompressionParams(compressor, DEFAULT_CHUNK_LENGTH, Integer.MAX_VALUE, DEFAULT_MIN_COMPRESS_RATIO, Collections.emptyMap());
     }
 
+    @VisibleForTesting
+    public static CompressionParams qpl()
+    {
+        return qpl(DEFAULT_CHUNK_LENGTH);
+    }
+
+    @VisibleForTesting
+    public static CompressionParams qpl(int chunkLength)
+    {
+        QPLCompressor compressor = QPLCompressor.create(Collections.emptyMap());
+        return new CompressionParams(compressor, chunkLength, Integer.MAX_VALUE, DEFAULT_MIN_COMPRESS_RATIO, Collections.emptyMap());
+    }
+
     public CompressionParams(String sstableCompressorClass, Map<String, String> otherOptions, int chunkLength, double minCompressRatio) throws ConfigurationException
     {
         this(createCompressor(parseCompressorClass(sstableCompressorClass), otherOptions), chunkLength, calcMaxCompressedLength(chunkLength, minCompressRatio), minCompressRatio, otherOptions);

--- a/test/distributed/org/apache/cassandra/distributed/test/SimpleReadWriteTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SimpleReadWriteTest.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.distributed.api.ICoordinator;
 import org.apache.cassandra.io.compress.DeflateCompressor;
 import org.apache.cassandra.io.compress.LZ4Compressor;
 import org.apache.cassandra.io.compress.NoopCompressor;
+import org.apache.cassandra.io.compress.QPLCompressor;
 import org.apache.cassandra.io.compress.SnappyCompressor;
 import org.apache.cassandra.io.compress.ZstdCompressor;
 
@@ -70,7 +71,8 @@ public class SimpleReadWriteTest extends TestBaseImpl
                                                               LZ4Compressor.class.getSimpleName(),
                                                               DeflateCompressor.class.getSimpleName(),
                                                               SnappyCompressor.class.getSimpleName(),
-                                                              ZstdCompressor.class.getSimpleName() };
+                                                              ZstdCompressor.class.getSimpleName(),
+                                                              QPLCompressor.class.getSimpleName()};
     private static final int SECOND_SSTABLE_INTERVAL = 2;
     private static final int MEMTABLE_INTERVAL = 5;
 

--- a/test/distributed/org/apache/cassandra/distributed/test/SimpleReadWriteTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SimpleReadWriteTest.java
@@ -72,7 +72,7 @@ public class SimpleReadWriteTest extends TestBaseImpl
                                                               DeflateCompressor.class.getSimpleName(),
                                                               SnappyCompressor.class.getSimpleName(),
                                                               ZstdCompressor.class.getSimpleName(),
-                                                              QPLCompressor.class.getSimpleName()};
+                                                              QPLCompressor.class.getSimpleName() };
     private static final int SECOND_SSTABLE_INTERVAL = 2;
     private static final int MEMTABLE_INTERVAL = 5;
 

--- a/test/long/org/apache/cassandra/io/compress/CompressorPerformance.java
+++ b/test/long/org/apache/cassandra/io/compress/CompressorPerformance.java
@@ -40,7 +40,8 @@ public class CompressorPerformance
                 LZ4Compressor.create(Collections.emptyMap()),
                 SnappyCompressor.instance,
                 ZstdCompressor.getOrCreate(ZstdCompressor.FAST_COMPRESSION_LEVEL),
-                ZstdCompressor.getOrCreate(ZstdCompressor.DEFAULT_COMPRESSION_LEVEL)
+                ZstdCompressor.getOrCreate(ZstdCompressor.DEFAULT_COMPRESSION_LEVEL),
+                QPLCompressor.create(Collections.emptyMap())
         })
         {
             for (BufferType in: BufferType.values())

--- a/test/unit/org/apache/cassandra/SchemaLoader.java
+++ b/test/unit/org/apache/cassandra/SchemaLoader.java
@@ -760,6 +760,8 @@ public static TableMetadata.Builder clusteringSASICFMD(String ksName, String cfN
                 return CompressionParams.zstd(chunkLength);
             case "none":
                 return CompressionParams.noCompression();
+            case "qpl":
+                return CompressionParams.qpl(chunkLength);
             default:
                 throw new IllegalArgumentException("Invalid compression algorithm has been provided in cassandra.test.compression system property: " + algo);
         }

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerFlushedTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerFlushedTest.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.security.EncryptionContext;
 import org.apache.cassandra.security.EncryptionContextGenerator;
+import org.apache.cassandra.io.compress.QPLCompressor;
 
 @RunWith(Parameterized.class)
 public class RecoveryManagerFlushedTest
@@ -74,7 +75,8 @@ public class RecoveryManagerFlushedTest
             {new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
+            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerFlushedTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerFlushedTest.java
@@ -76,7 +76,7 @@ public class RecoveryManagerFlushedTest
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            { new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() } });
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerMissingHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerMissingHeaderTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.cassandra.io.compress.QPLCompressor;
 import org.apache.cassandra.io.util.File;
 import org.junit.Assert;
 import org.junit.Before;
@@ -73,7 +74,8 @@ public class RecoveryManagerMissingHeaderTest
             {new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
+            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerMissingHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerMissingHeaderTest.java
@@ -75,7 +75,7 @@ public class RecoveryManagerMissingHeaderTest
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            { new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() } });
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.db.rows.*;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.compress.DeflateCompressor;
 import org.apache.cassandra.io.compress.LZ4Compressor;
+import org.apache.cassandra.io.compress.QPLCompressor;
 import org.apache.cassandra.io.compress.SnappyCompressor;
 import org.apache.cassandra.io.compress.ZstdCompressor;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -90,7 +91,8 @@ public class RecoveryManagerTest
             {new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
+            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
@@ -92,7 +92,7 @@ public class RecoveryManagerTest
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            { new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() } });
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.compress.DeflateCompressor;
 import org.apache.cassandra.io.compress.LZ4Compressor;
+import org.apache.cassandra.io.compress.QPLCompressor;
 import org.apache.cassandra.io.compress.SnappyCompressor;
 import org.apache.cassandra.io.compress.ZstdCompressor;
 import org.apache.cassandra.schema.KeyspaceParams;
@@ -71,7 +72,8 @@ public class RecoveryManagerTruncateTest
             {new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
+            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTruncateTest.java
@@ -73,7 +73,7 @@ public class RecoveryManagerTruncateTest
             {new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
             {new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()},
-            {new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext()}});
+            { new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() } });
     }
 
     @Before

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogTest.java
@@ -107,6 +107,7 @@ import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.KillerForTests;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.vint.VIntCoding;
+import org.apache.cassandra.io.compress.QPLCompressor;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_IGNORE_REPLAY_ERRORS;
@@ -153,7 +154,8 @@ public abstract class CommitLogTest
                              { new ParameterizedClass(LZ4Compressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() },
                              { new ParameterizedClass(SnappyCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() },
                              { new ParameterizedClass(DeflateCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() },
-                             { new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() }
+                             { new ParameterizedClass(ZstdCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() },
+                             { new ParameterizedClass(QPLCompressor.class.getName(), Collections.emptyMap()), EncryptionContextGenerator.createDisabledContext() }
                              });
     }
 

--- a/test/unit/org/apache/cassandra/db/commitlog/SegmentReaderTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/SegmentReaderTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.db.commitlog;
 
+import org.apache.cassandra.io.compress.QPLCompressor;
 import org.apache.cassandra.io.util.*;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -78,6 +79,12 @@ public class SegmentReaderTest
     public void compressedSegmenter_Zstd() throws IOException
     {
         compressedSegmenter(ZstdCompressor.create(Collections.emptyMap()));
+    }
+
+    @Test
+    public void compressedSegmenter_QPL() throws IOException
+    {
+        compressedSegmenter(QPLCompressor.create(Collections.emptyMap()));
     }
 
     private void compressedSegmenter(ICompressor compressor) throws IOException

--- a/test/unit/org/apache/cassandra/hints/HintsCompressionTest.java
+++ b/test/unit/org/apache/cassandra/hints/HintsCompressionTest.java
@@ -25,6 +25,7 @@ import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.io.compress.DeflateCompressor;
 import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.compress.LZ4Compressor;
+import org.apache.cassandra.io.compress.QPLCompressor;
 import org.apache.cassandra.io.compress.SnappyCompressor;
 import org.apache.cassandra.io.compress.ZstdCompressor;
 
@@ -83,6 +84,13 @@ public class HintsCompressionTest extends AlteredHints
     public void zstdCompressor() throws Exception
     {
         compressorClass = ZstdCompressor.class;
+        multiFlushAndDeserializeTest();
+    }
+
+    @Test
+    public void qplCompressor() throws Exception
+    {
+        compressorClass = QPLCompressor.class;
         multiFlushAndDeserializeTest();
     }
 

--- a/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CQLCompressionTest.java
@@ -258,17 +258,17 @@ public class CQLCompressionTest extends CQLTester
     public void qplParamsTest()
     {
         createTable("create table %s (id int primary key, uh text) with compression = {'class':'QPLCompressor', 'execution_path':'software'}");
-        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).executionPath,"software");
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).executionPath, "software");
         createTable("create table %s (id int primary key, uh text) with compression = {'class':'QPLCompressor', 'execution_path':'software', 'compressor_level':1}");
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).executionPath, "software");
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).compressionLevel, (Integer)1);
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).executionPath, "software");
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).compressionLevel, (Integer) 1);
         createTable("create table %s (id int primary key, uh text) with compression = {'class':'QPLCompressor', 'execution_path':'software', 'compressor_level':1,'retry_count':12}");
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).executionPath, "software");
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).compressionLevel, (Integer)1);
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).retryCount, (Integer)12);
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).executionPath, "software");
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).compressionLevel, (Integer) 1);
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).retryCount, (Integer) 12);
         createTable("create table %s (id int primary key, uh text) with compression = {'class':'QPLCompressor'}");
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).compressionLevel, (Integer) QPLCompressor.DEFAULT_COMPRESSION_LEVEL);
-        assertEquals(((QPLCompressor)getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).retryCount, (Integer) QPLCompressor.DEFAULT_RETRY_COUNT);
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).compressionLevel, (Integer) QPLCompressor.DEFAULT_COMPRESSION_LEVEL);
+        assertEquals(((QPLCompressor) getCurrentColumnFamilyStore().metadata().params.compression.getSstableCompressor()).retryCount, (Integer) QPLCompressor.DEFAULT_RETRY_COUNT);
     }
 
     @Test(expected = ConfigurationException.class)
@@ -284,7 +284,7 @@ public class CQLCompressionTest extends CQLTester
         }
     }
 
-     @Test(expected = ConfigurationException.class)
+    @Test(expected = ConfigurationException.class)
     public void qplBadRetryCountTest() throws Throwable
     {
         try

--- a/test/unit/org/apache/cassandra/io/compress/CompressedSequentialWriterTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressedSequentialWriterTest.java
@@ -120,6 +120,13 @@ public class CompressedSequentialWriterTest extends SequentialWriterTest
         runTests("Noop");
     }
 
+    @Test
+    public void testQPLWriter() throws IOException
+    {
+        compressionParameters = CompressionParams.qpl();
+        runTests("QPL");
+    }
+
     private void testWrite(File f, int bytesToTest, boolean useMemmap) throws IOException
     {
         final String filename = f.absolutePath();

--- a/test/unit/org/apache/cassandra/io/compress/CompressorTest.java
+++ b/test/unit/org/apache/cassandra/io/compress/CompressorTest.java
@@ -45,7 +45,8 @@ public class CompressorTest
             DeflateCompressor.create(Collections.<String, String>emptyMap()),
             SnappyCompressor.create(Collections.<String, String>emptyMap()),
             ZstdCompressor.create(Collections.emptyMap()),
-            NoopCompressor.create(Collections.emptyMap())
+            NoopCompressor.create(Collections.emptyMap()),
+            QPLCompressor.create(Collections.emptyMap())
     };
 
     @Test
@@ -184,6 +185,13 @@ public class CompressorTest
     public void testZstdByteBuffers() throws IOException
     {
         compressor = ZstdCompressor.create(Collections.<String, String>emptyMap());
+        testByteBuffers();
+    }
+
+    @Test
+    public void testQPLByteBuffers() throws IOException
+    {
+        compressor = QPLCompressor.create(Collections.<String, String>emptyMap());
         testByteBuffers();
     }
 


### PR DESCRIPTION
This PR adds a new compressor to accelerate compress/decompress operations using Intel® IAA hardware. 

This new feature is added for [CASSANDRA-19268.](https://issues.apache.org/jira/browse/CASSANDRA-19268) 

### **Details:** 

QPLCompressor is a new compressor, which accelerates Cassandra to perform compress/decompress operations using Intel® In-Memory Analytics Accelerator ([Intel® IAA](https://cdrdv2.intel.com/v1/dl/getContent/721858)) . Its relies on open source  [qpl-java](https://github.com/intel/qpl-java)  library , which is available in [Maven Central](https://central.sonatype.com/artifact/com.intel.qpl/qpl-java/1.0.0). 

QPLCompressor can be set up for per-table compression, similar to how we enable other compression algorithms in Cassandra (ex: ZstdCompressor).  

For this new compressor, we performed microbenchmark on Cassandra version 4.1.1 using NoSQLBench. 

### **Configuring QPLCompressor at table level:**  

CREATE TABLE users (user_id varchar PRIMARY KEY, first varchar, last varchar, age int) WITH compression = {'class': 'QPLCompressor'};  

  

### **QPLCompressor supports followings advanced options:**  

**execution_path**(default hardware): Specifies whether operation should be executed on the IAA hardware or emulated in software. And  operation will fall back to software when hardware is not present. Currently supported options: hardware and software. For more information on execution path, please refer [here](https://javadoc.io/doc/com.intel.qpl/qpl-java/latest/com/intel/qpl/QPLUtils.ExecutionPaths.html). 

**compressor_level**(default 1): User can set any of these [supported](https://intel.github.io/qpl/documentation/dev_ref_docs/c_ref/c_common_definitions.html?highlight=compression_level#c.qpl_compression_levels) compression levels.   

**retry_count**(default 0): This option determines how long QPLCompressor should retry compress/decompress operations if hardware is busy.  


 **Example:** 
CREATE TABLE users (user_id varchar PRIMARY KEY, first varchar, last varchar, age int) WITH compression = {'class': 'QPLCompressor', 'execution_path':'hardware','compressor_level':'1', 'retry_count':'1'};