### PR TITLE
CASSANDRA-17846-Fix typo in UNLOGGED BATCH section of CQL DML page

### DIFF
--- a/doc/modules/cassandra/pages/developing/cql/dml.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/dml.adoc
@@ -456,7 +456,7 @@ only isolated within a single partition).
 There is a performance penalty for batch atomicity when a batch spans
 multiple partitions. If you do not want to incur this penalty, you can
 tell Cassandra to skip the batchlog with the `UNLOGGED` option. If the
-`UNLOGGED` option is used, a failed batch might leave the patch only
+`UNLOGGED` option is used, a failed batch might leave the batch only
 partly applied.
 
 === `COUNTER` batches


### PR DESCRIPTION
**Fix typo in UNLOGGED BATCH section of CQL DML page**
This patch fixes the typo in UNLOGGED BATCH section of CQL DML page. 
Tested the updated cassandra webpages by deploying the website locally using instructions from [cassandra-website](https://github.com/apache/cassandra-website)

patch by V Sri Charan Reddy ; reviewed by Erick Ramirez for [CASSANDRA-17846(https://issues.apache.org/jira/browse/CASSANDRA-17846)