### PR TITLE
CASSANDRA-19305: Ephemeral reads

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "modules/accord"]
 	path = modules/accord
-	url = https://github.com/apache/cassandra-accord.git
-	branch = trunk
+	url = https://github.com/belliottsmith/cassandra-accord.git
+	branch = ephemeral-reads

--- a/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
@@ -79,6 +79,10 @@ import org.apache.cassandra.service.accord.txn.TxnWrite;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.FBUtilities;
 
+import static accord.primitives.Txn.Kind.EphemeralRead;
+import static accord.primitives.Txn.Kind.Read;
+import static org.apache.cassandra.config.Config.NonSerialWriteStrategy.accord;
+import static org.apache.cassandra.config.DatabaseDescriptor.getNonSerialWriteStrategy;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
@@ -321,7 +325,8 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
             List<TxnNamedRead> reads = createNamedReads(options, state, ImmutableMap.of(), keySet::add);
             Keys txnKeys = toKeys(keySet);
             TxnRead read = createTxnRead(reads, txnKeys, null);
-            return new Txn.InMemory(txnKeys, read, TxnQuery.ALL);
+            Txn.Kind kind = txnKeys.size() == 1 && getNonSerialWriteStrategy() == accord ? EphemeralRead : Read;
+            return new Txn.InMemory(kind, txnKeys, read, TxnQuery.ALL, null);
         }
         else
         {

--- a/src/java/org/apache/cassandra/net/Verb.java
+++ b/src/java/org/apache/cassandra/net/Verb.java
@@ -93,6 +93,7 @@ import org.apache.cassandra.service.accord.serializers.CommitSerializers;
 import org.apache.cassandra.service.accord.serializers.EnumSerializer;
 import org.apache.cassandra.service.accord.serializers.FetchSerializers;
 import org.apache.cassandra.service.accord.serializers.GetDepsSerializers;
+import org.apache.cassandra.service.accord.serializers.GetEphmrlReadDepsSerializers;
 import org.apache.cassandra.service.accord.serializers.InformDurableSerializers;
 import org.apache.cassandra.service.accord.serializers.InformHomeDurableSerializers;
 import org.apache.cassandra.service.accord.serializers.InformOfTxnIdSerializers;
@@ -329,6 +330,8 @@ public enum Verb
     ACCORD_CHECK_STATUS_REQ         (142, P2, writeTimeout, IMMEDIATE,          () -> CheckStatusSerializers.request,       AccordService::verbHandlerOrNoop, ACCORD_CHECK_STATUS_RSP                   ),
     ACCORD_GET_DEPS_RSP             (143, P2, writeTimeout, REQUEST_RESPONSE,   () -> GetDepsSerializers.reply,             RESPONSE_HANDLER                                                            ),
     ACCORD_GET_DEPS_REQ             (144, P2, writeTimeout, IMMEDIATE,          () -> GetDepsSerializers.request,           AccordService::verbHandlerOrNoop, ACCORD_GET_DEPS_RSP                       ),
+    ACCORD_GET_EPHMRL_READ_DEPS_RSP (161, P2, writeTimeout, REQUEST_RESPONSE,   () -> GetEphmrlReadDepsSerializers.reply,   RESPONSE_HANDLER                                                            ),
+    ACCORD_GET_EPHMRL_READ_DEPS_REQ (162, P2, writeTimeout, IMMEDIATE,          () -> GetEphmrlReadDepsSerializers.request, AccordService::verbHandlerOrNoop, ACCORD_GET_EPHMRL_READ_DEPS_RSP),
     ACCORD_FETCH_DATA_RSP           (145, P2, repairTimeout,REQUEST_RESPONSE,   () -> FetchSerializers.reply,               RESPONSE_HANDLER                                                            ),
     ACCORD_FETCH_DATA_REQ           (146, P2, repairTimeout,IMMEDIATE,          () -> FetchSerializers.request,             AccordService::verbHandlerOrNoop, ACCORD_FETCH_DATA_RSP                     ),
     ACCORD_SET_SHARD_DURABLE_REQ    (147, P2, writeTimeout, IMMEDIATE,          () -> SetDurableSerializers.shardDurable,   AccordService::verbHandlerOrNoop, ACCORD_SIMPLE_RSP                         ),

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import accord.primitives.Keys;
 import accord.primitives.Txn;
+import accord.utils.Invariants;
 import org.apache.cassandra.batchlog.Batch;
 import org.apache.cassandra.batchlog.BatchlogManager;
 import org.apache.cassandra.concurrent.DebuggableTask.RunnableDebuggableTask;
@@ -166,10 +167,14 @@ import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.CountDownLatch;
 import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
+import static accord.primitives.Txn.Kind.EphemeralRead;
+import static accord.primitives.Txn.Kind.Read;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.apache.cassandra.config.Config.NonSerialWriteStrategy.accord;
+import static org.apache.cassandra.config.DatabaseDescriptor.getNonSerialWriteStrategy;
 import static org.apache.cassandra.db.ConsistencyLevel.SERIAL;
 import static org.apache.cassandra.metrics.ClientRequestsMetricsHolder.casReadMetrics;
 import static org.apache.cassandra.metrics.ClientRequestsMetricsHolder.casWriteMetrics;
@@ -1223,7 +1228,7 @@ public class StorageProxy implements StorageProxyMBean
         long size = IMutation.dataSize(mutations);
         writeMetrics.mutationSize.update(size);
         writeMetricsForLevel(consistencyLevel).mutationSize.update(size);
-        NonSerialWriteStrategy nonSerialWriteStrategy = DatabaseDescriptor.getNonSerialWriteStrategy();
+        NonSerialWriteStrategy nonSerialWriteStrategy = getNonSerialWriteStrategy();
         if (nonSerialWriteStrategy.writesThroughAccord && !SchemaConstants.getSystemKeyspaces().contains(keyspaceName))
             mutateWithAccord(augmented != null ? augmented : mutations, consistencyLevel, queryStartNanoTime, nonSerialWriteStrategy);
         else if (augmented != null)
@@ -1979,9 +1984,11 @@ public class StorageProxy implements StorageProxyMBean
         SinglePartitionReadCommand readCommand = group.queries.get(0);
         // If the non-SERIAL write strategy is sending all writes through Accord there is no need to use the supplied consistency
         // level since Accord will manage reading safely
-        consistencyLevel = DatabaseDescriptor.getNonSerialWriteStrategy().readCLForStrategy(consistencyLevel);
+        NonSerialWriteStrategy nonSerialWriteStrategy = getNonSerialWriteStrategy();
+        consistencyLevel = nonSerialWriteStrategy.readCLForStrategy(consistencyLevel);
         TxnRead read = TxnRead.createSerialRead(readCommand, consistencyLevel);
-        Txn txn = new Txn.InMemory(read.keys(), read, TxnQuery.ALL);
+        Invariants.checkState(read.keys().size() == 1, "Ephemeral reads are only strict-serializable for single partition reads");
+        Txn txn = new Txn.InMemory(nonSerialWriteStrategy == accord ? EphemeralRead : Read, read.keys(), read, TxnQuery.ALL, null);
         IAccordService accordService = AccordService.instance();
         accordService.maybeConvertTablesToAccord(txn);
         TxnResult txnResult = accordService.coordinate(txn, consistencyLevel, queryStartNanoTime);

--- a/src/java/org/apache/cassandra/service/accord/AccordMessageSink.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordMessageSink.java
@@ -124,6 +124,8 @@ public class AccordMessageSink implements MessageSink
             builder.put(MessageType.ACCEPT_INVALIDATE_REQ,                    Verb.ACCORD_ACCEPT_INVALIDATE_REQ);
             builder.put(MessageType.GET_DEPS_REQ,                             Verb.ACCORD_GET_DEPS_REQ);
             builder.put(MessageType.GET_DEPS_RSP,                             Verb.ACCORD_GET_DEPS_RSP);
+            builder.put(MessageType.GET_EPHEMERAL_READ_DEPS_REQ,              Verb.ACCORD_GET_EPHMRL_READ_DEPS_REQ);
+            builder.put(MessageType.GET_EPHEMERAL_READ_DEPS_RSP,              Verb.ACCORD_GET_EPHMRL_READ_DEPS_RSP);
             builder.put(MessageType.COMMIT_SLOW_PATH_REQ,                     Verb.ACCORD_COMMIT_REQ);
             builder.put(MessageType.COMMIT_MAXIMAL_REQ,                       Verb.ACCORD_COMMIT_REQ);
             builder.put(MessageType.STABLE_FAST_PATH_REQ,                     Verb.ACCORD_COMMIT_REQ);
@@ -134,6 +136,7 @@ public class AccordMessageSink implements MessageSink
             builder.put(MessageType.APPLY_MAXIMAL_REQ,                        Verb.ACCORD_APPLY_REQ);
             builder.put(MessageType.APPLY_RSP,                                Verb.ACCORD_APPLY_RSP);
             builder.put(MessageType.READ_REQ,                                 Verb.ACCORD_READ_REQ);
+            builder.put(MessageType.READ_EPHEMERAL_REQ,                       Verb.ACCORD_READ_REQ);
             builder.put(MessageType.READ_RSP,                                 Verb.ACCORD_READ_RSP);
             builder.put(MessageType.BEGIN_RECOVER_REQ,                        Verb.ACCORD_BEGIN_RECOVER_REQ);
             builder.put(MessageType.BEGIN_RECOVER_RSP,                        Verb.ACCORD_BEGIN_RECOVER_RSP);

--- a/src/java/org/apache/cassandra/service/accord/interop/AccordInteropExecution.java
+++ b/src/java/org/apache/cassandra/service/accord/interop/AccordInteropExecution.java
@@ -253,7 +253,7 @@ public class AccordInteropExecution implements Execute, ReadCoordinator, Maximal
     {
         Node.Id id = endpointMapper.mappedId(to);
         SinglePartitionReadCommand command = (SinglePartitionReadCommand) message.payload;
-        AccordInteropRead read = new AccordInteropRead(id, executes, txnId, readScope, executeAt, command);
+        AccordInteropRead read = new AccordInteropRead(id, executes, txnId, readScope, executeAt.epoch(), command);
         // TODO (required): understand interop and whether StableFastPath is appropriate
         AccordInteropCommit commit = new AccordInteropCommit(Kind.StableFastPath, id, coordinateTopology, allTopologies,
                                                              txnId, txn, route, executeAt, deps, read);
@@ -265,7 +265,7 @@ public class AccordInteropExecution implements Execute, ReadCoordinator, Maximal
     {
         Node.Id id = endpointMapper.mappedId(to);
         Mutation mutation = message.payload;
-        AccordInteropReadRepair readRepair = new AccordInteropReadRepair(id, executes, txnId, readScope, executeAt, mutation);
+        AccordInteropReadRepair readRepair = new AccordInteropReadRepair(id, executes, txnId, readScope, executeAt.epoch(), mutation);
         node.send(id, readRepair, executor, new AccordInteropReadRepair.ReadRepairCallback(id, to, message, callback, this));
     }
 

--- a/src/java/org/apache/cassandra/service/accord/serializers/GetEphmrlReadDepsSerializers.java
+++ b/src/java/org/apache/cassandra/service/accord/serializers/GetEphmrlReadDepsSerializers.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.accord.serializers;
+
+import java.io.IOException;
+
+import accord.messages.GetEphemeralReadDeps;
+import accord.messages.GetEphemeralReadDeps.GetEphemeralReadDepsOk;
+import accord.primitives.PartialDeps;
+import accord.primitives.PartialRoute;
+import accord.primitives.Seekables;
+import accord.primitives.TxnId;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.io.IVersionedSerializer;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+
+public class GetEphmrlReadDepsSerializers
+{
+    public static final IVersionedSerializer<GetEphemeralReadDeps> request = new TxnRequestSerializer.WithUnsyncedSerializer<GetEphemeralReadDeps>()
+    {
+        @Override
+        public void serializeBody(GetEphemeralReadDeps msg, DataOutputPlus out, int version) throws IOException
+        {
+            KeySerializers.seekables.serialize(msg.keys, out, version);
+            out.writeUnsignedVInt(msg.executionEpoch);
+        }
+
+        @Override
+        public GetEphemeralReadDeps deserializeBody(DataInputPlus in, int version, TxnId txnId, PartialRoute<?> scope, long waitForEpoch, long minEpoch, boolean doNotComputeProgressKey) throws IOException
+        {
+            Seekables<?, ?> keys = KeySerializers.seekables.deserialize(in, version);
+            long executionEpoch = in.readUnsignedVInt();
+            return GetEphemeralReadDeps.SerializationSupport.create(txnId, scope, waitForEpoch, minEpoch, keys, executionEpoch);
+        }
+
+        @Override
+        public long serializedBodySize(GetEphemeralReadDeps msg, int version)
+        {
+            return KeySerializers.seekables.serializedSize(msg.keys, version)
+                   + TypeSizes.sizeofUnsignedVInt(msg.executionEpoch);
+        }
+    };
+
+    public static final IVersionedSerializer<GetEphemeralReadDepsOk> reply = new IVersionedSerializer<GetEphemeralReadDepsOk>()
+    {
+        @Override
+        public void serialize(GetEphemeralReadDepsOk reply, DataOutputPlus out, int version) throws IOException
+        {
+            DepsSerializer.partialDeps.serialize(reply.deps, out, version);
+            out.writeUnsignedVInt(reply.latestEpoch);
+        }
+
+        @Override
+        public GetEphemeralReadDepsOk deserialize(DataInputPlus in, int version) throws IOException
+        {
+            PartialDeps deps = DepsSerializer.partialDeps.deserialize(in, version);
+            long latestEpoch = in.readUnsignedVInt();
+            return new GetEphemeralReadDepsOk(deps, latestEpoch);
+        }
+
+        @Override
+        public long serializedSize(GetEphemeralReadDepsOk reply, int version)
+        {
+            return DepsSerializer.partialDeps.serializedSize(reply.deps, version)
+                   + TypeSizes.sizeofUnsignedVInt(reply.latestEpoch);
+        }
+    };
+}

--- a/src/java/org/apache/cassandra/service/reads/repair/BlockingReadRepair.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/BlockingReadRepair.java
@@ -208,7 +208,7 @@ public class BlockingReadRepair<E extends Endpoints<E>, P extends ReplicaPlan.Fo
             Future<TxnResult> repairFuture;
             try
             {
-                Txn txn = new Txn.InMemory(key, TxnRead.createNoOpRead(key), TxnQuery.NONE, repairUpdate);
+                Txn txn = new Txn.InMemory(Txn.Kind.Read, key, TxnRead.createNoOpRead(key), TxnQuery.NONE, repairUpdate);
                 repairFuture = Stage.ACCORD_MIGRATION.submit(() -> {
                     try
                     {

--- a/test/simulator/main/org/apache/cassandra/simulator/paxos/StrictSerializabilityValidator.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/paxos/StrictSerializabilityValidator.java
@@ -32,7 +32,7 @@ public class StrictSerializabilityValidator implements HistoryValidator
 
     public StrictSerializabilityValidator(int[] primaryKeys)
     {
-        this.verifier = new StrictSerializabilityVerifier(primaryKeys.length);
+        this.verifier = new StrictSerializabilityVerifier("", primaryKeys.length);
         pkToIndex = new IntIntHashMap(primaryKeys.length);
         indexToPk = new int[primaryKeys.length];
         for (int i = 0; i < primaryKeys.length; i++)

--- a/test/unit/org/apache/cassandra/service/accord/AccordMessageSinkTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/AccordMessageSinkTest.java
@@ -21,6 +21,8 @@ package org.apache.cassandra.service.accord;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import accord.messages.ReadData;
+import accord.messages.ReadData.CommitOrReadNack;
 import accord.topology.TopologyUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -32,7 +34,6 @@ import accord.impl.IntKey;
 import accord.local.Node;
 import accord.messages.InformOfTxnId;
 import accord.messages.MessageType;
-import accord.messages.ReadData;
 import accord.messages.ReadTxnData;
 import accord.messages.Reply;
 import accord.messages.Request;
@@ -92,7 +93,7 @@ public class AccordMessageSinkTest
 
         checkRequestReplies(request,
                             new AbstractFetchCoordinator.FetchResponse(null, null, id),
-                            ReadData.CommitOrReadNack.Insufficient);
+                            CommitOrReadNack.Insufficient);
 
     }
 
@@ -100,10 +101,10 @@ public class AccordMessageSinkTest
     public void txnRead()
     {
         TxnId txnId = nextTxnId(42, Txn.Kind.Read, Routable.Domain.Key);
-        Request request = new ReadTxnData(node, topologies, txnId, topology.ranges(), txnId);
+        Request request = new ReadTxnData(node, topologies, txnId, topology.ranges(), txnId.epoch());
         checkRequestReplies(request,
                             new ReadData.ReadOk(null, null),
-                            ReadData.CommitOrReadNack.Insufficient);
+                            CommitOrReadNack.Insufficient);
     }
 
     private static void checkRequestReplies(Request request, Reply... replies)


### PR DESCRIPTION
Introduce faster per-key linearizable reads (suitable for any single key transactional read, or weaker multi-key reads). These guarantee 1 WAN RT, require minimal state, and offer single replica consistent execution. This is achieved by only calculating dependencies for execution, no execution timestamp.