### PR TITLE
CASSANDRA-19360 | Quickstart commands are slightly wrong

### DIFF
--- a/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
+++ b/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
@@ -1,3 +1,3 @@
 docker run --rm -it --network \
 cassandra nuvo/docker-cqlsh cqlsh cassandra \
-9042 --cqlversion='3.4.5' 
+9042 --cqlversion='3.4.6' 

--- a/doc/modules/cassandra/examples/CQL/insert-more-data-shopping-cart.cql
+++ b/doc/modules/cassandra/examples/CQL/insert-more-data-shopping-cart.cql
@@ -1,3 +1,3 @@
 INSERT INTO store.shopping_cart 
-    (userid, item_count) 
-    VALUES ('4567', 20); 
+    (userid, item_count, last_update_timestamp) 
+    VALUES ('4567', 20, toTimeStamp(now()));

--- a/doc/modules/cassandra/examples/RESULTS/docker-run-cqlsh-quickstart.result
+++ b/doc/modules/cassandra/examples/RESULTS/docker-run-cqlsh-quickstart.result
@@ -1,4 +1,4 @@
 Connected to Test Cluster at cassandra:9042.
-[cqlsh 5.0.1 | Cassandra 4.0.4 | CQL spec 3.4.5 | Native protocol v5]
+[cqlsh 5.0.1 | Cassandra 4.1.3 | CQL spec 3.4.6 | Native protocol v5]
 Use HELP for help.
 cqlsh>


### PR DESCRIPTION
> Thanks for sending a pull request! Here are some tips if you're new here:
>  
>  * [x] Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
>  * [x] Be sure to keep the PR description updated to reflect all changes.
>  * [x] Write your PR title to summarize what this PR proposes.
>  * [x] If possible, provide a concise example to reproduce the issue for a faster review.
>  * [x] Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
>  * [x] If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)

# [CASSANDRA-19360](https://issues.apache.org/jira/browse/CASSANDRA-19360) | Quickstart commands are slightly wrong

I'm new to Cassandra. I tried [the quickstart](https://cassandra.apache.org/_/quickstart.html) and noticed some things that I figured I'd fix.

1. The csqlsh versions are inconsistent between commands, resulting in the second command failing.
2. The prompt message is slightly out of date, I figured I'd update it while I was here
3. In step 7, the insert forgets to include a timestamp. I assume that was accidental, so I fixed that too.


