### PR TITLE
Fix the duration of speculative read delay

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2063,7 +2063,7 @@ public class StorageProxy implements StorageProxyMBean
             reads[i].executeAsync();
         }
 
-        // if we have a speculating read executor and it looks like we may not receive a response from the initial
+        // if we have a speculating read executor, and it looks like we may not receive a response from the initial
         // set of replicas we sent messages to, speculatively send an additional messages to an un-contacted replica
         for (int i=0; i<cmdCount; i++)
         {

--- a/src/java/org/apache/cassandra/service/reads/repair/AbstractReadRepair.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/AbstractReadRepair.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.service.reads.ReadCallback;
 import org.apache.cassandra.tracing.Tracing;
 
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 
 public abstract class AbstractReadRepair<E extends Endpoints<E>, P extends ReplicaPlan.ForRead<E, P>>
         implements ReadRepair<E, P>
@@ -190,7 +191,7 @@ public abstract class AbstractReadRepair<E extends Endpoints<E>, P extends Repli
         if (repair == null)
             return;
 
-        if (shouldSpeculate() && !repair.readCallback.await(cfs.sampleReadLatencyMicros, MICROSECONDS))
+        if (shouldSpeculate() && !repair.readCallback.awaitFrom(nanoTime(), cfs.sampleReadLatencyMicros, MICROSECONDS))
         {
             Replica uncontacted = replicaPlan().firstUncontactedCandidate(replica -> true);
             if (uncontacted == null)

--- a/src/java/org/apache/cassandra/service/reads/repair/ReadRepair.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/ReadRepair.java
@@ -69,7 +69,7 @@ public interface ReadRepair<E extends Endpoints<E>, P extends ReplicaPlan.ForRea
      * to additional replicas not contacted in the initial full data read. If the collection of nodes that
      * end up responding in time end up agreeing on the data, and we don't consider the response from the
      * disagreeing replica that triggered the read repair, that's ok, since the disagreeing data would not
-     * have been successfully written and won't be included in the response the the client, preserving the
+     * have been successfully written and won't be included in the response the client, preserving the
      * expectation of monotonic quorum reads
      */
     public void maybeSendAdditionalReads();


### PR DESCRIPTION
Speculative reads will now be triggered after sampleReadLatency past the replica reads are issued instead of past queryStartNanoTime. It's because sampleReadLatency measures the actual execution of read request whereas queryStartNanoTime may, after CASSANDRA-19215, be measured before wait in the NativeTransportRequests queue.

Patch by Jakub Zytka; reviewed by TBD for CASSANDRA-19330