### PR TITLE
CASSANDRA-19412: delete useless collection:backPressureHosts in the sendToHintedReplicas

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -1483,8 +1483,6 @@ public class StorageProxy implements StorageProxyMBean
         Replica localReplica = null;
         Collection<Replica> endpointsToHint = null;
 
-        List<InetAddressAndPort> backPressureHosts = null;
-
         // For performance, Mutation caches serialized buffers that are computed lazily in serializedBuffer(). That
         // computation is not synchronized however and we will potentially call that method concurrently for each
         // dispatched message (not that concurrent calls to serializedBuffer() are "unsafe" per se, just that they
@@ -1533,11 +1531,6 @@ public class StorageProxy implements StorageProxyMBean
 
                         messages.add(destination);
                     }
-
-                    if (backPressureHosts == null)
-                        backPressureHosts = new ArrayList<>(plan.contacts().size());
-
-                    backPressureHosts.add(destination.endpoint());
                 }
             }
             else


### PR DESCRIPTION
- more details in the [CASSANDRA-19412](https://issues.apache.org/jira/browse/CASSANDRA-19412)