### PR TITLE
CASSANDRA-19422 trunk Fix Git repository link

### DIFF
--- a/.build/cassandra-deps-template.xml
+++ b/.build/cassandra-deps-template.xml
@@ -37,7 +37,7 @@
   <scm>
     <connection>scm:https://gitbox.apache.org/repos/asf/cassandra.git</connection>
     <developerConnection>scm:https://gitbox.apache.org/repos/asf/cassandra.git</developerConnection>
-    <url>https://gitbox.apache.org/repos/asf?p=cassandra.git;a=tree</url>
+    <url>https://gitbox.apache.org/repos/asf?p=cassandra.git</url>
   </scm>
   <dependencies>
     <dependency>

--- a/.build/parent-pom-template.xml
+++ b/.build/parent-pom-template.xml
@@ -241,7 +241,7 @@
   <scm>
     <connection>scm:https://gitbox.apache.org/repos/asf/cassandra.git</connection>
     <developerConnection>scm:https://gitbox.apache.org/repos/asf/cassandra.git</developerConnection>
-    <url>https://gitbox.apache.org/repos/asf?p=cassandra.git;a=tree</url>
+    <url>https://gitbox.apache.org/repos/asf?p=cassandra.git</url>
   </scm>
 
   <profiles>

--- a/build.xml
+++ b/build.xml
@@ -36,7 +36,7 @@
     <property name="base.version" value="5.1"/>
     <property name="scm.connection" value="scm:https://gitbox.apache.org/repos/asf/cassandra.git"/>
     <property name="scm.developerConnection" value="scm:https://gitbox.apache.org/repos/asf/cassandra.git"/>
-    <property name="scm.url" value="https://gitbox.apache.org/repos/asf?p=cassandra.git;a=tree"/>
+    <property name="scm.url" value="https://gitbox.apache.org/repos/asf?p=cassandra.git"/>
 
     <!-- JDKs supported.
         All releases are built with the default JDK.


### PR DESCRIPTION
Links to the Git repository with the `;a=tree` parameter, without a branch specifier, do not work - update those links to remove this.