### PR TITLE
CASSANDRA-19454 5.0 Switch to nanoTime from approxTime in Dispatcher

### DIFF
--- a/src/java/org/apache/cassandra/db/virtual/QueriesTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/QueriesTable.java
@@ -26,7 +26,8 @@ import org.apache.cassandra.schema.TableMetadata;
 
 import static java.lang.Long.max;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.apache.cassandra.utils.MonotonicClock.Global.approxTime;
+
+import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 
 /**
  * Virtual table that lists currently running queries on the NTR (coordinator) and Read/Mutation (local) stages
@@ -78,7 +79,7 @@ final class QueriesTable extends AbstractVirtualTable
             
             long creationTimeNanos = task.creationTimeNanos();
             long startTimeNanos = task.startTimeNanos();
-            long now = approxTime.now();
+            long now = nanoTime();
 
             long queuedMicros = NANOSECONDS.toMicros(max((startTimeNanos > 0 ? startTimeNanos : now) - creationTimeNanos, 0));
             long runningMicros = startTimeNanos > 0 ? NANOSECONDS.toMicros(now - startTimeNanos) : 0;

--- a/test/unit/org/apache/cassandra/transport/MessageDispatcherTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageDispatcherTest.java
@@ -164,7 +164,7 @@ public class MessageDispatcherTest
                             Message.Request request,
                             FlushItemConverter forFlusher,
                             ClientResourceLimits.Overload backpressure,
-                            long approxStartTimeNanos)
+                            long startTimeNanos)
         {
             // noop
         }


### PR DESCRIPTION
CASSANDRA-19454 for `cassandra-5.0`

This patch reverts the switch to `approxTime` from `nanoTime` in `Dispatcher` (and `QueriesTable`), that was changed in [CASSANDRA-15241](https://issues.apache.org/jira/browse/CASSANDRA-15241).