### PR TITLE
Deprecate Python 3.7 and earlier, but allow cqlsh to run with Python 3.6-3.11

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0-beta2
+ * Deprecate Python 3.7 and earlier, but allow cqlsh to run with Python 3.6-3.11 (CASSANDRA-19467)
  * Set uuid_sstable_identifiers_enabled to true in cassandra-latest.yaml (CASSANDRA-19460)
  * Revert switching to approxTime in Dispatcher (CASSANDRA-19454)
  * Add an optimized default configuration to tests and make it available for new users (CASSANDRA-18753)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -203,8 +203,8 @@ Upgrading
 ---------
     - Default disk_access_mode value changed from "auto" to "mmap_index_only". Override this setting with "disk_access_mode: auto" on
       cassandra.yaml to keep the previous default. See CASSANDRA-19021 for details.
-    - The Python version required to run cqlsh has been bumped from 3.6+ to 3.8-3.11. Python 3.6 and 3.7 are past their
-      end-of-life, and 3.8 is now the minimum version supported by the Python driver.
+    - The Python versions recommended for running cqlsh have been bumped from 3.6+ to 3.8-3.11. Python 3.6-3.7 are now 
+      deprecated, as they have reached end-of-life, and support will be removed in a future major release.
     - Java 8 has been removed. Lowest supported version is Java 11.
     - Ephemeral marker files for snapshots done by repairs are not created anymore,
       there is a dedicated flag in snapshot manifest instead. On upgrade of a node to this version, on node's start, in case there

--- a/bin/cqlsh
+++ b/bin/cqlsh
@@ -62,9 +62,12 @@ is_supported_version() {
     version=$1
     major_version="${version%.*}"
     minor_version="${version#*.}"
-    # python 3.8-3.11 is supported
+    # python 3.8-3.11 are supported
     if [ "$major_version" = 3 ] && [ "$minor_version" -ge 8 ] && [ "$minor_version" -le 11 ]; then
         echo "supported"
+    # python 3.6-3.7 are deprecated
+    elif [ "$major_version" = 3 ] && [ "$minor_version" -ge 6 ] && [ "$minor_version" -le 7 ]; then
+        echo "deprecated"
     else
         echo "unsupported"
     fi
@@ -75,12 +78,17 @@ run_if_supported_version() {
     interpreter="$1" shift
 
     version=$(get_python_version "$interpreter")
+    version_status=$(is_supported_version "$version")
     if [ -n "$version" ]; then
-        if [ "$(is_supported_version "$version")" = "supported" ]; then
+        if [ "$version_status" = "supported" ] || [ "$version_status" = "deprecated" ]; then
+            if [ "$version_status" = "deprecated" ]; then
+                echo "Warning: using deprecated version of Python:" "$version" >&2
+            fi
+
             exec "$interpreter" "$($interpreter -c "import os; print(os.path.dirname(os.path.realpath('$0')))")/cqlsh.py" "$@"
             exit
         else
-            echo "Warning: unsupported version of Python, required 3.8-3.11 but found" $version >&2
+            echo "Warning: unsupported version of Python, required 3.6-3.11 but found" "$version" >&2
         fi
     fi
 }

--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -21,8 +21,8 @@ import platform
 import sys
 from glob import glob
 
-if sys.version_info < (3, 8) or sys.version_info >= (3, 12):
-    sys.exit("\ncqlsh requires Python 3.8-3.11\n")
+if sys.version_info < (3, 6) or sys.version_info >= (3, 12):
+    sys.exit("\ncqlsh requires Python 3.6-3.11\n")
 
 # see CASSANDRA-10428
 if platform.python_implementation().startswith('Jython'):

--- a/pylib/cqlshlib/test/run_cqlsh.py
+++ b/pylib/cqlshlib/test/run_cqlsh.py
@@ -36,7 +36,7 @@ DEFAULT_CQLSH_TERM = 'xterm'
 try:
     Pattern = re._pattern_type
 except AttributeError:
-    # Python 3.8-3.11
+    # Python 3.6+
     Pattern = re.Pattern
 
 


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by ? for CASSANDRA-19467