### PR TITLE
CASSANDRA-19344 Range movements involving transient replicas must safely enact changes to read and write replica sets

### DIFF
--- a/src/java/org/apache/cassandra/tcm/ownership/PlacementForRange.java
+++ b/src/java/org/apache/cassandra/tcm/ownership/PlacementForRange.java
@@ -336,7 +336,7 @@ public class PlacementForRange
          *
          * Where an endpoint is present in both groups, prefer the proposed iff it is a FULL replica. During a
          * multi-step operation (join/leave/move), we want any change from transient to full to happen as early
-         * as possible so that a replica being whose ownership is modified in this way becomes FULL for writes before it
+         * as possible so that a replica whose ownership is modified in this way becomes FULL for writes before it
          * becomes FULL for reads. This works as additions to write replica groups are applied before any other
          * placement changes (i.e. in START_[JOIN|LEAVE|MOVE]).
          *

--- a/src/java/org/apache/cassandra/tcm/ownership/PlacementForRange.java
+++ b/src/java/org/apache/cassandra/tcm/ownership/PlacementForRange.java
@@ -321,15 +321,49 @@ public class PlacementForRange
                                                (t, v) -> {
                                                    EndpointsForRange old = v.get();
                                                    return VersionedEndpoints.forRange(Epoch.max(v.lastModified(), replicas.lastModified()),
-                                                                                      replicas.get()
-                                                                                              .newBuilder(replicas.size() + old.size())
-                                                                                              .addAll(old)
-                                                                                              .addAll(replicas.get(), ReplicaCollection.Builder.Conflict.ALL)
-                                                                                              .build());
+                                                                                      combine(old, replicas.get()));
                                                });
             if (group == null)
                 replicaGroups.put(replicas.range(), replicas);
             return this;
+        }
+
+        /**
+         * Combine two replica groups, assuming one is the current group and the other is the proposed.
+         * During range movements this is used when calculating the maximal placement, which combines the current and
+         * future replica groups. This special cases the merging of two replica groups to make sure that when a replica
+         * moves from transient to full, it starts to act as a FULL write replica as early as possible.
+         *
+         * Where an endpoint is present in both groups, prefer the proposed iff it is a FULL replica. During a
+         * multi-step operation (join/leave/move), we want any change from transient to full to happen as early
+         * as possible so that a replica being whose ownership is modified in this way becomes FULL for writes before it
+         * becomes FULL for reads. This works as additions to write replica groups are applied before any other
+         * placement changes (i.e. in START_[JOIN|LEAVE|MOVE]).
+         *
+         * @param prev Initial set of replicas for a given range
+         * @param next Proposed set of replicas for the same range.
+         * @return The union of the two groups
+         */
+        private EndpointsForRange combine(EndpointsForRange prev, EndpointsForRange next)
+        {
+            Map<InetAddressAndPort, Replica> e1 = prev.byEndpoint();
+            Map<InetAddressAndPort, Replica> e2 = next.byEndpoint();
+            EndpointsForRange.Builder combined = prev.newBuilder(prev.size() + next.size());
+            e1.forEach((e, r1) -> {
+                Replica r2 = e2.get(e);
+                if (null == r2)          // not present in next
+                    combined.add(r1);
+                else if (r2.isFull())    // prefer replica from next, if it is moving from transient to full
+                    combined.add(r2);
+                else
+                    combined.add(r1);    // replica is moving from full to transient, or staying the same
+            });
+            // any new replicas not in prev
+            e2.forEach((e, r2) -> {
+                if (!combined.contains(e))
+                    combined.add(r2);
+            });
+            return combined.build();
         }
 
         public Builder withReplicaGroups(Iterable<VersionedEndpoints.ForRange> replicas)

--- a/src/java/org/apache/cassandra/tcm/ownership/PlacementTransitionPlan.java
+++ b/src/java/org/apache/cassandra/tcm/ownership/PlacementTransitionPlan.java
@@ -18,6 +18,23 @@
 
 package org.apache.cassandra.tcm.ownership;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.exceptions.ExceptionCode;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.RangesAtEndpoint;
+import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.schema.ReplicationParams;
+import org.apache.cassandra.tcm.Epoch;
+import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.tcm.sequences.LockedRanges;
 
 /**
@@ -32,6 +49,8 @@ import org.apache.cassandra.tcm.sequences.LockedRanges;
  */
 public class PlacementTransitionPlan
 {
+    private static final Logger logger = LoggerFactory.getLogger(MovementMap.class);
+
     public final PlacementDeltas toSplit;
     public final PlacementDeltas toMaximal;
     public final PlacementDeltas toFinal;
@@ -124,5 +143,79 @@ public class PlacementTransitionPlan
                ", toMerged=" + toMerged +
                ", compiled=" + (addToWrites == null) +
                '}';
+    }
+
+
+    /**
+     * Makes sure that a newly added read replica for a range already exists as a write replica
+     *
+     * We should never add both read & write replicas for the same range at the same time (or read replica before write)
+     *
+     * Also makes sure that we don't add a full read replica while the same write replica is only transient - we should
+     * always make the write replica full before adding the read replica.
+     *
+     * We split and merge ranges, so in the previous placements we could have full write replicas (a, b], (b, c], but then
+     * add a full read replica (a, c].
+     *
+     * @return null if everything is good, otherwise a Transformation.Result rejection containing information about the bad replica
+     */
+    @Nullable
+    public static Transformation.Result assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
+    {
+        return assertPreExistingWriteReplica(placements,
+                                             transitionPlan.toSplit,
+                                             transitionPlan.addToWrites(),
+                                             transitionPlan.moveReads(),
+                                             transitionPlan.removeFromWrites());
+    }
+
+    @Nullable
+    public static Transformation.Result assertPreExistingWriteReplica(DataPlacements placements, PlacementDeltas ... deltasInOrder)
+    {
+        for (PlacementDeltas deltas : deltasInOrder)
+        {
+            for (Map.Entry<ReplicationParams, PlacementDeltas.PlacementDelta> entry : deltas)
+            {
+                ReplicationParams params = entry.getKey();
+                PlacementDeltas.PlacementDelta delta = entry.getValue();
+                for (Map.Entry<InetAddressAndPort, RangesAtEndpoint> addedRead : delta.reads.additions.entrySet())
+                {
+                    RangesAtEndpoint addedReadReplicas = addedRead.getValue();
+                    RangesAtEndpoint existingWriteReplicas = placements.get(params).writes.byEndpoint().get(addedRead.getKey());
+                    // we're adding read replicas - they should always exist as write replicas before doing that
+                    // BUT we split and merge ranges so we need to check containment both ways
+                    for (Replica newReadReplica : addedReadReplicas)
+                    {
+                        if (existingWriteReplicas.contains(newReadReplica))
+                            continue;
+                        boolean contained = false;
+                        Set<Range<Token>> intersectingRanges = new HashSet<>();
+                        for (Replica writeReplica : existingWriteReplicas)
+                        {
+                            if (writeReplica.isFull() == newReadReplica.isFull() || writeReplica.isFull() && newReadReplica.isTransient())
+                            {
+                                if (writeReplica.range().contains(newReadReplica.range()))
+                                {
+                                    contained = true;
+                                    break;
+                                }
+                                else if (writeReplica.range().intersects(newReadReplica.range()))
+                                {
+                                    intersectingRanges.add(writeReplica.range());
+                                }
+                            }
+                        }
+                        if (!contained && Range.normalize(intersectingRanges).stream().noneMatch(writeReplica -> writeReplica.contains(newReadReplica.range())))
+                        {
+                            String message = "When adding a read replica, that replica needs to exist as a write replica before that: " + newReadReplica + '\n' + placements.get(params) + '\n' + delta;
+                            logger.warn(message);
+                            return new Transformation.Rejected(ExceptionCode.SERVER_ERROR, message);
+                        }
+                    }
+                }
+            }
+            placements = deltas.apply(Epoch.FIRST, placements);
+        }
+        return null;
     }
 }

--- a/src/java/org/apache/cassandra/tcm/ownership/PlacementTransitionPlan.java
+++ b/src/java/org/apache/cassandra/tcm/ownership/PlacementTransitionPlan.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.exceptions.ExceptionCode;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.RangesAtEndpoint;
 import org.apache.cassandra.locator.Replica;
@@ -160,17 +159,17 @@ public class PlacementTransitionPlan
      * @return null if everything is good, otherwise a Transformation.Result rejection containing information about the bad replica
      */
     @Nullable
-    public static Transformation.Result assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
+    public static void assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
     {
-        return assertPreExistingWriteReplica(placements,
-                                             transitionPlan.toSplit,
-                                             transitionPlan.addToWrites(),
-                                             transitionPlan.moveReads(),
-                                             transitionPlan.removeFromWrites());
+        assertPreExistingWriteReplica(placements,
+                                      transitionPlan.toSplit,
+                                      transitionPlan.addToWrites(),
+                                      transitionPlan.moveReads(),
+                                      transitionPlan.removeFromWrites());
     }
 
     @Nullable
-    public static Transformation.Result assertPreExistingWriteReplica(DataPlacements placements, PlacementDeltas ... deltasInOrder)
+    public static void assertPreExistingWriteReplica(DataPlacements placements, PlacementDeltas ... deltasInOrder)
     {
         for (PlacementDeltas deltas : deltasInOrder)
         {
@@ -209,13 +208,12 @@ public class PlacementTransitionPlan
                         {
                             String message = "When adding a read replica, that replica needs to exist as a write replica before that: " + newReadReplica + '\n' + placements.get(params) + '\n' + delta;
                             logger.warn(message);
-                            return new Transformation.Rejected(ExceptionCode.SERVER_ERROR, message);
+                            throw new Transformation.RejectedTransformationException(message);
                         }
                     }
                 }
             }
             placements = deltas.apply(Epoch.FIRST, placements);
         }
-        return null;
     }
 }

--- a/src/java/org/apache/cassandra/tcm/ownership/PlacementTransitionPlan.java
+++ b/src/java/org/apache/cassandra/tcm/ownership/PlacementTransitionPlan.java
@@ -192,7 +192,7 @@ public class PlacementTransitionPlan
                         Set<Range<Token>> intersectingRanges = new HashSet<>();
                         for (Replica writeReplica : existingWriteReplicas)
                         {
-                            if (writeReplica.isFull() == newReadReplica.isFull() || writeReplica.isFull() && newReadReplica.isTransient())
+                            if (writeReplica.isFull() == newReadReplica.isFull() || (writeReplica.isFull() && newReadReplica.isTransient()))
                             {
                                 if (writeReplica.range().contains(newReadReplica.range()))
                                 {

--- a/src/java/org/apache/cassandra/tcm/sequences/RemoveNodeStreams.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/RemoveNodeStreams.java
@@ -56,9 +56,7 @@ public class RemoveNodeStreams implements LeaveStreams
         ClusterMetadata metadata = ClusterMetadata.current();
         MovementMap movements = movementMap(metadata.directory.endpoint(leaving),
                                             metadata,
-                                            startLeave,
-                                            midLeave,
-                                            finishLeave);
+                                            startLeave);
         movements.forEach((params, eps) -> logger.info("Removenode movements: {}: {}", params, eps));
         String operationId = leaving.toUUID().toString();
         responseTracker = DataMovements.instance.registerMovements(RESTORE_REPLICA_COUNT, operationId, movements);
@@ -109,7 +107,7 @@ public class RemoveNodeStreams implements LeaveStreams
      * create a map where the key is the destination, and the values are possible sources
      * @return
      */
-    private static MovementMap movementMap(InetAddressAndPort leaving, ClusterMetadata metadata, PlacementDeltas startDelta, PlacementDeltas midDelta, PlacementDeltas finishDelta)
+    private static MovementMap movementMap(InetAddressAndPort leaving, ClusterMetadata metadata, PlacementDeltas startDelta)
     {
         MovementMap.Builder allMovements = MovementMap.builder();
         // map of dest->src* movements, keyed by replication settings. During unbootstrap, this will be used to construct

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareJoin.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareJoin.java
@@ -35,7 +35,6 @@ import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
 import org.apache.cassandra.tcm.ownership.DataPlacements;
-import org.apache.cassandra.tcm.ownership.MovementMap;
 import org.apache.cassandra.tcm.ownership.PlacementDeltas;
 import org.apache.cassandra.tcm.ownership.PlacementProvider;
 import org.apache.cassandra.tcm.ownership.PlacementTransitionPlan;
@@ -153,9 +152,9 @@ public class PrepareJoin implements Transformation
                                                              transitionPlan.toSplit,
                                                              startJoin, midJoin, finishJoin,
                                                              joinTokenRing, streamData);
-        if (!(this instanceof UnsafeJoin) && !prev.tokenMap.isEmpty())
+        if (!prev.tokenMap.isEmpty())
         {
-            Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
+            Result res = assertPreExistingWriteReplica(prev.placements, transitionPlan);
             if (res != null)
                 return res;
         }
@@ -168,6 +167,11 @@ public class PrepareJoin implements Transformation
                                                    .with(prev.inProgressSequences.with(nodeId, plan));
 
         return Transformation.success(proposed, rangesToLock);
+    }
+
+    Result assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
+    {
+        return PlacementTransitionPlan.assertPreExistingWriteReplica(placements, transitionPlan);
     }
 
     public static abstract class Serializer<T extends PrepareJoin> implements AsymmetricMetadataSerializer<Transformation, T>

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareJoin.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareJoin.java
@@ -153,11 +153,7 @@ public class PrepareJoin implements Transformation
                                                              startJoin, midJoin, finishJoin,
                                                              joinTokenRing, streamData);
         if (!prev.tokenMap.isEmpty())
-        {
-            Result res = assertPreExistingWriteReplica(prev.placements, transitionPlan);
-            if (res != null)
-                return res;
-        }
+            assertPreExistingWriteReplica(prev.placements, transitionPlan);
 
         LockedRanges newLockedRanges = prev.lockedRanges.lock(lockKey, rangesToLock);
         DataPlacements startingPlacements = transitionPlan.toSplit.apply(prev.nextEpoch(), prev.placements);
@@ -169,9 +165,9 @@ public class PrepareJoin implements Transformation
         return Transformation.success(proposed, rangesToLock);
     }
 
-    Result assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
+    void assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
     {
-        return PlacementTransitionPlan.assertPreExistingWriteReplica(placements, transitionPlan);
+        PlacementTransitionPlan.assertPreExistingWriteReplica(placements, transitionPlan);
     }
 
     public static abstract class Serializer<T extends PrepareJoin> implements AsymmetricMetadataSerializer<Transformation, T>

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareLeave.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareLeave.java
@@ -36,7 +36,6 @@ import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.tcm.membership.Directory;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
-import org.apache.cassandra.tcm.ownership.MovementMap;
 import org.apache.cassandra.tcm.ownership.PlacementDeltas;
 import org.apache.cassandra.tcm.ownership.PlacementProvider;
 import org.apache.cassandra.tcm.ownership.PlacementTransitionPlan;
@@ -116,9 +115,8 @@ public class PrepareLeave implements Transformation
         PlacementDeltas startDelta = transitionPlan.addToWrites();
         PlacementDeltas midDelta = transitionPlan.moveReads();
         PlacementDeltas finishDelta = transitionPlan.removeFromWrites();
-        Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
-        if (res != null)
-            return res;
+        PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
+
         LockedRanges.Key unlockKey = LockedRanges.keyFor(proposed.epoch);
 
         StartLeave start = new StartLeave(leaving, startDelta, unlockKey);

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareLeave.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareLeave.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.tcm.membership.Directory;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
+import org.apache.cassandra.tcm.ownership.MovementMap;
 import org.apache.cassandra.tcm.ownership.PlacementDeltas;
 import org.apache.cassandra.tcm.ownership.PlacementProvider;
 import org.apache.cassandra.tcm.ownership.PlacementTransitionPlan;
@@ -115,7 +116,9 @@ public class PrepareLeave implements Transformation
         PlacementDeltas startDelta = transitionPlan.addToWrites();
         PlacementDeltas midDelta = transitionPlan.moveReads();
         PlacementDeltas finishDelta = transitionPlan.removeFromWrites();
-
+        Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
+        if (res != null)
+            return res;
         LockedRanges.Key unlockKey = LockedRanges.keyFor(proposed.epoch);
 
         StartLeave start = new StartLeave(leaving, startDelta, unlockKey);

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareMove.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareMove.java
@@ -37,7 +37,6 @@ import org.apache.cassandra.tcm.ClusterMetadataService;
 import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
-import org.apache.cassandra.tcm.ownership.MovementMap;
 import org.apache.cassandra.tcm.ownership.PlacementDeltas;
 import org.apache.cassandra.tcm.ownership.PlacementProvider;
 import org.apache.cassandra.tcm.ownership.PlacementTransitionPlan;
@@ -110,9 +109,8 @@ public class PrepareMove implements Transformation
         StartMove startMove = new StartMove(nodeId, transitionPlan.addToWrites(), lockKey);
         MidMove midMove = new MidMove(nodeId, transitionPlan.moveReads(), lockKey);
         FinishMove finishMove = new FinishMove(nodeId, tokens, transitionPlan.removeFromWrites(), lockKey);
-        Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
-        if (res != null)
-            return res;
+        PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
+
         Move sequence = Move.newSequence(prev.nextEpoch(),
                                          lockKey,
                                          tokens,

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareMove.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareMove.java
@@ -37,6 +37,7 @@ import org.apache.cassandra.tcm.ClusterMetadataService;
 import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
+import org.apache.cassandra.tcm.ownership.MovementMap;
 import org.apache.cassandra.tcm.ownership.PlacementDeltas;
 import org.apache.cassandra.tcm.ownership.PlacementProvider;
 import org.apache.cassandra.tcm.ownership.PlacementTransitionPlan;
@@ -109,7 +110,9 @@ public class PrepareMove implements Transformation
         StartMove startMove = new StartMove(nodeId, transitionPlan.addToWrites(), lockKey);
         MidMove midMove = new MidMove(nodeId, transitionPlan.moveReads(), lockKey);
         FinishMove finishMove = new FinishMove(nodeId, tokens, transitionPlan.removeFromWrites(), lockKey);
-
+        Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, transitionPlan);
+        if (res != null)
+            return res;
         Move sequence = Move.newSequence(prev.nextEpoch(),
                                          lockKey,
                                          tokens,

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareReplace.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareReplace.java
@@ -130,9 +130,8 @@ public class PrepareReplace implements Transformation
         StartReplace start = new StartReplace(replaced, replacement, addNewNodeToWrites.build(), unlockKey);
         MidReplace mid = new MidReplace(replaced, replacement, addNewNodeToReads.build(), unlockKey);
         FinishReplace finish = new FinishReplace(replaced, replacement, removeOldNodeFromWrites.build(), unlockKey);
-        Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, start.delta, mid.delta, finish.delta);
-        if (res != null)
-            return res;
+        PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, start.delta, mid.delta, finish.delta);
+
         Set<Token> tokens = new HashSet<>(prev.tokenMap.tokens(replaced));
         BootstrapAndReplace plan = BootstrapAndReplace.newSequence(prev.nextEpoch(),
                                                                    unlockKey,

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareReplace.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareReplace.java
@@ -130,7 +130,9 @@ public class PrepareReplace implements Transformation
         StartReplace start = new StartReplace(replaced, replacement, addNewNodeToWrites.build(), unlockKey);
         MidReplace mid = new MidReplace(replaced, replacement, addNewNodeToReads.build(), unlockKey);
         FinishReplace finish = new FinishReplace(replaced, replacement, removeOldNodeFromWrites.build(), unlockKey);
-
+        Result res = PlacementTransitionPlan.assertPreExistingWriteReplica(prev.placements, start.delta, mid.delta, finish.delta);
+        if (res != null)
+            return res;
         Set<Token> tokens = new HashSet<>(prev.tokenMap.tokens(replaced));
         BootstrapAndReplace plan = BootstrapAndReplace.newSequence(prev.nextEpoch(),
                                                                    unlockKey,

--- a/src/java/org/apache/cassandra/tcm/transformations/UnsafeJoin.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/UnsafeJoin.java
@@ -86,8 +86,5 @@ public class UnsafeJoin extends PrepareJoin
     }
 
     @Override
-    Result assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
-    {
-        return null;
-    }
+    void assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan) {}
 }

--- a/src/java/org/apache/cassandra/tcm/transformations/UnsafeJoin.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/UnsafeJoin.java
@@ -24,7 +24,9 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.ClusterMetadataService;
 import org.apache.cassandra.tcm.membership.NodeId;
+import org.apache.cassandra.tcm.ownership.DataPlacements;
 import org.apache.cassandra.tcm.ownership.PlacementProvider;
+import org.apache.cassandra.tcm.ownership.PlacementTransitionPlan;
 import org.apache.cassandra.tcm.sequences.BootstrapAndJoin;
 import org.apache.cassandra.tcm.sequences.LockedRanges;
 
@@ -81,5 +83,11 @@ public class UnsafeJoin extends PrepareJoin
     {
         UnsafeJoin join = new UnsafeJoin(nodeId, tokens, ClusterMetadataService.instance().placementProvider());
         ClusterMetadataService.instance().commit(join);
+    }
+
+    @Override
+    Result assertPreExistingWriteReplica(DataPlacements placements, PlacementTransitionPlan transitionPlan)
+    {
+        return null;
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/TransientRangeMovement2Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/TransientRangeMovement2Test.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.distributed.test;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
@@ -28,9 +29,16 @@ import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.IInstanceConfig;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.distributed.shared.NetworkTopology;
+import org.apache.cassandra.tcm.Epoch;
+import org.apache.cassandra.tcm.transformations.PrepareMove;
 import org.apache.cassandra.utils.Pair;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.pauseBeforeCommit;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.pauseBeforeEnacting;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.unpauseCommits;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.unpauseEnactment;
+import static org.apache.cassandra.distributed.shared.ClusterUtils.waitForCMSToQuiesce;
 import static org.apache.cassandra.distributed.test.TransientRangeMovementTest.OPPTokens;
 import static org.apache.cassandra.distributed.test.TransientRangeMovementTest.assertAllContained;
 import static org.apache.cassandra.distributed.test.TransientRangeMovementTest.localStrs;
@@ -40,7 +48,7 @@ import static org.apache.cassandra.distributed.test.TransientRangeMovementTest.p
 public class TransientRangeMovement2Test extends TestBaseImpl
 {
     @Test
-    public void testMoveBackward() throws IOException, ExecutionException, InterruptedException
+    public void testMoveBackward() throws Exception
     {
         try (Cluster cluster = init(Cluster.build(4)
                                            .withTokenSupplier(new OPPTokens())
@@ -51,9 +59,23 @@ public class TransientRangeMovement2Test extends TestBaseImpl
                                            .start()))
         {
             populate(cluster);
-            cluster.get(3).nodetoolResult("move", "25").asserts().success();
+            // Have the CMS node pause before the step MidMove is committed, node1 gains (25, 30] as a full write replica
+            // in StartMove, before the fix (25, 30] was added as a transient replica.
+            Callable<Epoch> pending = pauseBeforeCommit(cluster.get(1), (e) -> e instanceof PrepareMove.MidMove);
+
+            new Thread(() -> cluster.get(3).nodetoolResult("move", "25").asserts().success()).start();
+            Epoch pauseBeforeEnacting = pending.call().nextEpoch();
+
+            Callable<?> beforeEnacted = pauseBeforeEnacting(cluster.get(3), pauseBeforeEnacting);
+            unpauseCommits(cluster.get(1));
+            beforeEnacted.call();
+
+            // before node3 completes the move, run cleanup (but its actually node1 where the corruption occurs).
             cluster.forEach(i -> i.nodetoolResult("cleanup").asserts().success());
 
+            unpauseEnactment(cluster.get(3));
+            waitForCMSToQuiesce(cluster, cluster.get(1));
+            cluster.forEach(i -> i.nodetoolResult("cleanup").asserts().success());
             assertAllContained(localStrs(cluster.get(1)),
                                newArrayList("22", "24"),
                                Pair.create("00", "10"),
@@ -72,7 +94,7 @@ public class TransientRangeMovement2Test extends TestBaseImpl
     }
 
     @Test
-    public void testMoveForward() throws IOException, ExecutionException, InterruptedException
+    public void testMoveForward() throws Exception
     {
 
         try (Cluster cluster = init(Cluster.build(4)
@@ -85,8 +107,24 @@ public class TransientRangeMovement2Test extends TestBaseImpl
                                            .start()))
         {
             populate(cluster);
-            cluster.get(1).nodetoolResult("move", "15").asserts().success();
-            cluster.forEach((i) -> i.nodetoolResult("cleanup").asserts().success());
+            // Have the CMS node pause before the step MidMove is committed - this doesn't break without the CASSANDRA-19344 fix, but leaving
+            // pausing + cleanup in.
+            Callable<Epoch> pending = pauseBeforeCommit(cluster.get(1), (e) -> e instanceof PrepareMove.MidMove);
+
+            new Thread(() -> cluster.get(1).nodetoolResult("move", "15").asserts().success()).start();
+            Epoch pauseBeforeEnacting = pending.call().nextEpoch();
+
+            Callable<?> beforeEnacted = pauseBeforeEnacting(cluster.get(3), pauseBeforeEnacting);
+            unpauseCommits(cluster.get(1));
+            beforeEnacted.call();
+
+            // before node3 completes the move, run cleanup (but its actually node1 where the corruption occurs).
+            cluster.forEach(i -> i.nodetoolResult("cleanup").asserts().success());
+
+            unpauseEnactment(cluster.get(3));
+            waitForCMSToQuiesce(cluster, cluster.get(1));
+
+            cluster.forEach(i -> i.nodetoolResult("cleanup").asserts().success());
             assertAllContained(localStrs(cluster.get(1)),
                                newArrayList("22", "24", "26", "28", "30"),
                                Pair.create("00", "15"),

--- a/test/distributed/org/apache/cassandra/distributed/test/TransientRangeMovement2Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/TransientRangeMovement2Test.java
@@ -142,8 +142,6 @@ public class TransientRangeMovement2Test extends TestBaseImpl
         }
     }
 
-
-
     @Test
     public void testRebuild() throws ExecutionException, InterruptedException, IOException
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
+import org.apache.cassandra.harry.sut.TokenPlacementModel.DCReplicas;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -372,9 +373,9 @@ public class MetadataChangeSimulationTest extends CMSTestBase
                     // Sequentially bootstrap rf nodes first
                     .step((state, sut) -> state.currentNodes.isEmpty(),
                           (state, sut, entropySource) -> {
-                              for (Map.Entry<String, Integer> e : rf.asMap().entrySet())
+                              for (Map.Entry<String, DCReplicas> e : rf.asMap().entrySet())
                               {
-                                  int dcRf = e.getValue();
+                                  int dcRf = e.getValue().totalCount;
                                   int dc = Integer.parseInt(e.getKey().replace("datacenter", ""));
 
                                   for (int i = 0; i < dcRf + 1; i++)
@@ -505,7 +506,7 @@ public class MetadataChangeSimulationTest extends CMSTestBase
         {
             ModelState state = ModelState.empty(nodeFactory(), 300, 1);
 
-            for (Map.Entry<String, Integer> e : rf.asMap().entrySet())
+            for (Map.Entry<String, DCReplicas> e : rf.asMap().entrySet())
             {
                 int dc = Integer.parseInt(e.getKey().replace("datacenter", ""));
 
@@ -639,7 +640,7 @@ public class MetadataChangeSimulationTest extends CMSTestBase
             for (SimulatedOperation op : modelState.inFlightOperations)
                 candidates.removeAll(Arrays.asList(op.nodes));
 
-            int rf = modelState.simulatedPlacements.rf.asMap().get(dc);
+            int rf = modelState.simulatedPlacements.rf.asMap().get(dc).totalCount;
             if (candidates.size() <= rf)
                 continue;
 
@@ -808,9 +809,9 @@ public class MetadataChangeSimulationTest extends CMSTestBase
                              .add(replica.endpoint());
             }
 
-            for (Map.Entry<String, Integer> e : rf.asMap().entrySet())
+            for (Map.Entry<String, DCReplicas> e : rf.asMap().entrySet())
             {
-                int expectedRf = e.getValue();
+                int expectedRf = e.getValue().totalCount;
                 String dc = e.getKey();
                 int actualRf = endpointsByDc.get(dc).size();
 

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -109,6 +109,19 @@ public class MetadataChangeSimulationTest extends CMSTestBase
     }
 
     @Test
+    public void simulateSimpleOneTransient() throws Throwable
+    {
+        DatabaseDescriptor.setTransientReplicationEnabledUnsafe(true);
+        simulate(5, 0, new SimpleReplicationFactor(3, 1), 1);
+    }
+
+    @Test
+    public void simulateSimpleOneNonTransient() throws Throwable
+    {
+        simulate(5, 0, new SimpleReplicationFactor(3), 1);
+    }
+
+    @Test
     public void testMoveReal() throws Throwable
     {
         for (int i = 0; i < 4; i++)

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -131,13 +131,13 @@ public class MetadataChangeSimulationTest extends CMSTestBase
     public void simulateSimpleOneTransient() throws Throwable
     {
         DatabaseDescriptor.setTransientReplicationEnabledUnsafe(true);
-        simulate(5, 0, new SimpleReplicationFactor(3, 2), 1);
+        simulate(50, 0, new SimpleReplicationFactor(5, 2), 1);
     }
 
     @Test
     public void simulateSimpleOneNonTransient() throws Throwable
     {
-        simulate(5, 0, new SimpleReplicationFactor(3), 1);
+        simulate(50, 0, new SimpleReplicationFactor(3), 1);
     }
 
     @Test

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -874,7 +874,6 @@ public class MetadataChangeSimulationTest extends CMSTestBase
                 int expectedRf = e.getValue().totalCount;
                 String dc = e.getKey();
                 int actualRf = endpointsByDc.get(dc).size();
-
                 if (allowPending)
                 {
                     int diff = actualRf - expectedRf;

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -949,10 +949,9 @@ public class MetadataChangeSimulationTest extends CMSTestBase
             Node toMove = null;
             Node toReplace = null;
             Node toLeave = null;
-            for (Map.Entry<String, Integer> e : rf.asMap().entrySet())
+            for (String replicationFactor : rf.asMap().keySet())
             {
-                int dc = Integer.parseInt(e.getKey().replace("datacenter", ""));
-
+                int dc = Integer.parseInt(replicationFactor.replace("datacenter", ""));
                 for (int i = 0; i < 100; i++)
                 {
                     ModelChecker.Pair<ModelState, Node> registration = registerNewNode(state, sut, dc, random.nextInt(5) + 1);

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -669,17 +669,17 @@ public class MetadataChangeSimulationTest extends CMSTestBase
         return sb.toString();
     }
 
-    public static void match(PlacementForRange actual, Map<TokenPlacementModel.Range, List<Node>> predicted) throws Throwable
+    public static void match(PlacementForRange actual, Map<TokenPlacementModel.Range, List<TokenPlacementModel.Replica>> predicted) throws Throwable
     {
         Map<Range<Token>, VersionedEndpoints.ForRange> actualGroups = actual.replicaGroups();
         assert predicted.size() == actualGroups.size() :
         String.format("\nPredicted:\n%s(%d)" +
                       "\nActual:\n%s(%d)", toString(predicted), predicted.size(), toString(actual.replicaGroups()), actualGroups.size());
 
-        for (Map.Entry<TokenPlacementModel.Range, List<Node>> entry : predicted.entrySet())
+        for (Map.Entry<TokenPlacementModel.Range, List<TokenPlacementModel.Replica>> entry : predicted.entrySet())
         {
             TokenPlacementModel.Range range = entry.getKey();
-            List<Node> predictedNodes = entry.getValue();
+            List<TokenPlacementModel.Replica> predictedReplicas = entry.getValue();
             Range<Token> predictedRange = new Range<Token>(new Murmur3Partitioner.LongToken(range.start),
                                                            new Murmur3Partitioner.LongToken(range.end));
             EndpointsForRange endpointsForRange = actualGroups.get(predictedRange).get();
@@ -689,19 +689,19 @@ public class MetadataChangeSimulationTest extends CMSTestBase
                                              "\nExpected: %s" +
                                              "\nActual:   %s",
                                              range,
-                                             predictedNodes.stream().sorted().collect(Collectors.toList()),
+                                             predictedReplicas.stream().sorted().collect(Collectors.toList()),
                                              endpointsForRange.endpoints().stream().sorted().collect(Collectors.toList())),
-                         predictedNodes.size(), endpointsForRange.size());
-            for (Node node : predictedNodes)
+                         predictedReplicas.size(), endpointsForRange.size());
+            for (TokenPlacementModel.Replica replica : predictedReplicas)
             {
                 assertTrue(() -> String.format("Endpoints for range %s should have contained %s, but they have not." +
                                                "\nExpected: %s" +
                                                "\nActual:   %s.",
                                                endpointsForRange.range(),
-                                               node.id(),
-                                               predictedNodes,
+                                               replica.node().id(),
+                                               predictedReplicas,
                                                endpointsForRange.endpoints()),
-                           endpointsForRange.endpoints().contains(InetAddressAndPort.getByAddress(InetAddress.getByName(node.id()))));
+                           endpointsForRange.endpoints().contains(InetAddressAndPort.getByAddress(InetAddress.getByName(replica.node().id()))));
             }
         }
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/MetadataChangeSimulationTest.java
@@ -716,6 +716,7 @@ public class MetadataChangeSimulationTest extends CMSTestBase
             EndpointsForRange endpointsForRange = actualGroups.get(predictedRange).get();
             assertNotNull(() -> String.format("Could not find %s in ranges %s", predictedRange, actualGroups.keySet()),
                           endpointsForRange);
+
             assertEquals(() -> String.format("Predicted to have different endpoints for range %s" +
                                              "\nExpected: %s" +
                                              "\nActual:   %s",
@@ -723,16 +724,18 @@ public class MetadataChangeSimulationTest extends CMSTestBase
                                              predictedReplicas.stream().sorted().collect(Collectors.toList()),
                                              endpointsForRange.endpoints().stream().sorted().collect(Collectors.toList())),
                          predictedReplicas.size(), endpointsForRange.size());
-            for (TokenPlacementModel.Replica replica : predictedReplicas)
+            for (TokenPlacementModel.Replica fromModel : predictedReplicas)
             {
+                Replica replica = endpointsForRange.byEndpoint().
+                                                   get(InetAddressAndPort.getByAddress(InetAddress.getByName(fromModel.node().id())));
                 assertTrue(() -> String.format("Endpoints for range %s should have contained %s, but they have not." +
                                                "\nExpected: %s" +
                                                "\nActual:   %s.",
                                                endpointsForRange.range(),
-                                               replica.node().id(),
+                                               fromModel,
                                                predictedReplicas,
-                                               endpointsForRange.endpoints()),
-                           endpointsForRange.endpoints().contains(InetAddressAndPort.getByAddress(InetAddress.getByName(replica.node().id()))));
+                                               endpointsForRange),
+                           replica != null && replica.isFull() == fromModel.isFull());
             }
         }
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/log/ModelState.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/ModelState.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.cassandra.harry.sut.TokenPlacementModel;
+import org.apache.cassandra.harry.sut.TokenPlacementModel.DCReplicas;
 
 public class ModelState
 {
@@ -138,10 +139,10 @@ public class ModelState
     private boolean canRemove(TokenPlacementModel.ReplicationFactor rfs)
     {
         if (!withinConcurrencyLimit()) return false;
-        for (Map.Entry<String, Integer> e : rfs.asMap().entrySet())
+        for (Map.Entry<String, DCReplicas> e : rfs.asMap().entrySet())
         {
             String dc = e.getKey();
-            int rf = e.getValue();
+            int rf = e.getValue().totalCount;
             List<TokenPlacementModel.Node> nodes = nodesByDc.get(dc);
             Set<TokenPlacementModel.Node> nodesInDc = nodes == null ? new HashSet<>() : new HashSet<>(nodes);
             for (SimulatedOperation op : inFlightOperations)

--- a/test/distributed/org/apache/cassandra/distributed/test/log/ModelState.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/ModelState.java
@@ -319,7 +319,7 @@ public class ModelState
             assert currentNodes.contains(node);
             // for now... assassinate may change this assertion
             assert leavingNodes.contains(node);
-            finished[1]++;
+            finished[2]++;
             removeFromCluster(node);
             return this;
         }

--- a/test/distributed/org/apache/cassandra/distributed/test/log/OperationalEquivalenceTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/OperationalEquivalenceTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -34,7 +33,6 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.harry.sut.TokenPlacementModel;
 import org.apache.cassandra.locator.EndpointsForRange;
 import org.apache.cassandra.locator.Replica;
-import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.tcm.AtomicLongBackedProcessor;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.membership.Location;
@@ -60,49 +58,6 @@ public class OperationalEquivalenceTest extends CMSTestBase
         DatabaseDescriptor.setTransientReplicationEnabledUnsafe(true);
     }
 
-    // Private to this class for now as this is only a limited implementation
-    private static class TransientReplicationFactor extends TokenPlacementModel.ReplicationFactor
-    {
-        private final TokenPlacementModel.Lookup lookup = new TokenPlacementModel.DefaultLookup();
-        private final int dcs;
-        private final int full;
-        private final int trans;
-
-        public TransientReplicationFactor(int dcs, int full, int trans)
-        {
-            super(dcs * (full + trans));
-            this.dcs = dcs;
-            this.full = full;
-            this.trans = trans;
-        }
-
-        public int dcs()
-        {
-            return dcs;
-        }
-
-        public KeyspaceParams asKeyspaceParams()
-        {
-            Object[] rf = new Object[dcs * 2];
-            for (int i = 0; i < dcs * 2;)
-            {
-                rf[i++] = lookup.dc(i);
-                rf[i++] = String.format("%s/%s", full, trans);
-            }
-            return KeyspaceParams.nts(rf);
-        }
-
-        public Map<String, Integer> asMap()
-        {
-            throw new IllegalStateException("Does not work with transient replication");
-        }
-
-        public TokenPlacementModel.ReplicatedRanges replicate(TokenPlacementModel.Range[] ranges, List<TokenPlacementModel.Node> nodes)
-        {
-            throw new IllegalStateException("Does not work with transient replication (yet)");
-        }
-    }
-
     @Test
     public void testMove() throws Exception
     {
@@ -118,8 +73,10 @@ public class OperationalEquivalenceTest extends CMSTestBase
         testMove(new TokenPlacementModel.NtsReplicationFactor(3, 3));
         testMove(new TokenPlacementModel.NtsReplicationFactor(3, 5));
 
-        testMove(new TransientReplicationFactor(3, 3, 1));
-        testMove(new TransientReplicationFactor(3, 3, 2));
+        testMove(new TokenPlacementModel.SimpleReplicationFactor(3, 1));
+        testMove(new TokenPlacementModel.SimpleReplicationFactor(3, 2));
+        testMove(new TokenPlacementModel.NtsReplicationFactor(3, 3, 1));
+        testMove(new TokenPlacementModel.NtsReplicationFactor(3, 5, 2));
     }
 
     public void testMove(TokenPlacementModel.ReplicationFactor rf) throws Exception

--- a/test/distributed/org/apache/cassandra/distributed/test/log/PlacementSimulator.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/PlacementSimulator.java
@@ -991,9 +991,11 @@ public class PlacementSimulator
             if (added.isFull())
             {
                 additions.add(added);
-                for (Replica removed : unfiltered.removals)
-                    if (removed.node().equals(added.node()) && removed.isTransient())
-                        removals.add(removed);
+                Optional<Replica> removed = unfiltered.removals.stream()
+                                                               .filter(r -> r.isTransient() && r.node().equals(added.node()))
+                                                               .findFirst();
+
+                removed.ifPresent(removals::add);
             }
             else
             {
@@ -1023,9 +1025,11 @@ public class PlacementSimulator
             if (removed.isFull())
             {
                 removals.add(removed);
-                for (Replica added : unfiltered.additions)
-                    if (added.node().equals(removed.node()) && added.isTransient())
-                        additions.add(added);
+                Optional<Replica> added = unfiltered.additions.stream()
+                                                               .filter(r -> r.isTransient() && r.node().equals(removed.node()))
+                                                               .findFirst();
+
+                added.ifPresent(additions::add);
             }
             else
             {

--- a/test/distributed/org/apache/cassandra/distributed/test/log/PlacementSimulatorTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/PlacementSimulatorTest.java
@@ -29,6 +29,7 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import org.apache.cassandra.harry.sut.TokenPlacementModel.Replica;
 import org.junit.Test;
 
 import org.apache.cassandra.harry.sut.TokenPlacementModel;
@@ -395,8 +396,8 @@ public class PlacementSimulatorTest
                                    Supplier<Transformations> opProvider,
                                    int stepsToExecute)
     {
-        Map<Range, List<Node>> startingReadPlacements = sim.readPlacements;
-        Map<Range, List<Node>> startingWritePlacements = sim.writePlacements;
+        Map<Range, List<Replica>> startingReadPlacements = sim.readPlacements;
+        Map<Range, List<Replica>> startingWritePlacements = sim.writePlacements;
         Transformations steps = opProvider.get();
         sim = sim.withStashed(steps);
         // execute the required steps

--- a/test/harry/main/org/apache/cassandra/harry/sut/TokenPlacementModel.java
+++ b/test/harry/main/org/apache/cassandra/harry/sut/TokenPlacementModel.java
@@ -85,7 +85,7 @@ public class TokenPlacementModel
             this.transientCount = transientCount;
         }
 
-        public String toRFString()
+        public String toString()
         {
             return totalCount + ((transientCount > 0) ? "/" + transientCount : "");
         }
@@ -360,7 +360,7 @@ public class TokenPlacementModel
             for (Map.Entry<String, DCReplicas> e : replication.entrySet())
             {
                 args[i * 2] = e.getKey();
-                args[i * 2 + 1] = e.getValue().toRFString();
+                args[i * 2 + 1] = e.getValue().toString();
                 i++;
             }
 
@@ -560,7 +560,7 @@ public class TokenPlacementModel
         {
             Map<String, String> options = new HashMap<>();
             options.put(ReplicationParams.CLASS, SimpleStrategy.class.getName());
-            options.put(SimpleStrategy.REPLICATION_FACTOR, dcReplicas().toRFString());
+            options.put(SimpleStrategy.REPLICATION_FACTOR, dcReplicas().toString());
             return KeyspaceParams.create(true, options);
         }
 
@@ -614,7 +614,7 @@ public class TokenPlacementModel
         public String toString()
         {
             return "SimpleReplicationFactor{" +
-                   "rf=" + dcReplicas().toRFString() +
+                   "rf=" + dcReplicas().toString() +
                    '}';
         }
     }

--- a/test/harry/main/org/apache/cassandra/harry/sut/TokenPlacementModel.java
+++ b/test/harry/main/org/apache/cassandra/harry/sut/TokenPlacementModel.java
@@ -583,7 +583,10 @@ public class TokenPlacementModel
                 if (idx >= 0)
                 {
                     for (int i = 0; i < nodes.size() && replicas.size() < dcReplicas.totalCount; i++)
-                        addIfUnique(replicas, names, new Replica(nodes.get((idx + i) % nodes.size()), true));
+                    {
+                        boolean full = replicas.size() < dcReplicas.totalCount - dcReplicas.transientCount;
+                        addIfUnique(replicas, names, new Replica(nodes.get((idx + i) % nodes.size()), full));
+                    }
                     if (!minTokenOwned && range.start == Long.MIN_VALUE)
                         replication.put(ranges[ranges.length - 1], replicas);
                     replication.put(range, replicas);

--- a/test/harry/main/org/apache/cassandra/harry/sut/injvm/InJVMTokenAwareVisitExecutor.java
+++ b/test/harry/main/org/apache/cassandra/harry/sut/injvm/InJVMTokenAwareVisitExecutor.java
@@ -85,21 +85,21 @@ public class InJVMTokenAwareVisitExecutor extends LoggingVisitor.LoggingVisitorE
         int retries = 0;
 
         Object[] pk = schema.inflatePartitionKey(pd);
-        List<TokenPlacementModel.Node> replicas = getRing().replicasFor(TokenUtil.token(ByteUtils.compose(ByteUtils.objectsToBytes(pk))));
+        List<TokenPlacementModel.Replica> replicas = getRing().replicasFor(TokenUtil.token(ByteUtils.compose(ByteUtils.objectsToBytes(pk))));
         while (retries++ < MAX_RETRIES)
         {
             try
             {
-                TokenPlacementModel.Node replica = replicas.get((int) (lts % replicas.size()));
+                TokenPlacementModel.Replica replica = replicas.get((int) (lts % replicas.size()));
                 if (cl == SystemUnderTest.ConsistencyLevel.NODE_LOCAL)
                 {
-                    return executeNodeLocal(statement.cql(), replica, statement.bindings());
+                    return executeNodeLocal(statement.cql(), replica.node(), statement.bindings());
                 }
                 else
                 {
                     return sut.cluster
                            .stream()
-                           .filter((n) -> n.config().broadcastAddress().toString().contains(replica.id()))
+                           .filter((n) -> n.config().broadcastAddress().toString().contains(replica.node().id()))
                            .findFirst()
                            .get()
                            .coordinator()

--- a/test/simulator/main/org/apache/cassandra/simulator/cluster/KeyspaceActions.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/cluster/KeyspaceActions.java
@@ -215,14 +215,14 @@ public class KeyspaceActions extends ClusterActions
         {
             int primaryKey = primaryKeys[i];
             LongToken token = new Murmur3Partitioner().getToken(Int32Type.instance.decompose(primaryKey));
-            List<TokenPlacementModel.Node> readReplicas = readPlacements.replicasFor(token.token);
-            List<TokenPlacementModel.Node> writeReplicas = writePlacements.replicasFor(token.token);
+            List<TokenPlacementModel.Replica> readReplicas = readPlacements.replicasFor(token.token);
+            List<TokenPlacementModel.Replica> writeReplicas = writePlacements.replicasFor(token.token);
 
-            replicasForKey[i] = readReplicas.stream().mapToInt(TokenPlacementModel.Node::idx).toArray();
-            Set<TokenPlacementModel.Node> pendingReplicas = new HashSet<>(writeReplicas);
+            replicasForKey[i] = readReplicas.stream().mapToInt(r -> r.node().idx()).toArray();
+            Set<TokenPlacementModel.Replica> pendingReplicas = new HashSet<>(writeReplicas);
             pendingReplicas.removeAll(readReplicas);
-            replicasForKey[i] = readReplicas.stream().mapToInt(TokenPlacementModel.Node::idx).toArray();
-            pendingReplicasForKey[i] = pendingReplicas.stream().mapToInt(TokenPlacementModel.Node::idx).toArray();
+            replicasForKey[i] = readReplicas.stream().mapToInt(r -> r.node().idx()).toArray();
+            pendingReplicasForKey[i] = pendingReplicas.stream().mapToInt(r -> r.node().idx()).toArray();
         }
 
         int[] membersOfRing = joined.toArray();

--- a/test/simulator/main/org/apache/cassandra/simulator/harry/HarryValidatingQuery.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/harry/HarryValidatingQuery.java
@@ -85,15 +85,15 @@ public class HarryValidatingQuery extends SimulatedAction
                         protected void validate(Query query, TokenPlacementModel.ReplicatedRanges ring)
                         {
                             CompiledStatement compiled = query.toSelectStatement();
-                            List<TokenPlacementModel.Node> replicas = ring.replicasFor(this.token(query.pd));
+                            List<TokenPlacementModel.Replica> replicas = ring.replicasFor(this.token(query.pd));
                             logger.trace("Predicted {} as replicas for {}. Ring: {}", new Object[]{ replicas, query.pd, ring });
                             List<Throwable> throwables = new ArrayList<>();
-                            for (TokenPlacementModel.Node node : replicas)
+                            for (TokenPlacementModel.Replica replica : replicas)
                             {
                                 try
                                 {
                                     validate(() -> {
-                                        Object[][] objects = this.executeNodeLocal(compiled.cql(), node, compiled.bindings());
+                                        Object[][] objects = this.executeNodeLocal(compiled.cql(), replica.node(), compiled.bindings());
                                         List<ResultSetRow> result = new ArrayList();
                                         int length = objects.length;
                                         for (int i = 0; i < length; ++i)
@@ -107,7 +107,7 @@ public class HarryValidatingQuery extends SimulatedAction
                                 }
                                 catch (Model.ValidationException t)
                                 {
-                                    throwables.add(new AssertionError(String.format("Caught an exception while validating %s on %s", query, node), t));
+                                    throwables.add(new AssertionError(String.format("Caught an exception while validating %s on %s", query, replica), t));
                                 }
                             }
 

--- a/test/unit/org/apache/cassandra/tcm/ownership/PlacementTransitionPlanTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ownership/PlacementTransitionPlanTest.java
@@ -29,16 +29,14 @@ import org.apache.cassandra.locator.RangesAtEndpoint;
 import org.apache.cassandra.locator.RangesByEndpoint;
 import org.apache.cassandra.locator.Replica;
 import org.apache.cassandra.schema.ReplicationParams;
+import org.apache.cassandra.tcm.Transformation;
 import org.apache.cassandra.utils.FBUtilities;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public class PlacementTransitionPlanTest
 {
     private static final ReplicationParams params = ReplicationParams.simple(2);
     private static final InetAddressAndPort ep = FBUtilities.getBroadcastAddressAndPort();
-    @Test
+    @Test(expected = Transformation.RejectedTransformationException.class)
     public void testEmptyWriteReplica()
     {
         DataPlacements startPlacements = DataPlacements.EMPTY;
@@ -46,7 +44,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(newReads)).build();
-        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addRead);
     }
 
     @Test
@@ -61,7 +59,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(newReplica)).build();
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
     @Test
@@ -76,7 +74,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(readReplicas)).build();
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
     @Test
     public void testAddSplitReadReplica()
@@ -90,7 +88,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(readReplicas)).build();
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
     @Test
@@ -105,10 +103,10 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(readReplicas)).build();
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
-    @Test
+    @Test(expected = Transformation.RejectedTransformationException.class)
     public void testHasSplitWriteReplicaWithGaps()
     {
         DataPlacements startPlacements = DataPlacements.EMPTY;
@@ -120,7 +118,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(readReplicas)).build();
-        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
     @Test
@@ -140,10 +138,10 @@ public class PlacementTransitionPlanTest
                                                  .put(params,
                                                       addReadDelta(readReplicas)).build();
         // first delta adds (0, 20] as write, second (20, 40] - make sure both are in placements when adding the read replica;
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite1, addWrite2, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite1, addWrite2, addRead);
     }
 
-    @Test
+    @Test(expected = Transformation.RejectedTransformationException.class)
     public void testDisallowAddingFullReadWithTransientWrite()
     {
         DataPlacements startPlacements = DataPlacements.EMPTY;
@@ -156,7 +154,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(fullRead)).build();
-        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
     @Test
@@ -172,7 +170,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(transientRead)).build();
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
     @Test
@@ -188,10 +186,10 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(transientRead)).build();
-        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead);
     }
 
-    @Test
+    @Test(expected = Transformation.RejectedTransformationException.class)
     public void testHasSplitTransientWriteReplica()
     {
         DataPlacements startPlacements = DataPlacements.EMPTY;
@@ -208,7 +206,7 @@ public class PlacementTransitionPlanTest
         PlacementDeltas addRead = PlacementDeltas.builder()
                                                  .put(params,
                                                       addReadDelta(readReplicas)).build();
-        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWriteFull, addWriteTransient, addRead));
+        PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWriteFull, addWriteTransient, addRead);
     }
 
     private PlacementDeltas.PlacementDelta addReadDelta(RangesByEndpoint replica)

--- a/test/unit/org/apache/cassandra/tcm/ownership/PlacementTransitionPlanTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ownership/PlacementTransitionPlanTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm.ownership;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.locator.RangesAtEndpoint;
+import org.apache.cassandra.locator.RangesByEndpoint;
+import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.schema.ReplicationParams;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class PlacementTransitionPlanTest
+{
+    private static final ReplicationParams params = ReplicationParams.simple(2);
+    private static final InetAddressAndPort ep = FBUtilities.getBroadcastAddressAndPort();
+    @Test
+    public void testEmptyWriteReplica()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint newReads = rbe(r(0, 20));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(newReads)).build();
+        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addRead));
+    }
+
+    @Test
+    public void testHasWriteReplica()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint newReplica = rbe(r(0, 20));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(newReplica)).build();
+
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(newReplica)).build();
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testHasSplitWriteReplica()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint writeReplicas = rbe(r(0, 20), r(20, 40));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(writeReplicas)).build();
+        RangesByEndpoint readReplicas = rbe(r(0, 40));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(readReplicas)).build();
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+    @Test
+    public void testAddSplitReadReplica()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint writeReplicas = rbe(r(0, 40));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(writeReplicas)).build();
+        RangesByEndpoint readReplicas = rbe(r(0, 20), r(20, 40));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(readReplicas)).build();
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testAddSplitReadReplicaGap()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint writeReplicas = rbe(r(0, 40));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(writeReplicas)).build();
+        RangesByEndpoint readReplicas = rbe(r(0, 20), r(25, 40)); // this won't happen, but all read replicas are "covered" by the write replica above
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(readReplicas)).build();
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testHasSplitWriteReplicaWithGaps()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint writeReplicas = rbe(r(0, 20), r(21, 40)); // token 21 missing
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(writeReplicas)).build();
+        RangesByEndpoint readReplicas = rbe(r(0, 40));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(readReplicas)).build();
+        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testPlacementsAreUpdatedByDeltas()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint writeReplicas1 = rbe(r(0, 20));
+        PlacementDeltas addWrite1 = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(writeReplicas1)).build();
+        RangesByEndpoint writeReplicas2 = rbe(r(20, 40));
+        PlacementDeltas addWrite2 = PlacementDeltas.builder()
+                                                   .put(params,
+                                                        addWriteDelta(writeReplicas2)).build();
+        RangesByEndpoint readReplicas = rbe(r(0, 40));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(readReplicas)).build();
+        // first delta adds (0, 20] as write, second (20, 40] - make sure both are in placements when adding the read replica;
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite1, addWrite2, addRead));
+    }
+
+    @Test
+    public void testDisallowAddingFullReadWithTransientWrite()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint transientWrite = rbeTransient(r(0, 20));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(transientWrite)).build();
+
+        RangesByEndpoint fullRead = rbe(r(0,20));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(fullRead)).build();
+        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testAllowAddingTransientReadWithTransientWrite()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint transientWrite = rbeTransient(r(0, 20));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(transientWrite)).build();
+
+        RangesByEndpoint transientRead = rbeTransient(r(0,20));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(transientRead)).build();
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testAllowAddingTransientReadWithFullWrite()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint fullWrite = rbe(r(0, 20));
+        PlacementDeltas addWrite = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(fullWrite)).build();
+
+        RangesByEndpoint transientRead = rbeTransient(r(0,20));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(transientRead)).build();
+        assertNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWrite, addRead));
+    }
+
+    @Test
+    public void testHasSplitTransientWriteReplica()
+    {
+        DataPlacements startPlacements = DataPlacements.EMPTY;
+        RangesByEndpoint writeReplicas1 = rbe(r(0, 20));
+        RangesByEndpoint writeReplicas2 = rbeTransient(r(20, 40));
+        PlacementDeltas addWriteFull = PlacementDeltas.builder()
+                                                  .put(params,
+                                                       addWriteDelta(writeReplicas1)).build();
+        PlacementDeltas addWriteTransient = PlacementDeltas.builder()
+                                                           .put(params,
+                                                           addWriteDelta(writeReplicas2)).build();
+
+        RangesByEndpoint readReplicas = rbe(r(0, 40));
+        PlacementDeltas addRead = PlacementDeltas.builder()
+                                                 .put(params,
+                                                      addReadDelta(readReplicas)).build();
+        assertNotNull(PlacementTransitionPlan.assertPreExistingWriteReplica(startPlacements, addWriteFull, addWriteTransient, addRead));
+    }
+
+    private PlacementDeltas.PlacementDelta addReadDelta(RangesByEndpoint replica)
+    {
+        return new PlacementDeltas.PlacementDelta(new Delta(RangesByEndpoint.EMPTY, replica), Delta.empty());
+    }
+
+    private PlacementDeltas.PlacementDelta addWriteDelta(RangesByEndpoint replica)
+    {
+        return new PlacementDeltas.PlacementDelta(Delta.empty(), new Delta(RangesByEndpoint.EMPTY, replica));
+    }
+
+    private RangesByEndpoint rbe(Range<Token> ... ranges)
+    {
+        RangesAtEndpoint.Builder builder = RangesAtEndpoint.builder(ep);
+        for (Range<Token> r : ranges)
+            builder.add(Replica.fullReplica(ep, r));
+        return new RangesByEndpoint(ImmutableMap.of(ep, builder.build()));
+    }
+
+    private RangesByEndpoint rbeTransient(Range<Token> ... ranges)
+    {
+        RangesAtEndpoint.Builder builder = RangesAtEndpoint.builder(ep);
+        for (Range<Token> r : ranges)
+            builder.add(Replica.transientReplica(ep, r));
+        return new RangesByEndpoint(ImmutableMap.of(ep, builder.build()));
+    }
+
+
+    private Range<Token> r(long start, long end)
+    {
+        return new Range<>(new Murmur3Partitioner.LongToken(start), new Murmur3Partitioner.LongToken(end));
+    }
+}

--- a/test/unit/org/apache/cassandra/tcm/ownership/UniformRangePlacementTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ownership/UniformRangePlacementTest.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.schema.ReplicationParams;
 import org.apache.cassandra.tcm.Epoch;
 
 import static org.apache.cassandra.tcm.membership.MembershipUtils.endpoint;
+import static org.apache.cassandra.tcm.ownership.OwnershipUtils.bytesToken;
 import static org.apache.cassandra.tcm.ownership.OwnershipUtils.token;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/test/unit/org/apache/cassandra/tcm/sequences/ProgressBarrierTest.java
+++ b/test/unit/org/apache/cassandra/tcm/sequences/ProgressBarrierTest.java
@@ -213,7 +213,7 @@ public class ProgressBarrierTest extends CMSTestBase
                             if (rf instanceof TokenPlacementModel.SimpleReplicationFactor)
                                 expected = rf.total() / 2 + 1;
                             else
-                                expected = rf.asMap().get(dc) / 2 + 1;
+                                expected = rf.asMap().get(dc).totalCount / 2 + 1;
                             Assert.assertTrue(String.format("Should have collected at least %d nodes but got %d." +
                                                             "\nRF: %s" +
                                                             "\nReplicas: %s" +
@@ -233,7 +233,7 @@ public class ProgressBarrierTest extends CMSTestBase
                             if (rf instanceof TokenPlacementModel.SimpleReplicationFactor)
                             {
                                 int actual = byDc.get(dc);
-                                int expected = rf.asMap().get(dc) / 2 + 1;
+                                int expected = rf.asMap().get(dc).totalCount / 2 + 1;
                                 Assert.assertTrue(String.format("Shuold have collected at least %d nodes, but got %d." +
                                                                 "\nRF: %s" +
                                                                 "\nNodes: %s", expected, byDc.size(), rf, byDc),
@@ -244,7 +244,7 @@ public class ProgressBarrierTest extends CMSTestBase
                                 for (Map.Entry<String, Integer> e : byDc.entrySet())
                                 {
                                     int actual = e.getValue();
-                                    int expected = rf.asMap().get(e.getKey()) / 2 + 1;
+                                    int expected = rf.asMap().get(e.getKey()).totalCount / 2 + 1;
                                     Assert.assertTrue(String.format("Shuold have collected at least %d nodes, but got %d." +
                                                                     "\nRF: %s" +
                                                                     "\nNodes: %s", expected, byDc.size(), rf, byDc),


### PR DESCRIPTION
When an instance moves from a transient to a full replica for a given range, it must begin acting as a full replica for writes before it does so for reads. Otherwise, consistency can be violated as data streamed to the instance early in the operation can be removed by cleanup if it occurs before the instance assumes responsibility for full writes. Also, coordinators will route read requests to instances which may not have received all preceding writes, causing unnecessary read repair or potentially inconsistent results. 

The root cause of the flaky test failure which originally produced this issue was that in `TransientRangeMovementTest::testRemoveNode` cleanup happened to run on one instance before it had enacted the final step of the removal operation, leading it to remove more data than it should. 


