### PR TITLE
Docs: Update CQL version in docker-run-cqlsh-quickstart.sh to match version in docker-run-cqlsh-load-data.

### DIFF
--- a/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
+++ b/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
@@ -1,3 +1,3 @@
 docker run --rm -it --network \
 cassandra nuvo/docker-cqlsh cqlsh cassandra \
-9042 --cqlversion='3.4.5' 
+9042 --cqlversion='3.4.6' 


### PR DESCRIPTION
Docs: Update CQL version in `docker-run-cqlsh-quickstart.sh` to match version in `docker-run-cqlsh-load-data`.


Description:

**Page**: [Quickstart](https://cassandra.apache.org/doc/latest/cassandra/getting-started/cassandra-quickstart.html) 

**Problem**: When following the Quickstart, the script in Step 5 throws an error because the CQL version is different than what's used in the script in Step 4.
 ```Connection error: ('Unable to connect to any servers', {'172.19.0.2': ProtocolError("cql_version '3.4.5' is not supported by remote (w/ native protocol). Supported versions: [u'3.4.6']",)})```

**Fix**: Step 5 script: Update the CQL version to match the version used in the Step 4 script.



patch by Aimee Ukasick (aimeeu.opensource@gmail.com) reviewed by TBD


