### PR TITLE
CASSANDRA-19498 Fixed ignoring username and password from the credentials file

### DIFF
--- a/conf/credentials.sample
+++ b/conf/credentials.sample
@@ -17,6 +17,15 @@
 ;
 ; Sample ~/.cassandra/credentials file.
 ;
+; The section name must match the classname from the cqlshrc file
+; For example, if cqlshrc contains settings
+;
+; [auth_provider]
+; module = cassandra.auth
+; classname = PlainTextAuthProvider
+;
+; then the credentials file should contain a [PlainTextAuthProvider] section with the username and password parameters, as indicated in this example
+;
 ; Please ensure this file is owned by the user and is not readable by group and other users
 
 [PlainTextAuthProvider]

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -44,6 +44,18 @@ Example config values and documentation can be found in the
 You can also view the latest version of the
 https://github.com/apache/cassandra/blob/trunk/conf/cqlshrc.sample[cqlshrc file online].
 
+[[credentials]]
+== credentials
+
+The credentials file contains the login and password for cqlsh
+The login and password must be located in a section whose name matches the classname from the [auth_provider] section of the cqlshrc file
+The credentials file must be owned by the user and no one else has permission to read the file.
+
+Example config values and documentation can be found in the
+`conf/credentials.sample` file of a tarball installation.
+You can also view the latest version of the
+https://github.com/apache/cassandra/blob/trunk/conf/credentials.sample[credentials file online].
+
 [[cql_history]]
 == cql history
 

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -1999,8 +1999,8 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
             print("\nWarning: Password is found in an insecure cqlshrc file. The file is owned or readable by other users on the system.",
                   end='', file=sys.stderr)
         print("\nNotice: Credentials in the cqlshrc file is deprecated and will be ignored in the future."
-              "\nPlease use a credentials file to specify the username and password."
-              "\nTo use basic authentication, place the username and password in the [PlainTextAuthProvider] section of the credentials file.\n", file=sys.stderr)
+              "\nFor basic authentication, please use a credentials file with username and password in the [PlainTextAuthProvider] section.",
+              file=sys.stderr)
 
     argvalues = argparse.Namespace()
 

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -1999,7 +1999,8 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
             print("\nWarning: Password is found in an insecure cqlshrc file. The file is owned or readable by other users on the system.",
                   end='', file=sys.stderr)
         print("\nNotice: Credentials in the cqlshrc file is deprecated and will be ignored in the future."
-              "\nPlease use a credentials file to specify the username and password.\n", file=sys.stderr)
+              "\nPlease use a credentials file to specify the username and password."
+              "\nTo use basic authentication, place the username and password in the [PlainTextAuthProvider] section of the credentials file.\n", file=sys.stderr)
 
     argvalues = argparse.Namespace()
 
@@ -2073,7 +2074,7 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
             credentials.read(options.credentials)
 
         # use the username from credentials file but fallback to cqlshrc if username is absent from the command line parameters
-        options.username = username_from_cqlshrc
+        options.username = option_with_default(credentials.get, 'plain_text_auth', 'username', username_from_cqlshrc)
 
     if not options.password:
         rawcredentials = configparser.RawConfigParser()
@@ -2082,7 +2083,7 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
 
         # handling password in the same way as username, priority cli > credentials > cqlshrc
         options.password = option_with_default(rawcredentials.get, 'plain_text_auth', 'password', password_from_cqlshrc)
-        options.password = password_from_cqlshrc
+        
     elif not options.insecure_password_without_warning:
         print("\nWarning: Using a password on the command line interface can be insecure."
               "\nRecommendation: use the credentials file to securely provide the password.\n", file=sys.stderr)

--- a/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_legacy
+++ b/pylib/cqlshlib/test/test_authproviderhandling_config/plain_text_legacy
@@ -1,0 +1,3 @@
+[plain_text_auth]
+password = pass4
+username = user4

--- a/pylib/cqlshlib/test/test_legacy_auth.py
+++ b/pylib/cqlshlib/test/test_legacy_auth.py
@@ -1,0 +1,55 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+import io
+import os
+import sys
+import pytest
+from unittest.mock import patch
+
+from cassandra.auth import PlainTextAuthProvider
+import cqlshlib.authproviderhandling as auth_prov
+from cqlshlib.test.test_authproviderhandling import construct_config_path, _assert_auth_provider_matches
+
+
+class CustomAuthLegacyTest(unittest.TestCase):
+
+    def setUp(self):
+        self._captured_std_err = io.StringIO()
+        sys.stderr = self._captured_std_err
+        self.fake_is_file_secure = lambda filename: True
+        self.patcher = patch('cqlshlib.util.is_file_secure', self.fake_is_file_secure)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self._captured_std_err.close()
+        sys.stdout = sys.__stderr__
+
+    def test_legacy_credentials(self):
+        from cqlshlib.util import is_file_secure
+        from bin.cqlsh import read_options as cqlsh_read_options
+
+        creds_file = construct_config_path('plain_text_legacy')
+        opts, _, _ = cqlsh_read_options(['--credentials='+creds_file], {})
+        actual = auth_prov.load_auth_provider(cred_file=creds_file, username=opts.username, password=opts.password)
+        _assert_auth_provider_matches(
+                actual,
+                PlainTextAuthProvider,
+                {"username": 'user4',
+                "password": 'pass4'})
+        


### PR DESCRIPTION
Now the username and password from credentials file can be used again.
Added description to notice on how to properly use the credentials file.
Added test to check legacy credential format
Added description of using AuthProvider to example config files and cqlsh documentation

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

