### PR TITLE
CommitlogArchiver only has granularity to seconds for restore_point_in_time

### DIFF
--- a/conf/commitlog_archiving.properties
+++ b/conf/commitlog_archiving.properties
@@ -37,12 +37,13 @@ restore_command=
 restore_directories=
 
 # Restore mutations created up to and including this timestamp in GMT.
-# Format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+# There are only three different formats to express three time precisions:
+# Seconds, Milliseconds, and Microseconds.
+# Seconds format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+# Milliseconds format: yyyy:MM:dd HH:mm:ss.SSS (2012:04:31 20:43:12.633)
+# Microseconds format: yyyy:MM:dd HH:mm:ss.SSSSSS (2012:04:31 20:43:12.633222)
 #
 # Recovery will continue through the segment when the first client-supplied
 # timestamp greater than this time is encountered, but only mutations less than
 # or equal to this timestamp will be applied.
 restore_point_in_time=
-
-# precision of the timestamp used in the inserts (MILLISECONDS, MICROSECONDS, ...)
-precision=MICROSECONDS

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -77,7 +77,7 @@ public class CommitLog implements CommitLogMBean
 
     final public AbstractCommitLogSegmentManager segmentManager;
 
-    public final CommitLogArchiver archiver;
+    public CommitLogArchiver archiver;
     public final CommitLogMetrics metrics;
     final AbstractCommitLogService executor;
 
@@ -181,8 +181,11 @@ public class CommitLog implements CommitLogMBean
         // archiving pass, which we should not treat as serious.
         for (File file : getUnmanagedFiles())
         {
-            archiver.maybeArchive(file.getPath(), file.getName());
-            archiver.maybeWaitForArchiving(file.getName());
+            if (file.exists())
+            {
+                archiver.maybeArchive(file.getPath(), file.getName());
+                archiver.maybeWaitForArchiving(file.getName());
+            }
         }
 
         assert archiver.archivePending.isEmpty() : "Not all commit log archive tasks were completed before restore";
@@ -395,13 +398,13 @@ public class CommitLog implements CommitLogMBean
     @Override
     public long getRestorePointInTime()
     {
-        return archiver.restorePointInTime;
+        return archiver.restorePointInTimeInMicros;
     }
 
-    @Override
-    public String getRestorePrecision()
+    @VisibleForTesting
+    public void setCommitlogArchiver(CommitLogArchiver archiver)
     {
-        return archiver.precision.toString();
+        this.archiver = archiver;
     }
 
     public List<String> getActiveSegmentNames()

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogMBean.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogMBean.java
@@ -41,19 +41,17 @@ public interface CommitLogMBean
 
     /**
      * Restore mutations created up to and including this timestamp in GMT
-     * Format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+     * There are only three different formats to express three time precisions:
+     * Seconds, Milliseconds, and Microseconds.
+     * Seconds format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+     * Milliseconds format: yyyy:MM:dd HH:mm:ss.SSS (2012:04:31 20:43:12.633)
+     * Microseconds format: yyyy:MM:dd HH:mm:ss.SSSSSS (2012:04:31 20:43:12.633222)
      *
      * Recovery will continue through the segment when the first client-supplied
      * timestamp greater than this time is encountered, but only mutations less than
      * or equal to this timestamp will be applied.
      */
     public long getRestorePointInTime();
-
-    /**
-     * get precision of the timestamp used in the restore (MILLISECONDS, MICROSECONDS, ...)
-     * to determine if passed the restore point in time.
-     */
-    public String getRestorePrecision();
 
     /**
      * Recover a single file.

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -76,7 +76,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
     private long pendingMutationBytes = 0;
 
     private final ReplayFilter replayFilter;
-    private final CommitLogArchiver archiver;
+    private CommitLogArchiver archiver;
 
     @VisibleForTesting
     protected boolean sawCDCMutation;
@@ -115,7 +115,8 @@ public class CommitLogReplayer implements CommitLogReadHandler
                 // Point in time restore is taken to mean that the tables need to be replayed even if they were
                 // deleted at a later point in time. Any truncation record after that point must thus be cleared prior
                 // to replay (CASSANDRA-9195).
-                long restoreTime = commitLog.archiver.restorePointInTime;
+                // truncatedTime is millseconds level but restoreTime is microlevel
+                long restoreTime = commitLog.archiver.restorePointInTimeInMicros == Long.MAX_VALUE ? Long.MAX_VALUE : commitLog.archiver.restorePointInTimeInMicros / 1000;
                 long truncatedTime = SystemKeyspace.getTruncatedAt(cfs.metadata.id);
                 if (truncatedTime > restoreTime)
                 {
@@ -419,11 +420,11 @@ public class CommitLogReplayer implements CommitLogReadHandler
 
     protected boolean pointInTimeExceeded(Mutation fm)
     {
-        long restoreTarget = archiver.restorePointInTime;
+        long tsInMicroSecondsLevel = archiver.restorePointInTimeInMicros;
 
         for (PartitionUpdate upd : fm.getPartitionUpdates())
         {
-            if (archiver.precision.toMillis(upd.maxTimestamp()) > restoreTarget)
+            if (upd.maxTimestamp() > tsInMicroSecondsLevel)
                 return true;
         }
         return false;
@@ -473,6 +474,12 @@ public class CommitLogReplayer implements CommitLogReadHandler
     {
         // Don't care about return value, use this simply to throw exception as appropriate.
         shouldSkipSegmentOnError(exception);
+    }
+
+    @VisibleForTesting
+    public void setCommitlogArchiver(CommitLogArchiver archiver)
+    {
+        this.archiver = archiver;
     }
 
     @SuppressWarnings("serial")

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/DropRecreateAndRestoreTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/DropRecreateAndRestoreTest.java
@@ -38,17 +38,17 @@ public class DropRecreateAndRestoreTest extends CQLTester
     {
         createTable("CREATE TABLE %s (a int, b int, c int, PRIMARY KEY(a, b))");
 
-        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 0, 0);
-        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 1, 1);
+        long timeInMicroSecond1 = System.currentTimeMillis() * 1000;
+        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?) USING TIMESTAMP ? ", 0, 0, 0, timeInMicroSecond1);
+        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?) USING TIMESTAMP ? ", 0, 1, 1, timeInMicroSecond1);
 
-
-        long time = System.currentTimeMillis();
         TableId id = currentTableMetadata().id;
         assertRows(execute("SELECT * FROM %s"), row(0, 0, 0), row(0, 1, 1));
         Thread.sleep(5);
 
-        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 0, 2);
-        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 3);
+        long timeInMicroSecond2 = System.currentTimeMillis() * 1000;
+        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?) USING TIMESTAMP ? ", 1, 0, 2, timeInMicroSecond2);
+        execute("INSERT INTO %s (a, b, c) VALUES (?, ?, ?) USING TIMESTAMP ? ", 1, 1, 3, timeInMicroSecond2);
         assertRows(execute("SELECT * FROM %s"), row(1, 0, 2), row(1, 1, 3), row(0, 0, 0), row(0, 1, 1));
 
         // Drop will flush and clean segments. Hard-link them so that they can be restored later.
@@ -68,13 +68,13 @@ public class DropRecreateAndRestoreTest extends CQLTester
             FileUtils.renameWithConfirm(new File(logPath, segment + ".save"), new File(logPath, segment));
         try
         {
-            // Restore to point in time.
-            CommitLog.instance.archiver.restorePointInTime = time;
+            // Restore to point in time (microseconds granularity)
+            CommitLog.instance.archiver.setRestorePointInTime(timeInMicroSecond1);
             CommitLog.instance.resetUnsafe(false);
         }
         finally
         {
-            CommitLog.instance.archiver.restorePointInTime = Long.MAX_VALUE;
+            CommitLog.instance.archiver.setRestorePointInTime(Long.MAX_VALUE);
         }
 
         assertRows(execute("SELECT * FROM %s"), row(0, 0, 0), row(0, 1, 1));

--- a/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/RecoveryManagerTest.java
@@ -252,14 +252,17 @@ public class RecoveryManagerTest
     public void testRecoverPIT() throws Exception
     {
         CommitLog.instance.resetUnsafe(true);
+        long originalPIT = CommitLog.instance.archiver.restorePointInTimeInMicros;
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
-        Date date = CommitLogArchiver.format.parse("2112:12:12 12:12:12");
-        long timeMS = date.getTime() - 5000;
 
+        // seconds level
+        // the archiver's restorePointInTime use the commitlog_archiving_properties file's
+        long rpiTs = CommitLogArchiver.getMicroSeconds("2112:12:12 12:12:12");
+        long timeInMicroLevel =  rpiTs - 5000;
         Keyspace keyspace1 = Keyspace.open(KEYSPACE1);
         for (int i = 0; i < 10; ++i)
         {
-            long ts = TimeUnit.MILLISECONDS.toMicros(timeMS + (i * 1000));
+            long ts = timeInMicroLevel + (i * 1000);
             new RowUpdateBuilder(cfs.metadata(), ts, "name-" + i)
                 .clustering("cc")
                 .add("val", Integer.toString(i))
@@ -269,11 +272,66 @@ public class RecoveryManagerTest
 
         // Sanity check row count prior to clear and replay
         assertEquals(10, Util.getAll(Util.cmd(cfs).build()).size());
+        keyspace1.getColumnFamilyStore(CF_STANDARD1).clearUnsafe();
+        CommitLog.instance.resetUnsafe(false);
+        assertEquals(6, Util.getAll(Util.cmd(cfs).build()).size());
+        //reset the rpi
+        CommitLog.instance.archiver.setRestorePointInTime(originalPIT);
 
         keyspace1.getColumnFamilyStore("Standard1").clearUnsafe();
-        CommitLog.instance.resetUnsafe(false);
+        CommitLog.instance.resetUnsafe(true);
+        cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
+        keyspace1 = Keyspace.open(KEYSPACE1);
 
+        // milseconds level
+        keyspace1.getColumnFamilyStore(CF_STANDARD1).clearUnsafe();
+        rpiTs = CommitLogArchiver.getMicroSeconds("2112:12:12 12:12:12.063");
+        timeInMicroLevel = rpiTs - 5000;
+        keyspace1 = Keyspace.open(KEYSPACE1);
+        for (int i = 0; i < 10; ++i)
+        {
+            long ts = timeInMicroLevel + (i * 1000);
+            new RowUpdateBuilder(cfs.metadata(), ts, "name-" + i)
+                    .clustering("cc")
+                    .add("val", Integer.toString(i))
+                    .build()
+                    .apply();
+        }
+        // Sanity check row count prior to clear and replay
+        assertEquals(10, Util.getAll(Util.cmd(cfs).build()).size());
+        keyspace1.getColumnFamilyStore(CF_STANDARD1).clearUnsafe();
+        CommitLog.instance.archiver.setRestorePointInTime(rpiTs);
+        CommitLog.instance.resetUnsafe(false);
         assertEquals(6, Util.getAll(Util.cmd(cfs).build()).size());
+
+        //reset the rpi
+        CommitLog.instance.archiver.setRestorePointInTime(originalPIT);
+        CommitLog.instance.resetUnsafe(true);
+        cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
+        keyspace1 = Keyspace.open(KEYSPACE1);
+
+        // milseconds level
+        keyspace1.getColumnFamilyStore(CF_STANDARD1).clearUnsafe();
+        rpiTs = CommitLogArchiver.getMicroSeconds("2112:12:12 12:12:12.063222");
+        timeInMicroLevel = rpiTs - 5000;
+        keyspace1 = Keyspace.open(KEYSPACE1);
+        for (int i = 0; i < 10; ++i)
+        {
+            long ts = timeInMicroLevel + (i * 1000);
+            new RowUpdateBuilder(cfs.metadata(), ts, "name-" + i)
+                    .clustering("cc")
+                    .add("val", Integer.toString(i))
+                    .build()
+                    .apply();
+        }
+        // Sanity check row count prior to clear and replay
+        assertEquals(10, Util.getAll(Util.cmd(cfs).build()).size());
+        keyspace1.getColumnFamilyStore(CF_STANDARD1).clearUnsafe();
+        CommitLog.instance.archiver.setRestorePointInTime(rpiTs);
+        CommitLog.instance.resetUnsafe(false);
+        assertEquals(6, Util.getAll(Util.cmd(cfs).build()).size());
+        //reset the rpi
+        CommitLog.instance.archiver.setRestorePointInTime(originalPIT);
     }
 
     @Test
@@ -282,13 +340,11 @@ public class RecoveryManagerTest
         CommitLog.instance.resetUnsafe(true);
         Keyspace keyspace1 = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace1.getColumnFamilyStore(CF_STATIC1);
-        Date date = CommitLogArchiver.format.parse("2112:12:12 12:12:12");
-        long timeMS = date.getTime() - 5000;
 
-
+        long timeInMicroLevel = CommitLogArchiver.getMicroSeconds("2112:12:12 12:12:12") - 5000;
         for (int i = 0; i < 10; ++i)
         {
-            long ts = TimeUnit.MILLISECONDS.toMicros(timeMS + (i * 1000));
+            long ts = timeInMicroLevel + (i * 1000);
             new RowUpdateBuilder(cfs.metadata(), ts, "name-" + i)
             .add("val", Integer.toString(i))
             .build()
@@ -309,8 +365,8 @@ public class RecoveryManagerTest
     {
         CommitLog.instance.resetUnsafe(true);
         ColumnFamilyStore cfs = Keyspace.open(KEYSPACE1).getColumnFamilyStore(CF_STANDARD1);
-        Date date = CommitLogArchiver.format.parse("2112:12:12 12:12:12");
-        long timeMS = date.getTime();
+        // 2112:12:12 12:12:12 is from the commitlog_archiving.properties file for testing
+        long timeInMicroLevel = CommitLogArchiver.getMicroSeconds("2112:12:12 12:12:12");
 
         Keyspace keyspace1 = Keyspace.open(KEYSPACE1);
 
@@ -319,9 +375,9 @@ public class RecoveryManagerTest
         {
             long ts;
             if (i == 9)
-                ts = TimeUnit.MILLISECONDS.toMicros(timeMS - 1000);
+                ts = timeInMicroLevel - 1000;
             else
-                ts = TimeUnit.MILLISECONDS.toMicros(timeMS + (i * 1000));
+                ts = timeInMicroLevel + (i * 1000);
 
             new RowUpdateBuilder(cfs.metadata(), ts, "name-" + i)
                 .clustering("cc")
@@ -333,7 +389,7 @@ public class RecoveryManagerTest
         // Sanity check row count prior to clear and replay
         assertEquals(10, Util.getAll(Util.cmd(cfs).build()).size());
 
-        keyspace1.getColumnFamilyStore("Standard1").clearUnsafe();
+        keyspace1.getColumnFamilyStore(CF_STANDARD1).clearUnsafe();
         CommitLog.instance.resetUnsafe(false);
 
         assertEquals(2, Util.getAll(Util.cmd(cfs).build()).size());

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogArchiverTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogArchiverTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.io.util.FileUtils;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertTrue;
+
+public class CommitLogArchiverTest extends CQLTester
+{
+    private static Path dirName = Paths.get("/tmp/backup_commitlog_for_test");
+    private static String rpiTime = "2024:03:22 20:43:12.633222";
+    private static CommitLogArchiver archiver;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException
+    {
+        assert !Files.exists(dirName);
+        Files.createDirectory(dirName);
+        CommitLog commitLog = CommitLog.instance;
+        Properties properties = new Properties();
+        archiver = commitLog.archiver;
+        properties.putAll(new HashMap<String, String>() {{
+                          put("archive_command", "/bin/cp %path " + dirName.toString());
+                          put("restore_command", "/bin/cp -f %from %to");
+                          put("restore_directories", dirName.toString());
+                          put("restore_point_in_time", rpiTime);}});
+        CommitLogArchiver commitLogArchiver = CommitLogArchiver.getArchiverFromProperty(properties);
+        commitLog.setCommitlogArchiver(commitLogArchiver);
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        File dir = dirName.toFile();
+        assert dir.exists() && dir.isDirectory();
+        FileUtils.deleteRecursive(dir);
+    }
+
+    @Test
+    public void testArchiver()
+    {
+        File dir = dirName.toFile();
+        assertTrue(dir.isDirectory() && dir.listFiles().length == 0);
+        String table = createTable(KEYSPACE, "CREATE TABLE %s (a TEXT PRIMARY KEY, b TEXT);");
+
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(table);
+        long ts = CommitLogArchiver.getMicroSeconds(rpiTime);
+        String value = "";
+        // Make sure that new CommitLogSegment will be allocated as the CommitLogSegment size is 5M
+        // and if new CommitLogSegment is allocated then the old CommitLogSegment will be archived.
+        for (int i = 0; i != 50000; ++i)
+        {
+            value += i;
+        }
+        for (int i = 1; i <= 2000; ++i)
+        {
+            new RowUpdateBuilder(cfs.metadata(), ts - i, "name-" + i)
+                    .add("b", value)
+                    .build()
+                    .apply();
+        }
+
+        // If the number of files that under backup dir is bigger than 1, that means the
+        // arhiver for commitlog is effective.
+        assertTrue(dir.isDirectory() && dir.listFiles().length > 0);
+        // wait for all task to be executed
+        Map<String, Future<?>> archivePending = CommitLog.instance.archiver.archivePending;
+        CommitLogArchiver oldArchive = CommitLog.instance.archiver;
+        CommitLog.instance.setCommitlogArchiver(archiver);
+        for (String name : archivePending.keySet())
+        {
+            oldArchive.maybeWaitForArchiving(name);
+        }
+    }
+}


### PR DESCRIPTION
 for CASSANDRA-19448 4.0

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

