### PR TITLE
CASSANDRA-19532: Allow operators to disable the execution of triggers

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1695,7 +1695,7 @@ user_defined_functions_enabled: false
 # `enabled` executes queries and their triggers.
 # `disabled` executes queries but skips trigger execution, and logs a warning.
 # `forbidden` fails queries that would execute triggers with TriggerDisabledException.
-triggers_policy: enabled
+triggers_enabled: enabled
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1691,6 +1691,12 @@ trace_type_repair_ttl: 7d
 # As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
 user_defined_functions_enabled: false
 
+# Triggers are enabled by default.
+# `enabled` executes queries and their triggers.
+# `disabled` executes queries but skips trigger execution, and logs a warning.
+# `forbidden` fails queries that would execute triggers with TriggerDisabledException.
+triggers_policy: enabled
+
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
 # the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1695,7 +1695,7 @@ user_defined_functions_enabled: false
 # `enabled` executes queries and their triggers.
 # `disabled` executes queries but skips trigger execution, and logs a warning.
 # `forbidden` fails queries that would execute triggers with TriggerDisabledException.
-triggers_enabled: enabled
+triggers_policy: enabled
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -1655,6 +1655,12 @@ trace_type_repair_ttl: 7d
 # As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
 user_defined_functions_enabled: false
 
+# Triggers are enabled by default.
+# `enabled` executes queries and their triggers.
+# `disabled` executes queries but skips trigger execution, and logs a warning.
+# `forbidden` fails queries that would execute triggers with TriggerDisabledException.
+triggers_policy: enabled
+
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
 # the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -1659,7 +1659,7 @@ user_defined_functions_enabled: false
 # `enabled` executes queries and their triggers.
 # `disabled` executes queries but skips trigger execution, and logs a warning.
 # `forbidden` fails queries that would execute triggers with TriggerDisabledException.
-triggers_enabled: enabled
+triggers_policy: enabled
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -1659,7 +1659,7 @@ user_defined_functions_enabled: false
 # `enabled` executes queries and their triggers.
 # `disabled` executes queries but skips trigger execution, and logs a warning.
 # `forbidden` fails queries that would execute triggers with TriggerDisabledException.
-triggers_policy: enabled
+triggers_enabled: enabled
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by

--- a/doc/modules/cassandra/pages/developing/cql/triggers.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/triggers.adoc
@@ -48,3 +48,7 @@ For instance:
 ----
 include::cassandra:example$CQL/drop_trigger.cql[]
 ----
+
+Triggers can be disabled in two steps. `triggers_policy` is `enabled` by default, which runs all created triggers as
+mutations are executed. `disabled` skips trigger execution but otherwise executes query operations as normal (and logs a
+warning). `forbidden` will fail queries that would execute triggers.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -1311,5 +1311,5 @@ public class Config
         forbidden
     }
 
-    public TriggersPolicy triggers_enabled = TriggersPolicy.enabled;
+    public TriggersPolicy triggers_policy = TriggersPolicy.enabled;
 }

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -1311,5 +1311,5 @@ public class Config
         forbidden
     }
 
-    public volatile TriggersPolicy triggers_policy = TriggersPolicy.enabled;
+    public TriggersPolicy triggers_policy = TriggersPolicy.enabled;
 }

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -1300,4 +1300,16 @@ public class Config
     public volatile DurationSpec.LongMillisecondsBound progress_barrier_backoff = new DurationSpec.LongMillisecondsBound("1000ms");
     public volatile DurationSpec.LongSecondsBound discovery_timeout = new DurationSpec.LongSecondsBound("30s");
     public boolean unsafe_tcm_mode = false;
+
+    public enum TriggersPolicy
+    {
+        // Execute triggers
+        enabled,
+        // Don't execute triggers when executing queries
+        disabled,
+        // Throw an exception when attempting to execute a trigger
+        forbidden
+    }
+
+    public volatile TriggersPolicy triggers_policy = TriggersPolicy.enabled;
 }

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -1311,5 +1311,5 @@ public class Config
         forbidden
     }
 
-    public TriggersPolicy triggers_policy = TriggersPolicy.enabled;
+    public TriggersPolicy triggers_enabled = TriggersPolicy.enabled;
 }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -5153,4 +5153,15 @@ public class DatabaseDescriptor
     {
         return conf.sai_sstable_indexes_per_query_fail_threshold;
     }
+
+    public static void setTriggersPolicy(Config.TriggersPolicy policy)
+    {
+        logger.info("triggers_policy set to {}", policy);
+        conf.triggers_policy = policy;
+    }
+
+    public static Config.TriggersPolicy getTriggersPolicy()
+    {
+        return conf.triggers_policy;
+    }
 }

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -5154,6 +5154,7 @@ public class DatabaseDescriptor
         return conf.sai_sstable_indexes_per_query_fail_threshold;
     }
 
+    @VisibleForTesting
     public static void setTriggersPolicy(Config.TriggersPolicy policy)
     {
         logger.info("triggers_policy set to {}", policy);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTriggerStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTriggerStatement.java
@@ -21,6 +21,7 @@ import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QualifiedName;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.*;
 import org.apache.cassandra.schema.Keyspaces.KeyspacesDiff;
 import org.apache.cassandra.service.ClientState;
@@ -72,11 +73,13 @@ public final class CreateTriggerStatement extends AlterSchemaStatement
 
         try
         {
-            TriggerExecutor.instance.loadTriggerInstance(triggerClass);
+            TriggerExecutor.instance.loadTriggerClass(triggerClass);
         }
         catch (Exception e)
         {
-            throw ire("Trigger class '%s' couldn't be loaded", triggerClass);
+            InvalidRequestException thrown = ire("Trigger class '%s' couldn't be loaded", triggerClass);
+            thrown.initCause(e);
+            throw thrown;
         }
 
         TableMetadata newTable = table.withSwapped(table.triggers.with(TriggerMetadata.create(triggerName, triggerClass)));

--- a/src/java/org/apache/cassandra/triggers/TriggerDisabledException.java
+++ b/src/java/org/apache/cassandra/triggers/TriggerDisabledException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.triggers;
+
+import org.apache.cassandra.exceptions.InvalidRequestException;
+
+public class TriggerDisabledException extends InvalidRequestException
+{
+    public TriggerDisabledException(String message)
+    {
+        super(message);
+    }
+}

--- a/test/unit/org/apache/cassandra/config/DatabaseDescriptorRefTest.java
+++ b/test/unit/org/apache/cassandra/config/DatabaseDescriptorRefTest.java
@@ -95,6 +95,7 @@ public class DatabaseDescriptorRefTest
     "org.apache.cassandra.config.Config$PaxosVariant",
     "org.apache.cassandra.config.Config$RepairCommandPoolFullStrategy",
     "org.apache.cassandra.config.Config$SSTableConfig",
+    "org.apache.cassandra.config.Config$TriggersPolicy",
     "org.apache.cassandra.config.Config$UserFunctionTimeoutPolicy",
     "org.apache.cassandra.config.ConfigBeanInfo",
     "org.apache.cassandra.config.ConfigCustomizer",

--- a/test/unit/org/apache/cassandra/triggers/TriggersTest.java
+++ b/test/unit/org/apache/cassandra/triggers/TriggersTest.java
@@ -49,7 +49,6 @@ import static org.apache.cassandra.utils.ByteBufferUtil.toInt;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class TriggersTest
 {

--- a/test/unit/org/apache/cassandra/triggers/TriggersTest.java
+++ b/test/unit/org/apache/cassandra/triggers/TriggersTest.java
@@ -142,9 +142,9 @@ public class TriggersTest
     @Test
     public void executeTriggerOnCqlInsert() throws Exception
     {
-        String cql = String.format("INSERT INTO %s.%s (k, v1) VALUES (0, 0)", ksName, cfName);
+        String cql = String.format("INSERT INTO %s.%s (k, v1) VALUES (3, 3)", ksName, cfName);
         QueryProcessor.process(cql, ConsistencyLevel.ONE);
-        assertUpdateIsAugmented(0, "v1", 0);
+        assertUpdateIsAugmented(3, "v1", 3);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/triggers/TriggersTest.java
+++ b/test/unit/org/apache/cassandra/triggers/TriggersTest.java
@@ -39,7 +39,6 @@ import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.RowUpdateBuilder;
 import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.service.StorageService;
@@ -119,18 +118,11 @@ public class TriggersTest
         QueryProcessor.process(String.format("DELETE FROM %s.%s WHERE k = 0", ksName, cfName), ConsistencyLevel.ONE);
 
         DatabaseDescriptor.setTriggersPolicy(TriggersPolicy.forbidden);
-        try
-        {
+        Assertions.assertThatThrownBy(() -> {
             QueryProcessor.process(String.format("INSERT INTO %s.%s (k, v1) VALUES (0, 0)", ksName, cfName), ConsistencyLevel.ONE);
-            fail("Expected failure");
-        }
-        catch (Exception exception)
-        {
-            logger.info("Got expected exception when attempting to execute disabled trigger", exception);
-            Assertions.assertThat(exception)
-                      .isInstanceOf(TriggerDisabledException.class)
-                      .hasMessageContaining(TestTrigger.class.getName());
-        }
+        })
+        .isInstanceOf(TriggerDisabledException.class)
+        .hasMessageContaining(TestTrigger.class.getName());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/triggers/TriggersTest.java
+++ b/test/unit/org/apache/cassandra/triggers/TriggersTest.java
@@ -19,29 +19,43 @@ package org.apache.cassandra.triggers;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.SchemaLoader;
-import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.config.Config.TriggersPolicy;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.UntypedResultSet;
-import org.apache.cassandra.db.*;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.Mutation;
+import org.apache.cassandra.db.RowUpdateBuilder;
 import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
+import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
+import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.utils.ByteBufferUtil.toInt;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TriggersTest
 {
+    private static final Logger logger = LoggerFactory.getLogger(TriggersTest.class);
+    private TriggersPolicy originalTriggersPolicy;
     private static boolean triggerCreated = false;
 
     private static String ksName = "triggers_test_ks";
@@ -58,6 +72,7 @@ public class TriggersTest
     public void setup() throws Exception
     {
         StorageService.instance.initServer();
+        originalTriggersPolicy = DatabaseDescriptor.getTriggersPolicy();
 
         String cql = String.format("CREATE KEYSPACE IF NOT EXISTS %s " +
                                    "WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}",
@@ -70,13 +85,66 @@ public class TriggersTest
         cql = String.format("CREATE TABLE IF NOT EXISTS %s.%s (k int, v1 int, v2 int, PRIMARY KEY (k))", ksName, otherCf);
         QueryProcessor.process(cql, ConsistencyLevel.ONE);
 
+        DatabaseDescriptor.setTriggersPolicy(TriggersPolicy.enabled);
+
         // no conditional execution of create trigger stmt yet
-        if (! triggerCreated)
+        if (!triggerCreated)
         {
             cql = String.format("CREATE TRIGGER trigger_1 ON %s.%s USING '%s'",
                                 ksName, cfName, TestTrigger.class.getName());
             QueryProcessor.process(cql, ConsistencyLevel.ONE);
             triggerCreated = true;
+        }
+    }
+
+    @After
+    public void after()
+    {
+        DatabaseDescriptor.setTriggersPolicy(originalTriggersPolicy);
+    }
+
+    @Test
+    public void testTriggersPolicy()
+    {
+        QueryProcessor.process(String.format("INSERT INTO %s.%s (k, v1) VALUES (0, 0)", ksName, cfName), ConsistencyLevel.ONE);
+        assertUpdateIsAugmented(0, "v1", 0);
+        QueryProcessor.process(String.format("DELETE FROM %s.%s WHERE k = 0", ksName, cfName), ConsistencyLevel.ONE);
+
+        DatabaseDescriptor.setTriggersPolicy(TriggersPolicy.disabled);
+        QueryProcessor.process(String.format("INSERT INTO %s.%s (k, v1) VALUES (0, 0)", ksName, cfName), ConsistencyLevel.ONE);
+
+        UntypedResultSet rs = QueryProcessor.process(String.format("SELECT * FROM %s.%s WHERE k=%s", ksName, cfName, 0), ConsistencyLevel.ONE);
+        assertRowValue(rs.one(), 0, "v1", 0); // from original update
+        assertEquals(-1, rs.one().getInt("v2", -1)); // from trigger
+        QueryProcessor.process(String.format("DELETE FROM %s.%s WHERE k = 0", ksName, cfName), ConsistencyLevel.ONE);
+
+        DatabaseDescriptor.setTriggersPolicy(TriggersPolicy.forbidden);
+        try
+        {
+            QueryProcessor.process(String.format("INSERT INTO %s.%s (k, v1) VALUES (0, 0)", ksName, cfName), ConsistencyLevel.ONE);
+            fail("Expected failure");
+        }
+        catch (Exception exception)
+        {
+            logger.info("Got expected exception when attempting to execute disabled trigger", exception);
+            Assertions.assertThat(exception)
+                      .isInstanceOf(TriggerDisabledException.class)
+                      .hasMessageContaining(TestTrigger.class.getName());
+        }
+    }
+
+    @Test
+    public void triggerClassNotInitializedOnCreate()
+    {
+        for (TriggersPolicy policy : new TriggersPolicy[]{TriggersPolicy.disabled, TriggersPolicy.forbidden})
+        {
+            DatabaseDescriptor.setTriggersPolicy(policy);
+            String cql = String.format("CREATE TRIGGER initializationdetector ON %s.%s USING '%s'", ksName, cfName, InitializationDetector.class.getName());
+            QueryProcessor.process(cql, ConsistencyLevel.ONE);
+            Assert.assertFalse(INITIALIZATION_DETECTOR_MARKER.get());
+
+            cql = String.format("DROP TRIGGER initializationdetector ON %s.%s", ksName, cfName);
+            QueryProcessor.process(cql, ConsistencyLevel.ONE);
         }
     }
 
@@ -190,7 +258,6 @@ public class TriggersTest
         assertRowValue(rs.one(), key, "v2", 999); // from trigger
         assertRowValue(rs.one(), key, originColumnName, originColumnValue); // from original update
     }
-    
     private void assertRowValue(UntypedResultSet.Row row, int key, String columnName, Object columnValue)
     {
         assertTrue(String.format("Expected value (%s) for augmented cell %s was not found", key, columnName),
@@ -209,7 +276,8 @@ public class TriggersTest
     {
         public Collection<Mutation> augment(Partition partition)
         {
-            RowUpdateBuilder update = new RowUpdateBuilder(partition.metadata(), FBUtilities.timestampMicros(), partition.partitionKey().getKey());
+            // Use a fixed early timestamp so this update can be deleted
+            RowUpdateBuilder update = new RowUpdateBuilder(partition.metadata(), 1L, partition.partitionKey().getKey());
             update.add("v2", 999);
 
             return Collections.singletonList(update.build());
@@ -245,6 +313,31 @@ public class TriggersTest
         public Collection<Mutation> augment(Partition partition)
         {
             throw new org.apache.cassandra.exceptions.InvalidRequestException(MESSAGE);
+        }
+    }
+
+    public static class NoOpTrigger implements ITrigger
+    {
+        public Collection<Mutation> augment(Partition partition)
+        {
+            return null;
+        }
+    }
+
+    // This is not part of InitializationDetector because if it was, accessing it would initialize the class
+    final static AtomicBoolean INITIALIZATION_DETECTOR_MARKER = new AtomicBoolean();
+    public static class InitializationDetector implements ITrigger
+    {
+
+        static
+        {
+            logger.info("{} static block was executed", InitializationDetector.class.getSimpleName());
+            INITIALIZATION_DETECTOR_MARKER.set(true);
+        }
+
+        public Collection<Mutation> augment(Partition partition)
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
This PR adds a new TriggersPolicy configuration to allow operators to disable the execution of triggers. It does not prevent the creation of triggers (with CQL's CREATE TRIGGER) because Config can change between initial creation and metadata replay, and we don't want to break replay if triggers are disabled but still present in replay. So triggers can still be created with `TriggersPolicy.{disabled,forbidden}`, but care has been taken to prevent the trigger creation from executing class initialization (and static blocks).

This has already been reviewed by @beobal.