### PR TITLE
CASSANDRA-19378 skip jacocoInit in JMXStandardsTest

### DIFF
--- a/test/unit/org/apache/cassandra/tools/JMXStandardsTest.java
+++ b/test/unit/org/apache/cassandra/tools/JMXStandardsTest.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -111,6 +112,11 @@ public class JMXStandardsTest
                                                          .add(Exception.class)
                                                          .build();
 
+    /**
+     * These are the method names that shouldn't be included in this test
+     */
+    private static final Set<String> IGNORE_METHODS = ImmutableSet.of("$jacocoInit");
+
     @Test
     public void interfaces() throws ClassNotFoundException
     {
@@ -127,7 +133,9 @@ public class JMXStandardsTest
             for (Class<?> klass = Class.forName(className); klass != null && !Object.class.equals(klass); klass = klass.getSuperclass())
             {
                 Assertions.assertThat(klass).isInterface();
-                Method[] methods = klass.getDeclaredMethods();
+                Method[] methods = Arrays.stream(klass.getDeclaredMethods())
+                                         .filter(m -> !IGNORE_METHODS.contains(m.getName()))
+                                         .toArray(Method[]::new);
                 for (int i = 0; i < methods.length; i++)
                 {
                     Method method = methods[i];


### PR DESCRIPTION
Add IGNORE_METHODS to skip check for $jacocoInit method

```
skip $jacocoInit method in JMXStandardsTest

patch by Yuqi Yan; reviewed by <Reviewers> for CASSANDRA-19378

```

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19378)

