### PR TITLE
CASSANDRA-19483 return null on invalid legacy protocol magic

### DIFF
--- a/src/java/org/apache/cassandra/net/HandshakeProtocol.java
+++ b/src/java/org/apache/cassandra/net/HandshakeProtocol.java
@@ -34,7 +34,7 @@ import org.apache.cassandra.utils.memory.BufferPools;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.cassandra.locator.InetAddressAndPort.Serializer.inetAddressAndPortSerializer;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
-import static org.apache.cassandra.net.Message.validateLegacyProtocolMagic;
+import static org.apache.cassandra.net.Message.hasValidLegacyProtocolMagic;
 import static org.apache.cassandra.net.Crc.*;
 import static org.apache.cassandra.net.OutboundConnectionSettings.*;
 
@@ -147,7 +147,10 @@ class HandshakeProtocol
             int start = nio.position();
             try (DataInputBuffer in = new DataInputBuffer(nio, false))
             {
-                validateLegacyProtocolMagic(in.readInt());
+                if (!hasValidLegacyProtocolMagic(in.readInt())) {
+                    return null;
+                }
+
                 int flags = in.readInt();
 
                 // legacy pre40 messagingVersion flag

--- a/src/java/org/apache/cassandra/net/HandshakeProtocol.java
+++ b/src/java/org/apache/cassandra/net/HandshakeProtocol.java
@@ -147,7 +147,8 @@ class HandshakeProtocol
             int start = nio.position();
             try (DataInputBuffer in = new DataInputBuffer(nio, false))
             {
-                if (!hasValidLegacyProtocolMagic(in.readInt())) {
+                if (!hasValidLegacyProtocolMagic(in.readInt()))
+                {
                     return null;
                 }
 

--- a/src/java/org/apache/cassandra/net/InboundMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/InboundMessageHandler.java
@@ -302,10 +302,7 @@ public class InboundMessageHandler extends AbstractMessageHandler
 
         JVMStabilityInspector.inspectThrowable(cause);
 
-        if (cause instanceof Message.InvalidLegacyProtocolMagic)
-            logger.error("{} invalid, unrecoverable CRC mismatch detected while reading messages - closing the connection", id());
-        else
-            logger.error("{} unexpected exception caught while processing inbound messages; terminating connection", id(), cause);
+        logger.error("{} unexpected exception caught while processing inbound messages; terminating connection", id(), cause);
 
         channel.close();
     }

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -447,16 +447,6 @@ public class Message<T>
         return isValid;
     }
 
-    public static final class InvalidLegacyProtocolMagic extends IOException
-    {
-        public final int read;
-        private InvalidLegacyProtocolMagic(int read)
-        {
-            super(String.format("Read %d, Expected %d", read, PROTOCOL_MAGIC));
-            this.read = read;
-        }
-    }
-
     public String toString()
     {
         return "(from:" + from() + ", type:" + verb().stage + " verb:" + verb() + ')';

--- a/src/java/org/apache/cassandra/net/Message.java
+++ b/src/java/org/apache/cassandra/net/Message.java
@@ -437,10 +437,14 @@ public class Message<T>
     /** we preface every message with this number so the recipient can validate the sender is sane */
     static final int PROTOCOL_MAGIC = 0xCA552DFA;
 
-    static void validateLegacyProtocolMagic(int magic) throws InvalidLegacyProtocolMagic
+    static boolean hasValidLegacyProtocolMagic(int magic)
     {
-        if (magic != PROTOCOL_MAGIC)
-            throw new InvalidLegacyProtocolMagic(magic);
+        boolean isValid = magic == PROTOCOL_MAGIC;
+        if (!isValid)
+        {
+            noSpam1m.warn("Invalid legacy protocol magic. Read {}, expected {}", magic, PROTOCOL_MAGIC);
+        }
+        return isValid;
     }
 
     public static final class InvalidLegacyProtocolMagic extends IOException


### PR DESCRIPTION
Changed handling of invalid legacy protocol magic. We used to throw an `InvalidLegacyProtocolMagic`. With this PR `null` will be returned instead and that case will be logged at `WARN` with `NoSpamLogger`

```
return null on invalid legacy protocol magic

patch by ilyazr; reviewed by <Reviewers> for CASSANDRA-19483 

```

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19483)

