### PR TITLE
[CASSANDRA-15439] Add option to override the FatClient timeout for Bootstrapping nodes

### DIFF
--- a/conf/jvm-server.options
+++ b/conf/jvm-server.options
@@ -74,6 +74,10 @@
 # before joining the ring.
 #-Dcassandra.ring_delay_ms=ms
 
+# Allows overriding the timeout after which an unresponsive bootstrapping node is considered failed
+# and is removed from gossip state and bootstrapTokens. (Default: cassandra.ring_delay)
+#-Dcassandra.failed_bootstrap_timeout_ms=ms
+
 # Set the SSL port for encrypted communication. (Default: 7001)
 #-Dcassandra.ssl_storage_port=port
 

--- a/conf/jvm-server.options
+++ b/conf/jvm-server.options
@@ -75,7 +75,7 @@
 #-Dcassandra.ring_delay_ms=ms
 
 # Allows overriding the timeout after which an unresponsive bootstrapping node is considered failed
-# and is removed from gossip state and bootstrapTokens. (Default: cassandra.ring_delay)
+# and is removed from gossip state and bootstrapTokens. (Default: cassandra.ring_delay * 2)
 #-Dcassandra.failed_bootstrap_timeout_ms=ms
 
 # Set the SSL port for encrypted communication. (Default: 7001)

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -155,6 +155,8 @@ public enum CassandraRelevantProperties
 
     RING_DELAY("cassandra.ring_delay_ms"),
 
+    FAILED_BOOTSTRAP_TIMEOUT("cassandra.failed_bootstrap_timeout_ms"),
+
     /**
      * When bootstraping we wait for all schema versions found in gossip to be seen, and if not seen in time we fail
      * the bootstrap; this property will avoid failing and allow bootstrap to continue if set to true.

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -293,7 +293,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         }
         else
         {
-            return FAT_CLIENT_TIMEOUT;
+            return FAT_CLIENT_TIMEOUT * 2;
         }
     }
 

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -123,6 +123,9 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         SILENT_SHUTDOWN_STATES.add(VersionedValue.STATUS_BOOTSTRAPPING);
         SILENT_SHUTDOWN_STATES.add(VersionedValue.STATUS_BOOTSTRAPPING_REPLACE);
     }
+
+    static final List<String> BOOTSTRAPPING_STATES = Arrays.asList(VersionedValue.STATUS_BOOTSTRAPPING,
+            VersionedValue.STATUS_BOOTSTRAPPING_REPLACE);
     private static final List<String> ADMINISTRATIVELY_INACTIVE_STATES = Arrays.asList(VersionedValue.HIBERNATE,
                                                                                        VersionedValue.REMOVED_TOKEN,
                                                                                        VersionedValue.STATUS_LEFT);
@@ -142,7 +145,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
 
     // Maximimum difference between generation value and local time we are willing to accept about a peer
     static final int MAX_GENERATION_DIFFERENCE = 86400 * 365;
-    private final long fatClientTimeout;
+
+    // half of QUARATINE_DELAY, to ensure justRemovedEndpoints has enough leeway to prevent re-gossip
+    private static final long FAT_CLIENT_TIMEOUT = (QUARANTINE_DELAY / 2);
+    private static final long FAILED_BOOTSTRAP_TIMEOUT = getFailedBootstrapTimeout();
     private final Random random = new Random();
 
     /* subscribers for interest in EndpointState change */
@@ -272,6 +278,25 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         return 259200 * 1000; // 3 days
     }
 
+    private static long getFailedBootstrapTimeout()
+    {
+        String newtimeout = CassandraRelevantProperties.FAILED_BOOTSTRAP_TIMEOUT.getString();
+        if (newtimeout != null)
+        {
+            long longValue = Long.parseLong(newtimeout);
+            if (longValue == -1)
+            {
+                longValue = Long.MAX_VALUE;
+            }
+            logger.info("Overriding FAILED_BOOTSTRAP_TIMEOUT to {}ms", longValue);
+            return longValue;
+        }
+        else
+        {
+            return FAT_CLIENT_TIMEOUT;
+        }
+    }
+
     private static boolean isInGossipStage()
     {
         return Stage.GOSSIP.executor().inExecutor();
@@ -363,8 +388,6 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
     @VisibleForTesting
     public Gossiper(boolean registerJmx)
     {
-        // half of QUARATINE_DELAY, to ensure justRemovedEndpoints has enough leeway to prevent re-gossip
-        fatClientTimeout = (QUARANTINE_DELAY / 2);
         /* register with the Failure Detector for receiving Failure detector events */
         FailureDetector.instance.registerFailureDetectionEventListener(this);
 
@@ -1085,6 +1108,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             {
                 // check if this is a fat client. fat clients are removed automatically from
                 // gossip after FatClientTimeout.  Do not remove dead states here.
+                long fatClientTimeout = getFatClientTimeoutForEndpoint(epState);
                 if (isGossipOnlyMember(endpoint)
                     && !justRemovedEndpoints.containsKey(endpoint)
                     && TimeUnit.NANOSECONDS.toMillis(nowNano - epState.getUpdateTimestamp()) > fatClientTimeout)
@@ -1130,6 +1154,24 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
                 }
             }
         }
+    }
+
+    private static long getFatClientTimeoutForEndpoint(EndpointState epState)
+    {
+        return isBootstrappingState(epState) ?
+                FAILED_BOOTSTRAP_TIMEOUT :
+                FAT_CLIENT_TIMEOUT;
+    }
+
+    private static boolean isBootstrappingState(EndpointState epState)
+    {
+        String status = getGossipStatus(epState);
+        if (status.isEmpty())
+        {
+            return false;
+        }
+
+        return BOOTSTRAPPING_STATES.contains(status);
     }
 
     protected long getExpireTimeForEndpoint(InetAddressAndPort endpoint)

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -123,9 +123,6 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
         SILENT_SHUTDOWN_STATES.add(VersionedValue.STATUS_BOOTSTRAPPING);
         SILENT_SHUTDOWN_STATES.add(VersionedValue.STATUS_BOOTSTRAPPING_REPLACE);
     }
-
-    static final List<String> BOOTSTRAPPING_STATES = Arrays.asList(VersionedValue.STATUS_BOOTSTRAPPING,
-            VersionedValue.STATUS_BOOTSTRAPPING_REPLACE);
     private static final List<String> ADMINISTRATIVELY_INACTIVE_STATES = Arrays.asList(VersionedValue.HIBERNATE,
                                                                                        VersionedValue.REMOVED_TOKEN,
                                                                                        VersionedValue.STATUS_LEFT);
@@ -1171,7 +1168,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean
             return false;
         }
 
-        return BOOTSTRAPPING_STATES.contains(status);
+        return VersionedValue.BOOTSTRAPPING_STATUS.contains(status);
     }
 
     protected long getExpireTimeForEndpoint(InetAddressAndPort endpoint)

--- a/src/java/org/apache/cassandra/gms/VersionedValue.java
+++ b/src/java/org/apache/cassandra/gms/VersionedValue.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import org.apache.cassandra.db.TypeSizes;
@@ -83,6 +84,7 @@ public class VersionedValue implements Comparable<VersionedValue>
 
     // values for ApplicationState.REMOVAL_COORDINATOR
     public final static String REMOVAL_COORDINATOR = "REMOVER";
+    public final static Set<String> BOOTSTRAPPING_STATUS = ImmutableSet.of(STATUS_BOOTSTRAPPING, STATUS_BOOTSTRAPPING_REPLACE);
 
     public final int version;
     public final String value;


### PR DESCRIPTION
This implements the suggestion by @driftx in [CASSANDRA-15439](https://issues.apache.org/jira/browse/CASSANDRA-15439). See https://the-asf.slack.com/archives/CK23JSY2K/p1713820180414349 for further discussion.

If a bootstrapping node experiences a GC pause such that it fails to gossip for 30s, it may be removed from another node's Gossip state as it has exceeded the FatClient timeout, which by default is equal to RING_DELAY=30s.

This violates Cassandra's consistency guarantees. When there are pending ranges, the number of nodes that must ACK a write at quorum is increased. For example, with RF=3, quorum is 2. If there are pending ranges, quorum is 3. If a node is actually bootstrapping, but another node has removed it and believes there are no pending ranges, requests that it coordinates may only reach two other nodes. If the nodes reached are a node sending a stream (A) and one other node (B), then once the bootstrapping node joins the ring and takes ownership of the pending range, that write will only exist on node that owns the data (node B).

For operators who are particularly concerned with the durability of writes during expansion, this option can be set to a higher value - ideally longer than the longest expected GC pause. If this value is increased significantly, like to multiple hours, or set to -1, operators will need to take manual action when a bootstrap has failed, like assassinating the failed node.

Example usage:
```
-Dcassandra.bootstrapping_fat_client_timeout_ms=300000
```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

