### PR TITLE
CASSANDRA-19590 If legacy cell is dropped, avoid creating a buffer cell

### DIFF
--- a/src/java/org/apache/cassandra/db/LegacyLayout.java
+++ b/src/java/org/apache/cassandra/db/LegacyLayout.java
@@ -1472,10 +1472,12 @@ public abstract class LegacyLayout
                         if (!helper.includes(path))
                             return true;
                     }
-                    column.type.validateIfFixedSize(cell.value);
-                    Cell c = new BufferCell(column, cell.timestamp, cell.ttl, cell.localDeletionTime, cell.value, path);
-                    if (!helper.isDropped(c, column.isComplex()))
+                    if (!helper.isDropped(column, cell.timestamp, column.isComplex()))
+                    {
+                        column.type.validateIfFixedSize(cell.value);
+                        Cell c = new BufferCell(column, cell.timestamp, cell.ttl, cell.localDeletionTime, cell.value, path);
                         builder.addCell(c);
+                    }
                     if (column.isComplex())
                     {
                         helper.endOfComplexColumn();

--- a/src/java/org/apache/cassandra/db/rows/SerializationHelper.java
+++ b/src/java/org/apache/cassandra/db/rows/SerializationHelper.java
@@ -114,6 +114,12 @@ public class SerializationHelper
         return dropped != null && cell.timestamp() <= dropped.droppedTime;
     }
 
+    public boolean isDropped(ColumnDefinition column, long timestamp, boolean isComplex)
+    {
+        CFMetaData.DroppedColumn dropped = isComplex ? currentDroppedComplex : droppedColumns.get(column.name.bytes);
+        return dropped != null && timestamp <= dropped.droppedTime;
+    }
+
     public boolean isDroppedComplexDeletion(DeletionTime complexDeletion)
     {
         return currentDroppedComplex != null && complexDeletion.markedForDeleteAt() <= currentDroppedComplex.droppedTime;


### PR DESCRIPTION
When the legacy data (2.2) satisfies a certain condition
* Cell belongs to a column which is dropped
* Another complex column is readded with the same name as the dropped column

Read in 3.0/3.11 for the corresponding table run into the assertion error `assert column.isComplex() == (path != null);` in BufferCell.java because the column is a complex type while the cell is not a complex type.

This patch tries to check whether the cell is dropped first. If dropped, skip the creation of the BufferCell.