### PR TITLE
CASSANDRA-19624: ModificationStatement#casInternal leaks RowIterator

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -601,9 +601,12 @@ public abstract class ModificationStatement implements CQLStatement
 
         SinglePartitionReadCommand readCommand = request.readCommand(FBUtilities.nowInSeconds());
         FilteredPartition current;
-        try (ReadOrderGroup orderGroup = readCommand.startOrderGroup(); PartitionIterator iter = readCommand.executeInternal(orderGroup))
+        try (ReadOrderGroup orderGroup = readCommand.startOrderGroup();
+             PartitionIterator iter = readCommand.executeInternal(orderGroup);
+             RowIterator rowIterator = PartitionIterators.getOnlyElement(iter, readCommand))
         {
-            current = FilteredPartition.create(PartitionIterators.getOnlyElement(iter, readCommand));
+            // FilteredPartition consumes the row but does not close the iterator
+            current = FilteredPartition.create(rowIterator);
         }
 
         if (!request.appliesTo(current))


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CASSANDRA-19624

This patch closes the RowIterator created in the ModificationStatement#casInternal method, preventing the leak of resources initialized for the RowIterator.

This is my first C* patch, please let me know if I need to change anything.