### PR TITLE
CASSANDRA-19624: ModificationStatement#casInternal leaks RowIterator

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -652,8 +652,7 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         SinglePartitionReadQuery readCommand = request.readCommand(nowInSeconds);
         FilteredPartition current;
         try (ReadExecutionController executionController = readCommand.executionController();
-             PartitionIterator iter = readCommand.executeInternal(executionController);
-             RowIterator rowIterator = PartitionIterators.getOnlyElement(iter, readCommand))
+             RowIterator rowIterator = PartitionIterators.getOnlyElement(readCommand.executeInternal(executionController), readCommand))
         {
             // FilteredPartition consumes the row but does not close the iterator
             current = FilteredPartition.create(rowIterator);

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -652,9 +652,11 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         SinglePartitionReadQuery readCommand = request.readCommand(nowInSeconds);
         FilteredPartition current;
         try (ReadExecutionController executionController = readCommand.executionController();
-             PartitionIterator iter = readCommand.executeInternal(executionController))
+             PartitionIterator iter = readCommand.executeInternal(executionController);
+             RowIterator rowIterator = PartitionIterators.getOnlyElement(iter, readCommand))
         {
-            current = FilteredPartition.create(PartitionIterators.getOnlyElement(iter, readCommand));
+            // FilteredPartition consumes the row but does not close the iterator
+            current = FilteredPartition.create(rowIterator);
         }
 
         if (!request.appliesTo(current))


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CASSANDRA-19624

This patch closes the RowIterator created in the ModificationStatement#casInternal method, preventing the leak of resources initialized for the RowIterator.

This is my first C* patch, please let me know if I need to change anything.