### PR TITLE
CASSANDRA-19596 Improve IntervalTree build throughput

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.config;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nullable;
 
 import com.google.common.primitives.Ints;
@@ -576,6 +575,7 @@ public enum CassandraRelevantProperties
      * can be also done manually for that particular case: {@code flush(SchemaConstants.SCHEMA_KEYSPACE_NAME);}. */
     TEST_FLUSH_LOCAL_SCHEMA_CHANGES("cassandra.test.flush_local_schema_changes", "true"),
     TEST_HARRY_SWITCH_AFTER("cassandra.test.harry.progression.switch-after", "1"),
+    TEST_INTERVAL_TREE_EXPENSIVE_CHECKS("cassandra.test.interval_tree_expensive_checks"),
     TEST_INVALID_LEGACY_SSTABLE_ROOT("invalid-legacy-sstable-root"),
     TEST_JVM_DTEST_DISABLE_SSL("cassandra.test.disable_ssl"),
     TEST_JVM_SHUTDOWN_MESSAGING_GRACEFULLY("cassandra.test.messagingService.gracefulShutdown", "false"),

--- a/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
+++ b/src/java/org/apache/cassandra/db/SizeEstimatesRecorder.java
@@ -17,11 +17,18 @@
  */
 package org.apache.cassandra.db;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,7 +175,7 @@ public class SizeEstimatesRecorder implements SchemaChangeListener, Runnable
                     while (refs == null)
                     {
                         Iterable<SSTableReader> sstables = table.getTracker().getView().select(SSTableSet.CANONICAL);
-                        SSTableIntervalTree tree = SSTableIntervalTree.build(sstables);
+                        SSTableIntervalTree tree = SSTableIntervalTree.buildSSTableIntervalTree(ImmutableList.copyOf(sstables));
                         Range<PartitionPosition> r = Range.makeRowRange(unwrappedRange);
                         Iterable<SSTableReader> canonicalSSTables = View.sstablesInBounds(r.left, r.right, tree);
                         refs = Refs.tryRef(canonicalSSTables);

--- a/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -48,6 +48,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -130,6 +131,7 @@ import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFac
 import static org.apache.cassandra.concurrent.FutureTask.callable;
 import static org.apache.cassandra.config.DatabaseDescriptor.getConcurrentCompactors;
 import static org.apache.cassandra.db.compaction.CompactionManager.CompactionExecutor.compactionThreadGroup;
+import static org.apache.cassandra.db.lifecycle.SSTableIntervalTree.buildSSTableIntervalTree;
 import static org.apache.cassandra.service.ActiveRepairService.NO_PENDING_REPAIR;
 import static org.apache.cassandra.service.ActiveRepairService.UNREPAIRED_SSTABLE;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
@@ -1244,8 +1246,7 @@ public class CompactionManager implements CompactionManagerMBean, ICompactionMan
     {
         final Set<SSTableReader> sstables = new HashSet<>();
         Iterable<SSTableReader> liveTables = cfs.getTracker().getView().select(SSTableSet.LIVE);
-        SSTableIntervalTree tree = SSTableIntervalTree.build(liveTables);
-
+        SSTableIntervalTree tree = buildSSTableIntervalTree(ImmutableList.copyOf(liveTables));
         for (Range<Token> tokenRange : tokenRangeCollection)
         {
             if (!AbstractBounds.strictlyWrapsAround(tokenRange.left, tokenRange.right))

--- a/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LifecycleTransaction.java
@@ -161,7 +161,7 @@ public class LifecycleTransaction extends Transactional.AbstractTransactional im
     /**
      * construct a Transaction for use in an offline operation
      */
-    public static LifecycleTransaction offline(OperationType operationType, Iterable<SSTableReader> readers)
+    public static LifecycleTransaction offline(OperationType operationType, Collection<SSTableReader> readers)
     {
         // if offline, for simplicity we just use a dummy tracker
         Tracker dummy = Tracker.newDummyTracker();

--- a/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/Tracker.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -93,7 +93,10 @@ public class Tracker
     private final List<INotificationConsumer> subscribers = new CopyOnWriteArrayList<>();
 
     public final ColumnFamilyStore cfstore;
-    final AtomicReference<View> view;
+
+    // Constructing views update can be quite slow so locking generates less CPU/garbage compared to CAS
+    final ReentrantLock viewUpdateLock = new ReentrantLock(true);
+    volatile View view = null;
     public final boolean loadsstables;
 
     /**
@@ -104,7 +107,6 @@ public class Tracker
     public Tracker(ColumnFamilyStore columnFamilyStore, Memtable memtable, boolean loadsstables)
     {
         this.cfstore = columnFamilyStore;
-        this.view = new AtomicReference<>();
         this.loadsstables = loadsstables;
         this.reset(memtable);
     }
@@ -166,15 +168,22 @@ public class Tracker
      */
     Pair<View, View> apply(Predicate<View> permit, Function<View, View> function)
     {
-        while (true)
+        View updated;
+        View cur;
+        viewUpdateLock.lock();
+        try
         {
-            View cur = view.get();
+            cur = view;
             if (!permit.apply(cur))
                 return null;
-            View updated = function.apply(cur);
-            if (view.compareAndSet(cur, updated))
-                return Pair.create(cur, updated);
+            updated = function.apply(cur);
+            view = updated;
         }
+        finally
+        {
+            viewUpdateLock.unlock();
+        }
+        return Pair.create(cur, updated);
     }
 
     Throwable updateSizeTracking(Iterable<SSTableReader> oldSSTables, Iterable<SSTableReader> newSSTables, Throwable accumulate)
@@ -237,12 +246,12 @@ public class Tracker
 
     // SETUP / CLEANUP
 
-    public void addInitialSSTables(Iterable<SSTableReader> sstables)
+    public void addInitialSSTables(Collection<SSTableReader> sstables)
     {
         addSSTablesInternal(sstables, true, false, true);
     }
 
-    public void addInitialSSTablesWithoutUpdatingSize(Iterable<SSTableReader> sstables, ColumnFamilyStore cfs)
+    public void addInitialSSTablesWithoutUpdatingSize(Collection<SSTableReader> sstables, ColumnFamilyStore cfs)
     {
         if (!isDummy())
         {
@@ -258,12 +267,12 @@ public class Tracker
         maybeFail(updateSizeTracking(emptySet(), sstables, null));
     }
 
-    public void addSSTables(Iterable<SSTableReader> sstables)
+    public void addSSTables(Collection<SSTableReader> sstables)
     {
         addSSTablesInternal(sstables, false, true, true);
     }
 
-    private void addSSTablesInternal(Iterable<SSTableReader> sstables,
+    private void addSSTablesInternal(Collection<SSTableReader> sstables,
                                      boolean isInitialSSTables,
                                      boolean maybeIncrementallyBackup,
                                      boolean updateSize)
@@ -282,11 +291,19 @@ public class Tracker
     @VisibleForTesting
     public void reset(Memtable memtable)
     {
-        view.set(new View(memtable != null ? singletonList(memtable) : Collections.emptyList(),
-                          Collections.emptyList(),
-                          Collections.emptyMap(),
-                          Collections.emptyMap(),
-                          SSTableIntervalTree.empty()));
+        viewUpdateLock.lock();
+        try
+        {
+            view = new View(memtable != null ? singletonList(memtable) : Collections.emptyList(),
+                            Collections.emptyList(),
+                            Collections.emptyMap(),
+                            Collections.emptyMap(),
+                            SSTableIntervalTree.empty());
+        }
+        finally
+        {
+            viewUpdateLock.unlock();
+        }
     }
 
     public Throwable dropSSTablesIfInvalid(Throwable accumulate)
@@ -377,12 +394,13 @@ public class Tracker
         // there may be multiple memtables in the list that would 'accept' us, however we only ever choose
         // the oldest such memtable, as accepts() only prevents us falling behind (i.e. ensures we don't
         // assign operations to a memtable that was retired/queued before we started)
-        for (Memtable memtable : view.get().liveMemtables)
+        View view = this.view;
+        for (Memtable memtable : view.liveMemtables)
         {
             if (memtable.accepts(opGroup, commitLogPosition))
                 return memtable;
         }
-        throw new AssertionError(view.get().liveMemtables.toString());
+        throw new AssertionError(view.liveMemtables.toString());
     }
 
     /**
@@ -409,7 +427,7 @@ public class Tracker
         apply(View.markFlushing(memtable));
     }
 
-    public void replaceFlushed(Memtable memtable, Iterable<SSTableReader> sstables)
+    public void replaceFlushed(Memtable memtable, Collection<SSTableReader> sstables)
     {
         assert !isDummy();
         if (Iterables.isEmpty(sstables))
@@ -447,17 +465,17 @@ public class Tracker
 
     public Set<SSTableReader> getCompacting()
     {
-        return view.get().compacting;
+        return view.compacting;
     }
 
     public Iterable<SSTableReader> getUncompacting()
     {
-        return view.get().select(SSTableSet.NONCOMPACTING);
+        return view.select(SSTableSet.NONCOMPACTING);
     }
 
     public Iterable<SSTableReader> getUncompacting(Iterable<SSTableReader> candidates)
     {
-        return view.get().getUncompacting(candidates);
+        return view.getUncompacting(candidates);
     }
 
     public void maybeIncrementallyBackup(final Iterable<SSTableReader> sstables)
@@ -601,7 +619,7 @@ public class Tracker
 
     public View getView()
     {
-        return view.get();
+        return view;
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamManager.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamManager.java
@@ -18,10 +18,19 @@
 
 package org.apache.cassandra.db.streaming;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.db.lifecycle.SSTableIntervalTree;
@@ -44,13 +53,8 @@ import org.apache.cassandra.streaming.messages.StreamMessageHeader;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Ref;
 import org.apache.cassandra.utils.concurrent.Refs;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import static org.apache.cassandra.db.lifecycle.SSTableIntervalTree.buildSSTableIntervalTree;
 
 /**
  * Implements the streaming interface for the native cassandra storage engine.
@@ -93,7 +97,7 @@ public class CassandraStreamManager implements TableStreamManager
                 keyRanges.add(Range.makeRowRange(replica.range()));
             refs.addAll(cfs.selectAndReference(view -> {
                 Set<SSTableReader> sstables = Sets.newHashSet();
-                SSTableIntervalTree intervalTree = SSTableIntervalTree.build(view.select(SSTableSet.CANONICAL));
+                SSTableIntervalTree intervalTree = buildSSTableIntervalTree(ImmutableList.copyOf(view.select(SSTableSet.CANONICAL)));
                 Predicate<SSTableReader> predicate;
                 if (previewKind.isPreview())
                 {

--- a/src/java/org/apache/cassandra/index/sai/disk/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/SSTableIndex.java
@@ -36,11 +36,11 @@ import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.index.sai.QueryContext;
 import org.apache.cassandra.index.sai.SSTableContext;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
-import org.apache.cassandra.index.sai.utils.IndexIdentifier;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.index.sai.disk.v1.segment.SegmentOrdering;
 import org.apache.cassandra.index.sai.iterators.KeyRangeIterator;
 import org.apache.cassandra.index.sai.plan.Expression;
+import org.apache.cassandra.index.sai.utils.IndexIdentifier;
 import org.apache.cassandra.index.sai.utils.IndexTermType;
 import org.apache.cassandra.io.sstable.SSTableIdFactory;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
@@ -53,7 +53,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
  *     <li>Exposes the index metadata for the column index</li>
  * </ul>
  */
-public abstract class SSTableIndex implements SegmentOrdering
+public abstract class SSTableIndex implements SegmentOrdering, Comparable<SSTableIndex>
 {
     private static final Logger logger = LoggerFactory.getLogger(SSTableIndex.class);
 
@@ -266,5 +266,12 @@ public abstract class SSTableIndex implements SegmentOrdering
                           .add("maxTerm", indexTermType.asString(maxTerm()))
                           .add("totalRows", sstableContext.sstable.getTotalRows())
                           .toString();
+    }
+
+    @Override
+    public int compareTo(SSTableIndex index)
+    {
+        // SSTableReader is truly unique for comparison which is relied on in IntervalTree
+        return getSSTable().compareTo(index.getSSTable());
     }
 }

--- a/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/SSTableIndex.java
@@ -39,7 +39,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.concurrent.Ref;
 
-public class SSTableIndex
+public class SSTableIndex implements Comparable<SSTableIndex>
 {
     private final ColumnIndex columnIndex;
     private final Ref<SSTableReader> sstableRef;
@@ -160,6 +160,13 @@ public class SSTableIndex
     public String toString()
     {
         return String.format("SSTableIndex(column: %s, SSTable: %s)", columnIndex.getColumnName(), sstable.descriptor);
+    }
+
+    @Override
+    public int compareTo(SSTableIndex o)
+    {
+        // Relied on in IntervalTree to be unique
+        return sstable.compareTo(o.sstable);
     }
 
     private static class DecoratedKeyFetcher implements Function<Long, DecoratedKey>

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -100,6 +100,7 @@ import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.EstimatedHistogram;
 import org.apache.cassandra.utils.ExecutorUtils;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.NativeLibrary;
 import org.apache.cassandra.utils.OutputHandler;
@@ -112,6 +113,7 @@ import org.apache.cassandra.utils.concurrent.SharedCloseable;
 import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
+import static org.apache.cassandra.utils.TimeUUID.unixMicrosToRawTimestamp;
 import static org.apache.cassandra.utils.concurrent.BlockingQueues.newBlockingQueue;
 import static org.apache.cassandra.utils.concurrent.SharedCloseable.sharedCopyOrNull;
 
@@ -149,7 +151,7 @@ import static org.apache.cassandra.utils.concurrent.SharedCloseable.sharedCopyOr
  * <p>
  * TODO: fill in details about Tracker and lifecycle interactions for tools, and for compaction strategies
  */
-public abstract class SSTableReader extends SSTable implements UnfilteredSource, SelfRefCounted<SSTableReader>
+public abstract class SSTableReader extends SSTable implements UnfilteredSource, SelfRefCounted<SSTableReader>, Comparable<SSTableReader>
 {
     private static final Logger logger = LoggerFactory.getLogger(SSTableReader.class);
 
@@ -177,11 +179,25 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     public static final Comparator<SSTableReader> maxTimestampAscending = Comparator.comparingLong(SSTableReader::getMaxTimestamp);
     public static final Comparator<SSTableReader> maxTimestampDescending = maxTimestampAscending.reversed();
 
-    // it's just an object, which we use regular Object equality on; we introduce a special class just for easy recognition
-    public static final class UniqueIdentifier
+    private static final TimeUUID.Generator.Factory<UniqueIdentifier> UNIQUE_IDENTIFIER_FACTORY = new TimeUUID.Generator.Factory<UniqueIdentifier>()
     {
+        @Override
+        public UniqueIdentifier atUnixMicrosWithLsb(long unixMicros, long clockSeqAndNode)
+        {
+            return new UniqueIdentifier(unixMicrosToRawTimestamp(unixMicros), clockSeqAndNode);
+        }
+    };
+
+    // it's just an object, which we use regular Object equality on; we introduce a special class just for easy recognition
+    // Also includes a TimeUUID to make these sortable
+    public static final class UniqueIdentifier extends TimeUUID
+    {
+        private UniqueIdentifier(long unixMicros, long clockSeqAndNode)
+        {
+            super(unixMicros, clockSeqAndNode);
+        }
     }
-    public final UniqueIdentifier instanceId = new UniqueIdentifier();
+    public final UniqueIdentifier instanceId = TimeUUID.Generator.nextTimeUUID(UNIQUE_IDENTIFIER_FACTORY);
 
     public static final Comparator<SSTableReader> firstKeyComparator = (o1, o2) -> o1.getFirst().compareTo(o2.getFirst());
     public static final Ordering<SSTableReader> firstKeyOrdering = Ordering.from(firstKeyComparator);
@@ -271,6 +287,7 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     protected final DecoratedKey first;
     protected final DecoratedKey last;
     public final AbstractBounds<Token> bounds;
+    private final Interval<PartitionPosition, SSTableReader> interval;
 
     /**
      * Calculate approximate key count.
@@ -457,6 +474,7 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
         this.openReason = builder.getOpenReason();
         this.first = builder.getFirst();
         this.last = builder.getLast();
+        this.interval = Interval.create(first, last, this);
         this.bounds = first == null || last == null || AbstractBounds.strictlyWrapsAround(first.getToken(), last.getToken())
                       ? null // this will cause the validation to fail, but the reader is opened with no validation,
                              // e.g. for scrubbing, we should accept screwed bounds
@@ -476,6 +494,11 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     public DecoratedKey getLast()
     {
         return last;
+    }
+
+    public Interval<PartitionPosition, SSTableReader> getInterval()
+    {
+        return interval;
     }
 
     @Override
@@ -1844,6 +1867,13 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
                                           OutputHandler outputHandler,
                                           boolean isOffline,
                                           IVerifier.Options options);
+
+    @Override
+    public int compareTo(SSTableReader other)
+    {
+        // Used in IntervalTree with the expecation that compareTo uniquely identifies an SSTableReader
+        return instanceId.compareTo(other.instanceId);
+    }
 
     /**
      * A method to be called by {@link #getPosition(PartitionPosition, Operator, boolean, SSTableReadsListener)}

--- a/src/java/org/apache/cassandra/utils/Interval.java
+++ b/src/java/org/apache/cassandra/utils/Interval.java
@@ -65,35 +65,49 @@ public class Interval<C, D>
         return Objects.equal(min, that.min) && Objects.equal(max, that.max) && Objects.equal(data, that.data);
     }
 
-    private static final AsymmetricOrdering<Interval<Comparable, Object>, Comparable> minOrdering
-    = new AsymmetricOrdering<Interval<Comparable, Object>, Comparable>()
+    private static final AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable> minOrdering
+    = new AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable>()
     {
-        public int compareAsymmetric(Interval<Comparable, Object> left, Comparable right)
+        public int compareAsymmetric(Interval<Comparable, Comparable> left, Comparable right)
         {
             return left.min.compareTo(right);
         }
 
-        public int compare(Interval<Comparable, Object> i1, Interval<Comparable, Object> i2)
+        public int compare(Interval<Comparable, Comparable> i1, Interval<Comparable, Comparable> i2)
         {
-            return i1.min.compareTo(i2.min);
+            int cmpMin = i1.min.compareTo(i2.min);
+            if (cmpMin != 0)
+                return cmpMin;
+            int cmpMax = i1.max.compareTo(i2.max);
+            if (cmpMax != 0)
+                return cmpMax;
+            // Null is allowed if all data values are null otherwise NPE
+            return i1.data == i2.data ? 0 : i1.data.compareTo(i2.data);
         }
     };
 
-    private static final AsymmetricOrdering<Interval<Comparable, Object>, Comparable> maxOrdering
-    = new AsymmetricOrdering<Interval<Comparable, Object>, Comparable>()
+    private static final AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable> maxOrdering
+    = new AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable>()
     {
-        public int compareAsymmetric(Interval<Comparable, Object> left, Comparable right)
+        public int compareAsymmetric(Interval<Comparable, Comparable> left, Comparable right)
         {
             return left.max.compareTo(right);
         }
 
-        public int compare(Interval<Comparable, Object> i1, Interval<Comparable, Object> i2)
+        public int compare(Interval<Comparable, Comparable> i1, Interval<Comparable, Comparable> i2)
         {
-            return i1.max.compareTo(i2.max);
+            int cmpMax = i1.max.compareTo(i2.max);
+            if (cmpMax != 0)
+                return cmpMax;
+            int cmpMin = i1.min.compareTo(i2.min);
+            if (cmpMin != 0)
+                return cmpMin;
+            // Null is allowed if all data values are null otherwise NPE
+            return i1.data == i2.data ? 0 : i1.data.compareTo(i2.data);
         }
     };
 
-    private static final AsymmetricOrdering<Interval<Comparable, Object>, Comparable> reverseMaxOrdering = maxOrdering.reverse();
+    private static final AsymmetricOrdering<Interval<Comparable, Comparable>, Comparable> reverseMaxOrdering = maxOrdering.reverse();
 
     public static <C extends Comparable<? super C>, V> AsymmetricOrdering<Interval<C, V>, C> minOrdering()
     {

--- a/src/java/org/apache/cassandra/utils/TimeUUID.java
+++ b/src/java/org/apache/cassandra/utils/TimeUUID.java
@@ -390,6 +390,16 @@ public class TimeUUID implements Serializable, Comparable<TimeUUID>
 
         private static final AtomicLong lastMicros = new AtomicLong();
 
+        public interface Factory<T extends TimeUUID>
+        {
+            T atUnixMicrosWithLsb(long unixMicros, long clockSeqAndNode);
+        }
+
+        public static <T extends TimeUUID> T nextTimeUUID(Factory<T> factory)
+        {
+            return factory.atUnixMicrosWithLsb(nextUnixMicros(), clockSeqAndNode);
+        }
+
         public static TimeUUID nextTimeUUID()
         {
             return atUnixMicrosWithLsb(nextUnixMicros(), clockSeqAndNode);

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -32,6 +32,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.junit.After;
@@ -920,7 +921,7 @@ public class LeveledCompactionStrategyTest
         List<SSTableReader> l0sstables = new ArrayList<>();
         for (int i = 10; i < 20; i++)
             l0sstables.add(MockSchema.sstable(i, (i + 1) * 1024 * 1024, cfs));
-        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.COMPACTION, Iterables.concat(l0sstables, l1sstables)))
+        try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.COMPACTION, ImmutableList.copyOf(Iterables.concat(l0sstables, l1sstables))))
         {
             Set<SSTableReader> nonExpired = new HashSet<>(Sets.difference(txn.originals(), Collections.emptySet()));
             CompactionTask task = new LeveledCompactionTask(cfs, txn, 1, 0, 1024*1024, false);

--- a/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/UnifiedCompactionStrategyTest.java
@@ -38,6 +38,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.google.monitoring.runtime.instrumentation.common.collect.ImmutableList;
 import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.BufferDecoratedKey;
@@ -62,6 +63,7 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.Interval;
 import org.apache.cassandra.utils.Overlaps;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.concurrent.Transactional;
@@ -608,7 +610,7 @@ public class UnifiedCompactionStrategyTest
         List<SSTableReader> nonExpiredSSTables = createSStables(cfs.getPartitioner(), 0);
         strategy.addSSTables(expiredSSTables);
         strategy.addSSTables(nonExpiredSSTables.subList(0, 3));
-        dataTracker.addInitialSSTables(Iterables.concat(expiredSSTables, nonExpiredSSTables));
+        dataTracker.addInitialSSTables(ImmutableList.copyOf(Iterables.concat(expiredSSTables, nonExpiredSSTables)));
 
         long timestamp = expiredSSTables.get(expiredSSTables.size() - 1).getMaxLocalDeletionTime();
         long expirationPoint = timestamp + 1;
@@ -1050,6 +1052,7 @@ public class UnifiedCompactionStrategyTest
         when(ret.getMinTimestamp()).thenReturn(timestamp);
         when(ret.getFirst()).thenReturn(first);
         when(ret.getLast()).thenReturn(last);
+        when(ret.getInterval()).thenReturn(new Interval<>(first, last, ret));
         when(ret.isMarkedSuspect()).thenReturn(false);
         when(ret.isRepaired()).thenReturn(false);
         when(ret.getRepairedAt()).thenReturn(repairedAt);

--- a/test/unit/org/apache/cassandra/db/lifecycle/ViewTest.java
+++ b/test/unit/org/apache/cassandra/db/lifecycle/ViewTest.java
@@ -28,10 +28,9 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import org.junit.Assert;
 
 import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.db.ColumnFamilyStore;
@@ -47,6 +46,7 @@ import static com.google.common.collect.ImmutableSet.of;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Collections.singleton;
 import static org.apache.cassandra.db.lifecycle.Helpers.emptySet;
+import static org.apache.cassandra.db.lifecycle.SSTableIntervalTree.buildSSTableIntervalTree;
 
 public class ViewTest
 {
@@ -225,6 +225,6 @@ public class ViewTest
         for (int i = 0 ; i < sstableCount ; i++)
             sstables.add(MockSchema.sstable(i, keepRef, cfs));
         return new View(ImmutableList.copyOf(memtables), Collections.<Memtable>emptyList(), Helpers.identityMap(sstables),
-                        Collections.<SSTableReader, SSTableReader>emptyMap(), SSTableIntervalTree.build(sstables));
+                        Collections.<SSTableReader, SSTableReader>emptyMap(), buildSSTableIntervalTree(sstables));
     }
 }

--- a/test/unit/org/apache/cassandra/utils/IntervalTreeTest.java
+++ b/test/unit/org/apache/cassandra/utils/IntervalTreeTest.java
@@ -1,198 +1,443 @@
 package org.apache.cassandra.utils;
-/*
- *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- *
- */
 
-
-import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.cassandra.io.ISerializer;
-import org.apache.cassandra.io.IVersionedSerializer;
-import org.apache.cassandra.io.util.DataInputBuffer;
-import org.apache.cassandra.io.util.DataInputPlus;
-import org.apache.cassandra.io.util.DataOutputBuffer;
-import org.apache.cassandra.io.util.DataOutputPlus;
 
+import org.quicktheories.WithQuickTheories;
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.SourceDSL;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Predicate.not;
+import static org.apache.cassandra.config.CassandraRelevantProperties.TEST_INTERVAL_TREE_EXPENSIVE_CHECKS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class IntervalTreeTest
+public class IntervalTreeTest implements WithQuickTheories
 {
-    @Test
-    public void testSearch() throws Exception
+    @BeforeClass
+    public static void enableExpensiveRangeChecks()
     {
-        List<Interval<Integer, Void>> intervals = new ArrayList<Interval<Integer, Void>>();
+        assertFalse(TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean()); // Expect off by default
+        TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.setBoolean(true);
+        assertTrue(TEST_INTERVAL_TREE_EXPENSIVE_CHECKS.getBoolean());
+        assertTrue(IntervalTree.EXPENSIVE_CHECKS);
+    }
 
-        intervals.add(Interval.<Integer, Void>create(-300, -200));
-        intervals.add(Interval.<Integer, Void>create(-3, -2));
-        intervals.add(Interval.<Integer, Void>create(1, 2));
-        intervals.add(Interval.<Integer, Void>create(3, 6));
-        intervals.add(Interval.<Integer, Void>create(2, 4));
-        intervals.add(Interval.<Integer, Void>create(5, 7));
-        intervals.add(Interval.<Integer, Void>create(1, 3));
-        intervals.add(Interval.<Integer, Void>create(4, 6));
-        intervals.add(Interval.<Integer, Void>create(8, 9));
-        intervals.add(Interval.<Integer, Void>create(15, 20));
-        intervals.add(Interval.<Integer, Void>create(40, 50));
-        intervals.add(Interval.<Integer, Void>create(49, 60));
+    @Test
+    public void testSearch()
+    {
+        List<Interval<Integer, Integer>> intervals = new ArrayList<>();
 
+        intervals.add(Interval.create(-300, -200));
+        intervals.add(Interval.create(-3, -2));
+        intervals.add(Interval.create(1, 2));
+        intervals.add(Interval.create(3, 6));
+        intervals.add(Interval.create(2, 4));
+        intervals.add(Interval.create(5, 7));
+        intervals.add(Interval.create(1, 3));
+        intervals.add(Interval.create(4, 6));
+        intervals.add(Interval.create(8, 9));
+        intervals.add(Interval.create(15, 20));
+        intervals.add(Interval.create(40, 50));
+        intervals.add(Interval.create(49, 60));
 
-        IntervalTree<Integer, Void, Interval<Integer, Void>> it = IntervalTree.build(intervals);
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it = IntervalTree.build(intervals);
 
-        assertEquals(3, it.search(Interval.<Integer, Void>create(4, 4)).size());
-        assertEquals(4, it.search(Interval.<Integer, Void>create(4, 5)).size());
-        assertEquals(7, it.search(Interval.<Integer, Void>create(-1, 10)).size());
-        assertEquals(0, it.search(Interval.<Integer, Void>create(-1, -1)).size());
-        assertEquals(5, it.search(Interval.<Integer, Void>create(1, 4)).size());
-        assertEquals(2, it.search(Interval.<Integer, Void>create(0, 1)).size());
-        assertEquals(0, it.search(Interval.<Integer, Void>create(10, 12)).size());
+        assertEquals(3, it.search(Interval.create(4, 4)).size());
+        assertEquals(4, it.search(Interval.create(4, 5)).size());
+        assertEquals(7, it.search(Interval.create(-1, 10)).size());
+        assertEquals(0, it.search(Interval.create(-1, -1)).size());
+        assertEquals(5, it.search(Interval.create(1, 4)).size());
+        assertEquals(2, it.search(Interval.create(0, 1)).size());
+        assertEquals(0, it.search(Interval.create(10, 12)).size());
 
-        List<Interval<Integer, Void>> intervals2 = new ArrayList<Interval<Integer, Void>>();
+        List<Interval<Integer, Integer>> intervals2 = new ArrayList<>();
 
         //stravinsky 1880-1971
-        intervals2.add(Interval.<Integer, Void>create(1880, 1971));
+        intervals2.add(Interval.create(1880, 1971));
         //Schoenberg
-        intervals2.add(Interval.<Integer, Void>create(1874, 1951));
+        intervals2.add(Interval.create(1874, 1951));
         //Grieg
-        intervals2.add(Interval.<Integer, Void>create(1843, 1907));
+        intervals2.add(Interval.create(1843, 1907));
         //Schubert
-        intervals2.add(Interval.<Integer, Void>create(1779, 1828));
+        intervals2.add(Interval.create(1779, 1828));
         //Mozart
-        intervals2.add(Interval.<Integer, Void>create(1756, 1828));
+        intervals2.add(Interval.create(1756, 1828));
         //Schuetz
-        intervals2.add(Interval.<Integer, Void>create(1585, 1672));
+        intervals2.add(Interval.create(1585, 1672));
 
-        IntervalTree<Integer, Void, Interval<Integer, Void>> it2 = IntervalTree.build(intervals2);
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it2 = IntervalTree.build(intervals2);
 
-        assertEquals(0, it2.search(Interval.<Integer, Void>create(1829, 1842)).size());
+        assertEquals(0, it2.search(Interval.create(1829, 1842)).size());
 
-        List<Void> intersection1 = it2.search(Interval.<Integer, Void>create(1907, 1907));
+        List<Integer> intersection1 = it2.search(Interval.create(1907, 1907));
         assertEquals(3, intersection1.size());
 
-        intersection1 = it2.search(Interval.<Integer, Void>create(1780, 1790));
+        intersection1 = it2.search(Interval.create(1780, 1790));
         assertEquals(2, intersection1.size());
-
     }
 
     @Test
     public void testIteration()
     {
-        List<Interval<Integer, Void>> intervals = new ArrayList<Interval<Integer, Void>>();
+        List<Interval<Integer, Integer>> intervals = new ArrayList<>();
 
-        intervals.add(Interval.<Integer, Void>create(-300, -200));
-        intervals.add(Interval.<Integer, Void>create(-3, -2));
-        intervals.add(Interval.<Integer, Void>create(1, 2));
-        intervals.add(Interval.<Integer, Void>create(3, 6));
-        intervals.add(Interval.<Integer, Void>create(2, 4));
-        intervals.add(Interval.<Integer, Void>create(5, 7));
-        intervals.add(Interval.<Integer, Void>create(1, 3));
-        intervals.add(Interval.<Integer, Void>create(4, 6));
-        intervals.add(Interval.<Integer, Void>create(8, 9));
-        intervals.add(Interval.<Integer, Void>create(15, 20));
-        intervals.add(Interval.<Integer, Void>create(40, 50));
-        intervals.add(Interval.<Integer, Void>create(49, 60));
+        intervals.add(Interval.create(-300, -200));
+        intervals.add(Interval.create(-3, -2));
+        intervals.add(Interval.create(1, 2));
+        intervals.add(Interval.create(3, 6));
+        intervals.add(Interval.create(2, 4));
+        intervals.add(Interval.create(5, 7));
+        intervals.add(Interval.create(1, 3));
+        intervals.add(Interval.create(4, 6));
+        intervals.add(Interval.create(8, 9));
+        intervals.add(Interval.create(15, 20));
+        intervals.add(Interval.create(40, 50));
+        intervals.add(Interval.create(49, 60));
 
-        IntervalTree<Integer, Void, Interval<Integer, Void>> it = IntervalTree.build(intervals);
+        IntervalTree<Integer, Integer, Interval<Integer, Integer>> it = IntervalTree.build(intervals);
 
-        Collections.sort(intervals, Interval.<Integer, Void>minOrdering());
+        Collections.sort(intervals, Interval.minOrdering());
 
-        List<Interval<Integer, Void>> l = new ArrayList<Interval<Integer, Void>>();
-        for (Interval<Integer, Void> i : it)
-            l.add(i);
+        List<Interval<Integer, Integer>> l = ImmutableList.copyOf(it);
 
         assertEquals(intervals, l);
     }
 
     @Test
-    public void testSerialization() throws Exception
+    public void testEmptyTree()
     {
-        List<Interval<Integer, String>> intervals = new ArrayList<Interval<Integer, String>>();
+        IntervalTree<Integer, String, Interval<Integer, String>> emptyTree = IntervalTree.emptyTree();
 
-        intervals.add(Interval.<Integer, String>create(-300, -200, "a"));
-        intervals.add(Interval.<Integer, String>create(-3, -2, "b"));
-        intervals.add(Interval.<Integer, String>create(1, 2, "c"));
-        intervals.add(Interval.<Integer, String>create(1, 3, "d"));
-        intervals.add(Interval.<Integer, String>create(2, 4, "e"));
-        intervals.add(Interval.<Integer, String>create(3, 6, "f"));
-        intervals.add(Interval.<Integer, String>create(4, 6, "g"));
-        intervals.add(Interval.<Integer, String>create(5, 7, "h"));
-        intervals.add(Interval.<Integer, String>create(8, 9, "i"));
-        intervals.add(Interval.<Integer, String>create(15, 20, "j"));
-        intervals.add(Interval.<Integer, String>create(40, 50, "k"));
-        intervals.add(Interval.<Integer, String>create(49, 60, "l"));
+        assertTrue("Tree should be empty", emptyTree.isEmpty());
+        assertEquals("Interval count should be 0", 0, emptyTree.intervalCount());
 
-        IntervalTree<Integer, String, Interval<Integer, String>> it = IntervalTree.build(intervals);
+        try
+        {
+            emptyTree.min();
+            fail("Expected IllegalStateException when calling min() on empty tree");
+        }
+        catch (IllegalStateException e) { /* expected */ }
 
-        IVersionedSerializer<IntervalTree<Integer, String, Interval<Integer, String>>> serializer = IntervalTree.serializer(
-                new ISerializer<Integer>()
+        try
+        {
+            emptyTree.max();
+            fail("Expected IllegalStateException when calling max() on empty tree");
+        }
+        catch (IllegalStateException e) { /* expected */ }
+
+        assertTrue("Search should yield empty list for empty tree",
+                   emptyTree.search(Interval.create(1, 5, "data")).isEmpty());
+        assertTrue("Search by point should yield empty list for empty tree",
+                   emptyTree.search(5).isEmpty());
+
+        assertFalse("Iterator should have no elements", emptyTree.iterator().hasNext());
+    }
+
+    @Test
+    public void testSingleInterval()
+    {
+        Interval<Integer, String> interval = Interval.create(10, 20, "single");
+        List<Interval<Integer, String>> list = new ArrayList<>();
+        list.add(interval);
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(list);
+
+        assertFalse("Tree should not be empty", tree.isEmpty());
+        assertEquals("Interval count should be 1", 1, tree.intervalCount());
+        assertEquals("min() should match the only interval's min", Integer.valueOf(10), tree.min());
+        assertEquals("max() should match the only interval's max", Integer.valueOf(20), tree.max());
+
+        List<String> result = tree.search(Interval.create(10, 20));
+        assertEquals("Should find exactly 1 match", 1, result.size());
+        assertEquals("Data should match 'single'", "single", result.get(0));
+
+        result = tree.search(Interval.create(15, 25));
+        assertEquals("Should find overlap", 1, result.size());
+
+        result = tree.search(Interval.create(1, 9));
+        assertTrue("Should find no intervals that do not overlap", result.isEmpty());
+
+        List<Interval<Integer, String>> iterationList = ImmutableList.copyOf(tree);
+
+        assertEquals("Iteration should produce exactly our single interval",
+                     list, iterationList);
+    }
+
+    @Test
+    public void testMultipleIntervals()
+    {
+        List<Interval<Integer, String>> intervals = new ArrayList<>();
+        intervals.add(Interval.create(1, 3, "A"));
+        intervals.add(Interval.create(2, 4, "B"));
+        intervals.add(Interval.create(5, 7, "C"));
+        intervals.add(Interval.create(6, 6, "D"));   // single-point overlap within (5,7)
+        intervals.add(Interval.create(8, 10, "E"));
+        intervals.add(Interval.create(10, 12, "F")); // boundary adjacency with (8,10)
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+        assertFalse("Tree should not be empty", tree.isEmpty());
+        assertEquals("Interval count", intervals.size(), tree.intervalCount());
+
+        assertEquals("min()", Integer.valueOf(1), tree.min());
+        assertEquals("max()", Integer.valueOf(12), tree.max());
+
+        List<String> result = tree.search(Interval.create(2, 2)); // point in [1,3] and also in [2,4]
+        assertTrue(result.contains("A"));
+        assertTrue(result.contains("B"));
+        assertEquals("Should find 2 intervals for point=2", 2, result.size());
+
+        result = tree.search(Interval.create(4, 6));
+        assertTrue(result.contains("B"));
+        assertTrue(result.contains("C"));
+        assertTrue(result.contains("D"));
+        assertEquals("Should have 3 overlaps for [4,6]", 3, result.size());
+
+        result = tree.search(Interval.create(13, 14));
+        assertTrue("Should be no matches for [13,14]", result.isEmpty());
+
+        result = tree.search(Interval.create(10, 10));
+        assertTrue(result.contains("E"));
+        assertTrue(result.contains("F"));
+        assertEquals("Should find 2 intervals at boundary=10", 2, result.size());
+
+        Collections.sort(intervals, Interval.minOrdering());
+        List<Interval<Integer, String>> iterated = ImmutableList.copyOf(tree);
+        assertEquals("Iterated intervals should be in ascending min-order", intervals, iterated);
+    }
+
+    @Test
+    public void testDuplicateAndSameBoundaryIntervals()
+    {
+        List<Interval<Integer, String>> intervals = new ArrayList<>();
+        intervals.add(Interval.create(5, 5, "X"));  // single point
+        intervals.add(Interval.create(5, 5, "Y"));  // same single point, different data
+        intervals.add(Interval.create(5, 5, "X"));  // same data and boundary as first
+        intervals.add(Interval.create(5, 6, "Z"));  // partial overlap
+        intervals.add(Interval.create(4, 5, "W"));  // partial overlap at boundary
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+        assertEquals("min()", Integer.valueOf(4), tree.min());
+        assertEquals("max()", Integer.valueOf(6), tree.max());
+
+        List<String> result = tree.search(5);
+        assertEquals("Should have 5 matching intervals that contain point=5", 5, result.size());
+
+        result = tree.search(Interval.create(5, 5));
+        assertEquals("Should have 5 matching intervals that contain [5,5]", 5, result.size());
+
+        result = tree.search(Interval.create(6, 6));
+        assertEquals("Should match only [5,6] for point=6", 1, result.size());
+        assertTrue(result.contains("Z"));
+
+        result = tree.search(7);
+        assertTrue("No intervals should contain point=7", result.isEmpty());
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        List<Interval<Integer, String>> intervals1 = new ArrayList<>();
+        intervals1.add(Interval.create(1, 2, "A"));
+        intervals1.add(Interval.create(3, 5, "B"));
+        intervals1.add(Interval.create(4, 6, "C"));
+
+        List<Interval<Integer, String>> intervals2 = new ArrayList<>();
+        // same intervals but in different order
+        intervals2.add(Interval.create(4, 6, "C"));
+        intervals2.add(Interval.create(1, 2, "A"));
+        intervals2.add(Interval.create(3, 5, "B"));
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree1 = IntervalTree.build(intervals1);
+        IntervalTree<Integer, String, Interval<Integer, String>> tree2 = IntervalTree.build(intervals2);
+
+        assertTrue("tree1 should be equal to tree2 despite different input order", tree1.equals(tree2));
+        assertEquals("tree1.hashCode() should match tree2.hashCode()", tree1.hashCode(), tree2.hashCode());
+
+        // Create a slightly different set
+        List<Interval<Integer, String>> intervals3 = new ArrayList<>(intervals1);
+        intervals3.add(Interval.create(10, 11, "X")); // extra interval
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree3 = IntervalTree.build(intervals3);
+        assertFalse("tree1 should not equal tree3 which has an extra interval", tree1.equals(tree3));
+        assertNotEquals("hashCode should differ if intervals differ", tree1.hashCode(), tree3.hashCode());
+    }
+
+    @Test
+    public void testPointSearchEquivalence()
+    {
+        List<Interval<Integer, String>> intervals = new ArrayList<>();
+        intervals.add(Interval.create(1, 3, "A"));
+        intervals.add(Interval.create(2, 5, "B"));
+        intervals.add(Interval.create(10, 20, "C"));
+
+        IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+        List<String> resultPoint = tree.search(2);
+        List<String> resultInterval = tree.search(Interval.create(2, 2));
+
+        assertEquals("Results of point search and interval-based search should match",
+                     resultPoint, resultInterval);
+    }
+
+    private Gen<Interval<Integer, String>> intervalGen()
+    {
+        AtomicInteger id = new AtomicInteger();
+        return SourceDSL.integers().between(-5, 5)
+                        .flatMap(start ->
+                                 SourceDSL.integers().between(-5, 5)
+                                          .map(end -> {
+                                              int lo = Math.min(start, end);
+                                              int hi = Math.max(start, end);
+                                              String data = "(" + lo + "," + hi + "," + id.getAndIncrement() + ")";
+                                              return Interval.create(lo, hi, data);
+                                          }));
+    }
+
+    private Gen<List<Interval<Integer, String>>> intervalsListGen()
+    {
+        return lists().of(intervalGen())
+                      .ofSizeBetween(0, 7);
+    }
+
+    private Gen<Interval<Integer, String>> queryGen()
+    {
+        return SourceDSL.booleans().all()
+                        .flatMap(isPoint -> {
+                            if (isPoint)
+                            {
+                                return SourceDSL.integers().between(-5, 5)
+                                                .map(x -> Interval.create(x, x, "queryPoint(" + x + ")"));
+                            }
+                            else
+                            {
+                                return intervalGen().map(i -> Interval.create(i.min, i.max, "query[" + i.min + "," + i.max + "]"));
+                            }
+                        });
+    }
+
+    private boolean overlaps(Interval<Integer, ?> a, Interval<Integer, ?> b)
+    {
+        return a.min <= b.max && a.max >= b.min;
+    }
+
+    private <D> List<D> search(Collection<Interval<Integer, D>> intervals, Interval<Integer, ?> query)
+    {
+        List<D> results = new ArrayList<>();
+        for (Interval<Integer, D> candidate : intervals)
+        {
+            if (overlaps(candidate, query))
+                results.add(candidate.data);
+        }
+        return results;
+    }
+
+    @Test
+    public void qtIntervalTreeTest()
+    {
+        qt().forAll(intervalsListGen(), queryGen())
+            .check((intervals, query) -> {
+                IntervalTree<Integer, String, Interval<Integer, String>> tree = IntervalTree.build(intervals);
+
+                List<String> expected = search(intervals, query);
+                List<String> actual = tree.search(query);
+
+                Set<String> setExpected = new HashSet<>(expected);
+                Set<String> setActual = new HashSet<>(actual);
+
+                assertEquals(setExpected, setActual);
+
+                if (query.min.equals(query.max))
                 {
-                    public void serialize(Integer i, DataOutputPlus out) throws IOException
-                    {
-                        out.writeInt(i);
-                    }
+                    List<String> actualPoint = tree.search(query.min);
+                    assertEquals(setExpected, new HashSet<>(actualPoint));
+                }
 
-                    public Integer deserialize(DataInputPlus in) throws IOException
-                    {
-                        return in.readInt();
-                    }
+                Set<Interval<Integer, String>> fromTree = ImmutableSet.copyOf(tree);
 
-                    public long serializedSize(Integer i)
-                    {
-                        return 4;
-                    }
-                },
-                new ISerializer<String>()
+                assertEquals(intervals.size(), fromTree.size());
+                Set<Interval<Integer, String>> original = ImmutableSet.copyOf(intervals);
+
+                assertEquals(original, fromTree);
+
+                IntervalTree<Integer, String, Interval<Integer, String>> tree2 = IntervalTree.build(intervals);
+                assertEquals(tree, tree2);
+                assertEquals(tree.hashCode(), tree2.hashCode());
+
+                return true;
+            });
+    }
+
+    @Test
+    public void qtUpdateFunctionTest()
+    {
+        qt().withExamples(-1).withTestingTime(30, SECONDS).forAll(intervalsListGen(),
+                                                                  intervalsListGen(),
+                                                                  SourceDSL.lists().of(queryGen()).ofSizeBetween(1, 4),
+                                                                  SourceDSL.integers().all())
+            .check((original, toAdd, queries, seed) -> {
+                IntervalTree<Integer, String, Interval<Integer, String>> originalTree = IntervalTree.build(original);
+
+                java.util.Random rng = new java.util.Random(seed);
+
+                List<Interval<Integer, String>> removals = new ArrayList<>();
+                for (Interval<Integer, String> candidate : original)
                 {
-                    public void serialize(String v, DataOutputPlus out) throws IOException
+                    if (rng.nextBoolean())
+                        removals.add(candidate);
+                }
+
+                toAdd.removeAll(original.stream().filter(not(removals::contains)).collect(Collectors.toList()));
+
+                IntervalTree<Integer, String, Interval<Integer, String>> updatedTree = originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
+
+                Set<Interval<Integer, String>> naiveFinal = new HashSet<>(original);
+                naiveFinal.removeAll(removals);
+                naiveFinal.addAll(toAdd);
+
+                Set<Interval<Integer, String>> iteratedTree = ImmutableSet.copyOf(updatedTree);
+                if (!naiveFinal.equals(iteratedTree))
+                    originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
+                assertEquals(naiveFinal, iteratedTree);
+
+                for (Interval<Integer, String> query : queries)
+                {
+                    Set<String> actualResults = ImmutableSet.copyOf(updatedTree.search(query));
+                    Set<String> expectedResults = ImmutableSet.copyOf(search(naiveFinal, query));
+
+                    if (!expectedResults.equals(actualResults))
                     {
-                        out.writeUTF(v);
+                        originalTree.update(removals.toArray(new Interval[0]), toAdd.toArray(new Interval[0]));
+                        updatedTree.search(query);
                     }
 
-                    public String deserialize(DataInputPlus in) throws IOException
+                    assertEquals(expectedResults, actualResults);
+
+                    if (query.min.equals(query.max))
                     {
-                        return in.readUTF();
+                        List<String> pointResults = updatedTree.search(query.min);
+                        assertEquals(new HashSet<>(expectedResults), new HashSet<>(pointResults));
                     }
+                }
 
-                    public long serializedSize(String v)
-                    {
-                        return v.length();
-                    }
-                },
-                (Constructor<Interval<Integer, String>>) (Object) Interval.class.getConstructor(Object.class, Object.class, Object.class)
-        );
-
-        DataOutputBuffer out = new DataOutputBuffer();
-
-        serializer.serialize(it, out, 0);
-
-        DataInputPlus in = new DataInputBuffer(out.toByteArray());
-
-        IntervalTree<Integer, String, Interval<Integer, String>> it2 = serializer.deserialize(in, 0);
-        List<Interval<Integer, String>> intervals2 = new ArrayList<Interval<Integer, String>>();
-        for (Interval<Integer, String> i : it2)
-            intervals2.add(i);
-
-        assertEquals(intervals, intervals2);
+                return true;
+            });
     }
 }

--- a/test/unit/org/apache/cassandra/utils/OverlapIteratorTest.java
+++ b/test/unit/org/apache/cassandra/utils/OverlapIteratorTest.java
@@ -76,7 +76,7 @@ public class OverlapIteratorTest
         compare(randomIntervals(range, increment, count), random(range, increment, count), 3);
     }
 
-    private <I extends Comparable<I>, V> void compare(List<Interval<I, V>> intervals, List<I> points, int initCount)
+    private <I extends Comparable<I>, V extends Comparable<V>> void compare(List<Interval<I, V>> intervals, List<I> points, int initCount)
     {
         Collections.sort(points);
         IntervalTree<I, V, Interval<I, V>> tree = IntervalTree.build(intervals);
@@ -98,5 +98,4 @@ public class OverlapIteratorTest
             assertTrue(missing.isEmpty());
         }
     }
-
 }


### PR DESCRIPTION
IntervalTree does a ton of redundant sorting as it builds the tree when it could sort once and then leverage the already sorted order.

Patch by Ariel Weisberg; Reviewed by Marcus Eriksson for CASSANDRA-19596