### PR TITLE
CASSANDRA-19498 Fixed a bug where username and password from the credentials file were ignored

### DIFF
--- a/conf/credentials.sample
+++ b/conf/credentials.sample
@@ -17,6 +17,15 @@
 ;
 ; Sample ~/.cassandra/credentials file.
 ;
+; The section name must match the classname from the cqlshrc file
+; For example, if cqlshrc contains settings
+;
+; [auth_provider]
+; module = cassandra.auth
+; classname = PlainTextAuthProvider
+;
+; then the credentials file should contain a [PlainTextAuthProvider] section with the username and password parameters, as indicated in this example
+;
 ; Please ensure this file is owned by the user and is not readable by group and other users
 
 [PlainTextAuthProvider]

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -44,6 +44,18 @@ Example config values and documentation can be found in the
 You can also view the latest version of the
 https://github.com/apache/cassandra/blob/trunk/conf/cqlshrc.sample[cqlshrc file online].
 
+[[credentials]]
+== credentials
+
+The credentials file contains the login and password for cqlsh
+The login and password must be located in a section whose name matches the classname from the [auth_provider] section of the cqlshrc file
+The credentials file must be owned by the user and no one else has permission to read the file.
+
+Example config values and documentation can be found in the
+`conf/credentials.sample` file of a tarball installation.
+You can also view the latest version of the
+https://github.com/apache/cassandra/blob/trunk/conf/credentials.sample[credentials file online].
+
 [[cql_history]]
 == cql history
 

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -1999,7 +1999,8 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
             print("\nWarning: Password is found in an insecure cqlshrc file. The file is owned or readable by other users on the system.",
                   end='', file=sys.stderr)
         print("\nNotice: Credentials in the cqlshrc file is deprecated and will be ignored in the future."
-              "\nPlease use a credentials file to specify the username and password.\n", file=sys.stderr)
+              "\nFor basic authentication, please use a credentials file with username and password in the [PlainTextAuthProvider] section.\n",
+              file=sys.stderr)
 
     argvalues = argparse.Namespace()
 
@@ -2073,7 +2074,7 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
             credentials.read(options.credentials)
 
         # use the username from credentials file but fallback to cqlshrc if username is absent from the command line parameters
-        options.username = username_from_cqlshrc
+        options.username = option_with_default(credentials.get, 'plain_text_auth', 'username', username_from_cqlshrc)
 
     if not options.password:
         rawcredentials = configparser.RawConfigParser()
@@ -2082,7 +2083,7 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
 
         # handling password in the same way as username, priority cli > credentials > cqlshrc
         options.password = option_with_default(rawcredentials.get, 'plain_text_auth', 'password', password_from_cqlshrc)
-        options.password = password_from_cqlshrc
+        
     elif not options.insecure_password_without_warning:
         print("\nWarning: Using a password on the command line interface can be insecure."
               "\nRecommendation: use the credentials file to securely provide the password.\n", file=sys.stderr)


### PR DESCRIPTION

Now the username and password from credentials file can be used again. Added description to notice on how to properly use the credentials file Added description of using AuthProvider to example config files and cqlsh documentation Improved notice when placing login or password in cqlshrc file Skipped adding test to check legacy credential format in original PR

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

