### PR TITLE
CASSANDRA-19648: Flaky test: StartupChecksTest#testKernelBug1057843Check() on Non-Linux OS

### DIFF
--- a/test/unit/org/apache/cassandra/service/StartupChecksTest.java
+++ b/test/unit/org/apache/cassandra/service/StartupChecksTest.java
@@ -244,6 +244,7 @@ public class StartupChecksTest
     public void testKernelBug1057843Check() throws Exception
     {
         Assume.assumeTrue(DatabaseDescriptor.getCommitLogCompression() == null); // we would not be able to enable direct io otherwise
+        Assume.assumeTrue("Skipping this test on Non-Linux OS", FBUtilities.isLinux);
         testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.63.1-generic"), false);
         testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.64.1-generic"), true);
         testKernelBug1057843Check("ext4", DiskAccessMode.direct, new Semver("6.1.65.1-generic"), true);


### PR DESCRIPTION
- more details in the [CASSANDRA-19648](https://issues.apache.org/jira/browse/CASSANDRA-19648)