### PR TITLE
cassandra-17667: move the unclosed rules up

### DIFF
--- a/bin/cqlsh.py
+++ b/bin/cqlsh.py
@@ -509,7 +509,6 @@ class Shell(cmd.Cmd):
 
         self.statement = StringIO()
         self.lineno = 1
-        self.in_comment = False
 
         self.prompt = ''
         if stdin is None:
@@ -915,30 +914,12 @@ class Shell(cmd.Cmd):
                     self.reset_statement()
                     print('')
 
-    def strip_comment_blocks(self, statementtext):
-        comment_block_in_literal_string = re.search('["].*[/][*].*[*][/].*["]', statementtext)
-        if not comment_block_in_literal_string:
-            result = re.sub('[/][*].*[*][/]', "", statementtext)
-            if '*/' in result and '/*' not in result and not self.in_comment:
-                raise SyntaxError("Encountered comment block terminator without being in comment block")
-            if '/*' in result:
-                result = re.sub('[/][*].*', "", result)
-                self.in_comment = True
-            if '*/' in result:
-                result = re.sub('.*[*][/]', "", result)
-                self.in_comment = False
-            if self.in_comment and not re.findall('[/][*]|[*][/]', statementtext):
-                result = ''
-            return result
-        return statementtext
-
     def onecmd(self, statementtext):
         """
         Returns true if the statement is complete and was handled (meaning it
         can be reset).
         """
         statementtext = ensure_text(statementtext)
-        statementtext = self.strip_comment_blocks(statementtext)
         try:
             statements, endtoken_escaped = cqlruleset.cql_split_statements(statementtext)
         except pylexotron.LexingError as e:

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -162,7 +162,7 @@ syntax_rules = r'''
 <CQL_Statement> ::= [statements]=<statementBody> ";"
                   ;
 
-# The order of these terminal productions is significant. The input string is matched to the rule 
+# The order of these terminal productions is significant. The input string is matched to the rule
 # specified first in the grammar.
 
 <endline> ::= /\n/ ;

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -162,7 +162,9 @@ syntax_rules = r'''
 <CQL_Statement> ::= [statements]=<statementBody> ";"
                   ;
 
-# the order of these terminal productions is significant:
+# The order of these terminal productions is significant. The input string is matched to the rule 
+# specified first in the grammar.
+
 <endline> ::= /\n/ ;
 
 JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
@@ -172,6 +174,12 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
 <quotedStringLiteral> ::= /'([^']|'')*'/ ;
 <pgStringLiteral> ::= /\$\$(?:(?!\$\$).)*\$\$/;
 <quotedName> ::=    /"([^"]|"")*"/ ;
+
+<unclosedPgString>::= /\$\$(?:(?!\$\$).)*/ ;
+<unclosedString>  ::= /'([^']|'')*/ ;
+<unclosedName>    ::= /"([^"]|"")*/ ;
+<unclosedComment> ::= /[/][*].*$/ ;
+
 <float> ::=         /-?[0-9]+\.[0-9]+/ ;
 <uuid> ::=          /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/ ;
 <blobLiteral> ::=    /0x[0-9a-f]+/ ;
@@ -188,11 +196,6 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
 <boolean> ::= "true"
             | "false"
             ;
-
-<unclosedPgString>::= /\$\$(?:(?!\$\$).)*/ ;
-<unclosedString>  ::= /'([^']|'')*/ ;
-<unclosedName>    ::= /"([^"]|"")*/ ;
-<unclosedComment> ::= /[/][*].*$/ ;
 
 <term> ::= <stringLiteral>
          | <integer>

--- a/pylib/cqlshlib/test/test_cql_parsing.py
+++ b/pylib/cqlshlib/test/test_cql_parsing.py
@@ -774,27 +774,27 @@ class TestCqlParsing(TestCase):
         parsed = parse_cqlsh_statements('''
                                         INSERT into a (key,c1,c2) VALUES ('aKey','v1*/','/v2/*/v3');
                                         ''')
-        
+
         self.assertSequenceEqual(tokens_with_types(parsed),
-                                [('INSERT','reserved_identifier'),
-                                ('into','reserved_identifier'),
-                                ('a','identifier'),
-                                ('(','op'),
-                                ('key','identifier'),
-                                (',','op'),
-                                ('c1','identifier'),
-                                (',','op'),
-                                ('c2','identifier'),
-                                (')','op'),
-                                ('VALUES','identifier'),
-                                ('(','op'),
-                                ("'aKey'",'quotedStringLiteral'),
-                                (',','op'),
-                                ("'v1*/'",'quotedStringLiteral'),
-                                (',','op'),
-                                ("'/v2/*/v3'",'quotedStringLiteral'),
-                                (')','op'),
-                                (';','endtoken')])
+                                 [('INSERT', 'reserved_identifier'),
+                                  ('into', 'reserved_identifier'),
+                                  ('a', 'identifier'),
+                                  ('(', 'op'),
+                                  ('key', 'identifier'),
+                                  (',', 'op'),
+                                  ('c1', 'identifier'),
+                                  (',', 'op'),
+                                  ('c2', 'identifier'),
+                                  (')', 'op'),
+                                  ('VALUES', 'identifier'),
+                                  ('(', 'op'),
+                                  ("'aKey'", 'quotedStringLiteral'),
+                                  (',', 'op'),
+                                  ("'v1*/'", 'quotedStringLiteral'),
+                                  (',', 'op'),
+                                  ("'/v2/*/v3'", 'quotedStringLiteral'),
+                                  (')', 'op'),
+                                  (';', 'endtoken')])
 
         parse_cqlsh_statements('''
                                */ SELECT FROM "MyTable";

--- a/pylib/cqlshlib/test/test_cql_parsing.py
+++ b/pylib/cqlshlib/test/test_cql_parsing.py
@@ -771,6 +771,31 @@ class TestCqlParsing(TestCase):
                                   ('"/*MyTable*/"', 'quotedName'),
                                   (';', 'endtoken')])
 
+        parsed = parse_cqlsh_statements('''
+                                        INSERT into a (key,c1,c2) VALUES ('aKey','v1*/','/v2/*/v3');
+                                        ''')
+        
+        self.assertSequenceEqual(tokens_with_types(parsed),
+                                [('INSERT','reserved_identifier'),
+                                ('into','reserved_identifier'),
+                                ('a','identifier'),
+                                ('(','op'),
+                                ('key','identifier'),
+                                (',','op'),
+                                ('c1','identifier'),
+                                (',','op'),
+                                ('c2','identifier'),
+                                (')','op'),
+                                ('VALUES','identifier'),
+                                ('(','op'),
+                                ("'aKey'",'quotedStringLiteral'),
+                                (',','op'),
+                                ("'v1*/'",'quotedStringLiteral'),
+                                (',','op'),
+                                ("'/v2/*/v3'",'quotedStringLiteral'),
+                                (')','op'),
+                                (';','endtoken')])
+
         parse_cqlsh_statements('''
                                */ SELECT FROM "MyTable";
                                ''')


### PR DESCRIPTION
move the unclosed rules up to follow the valid string literals & names, added new unit test and removed strip comment function

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

