### PR TITLE
CASSANDRA-19679 - Replace Stream iteration with for-loop for SimpleRestriction::bindAndGetClusteringElements

### DIFF
--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -256,7 +256,8 @@ public final class SimpleRestriction implements SingleRestriction
     private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options)
     {
         List<List<ByteBuffer>> values = bindAndGetElements(options);
-        if (values.isEmpty()) {
+        if (values.isEmpty())
+        {
             return Collections.emptyList();
         }
 

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -243,7 +243,7 @@ public final class SimpleRestriction implements SingleRestriction
     {
         List<ByteBuffer> values = bindAndGet(options);
         if (!values.isEmpty()) {
-            List<ClusteringElements> elements = new ArrayList<>();
+            List<ClusteringElements> elements = new ArrayList<>(values.size());
             for (ByteBuffer value : values) {
                 ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), value);
                 elements.add(byteBuffers);
@@ -257,7 +257,7 @@ public final class SimpleRestriction implements SingleRestriction
     {
         List<List<ByteBuffer>> values = bindAndGetElements(options);
         if (!values.isEmpty()) {
-            List<ClusteringElements> elements = new ArrayList<>();
+            List<ClusteringElements> elements = new ArrayList<>(values.size());
             for (List<ByteBuffer> value : values) {
                 ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), value);
                 elements.add(byteBuffers);

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -248,7 +248,7 @@ public final class SimpleRestriction implements SingleRestriction
                 ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), value);
                 elements.add(byteBuffers);
             }
-            return elements;
+            return Collections.unmodifiableList(elements);
         }
         return Collections.emptyList();
     }
@@ -262,7 +262,7 @@ public final class SimpleRestriction implements SingleRestriction
                 ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), value);
                 elements.add(byteBuffers);
             }
-            return elements;
+            return Collections.unmodifiableList(elements);
         }
         return Collections.emptyList();
     }

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.cql3.restrictions;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -225,17 +226,22 @@ public final class SimpleRestriction implements SingleRestriction
 
     private List<ClusteringElements> bindAndGetClusteringElements(QueryOptions options)
     {
+        List<ClusteringElements> elements = new ArrayList<>();
         switch (columnsExpression.kind())
         {
             case SINGLE_COLUMN:
             case TOKEN:
-                return bindAndGet(options).stream()
-                                          .map(b ->  ClusteringElements.of(columnsExpression.columnSpecification(), b))
-                                          .collect(Collectors.toList());
+                for (ByteBuffer b : bindAndGet(options)) {
+                    ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), b);
+                    elements.add(byteBuffers);
+                }
+                return elements;
             case MULTI_COLUMN:
-                return bindAndGetElements(options).stream()
-                                                  .map(buffers -> ClusteringElements.of(columnsExpression.columns(), buffers))
-                                                  .collect(Collectors.toList());
+                for (List<ByteBuffer> buffers : bindAndGetElements(options)) {
+                    ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), buffers);
+                    elements.add(byteBuffers);
+                }
+                return elements;
             default:
                 throw new UnsupportedOperationException();
         }

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -238,7 +238,8 @@ public final class SimpleRestriction implements SingleRestriction
         }
     }
 
-    private List<ClusteringElements> bindAndGetSingleTermClusteringElements(QueryOptions options) {
+    private List<ClusteringElements> bindAndGetSingleTermClusteringElements(QueryOptions options)
+    {
         List<ClusteringElements> elements = new ArrayList<>();
         for (ByteBuffer b : bindAndGet(options)) {
             ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), b);
@@ -247,7 +248,8 @@ public final class SimpleRestriction implements SingleRestriction
         return elements;
     }
 
-    private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options) {
+    private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options)
+    {
         List<ClusteringElements> elements = new ArrayList<>();
         for (List<ByteBuffer> buffers : bindAndGetElements(options)) {
             ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), buffers);

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -242,27 +242,28 @@ public final class SimpleRestriction implements SingleRestriction
     private List<ClusteringElements> bindAndGetSingleTermClusteringElements(QueryOptions options)
     {
         List<ByteBuffer> values = bindAndGet(options);
-        if (!values.isEmpty())
+        if (values.isEmpty())
         {
-            List<ClusteringElements> elements = new ArrayList<>(values.size());
-            for (ByteBuffer value : values)
-                elements.add(ClusteringElements.of(columnsExpression.columnSpecification(), value));
-            return Collections.unmodifiableList(elements);
+            return Collections.emptyList();
         }
-        return Collections.emptyList();
+
+        List<ClusteringElements> elements = new ArrayList<>(values.size());
+        for (int i = 0; i < values.size(); i++)
+            elements.add(ClusteringElements.of(columnsExpression.columnSpecification(), values.get(i)));
+        return elements;
     }
 
     private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options)
     {
         List<List<ByteBuffer>> values = bindAndGetElements(options);
-        if (!values.isEmpty())
-        {
-            List<ClusteringElements> elements = new ArrayList<>(values.size());
-            for (List<ByteBuffer> value : values)
-                elements.add(ClusteringElements.of(columnsExpression.columns(), value));
-            return Collections.unmodifiableList(elements);
+        if (values.isEmpty()) {
+            return Collections.emptyList();
         }
-        return Collections.emptyList();
+
+        List<ClusteringElements> elements = new ArrayList<>(values.size());
+        for (int i = 0; i < values.size(); i++)
+            elements.add(ClusteringElements.of(columnsExpression.columns(), values.get(i)));
+        return elements;
     }
 
     private List<ByteBuffer> bindAndGet(QueryOptions options)

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.cql3.restrictions;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -240,22 +241,30 @@ public final class SimpleRestriction implements SingleRestriction
 
     private List<ClusteringElements> bindAndGetSingleTermClusteringElements(QueryOptions options)
     {
-        List<ClusteringElements> elements = new ArrayList<>();
-        for (ByteBuffer b : bindAndGet(options)) {
-            ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), b);
-            elements.add(byteBuffers);
+        List<ByteBuffer> values = bindAndGet(options);
+        if (!values.isEmpty()) {
+            List<ClusteringElements> elements = new ArrayList<>();
+            for (ByteBuffer value : values) {
+                ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), value);
+                elements.add(byteBuffers);
+            }
+            return elements;
         }
-        return elements;
+        return Collections.emptyList();
     }
 
     private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options)
     {
-        List<ClusteringElements> elements = new ArrayList<>();
-        for (List<ByteBuffer> buffers : bindAndGetElements(options)) {
-            ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), buffers);
-            elements.add(byteBuffers);
+        List<List<ByteBuffer>> values = bindAndGetElements(options);
+        if (!values.isEmpty()) {
+            List<ClusteringElements> elements = new ArrayList<>();
+            for (List<ByteBuffer> value : values) {
+                ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), value);
+                elements.add(byteBuffers);
+            }
+            return elements;
         }
-        return elements;
+        return Collections.emptyList();
     }
 
     private List<ByteBuffer> bindAndGet(QueryOptions options)

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -242,12 +242,11 @@ public final class SimpleRestriction implements SingleRestriction
     private List<ClusteringElements> bindAndGetSingleTermClusteringElements(QueryOptions options)
     {
         List<ByteBuffer> values = bindAndGet(options);
-        if (!values.isEmpty()) {
+        if (!values.isEmpty())
+        {
             List<ClusteringElements> elements = new ArrayList<>(values.size());
-            for (ByteBuffer value : values) {
-                ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), value);
-                elements.add(byteBuffers);
-            }
+            for (ByteBuffer value : values)
+                elements.add(ClusteringElements.of(columnsExpression.columnSpecification(), value));
             return Collections.unmodifiableList(elements);
         }
         return Collections.emptyList();
@@ -256,12 +255,11 @@ public final class SimpleRestriction implements SingleRestriction
     private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options)
     {
         List<List<ByteBuffer>> values = bindAndGetElements(options);
-        if (!values.isEmpty()) {
+        if (!values.isEmpty())
+        {
             List<ClusteringElements> elements = new ArrayList<>(values.size());
-            for (List<ByteBuffer> value : values) {
-                ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), value);
-                elements.add(byteBuffers);
-            }
+            for (List<ByteBuffer> value : values)
+                elements.add(ClusteringElements.of(columnsExpression.columns(), value));
             return Collections.unmodifiableList(elements);
         }
         return Collections.emptyList();

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -226,25 +226,34 @@ public final class SimpleRestriction implements SingleRestriction
 
     private List<ClusteringElements> bindAndGetClusteringElements(QueryOptions options)
     {
-        List<ClusteringElements> elements = new ArrayList<>();
         switch (columnsExpression.kind())
         {
             case SINGLE_COLUMN:
             case TOKEN:
-                for (ByteBuffer b : bindAndGet(options)) {
-                    ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), b);
-                    elements.add(byteBuffers);
-                }
-                return elements;
+                return bindAndGetSingleTermClusteringElements(options);
             case MULTI_COLUMN:
-                for (List<ByteBuffer> buffers : bindAndGetElements(options)) {
-                    ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), buffers);
-                    elements.add(byteBuffers);
-                }
-                return elements;
+                return bindAndGetMultiTermClusteringElements(options);
             default:
                 throw new UnsupportedOperationException();
         }
+    }
+
+    private List<ClusteringElements> bindAndGetSingleTermClusteringElements(QueryOptions options) {
+        List<ClusteringElements> elements = new ArrayList<>();
+        for (ByteBuffer b : bindAndGet(options)) {
+            ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columnSpecification(), b);
+            elements.add(byteBuffers);
+        }
+        return elements;
+    }
+
+    private List<ClusteringElements> bindAndGetMultiTermClusteringElements(QueryOptions options) {
+        List<ClusteringElements> elements = new ArrayList<>();
+        for (List<ByteBuffer> buffers : bindAndGetElements(options)) {
+            ClusteringElements byteBuffers = ClusteringElements.of(columnsExpression.columns(), buffers);
+            elements.add(byteBuffers);
+        }
+        return elements;
     }
 
     private List<ByteBuffer> bindAndGet(QueryOptions options)

--- a/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
+++ b/src/java/org/apache/cassandra/cql3/restrictions/SimpleRestriction.java
@@ -243,9 +243,7 @@ public final class SimpleRestriction implements SingleRestriction
     {
         List<ByteBuffer> values = bindAndGet(options);
         if (values.isEmpty())
-        {
             return Collections.emptyList();
-        }
 
         List<ClusteringElements> elements = new ArrayList<>(values.size());
         for (int i = 0; i < values.size(); i++)
@@ -257,9 +255,7 @@ public final class SimpleRestriction implements SingleRestriction
     {
         List<List<ByteBuffer>> values = bindAndGetElements(options);
         if (values.isEmpty())
-        {
             return Collections.emptyList();
-        }
 
         List<ClusteringElements> elements = new ArrayList<>(values.size());
         for (int i = 0; i < values.size(); i++)


### PR DESCRIPTION
Part 2 (of 2) of low-hanging fruit Stream performance improvements.

The second main Stream contributor to allocations and CPU was SimpleRestriction::bindAndGetClusteringElements, which contributes to 4.58% of all allocations for a 50/50 workload. The image attached shows allocation profiling with trunk (see purple highlighted sections).

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19679)

See Jira for full HTML flame graphs.

Before (4.58% allocations)

![image](https://github.com/apache/cassandra/assets/84812011/ba46d00c-ca59-4140-833f-17cd5225e6df)

After (1.37% allocations)

![image](https://github.com/apache/cassandra/assets/84812011/eb17ce4b-ee13-4a9d-8354-17036afe631f)

