### PR TITLE
CASSANDRA-19022: Nodetool gcstats correctly displays Direct Memory usage and supports printing in table format

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/GcStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GcStats.java
@@ -17,21 +17,58 @@
  */
 package org.apache.cassandra.tools.nodetool;
 
+import io.airlift.airline.Option;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
 import io.airlift.airline.Command;
+import org.apache.cassandra.tools.nodetool.formatter.TableBuilder;
 
 @Command(name = "gcstats", description = "Print GC Statistics")
 public class GcStats extends NodeToolCmd
 {
+
+    @Option(title = "human_readable",
+    name = {"-H", "--human-readable"},
+    description = "Display gcstats in the table format for human-readable")
+    private boolean humanReadable = false;
+
+    public static final String INTERVAL = "Interval (ms)";
+    public static final String MAX_GC = "Max GC Elapsed (ms)";
+    public static final String TOTAL_GC = "Total GC Elapsed (ms)";
+    public static final String STDEV_GC = "Stdev GC Elapsed (ms)";
+    public static final String RECLAIMED_GC = "GC Reclaimed (MB)";
+    public static final String COLLECTIONS = "Collections";
+    public static final String TOTAL_DIRECT_MEMORY = "Total Direct Memory Bytes";
+    public static final String MAX_DIRECT_MEMORY = "Max Direct Memory Bytes";
+    public static final String RESERVED_DIRECT_MEMORY = "Reserved Direct Memory Bytes";
+
     @Override
     public void execute(NodeProbe probe)
     {
         double[] stats = probe.getAndResetGCStats();
         double mean = stats[2] / stats[5];
         double stdev = Math.sqrt((stats[3] / stats[5]) - (mean * mean));
-        probe.output().out.printf("%20s%20s%20s%20s%20s%20s%25s%n", "Interval (ms)", "Max GC Elapsed (ms)", "Total GC Elapsed (ms)", "Stdev GC Elapsed (ms)", "GC Reclaimed (MB)", "Collections", "Direct Memory Bytes");
-        probe.output().out.printf("%20.0f%20.0f%20.0f%20.0f%20.0f%20.0f%25d%n", stats[0], stats[1], stats[2], stdev, stats[4], stats[5], (long)stats[6]);
+
+        if (!humanReadable)
+        {
+            probe.output().out.printf("%20s%20s%20s%20s%20s%20s%25s%n", INTERVAL, MAX_GC, TOTAL_GC, STDEV_GC, RECLAIMED_GC, COLLECTIONS, TOTAL_DIRECT_MEMORY);
+            probe.output().out.printf("%20.0f%20.0f%20.0f%20.0f%20.0f%20.0f%25d%n", stats[0], stats[1], stats[2], stdev, stats[4], stats[5], (long) stats[6]);
+        }
+        else
+        {
+            TableBuilder tableBuilder = new TableBuilder();
+            tableBuilder.add(INTERVAL, String.valueOf(stats[0]));
+            tableBuilder.add(MAX_GC, String.valueOf(stats[1]));
+            tableBuilder.add(TOTAL_GC, String.valueOf(stats[2]));
+            tableBuilder.add(STDEV_GC, String.valueOf(stats[3]));
+            tableBuilder.add(RECLAIMED_GC, String.valueOf(stats[4]));
+            tableBuilder.add(COLLECTIONS, String.valueOf(stats[5]));
+            tableBuilder.add(TOTAL_DIRECT_MEMORY, String.valueOf((long) stats[6]));
+            tableBuilder.add(MAX_DIRECT_MEMORY, String.valueOf((long) stats[7]));
+            tableBuilder.add(RESERVED_DIRECT_MEMORY, String.valueOf((long) stats[8]));
+
+            tableBuilder.printTo(probe.output().out);
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/GcStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GcStatsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.apache.cassandra.tools.nodetool.GcStats.COLLECTIONS;
+import static org.apache.cassandra.tools.nodetool.GcStats.INTERVAL;
+import static org.apache.cassandra.tools.nodetool.GcStats.MAX_DIRECT_MEMORY;
+import static org.apache.cassandra.tools.nodetool.GcStats.MAX_GC;
+import static org.apache.cassandra.tools.nodetool.GcStats.RECLAIMED_GC;
+import static org.apache.cassandra.tools.nodetool.GcStats.RESERVED_DIRECT_MEMORY;
+import static org.apache.cassandra.tools.nodetool.GcStats.STDEV_GC;
+import static org.apache.cassandra.tools.nodetool.GcStats.TOTAL_DIRECT_MEMORY;
+import static org.apache.cassandra.tools.nodetool.GcStats.TOTAL_GC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GcStatsTest extends CQLTester
+{
+    GCInspector gcInspector;
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        requireNetwork();
+        startJMXServer();
+    }
+
+    @Before
+    public void before()
+    {
+        gcInspector = new GCInspector();
+    }
+
+    @Test
+    @SuppressWarnings("SingleCharacterStringConcatenation")
+    public void testHelp()
+    {
+        // If you added, modified options or help, please update docs if necessary
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("help", "gcstats");
+        tool.assertOnCleanExit();
+        String help = "NAME\n" +
+                      "        nodetool gcstats - Print GC Statistics\n" +
+                      "\n" +
+                      "SYNOPSIS\n" +
+                      "        nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]\n" +
+                      "                [(-pp | --print-port)] [(-pw <password> | --password <password>)]\n" +
+                      "                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]\n" +
+                      "                [(-u <username> | --username <username>)] gcstats\n" +
+                      "                [(-H | --human-readable)]\n" +
+                      "\n" +
+                      "OPTIONS\n" +
+                      "        -h <host>, --host <host>\n" +
+                      "            Node hostname or ip address\n" +
+                      "\n" +
+                      "        -H, --human-readable\n" +
+                      "            Display gcstats in the table format for human-readable\n" +
+                      "\n" +
+                      "        -p <port>, --port <port>\n" +
+                      "            Remote jmx agent port number\n" +
+                      "\n" +
+                      "        -pp, --print-port\n" +
+                      "            Operate in 4.0 mode with hosts disambiguated by port number\n" +
+                      "\n" +
+                      "        -pw <password>, --password <password>\n" +
+                      "            Remote jmx agent password\n" +
+                      "\n" +
+                      "        -pwf <passwordFilePath>, --password-file <passwordFilePath>\n" +
+                      "            Path to the JMX password file\n" +
+                      "\n" +
+                      "        -u <username>, --username <username>\n" +
+                      "            Remote jmx agent username\n" +
+                      "\n" +
+                      "\n";
+        assertThat(tool.getStdout()).isEqualTo(help);
+    }
+
+    @Test
+    public void testWithoutAnyOption()
+    {
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("gcstats");
+        tool.assertOnCleanExit();
+        testBasicOutput(tool.getStdout());
+    }
+
+    @Test
+    public void testWithHOption()
+    {
+        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("gcstats", "--human-readable");
+        tool.assertOnCleanExit();
+        String gcStatsOutput = tool.getStdout();
+        testBasicOutput(gcStatsOutput);
+
+        assertThat(gcStatsOutput).contains(MAX_DIRECT_MEMORY);
+        assertThat(gcStatsOutput).contains(RESERVED_DIRECT_MEMORY);
+
+        String total = StringUtils.substringBetween(gcStatsOutput, TOTAL_DIRECT_MEMORY, "\n").trim();
+        assertThat(Long.parseLong(total)).isGreaterThan(0);
+        String max = StringUtils.substringBetween(gcStatsOutput, MAX_DIRECT_MEMORY, "\n").trim();
+        assertThat(Long.parseLong(max)).isGreaterThan(0);
+        String reserved = StringUtils.substringBetween(gcStatsOutput, RESERVED_DIRECT_MEMORY, "\n").trim();
+        assertThat(Long.parseLong(reserved)).isGreaterThan(0);
+    }
+
+    private void testBasicOutput(final String output)
+    {
+        assertThat(output).contains(INTERVAL);
+        assertThat(output).contains(MAX_GC);
+        assertThat(output).contains(TOTAL_GC);
+        assertThat(output).contains(STDEV_GC);
+        assertThat(output).contains(RECLAIMED_GC);
+        assertThat(output).contains(COLLECTIONS);
+        assertThat(output).contains(TOTAL_DIRECT_MEMORY);
+    }
+}


### PR DESCRIPTION
- more details in the [CASSANDRA-19022](https://issues.apache.org/jira/browse/CASSANDRA-19022)