### PR TITLE
CASSANDRA-19685 - Add auto_hints_cleanup_enabled to documentation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Add auto_hints_cleanup_enabled to web documentation (CASSANDRA-19685)
  * Add support for the BETWEEN operator in WHERE clauses (CASSANDRA-19604)
  * Replace Stream iteration with for-loop for SimpleRestriction::bindAndGetClusteringElements (CASSANDRA-19679)
  * Consolidate logging on trace level (CASSANDRA-19632)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,4 @@
 5.1
- * Add auto_hints_cleanup_enabled to web documentation (CASSANDRA-19685)
  * Add support for the BETWEEN operator in WHERE clauses (CASSANDRA-19604)
  * Replace Stream iteration with for-loop for SimpleRestriction::bindAndGetClusteringElements (CASSANDRA-19679)
  * Consolidate logging on trace level (CASSANDRA-19632)

--- a/doc/modules/cassandra/pages/managing/operating/hints.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/hints.adoc
@@ -155,7 +155,7 @@ omitted, hints files will be written uncompressed. LZ4, Snappy, and
 Deflate compressors are supported. |`false`
 
 |`auto_hints_cleanup_enabled` |Enable / disable automatic cleanup for the
-expired and orphaned hints file. Disable the option in order to preserve
+expired and orphaned hints files. Disable the option in order to preserve
 those hints on the disk. |`false`
 |===
 

--- a/doc/modules/cassandra/pages/managing/operating/hints.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/hints.adoc
@@ -152,7 +152,11 @@ megabytes. |`128MiB`
 
 |`hints_compression` |Compression to apply to the hint files. If
 omitted, hints files will be written uncompressed. LZ4, Snappy, and
-Deflate compressors are supported. |`LZ4Compressor`
+Deflate compressors are supported. |`false`
+
+|`auto_hints_cleanup_enabled` |Enable / disable automatic cleanup for the
+expired and orphaned hints file. Disable the option in order to preserve
+those hints on the disk. |`false`
 |===
 
 == Configuring Hints at Runtime with `nodetool`

--- a/doc/modules/cassandra/pages/managing/operating/hints.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/hints.adoc
@@ -156,7 +156,7 @@ Deflate compressors are supported. |`LZ4Compressor`
 
 |`auto_hints_cleanup_enabled` |Enable / disable automatic cleanup for the
 expired and orphaned hints files. Disable the option in order to preserve
-those hints on the disk. |`false`
+those hints on the disk. Available since version 4.1. |`false`
 |===
 
 == Configuring Hints at Runtime with `nodetool`

--- a/doc/modules/cassandra/pages/managing/operating/hints.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/hints.adoc
@@ -152,7 +152,7 @@ megabytes. |`128MiB`
 
 |`hints_compression` |Compression to apply to the hint files. If
 omitted, hints files will be written uncompressed. LZ4, Snappy, and
-Deflate compressors are supported. |`false`
+Deflate compressors are supported. |`LZ4Compressor`
 
 |`auto_hints_cleanup_enabled` |Enable / disable automatic cleanup for the
 expired and orphaned hints files. Disable the option in order to preserve


### PR DESCRIPTION
CASSANDRA-19685 - Add auto_hints_cleanup_enabled to web documentation

Adds `auto_hints_cleanup_enabled` flag to the hints web documentation.

patch by Bernardo Botella Corbi; reviewed by <Reviewers> for CASSANDRA-19685