### PR TITLE
[CASSANDRA-19651][4.1] Fix latency reported by ideal consistency level monitoring

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,6 @@
  * Refresh stale paxos commit (CASSANDRA-19617)
  * Reduce info logging from automatic paxos repair (CASSANDRA-19445)
  * Support legacy plain_text_auth section in credentials file removed unintentionally (CASSANDRA-19498)
- * Fix idealCLWriteLatency metric which reported the worst response time instead of the time when an ideal CL is satisfied (CASSANDRA-19651)
 Merged from 4.0:
  * Make LWT conditions behavior on frozen and non-frozen columns consistent for null column values (CASSANDRA-19637)
  * Add timeout specifically for bootstrapping nodes (CASSANDRA-15439)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * Refresh stale paxos commit (CASSANDRA-19617)
  * Reduce info logging from automatic paxos repair (CASSANDRA-19445)
  * Support legacy plain_text_auth section in credentials file removed unintentionally (CASSANDRA-19498)
+ * Fix idealCLWriteLatency metric which reported the worst response time instead of the time when an ideal CL is satisfied (CASSANDRA-19651)
 Merged from 4.0:
  * Make LWT conditions behavior on frozen and non-frozen columns consistent for null column values (CASSANDRA-19637)
  * Add timeout specifically for bootstrapping nodes (CASSANDRA-15439)

--- a/src/java/org/apache/cassandra/service/AbstractWriteResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/AbstractWriteResponseHandler.java
@@ -189,7 +189,7 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
         }
     }
 
-    public final void expired()
+    protected final void logFailureOrTimeoutToIdealCLDelegate()
     {
         //Tracking ideal CL was not configured
         if (idealCLDelegate == null)
@@ -207,6 +207,11 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
             //Have the delegate track the expired response
             idealCLDelegate.decrementResponseOrExpired();
         }
+    }
+
+    public final void expired()
+    {
+        logFailureOrTimeoutToIdealCLDelegate();
     }
 
     /**
@@ -259,9 +264,13 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
     {
         //The ideal CL should only count as a strike if the requested CL was achieved.
         //If the requested CL is not achieved it's fine for the ideal CL to also not be achieved.
-        if (idealCLDelegate != null)
+        if (idealCLDelegate != null && blockFor() + failures <= candidateReplicaCount())
         {
             idealCLDelegate.requestedCLAchieved = true;
+            if (idealCLDelegate == this)
+            {
+                replicaPlan.keyspace().metric.idealCLWriteLatency.addNano(nanoTime() - requestTime.startedAtNanos());
+            }
         }
 
         condition.signalAll();
@@ -279,6 +288,8 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
                 : failures;
 
         failureReasonByEndpoint.put(from, failureReason);
+
+        logFailureOrTimeoutToIdealCLDelegate();
 
         if (blockFor() + n > candidateReplicaCount())
             signal();
@@ -308,10 +319,6 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
             if (!condition.isSignalled() && requestedCLAchieved)
             {
                 replicaPlan.keyspace().metric.writeFailedIdealCL.inc();
-            }
-            else
-            {
-                replicaPlan.keyspace().metric.idealCLWriteLatency.addNano(nanoTime() - requestTime.startedAtNanos());
             }
         }
     }

--- a/test/unit/org/apache/cassandra/service/WriteResponseHandlerTest.java
+++ b/test/unit/org/apache/cassandra/service/WriteResponseHandlerTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Predicates;
 import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.locator.EndpointsForToken;
 import org.apache.cassandra.locator.ReplicaPlans;
 import org.junit.Before;
@@ -153,17 +154,23 @@ public class WriteResponseHandlerTest
         //dc1
         awr.onResponse(createDummyMessage(0));
         awr.onResponse(createDummyMessage(1));
+
+        // there are no enough responses for ideal EACH_QUORUM yet
+        assertEquals(startingCount, ks.metric.idealCLWriteLatency.latency.getCount());
+
         //dc2
         awr.onResponse(createDummyMessage(4));
         awr.onResponse(createDummyMessage(5));
+
+        // there are enough responses for ideal EACH_QUORUM, we should not wait for all responses
+        assertTrue( TimeUnit.DAYS.toMicros(1) < ks.metric.idealCLWriteLatency.totalLatency.getCount());
+        assertEquals(startingCount + 1, ks.metric.idealCLWriteLatency.latency.getCount());
 
         //Don't need the others
         awr.expired();
         awr.expired();
 
         assertEquals(0,  ks.metric.writeFailedIdealCL.getCount());
-        assertTrue( TimeUnit.DAYS.toMicros(1) < ks.metric.idealCLWriteLatency.totalLatency.getCount());
-        assertEquals(startingCount + 1, ks.metric.idealCLWriteLatency.latency.getCount());
     }
 
     /**
@@ -235,6 +242,30 @@ public class WriteResponseHandlerTest
         assertEquals(0, ks.metric.idealCLWriteLatency.totalLatency.getCount());
     }
 
+    @Test
+    public void failedIdealCLIncrementsStatForExplicitOnFailure()
+    {
+        AbstractWriteResponseHandler awr = createWriteResponseHandler(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.EACH_QUORUM);
+
+        long startingCountForWriteFailedIdealCL = ks.metric.writeFailedIdealCL.getCount();
+        long startingCountForIdealCLWriteLatency = ks.metric.idealCLWriteLatency.totalLatency.getCount();
+
+
+        //Succeed in local DC
+        awr.onResponse(createDummyMessage(0));
+        awr.onResponse(createDummyMessage(1));
+        awr.onResponse(createDummyMessage(2));
+
+
+        //Fail in remote DC
+        awr.onFailure(targets.get(3).endpoint(), RequestFailureReason.TIMEOUT);
+        awr.onFailure(targets.get(4).endpoint(), RequestFailureReason.TIMEOUT);
+        awr.onResponse(createDummyMessage(5));
+
+        assertEquals(startingCountForWriteFailedIdealCL + 1, ks.metric.writeFailedIdealCL.getCount());
+        assertEquals(startingCountForIdealCLWriteLatency, ks.metric.idealCLWriteLatency.totalLatency.getCount());
+    }
+
     /**
      * Validate that failing to achieve ideal CL doesn't increase the failure counter when not meeting CL
      * @throws Throwable
@@ -258,6 +289,30 @@ public class WriteResponseHandlerTest
         awr.expired();
 
         assertEquals(startingCount, ks.metric.writeFailedIdealCL.getCount());
+    }
+
+    @Test
+    public void failedIdealCLDoesNotIncrementsStatOnExplicitQueryFailure()
+    {
+        AbstractWriteResponseHandler awr = createWriteResponseHandler(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.EACH_QUORUM);
+
+        long startingCountForWriteFailedIdealCL = ks.metric.writeFailedIdealCL.getCount();
+        long startingCountForIdealCLWriteLatency = ks.metric.idealCLWriteLatency.totalLatency.getCount();
+
+
+        //Fail in local DC
+        awr.onFailure(targets.get(0).endpoint(), RequestFailureReason.TIMEOUT);
+        awr.onFailure(targets.get(1).endpoint(), RequestFailureReason.TIMEOUT);
+        awr.onResponse(createDummyMessage(2));
+
+
+        //Fail in remote DC
+        awr.onFailure(targets.get(3).endpoint(), RequestFailureReason.TIMEOUT);
+        awr.onFailure(targets.get(4).endpoint(), RequestFailureReason.TIMEOUT);
+        awr.onResponse(createDummyMessage(5));
+
+        assertEquals(startingCountForWriteFailedIdealCL, ks.metric.writeFailedIdealCL.getCount());
+        assertEquals(startingCountForIdealCLWriteLatency, ks.metric.idealCLWriteLatency.totalLatency.getCount());
     }
 
 

--- a/test/unit/org/apache/cassandra/service/WriteResponseHandlerTest.java
+++ b/test/unit/org/apache/cassandra/service/WriteResponseHandlerTest.java
@@ -155,7 +155,7 @@ public class WriteResponseHandlerTest
         awr.onResponse(createDummyMessage(0));
         awr.onResponse(createDummyMessage(1));
 
-        // there are no enough responses for ideal EACH_QUORUM yet
+        // there are not enough responses for ideal EACH_QUORUM yet
         assertEquals(startingCount, ks.metric.idealCLWriteLatency.latency.getCount());
 
         //dc2


### PR DESCRIPTION
idealCLWriteLatency metric reported the worst response time instead of the time when ideal CL is satisfied.

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-19651
