### PR TITLE
CASSANDRA-19746: Update CQLSH documentation to reflect compatibility with Python 3.

### DIFF
--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -7,7 +7,7 @@ executable.
 
 == Compatibility
 
-`cqlsh` is compatible with Python 3.6 and later.
+`cqlsh` is compatible with Python 3.
 
 In general, a given version of `cqlsh` is only guaranteed to work with the
 version of Cassandra that it was released with.

--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -7,6 +7,8 @@ executable.
 
 == Compatibility
 
+`cqlsh` is compatible with Python 3.6 and later.
+
 In general, a given version of `cqlsh` is only guaranteed to work with the
 version of Cassandra that it was released with.
 In some cases, `cqlsh` may work with older or newer versions of Cassandra, but this is not
@@ -591,3 +593,4 @@ cqlsh> SELECT data from test.complex_data; data
 ------------------
  {1: 'I''m fine'}
 ----
+


### PR DESCRIPTION
This patch updates the CQLSH documentation to remove references to Python 2.7 and clarify compatibility with Python 3.
patch by Mohammad Suhel; for CASSANDRA-19746

