### PR TITLE
CASSANDRA-19763: Reentrant locks should always be locked outside of a try block

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -244,10 +244,9 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
     {
         public void run()
         {
+            taskLock.lock();
             try
             {
-                taskLock.lock();
-
                 /* Update the local heartbeat counter. */
                 endpointStateMap.get(getBroadcastAddressAndPort()).getHeartBeatState().updateHeartBeat();
                 if (logger.isTraceEnabled())


### PR DESCRIPTION
- more details in the [CASSANDRA-19763](https://issues.apache.org/jira/browse/CASSANDRA-19763)