### PR TITLE
CASSANDRA-19767: Fix broken formatting in storage_compatibility_mode documentation

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2178,22 +2178,31 @@ drop_compact_storage_enabled: false
 # Uncomment the startup checks and configure them appropriately to cover your needs.
 #
 # Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
+#
 #  check_filesystem_ownership:
 #    enabled: false
 #    ownership_token: "sometoken" # (overriden by "CassandraOwnershipToken" system property)
 #    ownership_filename: ".cassandra_fs_ownership" # (overriden by "cassandra.fs_ownership_filename")
+#
 # Prevents a node from starting if snitch's data center differs from previous data center.
+#
 #  check_dc:
 #    enabled: true # (overriden by cassandra.ignore_dc system property)
+#
 # Prevents a node from starting if snitch's rack differs from previous rack.
+#
 #  check_rack:
 #    enabled: true # (overriden by cassandra.ignore_rack system property)
+#
 # Enable this property to fail startup if the node is down for longer than gc_grace_seconds, to potentially
 # prevent data resurrection on tables with deletes. By default, this will run against all keyspaces and tables
 # except the ones specified on excluded_keyspaces and excluded_tables.
+#
 #  check_data_resurrection:
 #    enabled: false
+#
 # file where Cassandra periodically writes the last time it was known to run
+#
 #    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
 #    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
 #    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2177,7 +2177,6 @@ drop_compact_storage_enabled: false
 # are configurable (so you can disable them) but these which are enumerated bellow.
 # Uncomment the startup checks and configure them appropriately to cover your needs.
 #
-#startup_checks:
 # Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
 #  check_filesystem_ownership:
 #    enabled: false
@@ -2198,6 +2197,8 @@ drop_compact_storage_enabled: false
 #    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
 #    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
 #    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
+#startup_checks:
+
 
 # This property indicates with what Cassandra major version the storage format will be compatible with.
 #
@@ -2210,17 +2211,19 @@ drop_compact_storage_enabled: false
 # feature won't be available if this property is set to CASSANDRA_4. See the upgrade guide for more details.
 #
 # Possible values are:
-# - CASSANDRA_4: Stays compatible with the 4.x line in features, formats and component versions.
-# - UPGRADING:   The cluster monitors the version of each node during this interim stage. This has a cost but ensures
+#
+# ** CASSANDRA_4: Stays compatible with the 4.x line in features, formats and component versions.
+# ** UPGRADING:   The cluster monitors the version of each node during this interim stage. This has a cost but ensures
 #                all new features, formats, versions, etc. are enabled safely.
-# - NONE:        Start with all the new features and formats enabled.
+# ** NONE:        Start with all the new features and formats enabled.
 #
 # A typical upgrade would be:
-# - Do a rolling upgrade, starting all nodes in CASSANDRA_X compatibility mode.
-# - Once the new binary is rendered stable, do a rolling restart with the UPGRADING mode. The cluster will keep new
+#
+# . Do a rolling upgrade, starting all nodes in CASSANDRA_X compatibility mode.
+# . Once the new binary is rendered stable, do a rolling restart with the UPGRADING mode. The cluster will keep new
 #   features disabled until all nodes are started in the UPGRADING mode; when that happens, new features controlled by
 #   the storage compatibility mode are enabled.
-# - Do a rolling restart with all nodes starting with the NONE mode. This eliminates the cost of checking node versions
+# . Do a rolling restart with all nodes starting with the NONE mode. This eliminates the cost of checking node versions
 #   and ensures stability. If Cassandra was started at the previous version by accident, a node with disabled
 #   compatibility mode would no longer toggle behaviors as when it was running in the UPGRADING mode.
 #


### PR DESCRIPTION
Fixing - https://issues.apache.org/jira/browse/CASSANDRA-19767 

Fixed an issue in the conf/cassandra.yaml file causing the documentation for storage_compatibility_mode to be broken.

The updated entries now appears as below (note formatting might be different on the real page, this is just intellijs/chromes rendering).

<img width="725" alt="image" src="https://github.com/user-attachments/assets/8ed1d077-cb40-432f-ad26-0cab6c620d45">
