### PR TITLE
CASSANDRA-19767: Fix broken formatting in startup_checks documentation

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1825,24 +1825,34 @@ drop_compact_storage_enabled: false
 # are configurable (so you can disable them) but these which are enumerated bellow.
 # Uncomment the startup checks and configure them appropriately to cover your needs.
 #
-#startup_checks:
 # Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
+#
 #  check_filesystem_ownership:
 #    enabled: false
 #    ownership_token: "sometoken" # (overriden by "CassandraOwnershipToken" system property)
 #    ownership_filename: ".cassandra_fs_ownership" # (overriden by "cassandra.fs_ownership_filename")
+#
 # Prevents a node from starting if snitch's data center differs from previous data center.
+#
 #  check_dc:
 #    enabled: true # (overriden by cassandra.ignore_dc system property)
+#
 # Prevents a node from starting if snitch's rack differs from previous rack.
+#
 #  check_rack:
 #    enabled: true # (overriden by cassandra.ignore_rack system property)
+#
 # Enable this property to fail startup if the node is down for longer than gc_grace_seconds, to potentially
 # prevent data resurrection on tables with deletes. By default, this will run against all keyspaces and tables
 # except the ones specified on excluded_keyspaces and excluded_tables.
+#
 #  check_data_resurrection:
 #    enabled: false
+#
 # file where Cassandra periodically writes the last time it was known to run
+#
 #    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
 #    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
 #    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
+#startup_checks:
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-19767

Fixed an issue that was causing the startup_checks documentation to not be included in https://cassandra.apache.org/doc/4.1/cassandra/configuration/cass_yaml_file.html#startup_checks

Note - the below is an example of how it renders after this change, intellij/chrome was used for this. It will probably look different on the website. Happy to edit as needed


<img width="653" alt="image" src="https://github.com/user-attachments/assets/0104e11e-2bb9-4ad6-8511-168f016feb94">
