### PR TITLE
[CASSANDRA-19818][trunk] Minor improvements in Cassandra shutdown and startup logs

### DIFF
--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -182,6 +182,7 @@ public class QueryProcessor implements QueryHandler
 
     public void preloadPreparedStatements()
     {
+        long startTime = nanoTime();
         int count = SystemKeyspace.loadPreparedStatements((id, query, keyspace) -> {
             try
             {
@@ -200,12 +201,13 @@ public class QueryProcessor implements QueryHandler
             catch (RequestValidationException e)
             {
                 JVMStabilityInspector.inspectThrowable(e);
-                logger.warn(String.format("Prepared statement recreation error, removing statement: %s %s %s", id, query, keyspace));
+                logger.warn("Prepared statement recreation error, removing statement: {} {} {}, error details: {}", id, query, keyspace, e.getMessage());
                 SystemKeyspace.removePreparedStatement(id);
                 return false;
             }
         });
-        logger.info("Preloaded {} prepared statements", count);
+        long endTime = nanoTime();
+        logger.info("Preloaded {} prepared statements in {} ms", count, TimeUnit.NANOSECONDS.toMillis(endTime - startTime));
     }
 
 

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -64,6 +64,7 @@ import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static org.apache.cassandra.db.commitlog.CommitLogSegment.Allocation;
 import static org.apache.cassandra.db.commitlog.CommitLogSegment.ENTRY_OVERHEAD_SIZE;
+import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.apache.cassandra.utils.FBUtilities.updateChecksum;
 import static org.apache.cassandra.utils.FBUtilities.updateChecksumInt;
 
@@ -203,8 +204,11 @@ public class CommitLog implements CommitLogMBean
         {
             Arrays.sort(files, new CommitLogSegment.CommitLogSegmentFileComparator());
             logger.info("Replaying {}", StringUtils.join(files, ", "));
+            long startTime = nanoTime();
             replayed = recoverFiles(files);
-            logger.info("Log replay complete, {} replayed mutations", replayed);
+            long endTime = nanoTime();
+            logger.info("Log replay complete, {} replayed mutations, it took {} ms", replayed,
+                        TimeUnit.NANOSECONDS.toMillis(endTime - startTime));
 
             for (File f : files)
                 segmentManager.handleReplayedSegment(f);

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -207,7 +207,7 @@ public class CommitLog implements CommitLogMBean
             long startTime = nanoTime();
             replayed = recoverFiles(files);
             long endTime = nanoTime();
-            logger.info("Log replay complete, {} replayed mutations, it took {} ms", replayed,
+            logger.info("Log replay complete, {} replayed mutations in {} ms", replayed,
                         TimeUnit.NANOSECONDS.toMillis(endTime - startTime));
 
             for (File f : files)

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -110,7 +110,6 @@ import static org.apache.cassandra.repair.consistent.ConsistentSession.State.*;
 import static org.apache.cassandra.repair.messages.RepairMessage.always;
 import static org.apache.cassandra.repair.messages.RepairMessage.sendAck;
 import static org.apache.cassandra.repair.messages.RepairMessage.sendFailureResponse;
-import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 
 /**
  * Manages all consistent repair sessions a node is participating in.
@@ -354,7 +353,7 @@ public class LocalSessions
      */
     public synchronized void start()
     {
-        long startTime = nanoTime();
+        long startTime = ctx.clock().nanoTime();
         int loadedSessionsCount = 0;
         Preconditions.checkArgument(!started, "LocalSessions.start can only be called once");
         Preconditions.checkArgument(sessions.isEmpty(), "No sessions should be added before start");
@@ -387,7 +386,7 @@ public class LocalSessions
 
         sessions = ImmutableMap.copyOf(loadedSessions);
         failOngoingRepairs();
-        long endTime = nanoTime();
+        long endTime = ctx.clock().nanoTime();
         logger.info("LocalSessions start completed in {} ms, sessions loaded from DB: {}",
                     TimeUnit.NANOSECONDS.toMillis(endTime - startTime), loadedSessionsCount);
         started = true;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -729,6 +729,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
                 try
                 {
                     ExecutorUtils.shutdownNowAndWait(1, MINUTES, ScheduledExecutors.scheduledFastTasks);
+                    logger.info("Cassandra shutdown complete");
                 }
                 catch (Throwable t)
                 {


### PR DESCRIPTION
To improve a DBA experience the following log messages would be nice to add/adjust: on shutdown: an explicit message at the end of Cassandra shutdown on startup:
- print the time spent to load prepared statements
- print the time spent to load repair session information and the number of loaded session records
- print the time spent to apply commit log

Patch by Dmitry Konstantinov; reviewed by TBD; for CASSANDRA-19818