### PR TITLE
JAVA-3164: Fix rendering UNSET collection types in query tracing

### DIFF
--- a/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ExecuteMessage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.transport.messages;
 
+import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +39,7 @@ import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.ProtocolException;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MD5Digest;
 import org.apache.cassandra.utils.NoSpamLogger;
@@ -220,7 +222,8 @@ public class ExecuteMessage extends Message.Request
         {
             ColumnSpecification cs = prepared.statement.getBindVariables().get(i);
             String boundName = cs.name.toString();
-            String boundValue = cs.type.asCQL3Type().toCQLLiteral(options.getValues().get(i));
+            ByteBuffer bytes = options.getValues().get(i);
+            String boundValue = (bytes == ByteBufferUtil.UNSET_BYTE_BUFFER) ? "<unset>" : cs.type.asCQL3Type().toCQLLiteral(bytes);
             if (boundValue.length() > 1000)
                 boundValue = boundValue.substring(0, 1000) + "...'";
 

--- a/test/unit/org/apache/cassandra/cql3/TraceCqlTest.java
+++ b/test/unit/org/apache/cassandra/cql3/TraceCqlTest.java
@@ -18,10 +18,16 @@
 
 package org.apache.cassandra.cql3;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.PreparedStatement;
@@ -140,6 +146,29 @@ public class TraceCqlTest extends CQLTester
             //when tracing is done, this boundValue will be surrounded by single quote, and first 1000 characters
             //will be filtered. Here we take into account single quotes by adding them to the expected output
             assertEquals("'" + boundValue.substring(0, 999) + "...'", trace.getParameters().get("bound_var_0_value(v3)"));
+
+            pstmt = session.prepare("INSERT INTO " + KEYSPACE + '.' + currentTable() + " (id, v1, v2, v3) values (?, ?, ?, ?)").enableTracing();
+            BoundStatement boundStatement = pstmt.bind(13, "lukasz", value, map(2024, "birthday", 40, "anniversary"));
+
+            boundStatement.unset(3); // test query tracing after UNSET collection type
+            trace = session.execute(boundStatement).getExecutionInfo().getQueryTrace();
+            Map<String, String> boundParameters = getBoundParameters(trace);
+            assertEquals(Arrays.asList("13", "'lukasz'", "(3, 'bar', 2.1)", "<unset>"), new ArrayList<>(boundParameters.values()));
+
+            boundStatement.unset(2); // test query tracing after UNSET tuple type
+            trace = session.execute(boundStatement).getExecutionInfo().getQueryTrace();
+            boundParameters = getBoundParameters(trace);
+            assertEquals(Arrays.asList("13", "'lukasz'", "<unset>", "<unset>"), new ArrayList<>(boundParameters.values()));
         }
+    }
+
+    private Map<String, String> getBoundParameters(QueryTrace trace) {
+        Map<String, String> boundParameters = new LinkedHashMap<>();
+        trace.getParameters().forEach((paramName, paramValue) -> {
+            if (paramName.startsWith("bound_")) {
+                boundParameters.put(paramName, paramValue);
+            }
+        });
+        return boundParameters;
     }
 }


### PR DESCRIPTION
Fix [JAVA-3164](https://datastax-oss.atlassian.net/jira/software/c/projects/JAVA/issues/JAVA-3164).

Without the change, request with unset collection type fails with:
```
java.lang.IndexOutOfBoundsException: null
	at java.base/java.nio.Buffer.checkIndex(Buffer.java:693)
	at java.base/java.nio.HeapByteBuffer.getInt(HeapByteBuffer.java:406)
	at org.apache.cassandra.utils.ByteBufferUtil.toInt(ByteBufferUtil.java:476)
	at org.apache.cassandra.db.marshal.ByteBufferAccessor.toInt(ByteBufferAccessor.java:208)
	at org.apache.cassandra.db.marshal.ByteBufferAccessor.toInt(ByteBufferAccessor.java:42)
	at org.apache.cassandra.serializers.CollectionSerializer.readCollectionSize(CollectionSerializer.java:147)
	at org.apache.cassandra.cql3.CQL3Type$Collection.toCQLLiteral(CQL3Type.java:222)
	at org.apache.cassandra.transport.messages.ExecuteMessage.traceQuery(ExecuteMessage.java:223)
	at org.apache.cassandra.transport.messages.ExecuteMessage.execute(ExecuteMessage.java:155)
	at org.apache.cassandra.transport.Message$Request.execute(Message.java:259)
	at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:416)
	at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:435)
	at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:462)
	at org.apache.cassandra.transport.Dispatcher$RequestProcessor.run(Dispatcher.java:307)
	at org.apache.cassandra.concurrent.FutureTask$1.call(FutureTask.java:99)
	at org.apache.cassandra.concurrent.FutureTask.call(FutureTask.java:61)
	at org.apache.cassandra.concurrent.FutureTask.run(FutureTask.java:71)
	at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:143)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Unset collection length (-2) is replaced by empty byte buffer.

Issue was wrongly submitted by the requestor to Java driver project.