### PR TITLE
[CASSANDRA-17298][4.1] Improve accuracy of memtable heap usage tracking

### DIFF
--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -436,7 +436,7 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
         if(this == NONE)
             return 0;
 
-        return EMPTY_SIZE;
+        return EMPTY_SIZE + BTree.sizeOnHeapOf(columns);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -436,7 +436,7 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
         if(this == NONE)
             return 0;
 
-        return EMPTY_SIZE + BTree.sizeOnHeapOf(columns);
+        return EMPTY_SIZE + BTree.sizeOfStructureOnHeap(columns);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/memtable/AbstractAllocatorMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/AbstractAllocatorMemtable.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.utils.memory.MemtableCleaner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.NativePool;
 import org.apache.cassandra.utils.memory.SlabPool;
+import org.github.jamm.Unmetered;
 
 /**
  * A memtable that uses memory tracked and maybe allocated via a MemtableAllocator from a MemtablePool.
@@ -57,12 +58,15 @@ public abstract class AbstractAllocatorMemtable extends AbstractMemtableWithComm
 
     public static final MemtablePool MEMORY_POOL = AbstractAllocatorMemtable.createMemtableAllocatorPool();
 
+    @Unmetered
     protected final Owner owner;
+    @Unmetered
     protected final MemtableAllocator allocator;
 
     // Record the comparator of the CFS at the creation of the memtable. This
     // is only used when a user update the CF comparator, to know if the
     // memtable was created with the new or old comparator.
+    @Unmetered
     protected final ClusteringComparator initialComparator;
 
     private final long creationNano = Clock.Global.nanoTime();

--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -251,6 +251,7 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
             allocator.setDiscarded();
 
             // Decorated key overhead with byte buffer (if needed) is included
+            logger.info("Estimated SkipListMemtable row overhead: {}", rowOverhead);
             return rowOverhead;
         }
     }

--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -239,7 +239,13 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
             // omitSharedBufferOverhead includes the given number of bytes even for
             // off-heap buffers, but not for direct memory.
             if (!(allocator instanceof NativeAllocator))
+            {
                 rowOverhead -= testBufferSize;
+                DecoratedKey clonedKey = cloner.clone(new BufferDecoratedKey(new LongToken(0), ByteBuffer.allocate(testBufferSize)));
+                // if we use a slab allocator the adjustment is 0, if it is unslabbed type the adjustment is byte array heap size
+                long nonSlabAdjustment = ObjectSizes.sizeOnHeapExcludingData(clonedKey.getKey()) - ObjectSizes.measure(clonedKey.getKey());
+                rowOverhead += nonSlabAdjustment;
+            }
 
             allocator.setDiscarding();
             allocator.setDiscarded();

--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.db.memtable;
 
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -52,11 +53,11 @@ import org.apache.cassandra.index.transactions.UpdateTransaction;
 import org.apache.cassandra.io.sstable.format.SSTableReadsListener;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.schema.TableMetadataRef;
-import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.Cloner;
 import org.apache.cassandra.utils.memory.MemtableAllocator;
+import org.apache.cassandra.utils.memory.NativeAllocator;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_OVERHEAD_COMPUTE_STEPS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.MEMTABLE_OVERHEAD_SIZE;
@@ -227,15 +228,23 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
             Cloner cloner = allocator.cloner(group);
             ConcurrentNavigableMap<PartitionPosition, Object> partitions = new ConcurrentSkipListMap<>();
             final Object val = new Object();
+            final int testBufferSize = 8;
             for (int i = 0 ; i < count ; i++)
-                partitions.put(cloner.clone(new BufferDecoratedKey(new LongToken(i), ByteBufferUtil.EMPTY_BYTE_BUFFER)), val);
-            double avgSize = ObjectSizes.measureDeep(partitions) / (double) count;
+                partitions.put(cloner.clone(new BufferDecoratedKey(new LongToken(i), ByteBuffer.allocate(testBufferSize))), val);
+            double avgSize = ObjectSizes.measureDeepOmitShared(partitions) / (double) count;
             rowOverhead = (int) ((avgSize - Math.floor(avgSize)) < 0.05 ? Math.floor(avgSize) : Math.ceil(avgSize));
-            rowOverhead -= ObjectSizes.measureDeep(new LongToken(0));
+            rowOverhead -= new LongToken(0).getHeapSize();
             rowOverhead += AtomicBTreePartition.EMPTY_SIZE;
             rowOverhead += AbstractBTreePartition.HOLDER_UNSHARED_HEAP_SIZE;
+            // omitSharedBufferOverhead includes the given number of bytes even for
+            // off-heap buffers, but not for direct memory.
+            if (!(allocator instanceof NativeAllocator))
+                rowOverhead -= testBufferSize;
+
             allocator.setDiscarding();
             allocator.setDiscarded();
+
+            // Decorated key overhead with byte buffer (if needed) is included
             return rowOverhead;
         }
     }

--- a/src/java/org/apache/cassandra/db/partitions/AtomicBTreePartition.java
+++ b/src/java/org/apache/cassandra/db/partitions/AtomicBTreePartition.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.Cloner;
 import org.apache.cassandra.utils.memory.HeapCloner;
 import org.apache.cassandra.utils.memory.MemtableAllocator;
+import org.github.jamm.Unmetered;
 import com.google.common.annotations.VisibleForTesting;
 
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
@@ -83,6 +84,7 @@ public final class AtomicBTreePartition extends AbstractBTreePartition
      */
     private volatile int wasteTracker = TRACKER_NEVER_WASTED;
 
+    @Unmetered
     private final MemtableAllocator allocator;
     private volatile Holder ref;
 

--- a/src/java/org/apache/cassandra/utils/ObjectSizes.java
+++ b/src/java/org/apache/cassandra/utils/ObjectSizes.java
@@ -32,6 +32,10 @@ public class ObjectSizes
     private static final MemoryMeter meter = new MemoryMeter().withGuessing(MemoryMeter.Guess.FALLBACK_UNSAFE)
                                                               .ignoreKnownSingletons();
 
+    private static final MemoryMeter omitSharedMeter = new MemoryMeter().omitSharedBufferOverhead()
+                                                              .withGuessing(MemoryMeter.Guess.FALLBACK_UNSAFE)
+                                                              .ignoreKnownSingletons();
+
     private static final long EMPTY_HEAP_BUFFER_SIZE = measure(ByteBufferUtil.EMPTY_BYTE_BUFFER);
     private static final long EMPTY_BYTE_ARRAY_SIZE = measure(new byte[0]);
     private static final long EMPTY_STRING_SIZE = measure("");
@@ -213,6 +217,11 @@ public class ObjectSizes
     public static long measureDeep(Object pojo)
     {
         return meter.measureDeep(pojo);
+    }
+
+    public static long measureDeepOmitShared(Object pojo)
+    {
+        return omitSharedMeter.measureDeep(pojo);
     }
 
     /**

--- a/src/java/org/apache/cassandra/utils/btree/BTree.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTree.java
@@ -949,6 +949,9 @@ public class BTree
 
     public static long sizeOfStructureOnHeap(Object[] tree)
     {
+        if (tree == EMPTY_LEAF)
+            return 0;
+
         long size = ObjectSizes.sizeOfArray(tree);
         if (isLeaf(tree))
             return size;

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeHeapBuffersTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeHeapBuffersTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.utils.memory.MemtablePool;
+import org.apache.cassandra.utils.memory.SlabPool;
+
+public class MemtableSizeHeapBuffersTest extends MemtableSizeTestBase
+{
+    // Overrides CQLTester.setUpClass to run before it
+    @BeforeClass
+    public static void setUpClass()
+    {
+        setup(Config.MemtableAllocationType.heap_buffers);
+    }
+
+    @Override
+    void checkMemtablePool()
+    {
+        MemtablePool memoryPool = AbstractAllocatorMemtable.MEMORY_POOL;
+        logger.info("Memtable pool {} off-heap limit {}", memoryPool, memoryPool.offHeap.limit);
+        Assert.assertTrue(memoryPool instanceof SlabPool);
+        Assert.assertEquals(0, memoryPool.offHeap.limit);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeHeapBuffersTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeHeapBuffersTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.SlabPool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeHeapBuffersTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.heap_buffers);
+        setup(Config.MemtableAllocationType.heap_buffers, Murmur3Partitioner.instance);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapBuffersTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapBuffersTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.utils.memory.MemtablePool;
+import org.apache.cassandra.utils.memory.SlabPool;
+
+public class MemtableSizeOffheapBuffersTest extends MemtableSizeTestBase
+{
+    // Overrides CQLTester.setUpClass to run before it
+    @BeforeClass
+    public static void setUpClass()
+    {
+        setup(Config.MemtableAllocationType.offheap_buffers);
+    }
+
+
+    @Override
+    void checkMemtablePool()
+    {
+        MemtablePool memoryPool = AbstractAllocatorMemtable.MEMORY_POOL;
+        logger.info("Memtable pool {} off-heap limit {}", memoryPool, memoryPool.offHeap.limit);
+        Assert.assertTrue(memoryPool instanceof SlabPool);
+        Assert.assertTrue(memoryPool.offHeap.limit > 0);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapBuffersTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapBuffersTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.SlabPool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeOffheapBuffersTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.offheap_buffers);
+        setup(Config.MemtableAllocationType.offheap_buffers, Murmur3Partitioner.instance);
     }
 
 

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapObjectsTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapObjectsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.utils.memory.MemtablePool;
+import org.apache.cassandra.utils.memory.NativePool;
+
+public class MemtableSizeOffheapObjectsTest extends MemtableSizeTestBase
+{
+    // Overrides CQLTester.setUpClass to run before it
+    @BeforeClass
+    public static void setUpClass()
+    {
+        setup(Config.MemtableAllocationType.offheap_objects);
+    }
+
+    @Override
+    void checkMemtablePool()
+    {
+        MemtablePool memoryPool = AbstractAllocatorMemtable.MEMORY_POOL;
+        logger.info("Memtable pool {} off-heap limit {}", memoryPool, memoryPool.offHeap.limit);
+        Assert.assertTrue(memoryPool instanceof NativePool);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapObjectsTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapObjectsTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.NativePool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeOffheapObjectsTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.offheap_objects);
+        setup(Config.MemtableAllocationType.offheap_objects, Murmur3Partitioner.instance);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeTestBase.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeTestBase.java
@@ -36,6 +36,8 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.github.jamm.MemoryMeter;
 
@@ -68,7 +70,7 @@ public abstract class MemtableSizeTestBase extends CQLTester
     // the main contributor to the actual size floating is randomness in ConcurrentSkipListMap
     final int MAX_DIFFERENCE_PERCENT = 3;
 
-    public static void setup(Config.MemtableAllocationType allocationType)
+    public static void setup(Config.MemtableAllocationType allocationType, IPartitioner partitioner)
     {
         ServerTestUtils.daemonInitialization();
         try
@@ -84,7 +86,7 @@ public abstract class MemtableSizeTestBase extends CQLTester
             throw new RuntimeException(e);
         }
 
-        CQLTester.setUpClass();
+        StorageService.instance.setPartitionerUnsafe(partitioner);
         CQLTester.prepareServer();
         logger.info("setupClass done, allocation type {}", allocationType);
     }

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeUnslabbedTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeUnslabbedTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.memtable;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.utils.memory.HeapPool;
+import org.apache.cassandra.utils.memory.MemtablePool;
+
+public class MemtableSizeUnslabbedTest extends MemtableSizeTestBase
+{
+    // Overrides CQLTester.setUpClass to run before it
+    @BeforeClass
+    public static void setUpClass()
+    {
+        setup(Config.MemtableAllocationType.unslabbed_heap_buffers);
+    }
+
+    @Override
+    void checkMemtablePool()
+    {
+        MemtablePool memoryPool = AbstractAllocatorMemtable.MEMORY_POOL;
+        logger.info("Memtable pool {} off-heap limit {}", memoryPool, memoryPool.offHeap.limit);
+        Assert.assertTrue(memoryPool instanceof HeapPool);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeUnslabbedTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeUnslabbedTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.HeapPool;
 import org.apache.cassandra.utils.memory.MemtablePool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeUnslabbedTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.unslabbed_heap_buffers);
+        setup(Config.MemtableAllocationType.unslabbed_heap_buffers, Murmur3Partitioner.instance);
     }
 
     @Override


### PR DESCRIPTION
Fix estimateRowOverhead in Memtable: ByteBuffer in Partition key was not counted + slab byte[] array was included due removal of omitSharedBuffer
Overhead Fix non-counted size of "columns" field in Columns.unsharedHeapSize 
BTree.sizeOfStructureOnHeap wrongly reported a non-zero size for EMPTY_LEAF shared constant value 
Fix MemtableSizeTest flakeness by not measuring of allocator and ColumnFamilyStore/Keyspace 
Add disablePreparedReuseForTest for every run of MemtableSizeTest test

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-17298