### PR TITLE
CommitlogArchiver only has granularity to seconds for restore_point_in_time for CASSANDRA-19448 4.1

### DIFF
--- a/conf/commitlog_archiving.properties
+++ b/conf/commitlog_archiving.properties
@@ -37,7 +37,11 @@ restore_command=
 restore_directories=
 
 # Restore mutations created up to and including this timestamp in GMT.
-# Format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+# There are only three different formats to express three time precisions:
+# Seconds, Milliseconds, and Microseconds.
+# Seconds format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+# Milliseconds format: yyyy:MM:dd HH:mm:ss.SSS (2012:04:31 20:43:12.633)
+# Microseconds format: yyyy:MM:dd HH:mm:ss.SSSSSS (2012:04:31 20:43:12.633222)
 #
 # Recovery will continue through the segment when the first client-supplied
 # timestamp greater than this time is encountered, but only mutations less than
@@ -52,6 +56,3 @@ restore_point_in_time=
 # intervals covered by existing sstables from the replay interval, i.e. it will replay data that may already be in
 # sstables.
 snapshot_commitlog_position=
-
-# precision of the timestamp used in the inserts (MILLISECONDS, MICROSECONDS, ...)
-precision=MICROSECONDS

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -80,7 +80,7 @@ public class CommitLog implements CommitLogMBean
 
     final public AbstractCommitLogSegmentManager segmentManager;
 
-    public final CommitLogArchiver archiver;
+    public CommitLogArchiver archiver;
     public final CommitLogMetrics metrics;
     final AbstractCommitLogService executor;
 
@@ -183,8 +183,11 @@ public class CommitLog implements CommitLogMBean
         // archiving pass, which we should not treat as serious.
         for (File file : getUnmanagedFiles())
         {
-            archiver.maybeArchive(file.path(), file.name());
-            archiver.maybeWaitForArchiving(file.name());
+            if (file.exists())
+            {
+                archiver.maybeArchive(file.path(), file.name());
+                archiver.maybeWaitForArchiving(file.name());
+            }
         }
 
         assert archiver.archivePending.isEmpty() : "Not all commit log archive tasks were completed before restore";
@@ -397,13 +400,13 @@ public class CommitLog implements CommitLogMBean
     @Override
     public long getRestorePointInTime()
     {
-        return archiver.restorePointInTime;
+        return archiver.restorePointInTimeInMicros;
     }
 
-    @Override
-    public String getRestorePrecision()
+    @VisibleForTesting
+    public void setCommitlogArchiver(CommitLogArchiver archiver)
     {
-        return archiver.precision.toString();
+        this.archiver = archiver;
     }
 
     public List<String> getActiveSegmentNames()

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
@@ -23,14 +23,22 @@ package org.apache.cassandra.db.commitlog;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TimeZone;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
@@ -49,35 +57,30 @@ import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFac
 public class CommitLogArchiver
 {
     private static final Logger logger = LoggerFactory.getLogger(CommitLogArchiver.class);
-    public static final SimpleDateFormat format = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+
+    public static final DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss[.[SSSSSS][SSS]]").withZone(ZoneId.of("GMT"));
     private static final String DELIMITER = ",";
     private static final Pattern NAME = Pattern.compile("%name");
     private static final Pattern PATH = Pattern.compile("%path");
     private static final Pattern FROM = Pattern.compile("%from");
     private static final Pattern TO = Pattern.compile("%to");
-    static
-    {
-        format.setTimeZone(TimeZone.getTimeZone("GMT"));
-    }
 
     public final Map<String, Future<?>> archivePending = new ConcurrentHashMap<String, Future<?>>();
     private final ExecutorService executor;
     final String archiveCommand;
     final String restoreCommand;
     final String restoreDirectories;
-    public long restorePointInTime;
+    public long restorePointInTimeInMicros;
     public CommitLogPosition snapshotCommitLogPosition;
-    public final TimeUnit precision;
 
     public CommitLogArchiver(String archiveCommand, String restoreCommand, String restoreDirectories,
-            long restorePointInTime, CommitLogPosition snapshotCommitLogPosition, TimeUnit precision)
+            long restorePointInTimeInMicros, CommitLogPosition snapshotCommitLogPosition)
     {
         this.archiveCommand = archiveCommand;
         this.restoreCommand = restoreCommand;
         this.restoreDirectories = restoreDirectories;
-        this.restorePointInTime = restorePointInTime;
+        this.restorePointInTimeInMicros = restorePointInTimeInMicros;
         this.snapshotCommitLogPosition = snapshotCommitLogPosition;
-        this.precision = precision;
         executor = !Strings.isNullOrEmpty(archiveCommand)
                 ? executorFactory()
                     .withJmxInternal()
@@ -87,7 +90,7 @@ public class CommitLogArchiver
 
     public static CommitLogArchiver disabled()
     {
-        return new CommitLogArchiver(null, null, null, Long.MAX_VALUE, CommitLogPosition.NONE, TimeUnit.MICROSECONDS);
+        return new CommitLogArchiver(null, null, null, Long.MAX_VALUE, CommitLogPosition.NONE);
     }
 
     public static CommitLogArchiver construct()
@@ -103,69 +106,80 @@ public class CommitLogArchiver
             else
             {
                 commitlog_commands.load(stream);
-                String archiveCommand = commitlog_commands.getProperty("archive_command");
-                String restoreCommand = commitlog_commands.getProperty("restore_command");
-                String restoreDirectories = commitlog_commands.getProperty("restore_directories");
-                if (restoreDirectories != null && !restoreDirectories.isEmpty())
-                {
-                    for (String dir : restoreDirectories.split(DELIMITER))
-                    {
-                        File directory = new File(dir);
-                        if (!directory.exists())
-                        {
-                            if (!directory.tryCreateDirectory())
-                            {
-                                throw new RuntimeException("Unable to create directory: " + dir);
-                            }
-                        }
-                    }
-                }
-                String targetTime = commitlog_commands.getProperty("restore_point_in_time");
-                TimeUnit precision = TimeUnit.valueOf(commitlog_commands.getProperty("precision", "MICROSECONDS"));
-                long restorePointInTime;
-                try
-                {
-                    restorePointInTime = Strings.isNullOrEmpty(targetTime) ? Long.MAX_VALUE : format.parse(targetTime).getTime();
-                }
-                catch (ParseException e)
-                {
-                    throw new RuntimeException("Unable to parse restore target time", e);
-                }
-
-                String snapshotPosition = commitlog_commands.getProperty("snapshot_commitlog_position");
-                CommitLogPosition snapshotCommitLogPosition;
-                try
-                {
-
-                    snapshotCommitLogPosition = Strings.isNullOrEmpty(snapshotPosition)
-                                                ? CommitLogPosition.NONE
-                                                : CommitLogPosition.serializer.fromString(snapshotPosition);
-                }
-                catch (ParseException | NumberFormatException e)
-                {
-                    throw new RuntimeException("Unable to parse snapshot commit log position", e);
-                }
-
-                return new CommitLogArchiver(archiveCommand,
-                                             restoreCommand,
-                                             restoreDirectories,
-                                             restorePointInTime,
-                                             snapshotCommitLogPosition,
-                                             precision);
+                return getArchiverFromProperty(commitlog_commands);
             }
         }
         catch (IOException e)
         {
             throw new RuntimeException("Unable to load commitlog_archiving.properties", e);
         }
+    }
 
+    public static CommitLogArchiver getArchiverFromProperty(Properties commitlogCommands)
+    {
+        assert !commitlogCommands.isEmpty();
+        String archiveCommand = commitlogCommands.getProperty("archive_command");
+        String restoreCommand = commitlogCommands.getProperty("restore_command");
+        String restoreDirectories = commitlogCommands.getProperty("restore_directories");
+        if (restoreDirectories != null && !restoreDirectories.isEmpty())
+        {
+            for (String dir : restoreDirectories.split(DELIMITER))
+            {
+                File directory = new File(dir);
+                if (!directory.exists())
+                {
+                    if (!directory.tryCreateDirectory())
+                    {
+                        throw new RuntimeException("Unable to create directory: " + dir);
+                    }
+                }
+            }
+        }
+        String targetTime = commitlogCommands.getProperty("restore_point_in_time");
+        long restorePointInTime = Long.MAX_VALUE;
+        try
+        {
+            if (!Strings.isNullOrEmpty(targetTime))
+            {
+                // get restorePointInTime in microseconds level by default as cassandra use this level's timestamp
+                restorePointInTime = getMicroSeconds(targetTime);
+            }
+        }
+        catch (DateTimeParseException e)
+        {
+            throw new RuntimeException("Unable to parse restore target time", e);
+        }
+
+        String snapshotPosition = commitlogCommands.getProperty("snapshot_commitlog_position");
+        CommitLogPosition snapshotCommitLogPosition;
+        try
+        {
+
+            snapshotCommitLogPosition = Strings.isNullOrEmpty(snapshotPosition)
+                                        ? CommitLogPosition.NONE
+                                        : CommitLogPosition.serializer.fromString(snapshotPosition);
+        }
+        catch (ParseException | NumberFormatException e)
+        {
+            throw new RuntimeException("Unable to parse snapshot commit log position", e);
+        }
+
+        return new CommitLogArchiver(archiveCommand,
+                                     restoreCommand,
+                                     restoreDirectories,
+                                     restorePointInTime,
+                                     snapshotCommitLogPosition);
     }
 
     public void maybeArchive(final CommitLogSegment segment)
     {
         if (Strings.isNullOrEmpty(archiveCommand))
             return;
-
+        if (!segment.logFile.exists())
+        {
+            logger.warn("Commitlog file : " + segment.logFile + " is not exist, skip archiving");
+            return;
+        }
         archivePending.put(segment.getName(), executor.submit(new WrappedRunnable()
         {
             protected void runMayThrow() throws IOException
@@ -309,5 +323,27 @@ public class CommitLogArchiver
         ProcessBuilder pb = new ProcessBuilder(command.split(" "));
         pb.redirectErrorStream(true);
         FBUtilities.exec(pb);
+    }
+
+    /**
+     * we change the restorePointInTime into MicroSeconds level as cassandra use MicroSeconds
+     * as the timestamp.
+     * */
+    public static long getMicroSeconds(String restorePointInTime)
+    {
+        assert format != null;
+        Instant instant = format.parse(restorePointInTime, Instant::from);
+        return instant.getEpochSecond() * 1000_000 + instant.getNano() / 1000;
+    }
+
+    public long getRestorePointInTimeInMicroLevel()
+    {
+        return this.restorePointInTimeInMicros;
+    }
+
+    @VisibleForTesting
+    public void setRestorePointInTime(long restorePointInTimeInMicros)
+    {
+        this.restorePointInTimeInMicros = restorePointInTimeInMicros;
     }
 }

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogMBean.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogMBean.java
@@ -41,19 +41,17 @@ public interface CommitLogMBean
 
     /**
      * Restore mutations created up to and including this timestamp in GMT
-     * Format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+     * There are only three different formats to express three time precisions:
+     * Seconds, Milliseconds, and Microseconds.
+     * Seconds format: yyyy:MM:dd HH:mm:ss (2012:04:31 20:43:12)
+     * Milliseconds format: yyyy:MM:dd HH:mm:ss.SSS (2012:04:31 20:43:12.633)
+     * Microseconds format: yyyy:MM:dd HH:mm:ss.SSSSSS (2012:04:31 20:43:12.633222)
      *
      * Recovery will continue through the segment when the first client-supplied
      * timestamp greater than this time is encountered, but only mutations less than
      * or equal to this timestamp will be applied.
      */
     public long getRestorePointInTime();
-
-    /**
-     * get precision of the timestamp used in the restore (MILLISECONDS, MICROSECONDS, ...)
-     * to determine if passed the restore point in time.
-     */
-    public String getRestorePrecision();
 
     /**
      * Recover a single file.

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogReplayer.java
@@ -76,7 +76,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
     private long pendingMutationBytes = 0;
 
     private final ReplayFilter replayFilter;
-    private final CommitLogArchiver archiver;
+    private CommitLogArchiver archiver;
 
     @VisibleForTesting
     protected boolean sawCDCMutation;
@@ -115,7 +115,8 @@ public class CommitLogReplayer implements CommitLogReadHandler
                 // Point in time restore is taken to mean that the tables need to be replayed even if they were
                 // deleted at a later point in time. Any truncation record after that point must thus be cleared prior
                 // to replay (CASSANDRA-9195).
-                long restoreTime = commitLog.archiver.restorePointInTime;
+                // truncatedTime is millseconds level but restoreTime is microlevel
+                long restoreTime = commitLog.archiver.restorePointInTimeInMicros == Long.MAX_VALUE ? Long.MAX_VALUE : commitLog.archiver.restorePointInTimeInMicros / 1000;
                 long truncatedTime = SystemKeyspace.getTruncatedAt(cfs.metadata.id);
                 if (truncatedTime > restoreTime)
                 {
@@ -141,7 +142,7 @@ public class CommitLogReplayer implements CommitLogReadHandler
                 }
                 else
                 {
-                    if (commitLog.archiver.restorePointInTime == Long.MAX_VALUE)
+                    if (commitLog.archiver.getRestorePointInTimeInMicroLevel() == Long.MAX_VALUE)
                     {
                         // Normal restart, everything is persisted and restored by the memtable itself.
                         filter = new IntervalSet<>(CommitLogPosition.NONE, CommitLog.instance.getCurrentPosition());
@@ -455,11 +456,11 @@ public class CommitLogReplayer implements CommitLogReadHandler
 
     protected boolean pointInTimeExceeded(Mutation fm)
     {
-        long restoreTarget = archiver.restorePointInTime;
+        long tsInMicroSecondsLevel = archiver.restorePointInTimeInMicros;
 
         for (PartitionUpdate upd : fm.getPartitionUpdates())
         {
-            if (archiver.precision.toMillis(upd.maxTimestamp()) > restoreTarget)
+            if (upd.maxTimestamp() > tsInMicroSecondsLevel)
                 return true;
         }
         return false;
@@ -509,6 +510,12 @@ public class CommitLogReplayer implements CommitLogReadHandler
     {
         // Don't care about return value, use this simply to throw exception as appropriate.
         shouldSkipSegmentOnError(exception);
+    }
+
+    @VisibleForTesting
+    public void setCommitlogArchiver(CommitLogArchiver archiver)
+    {
+        this.archiver = archiver;
     }
 
     @SuppressWarnings("serial")

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogArchiverTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogArchiverTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.commitlog;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.RowUpdateBuilder;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.PathUtils;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertTrue;
+
+public class CommitLogArchiverTest extends CQLTester
+{
+    private static Path dirName = Paths.get("/tmp/backup_commitlog_for_test");
+    private static String rpiTime = "2024:03:22 20:43:12.633222";
+    private static CommitLogArchiver archiver;
+
+    @BeforeClass
+    public static void beforeClass() throws IOException
+    {
+        PathUtils.createDirectoryIfNotExists(dirName);
+        CommitLog commitLog = CommitLog.instance;
+        Properties properties = new Properties();
+        archiver = commitLog.archiver;
+        properties.putAll(new HashMap<String, String>() {{
+                          put("archive_command", "/bin/cp %path " + dirName.toString());
+                          put("restore_command", "/bin/cp -f %from %to");
+                          put("restore_directories", dirName.toString());
+                          put("restore_point_in_time", rpiTime);}});
+        CommitLogArchiver commitLogArchiver = CommitLogArchiver.getArchiverFromProperty(properties);
+        commitLog.setCommitlogArchiver(commitLogArchiver);
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException
+    {
+        File dir = new File(dirName);
+        dir.deleteRecursive();
+    }
+
+    @Test
+    public void testArchiver() throws IOException
+    {
+        File dir = new File(dirName);
+        assertTrue(dir.isDirectory() && dir.tryList().length == 0);
+
+        String table = createTable(KEYSPACE, "CREATE TABLE %s (a TEXT PRIMARY KEY, b TEXT);");
+        ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore(table);
+        long ts = CommitLogArchiver.getMicroSeconds(rpiTime);
+
+        String value = "";
+        // Make sure that new CommitLogSegment will be allocated as the CommitLogSegment size is 5M
+        // and if new CommitLogSegment is allocated then the old CommitLogSegment will be archived.
+        for (int i = 0; i != 50000; ++i)
+        {
+            value += i;
+        }
+        for (int i = 1; i <= 2000; ++i)
+        {
+            new RowUpdateBuilder(cfs.metadata(), ts - i, "name-" + i)
+                    .add("b", value)
+                    .build()
+                    .apply();
+        }
+
+        // If the number of files that under backup dir is bigger than 1, that means the
+        // arhiver for commitlog is effective.
+        assertTrue(dir.isDirectory() && dir.tryList().length > 0);
+        Map<String, Future<?>>  archivePending = CommitLog.instance.archiver.archivePending;
+        CommitLogArchiver oldArchive = CommitLog.instance.archiver;
+        CommitLog.instance.setCommitlogArchiver(archiver);
+        for (String name : archivePending.keySet())
+        {
+            oldArchive.maybeWaitForArchiving(name);
+        }
+    }
+}


### PR DESCRIPTION
 
Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

