### PR TITLE
[CASSANDRA-17298][5.0] make SkipListMemtable.estimateRowOverhead partitioner-agnostic

### DIFF
--- a/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/SkipListMemtable.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.BufferDecoratedKey;
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
@@ -48,7 +49,6 @@ import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.IncludingExcludingBounds;
-import org.apache.cassandra.dht.Murmur3Partitioner.LongToken;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.index.transactions.UpdateTransaction;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
@@ -225,10 +225,10 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
             final Object val = new Object();
             final int testBufferSize = 8;
             for (int i = 0 ; i < count ; i++)
-                partitions.put(cloner.clone(new BufferDecoratedKey(new LongToken(i), ByteBuffer.allocate(testBufferSize))), val);
+                partitions.put(cloner.clone(new BufferDecoratedKey(DatabaseDescriptor.getPartitioner().getRandomToken(), ByteBuffer.allocate(testBufferSize))), val);
             double avgSize = ObjectSizes.measureDeepOmitShared(partitions) / (double) count;
             rowOverhead = (int) ((avgSize - Math.floor(avgSize)) < 0.05 ? Math.floor(avgSize) : Math.ceil(avgSize));
-            rowOverhead -= new LongToken(0).getHeapSize();
+            rowOverhead -= DatabaseDescriptor.getPartitioner().getRandomToken().getHeapSize();
             rowOverhead += AtomicBTreePartition.EMPTY_SIZE;
             rowOverhead += BTreePartitionData.UNSHARED_HEAP_SIZE;
             if (!(allocator instanceof NativeAllocator))
@@ -237,6 +237,7 @@ public class SkipListMemtable extends AbstractAllocatorMemtable
             // Decorated key overhead with byte buffer (if needed) is included
             allocator.setDiscarding();
             allocator.setDiscarded();
+            logger.info("Estimated SkipListMemtable row overhead: {}", rowOverhead);
             return rowOverhead;
         }
     }

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeHeapBuffersTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeHeapBuffersTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.SlabPool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeHeapBuffersTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.heap_buffers);
+        setup(Config.MemtableAllocationType.heap_buffers, Murmur3Partitioner.instance);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapBuffersTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapBuffersTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.SlabPool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeOffheapBuffersTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.offheap_buffers);
+        setup(Config.MemtableAllocationType.offheap_buffers, Murmur3Partitioner.instance);
     }
 
 

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapObjectsTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeOffheapObjectsTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.MemtablePool;
 import org.apache.cassandra.utils.memory.NativePool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeOffheapObjectsTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.offheap_objects);
+        setup(Config.MemtableAllocationType.offheap_objects, Murmur3Partitioner.instance);
     }
 
     @Override

--- a/test/unit/org/apache/cassandra/db/memtable/MemtableSizeUnslabbedTest.java
+++ b/test/unit/org/apache/cassandra/db/memtable/MemtableSizeUnslabbedTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.utils.memory.HeapPool;
 import org.apache.cassandra.utils.memory.MemtablePool;
 
@@ -31,7 +32,7 @@ public class MemtableSizeUnslabbedTest extends MemtableSizeTestBase
     @BeforeClass
     public static void setUpClass()
     {
-        setup(Config.MemtableAllocationType.unslabbed_heap_buffers);
+        setup(Config.MemtableAllocationType.unslabbed_heap_buffers, Murmur3Partitioner.instance);
     }
 
     @Override


### PR DESCRIPTION
Additionally:
- Print estimated Memtable row overhead to simplify troubleshooting
- Print per-partition delta between expected and actual heap usage in the tests

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-17298
