### PR TITLE
CASSANDRA-19889 - Indexing a frozen collection that is the clustering key and reversed is rejected

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget.Type;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.MapType;
+import org.apache.cassandra.db.marshal.ReversedType;
+import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.internal.CassandraIndex;
 import org.apache.cassandra.index.sasi.SASIIndex;
@@ -218,9 +220,17 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         return ImmutableSet.of();
     }
 
+    private AbstractType<?> unwrapType(AbstractType<?> type) {
+        if (type instanceof ReversedType) {
+            return ((ReversedType<?>) type).baseType;
+        }
+        return type;
+    }
+
     private void validateIndexTarget(TableMetadata table, IndexMetadata.Kind kind, IndexTarget target)
     {
         ColumnMetadata column = table.getColumn(target.column);
+        AbstractType<?> baseType = unwrapType(column.type);
 
         if (null == column)
             throw ire(COLUMN_DOES_NOT_EXIST, target.column);
@@ -254,16 +264,16 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         if (column.isPartitionKey() && table.partitionKeyColumns().size() == 1)
             throw ire(ONLY_PARTITION_KEY, column);
 
-        if (column.type.isFrozenCollection() && target.type != Type.FULL)
+        if (baseType.isFrozenCollection() && target.type != Type.FULL)
             throw ire(CREATE_ON_FROZEN_COLUMN, target.type, column, column.name.toCQLString());
 
-        if (!column.type.isFrozenCollection() && target.type == Type.FULL)
+        if (!baseType.isFrozenCollection() && target.type == Type.FULL)
             throw ire(FULL_ON_FROZEN_COLLECTIONS);
 
-        if (!column.type.isCollection() && target.type != Type.SIMPLE)
+        if (!baseType.isCollection() && target.type != Type.SIMPLE)
             throw ire(NON_COLLECTION_SIMPLE_INDEX, target.type, column);
 
-        if (!(column.type instanceof MapType && column.type.isMultiCell()) && (target.type == Type.KEYS || target.type == Type.KEYS_AND_VALUES))
+        if (!(baseType instanceof MapType && baseType.isMultiCell()) && (target.type == Type.KEYS || target.type == Type.KEYS_AND_VALUES))
             throw ire(CREATE_WITH_NON_MAP_TYPE, target.type, column);
 
         if (column.type.isUDT() && column.type.isMultiCell())

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.statements.schema.IndexTarget.Type;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.MapType;
-import org.apache.cassandra.db.marshal.ReversedType;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.index.internal.CassandraIndex;
@@ -220,17 +219,10 @@ public final class CreateIndexStatement extends AlterSchemaStatement
         return ImmutableSet.of();
     }
 
-    private AbstractType<?> unwrapType(AbstractType<?> type) {
-        if (type instanceof ReversedType) {
-            return ((ReversedType<?>) type).baseType;
-        }
-        return type;
-    }
-
     private void validateIndexTarget(TableMetadata table, IndexMetadata.Kind kind, IndexTarget target)
     {
         ColumnMetadata column = table.getColumn(target.column);
-        AbstractType<?> baseType = unwrapType(column.type);
+        AbstractType<?> baseType = column.type.unwrap();
 
         if (null == column)
             throw ire(COLUMN_DOES_NOT_EXIST, target.column);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateIndexStatement.java
@@ -222,10 +222,11 @@ public final class CreateIndexStatement extends AlterSchemaStatement
     private void validateIndexTarget(TableMetadata table, IndexMetadata.Kind kind, IndexTarget target)
     {
         ColumnMetadata column = table.getColumn(target.column);
-        AbstractType<?> baseType = column.type.unwrap();
 
         if (null == column)
             throw ire(COLUMN_DOES_NOT_EXIST, target.column);
+
+        AbstractType<?> baseType = column.type.unwrap();
 
         if ((kind == IndexMetadata.Kind.CUSTOM) && !SchemaConstants.isValidName(target.column.toString()))
             throw ire(INVALID_CUSTOM_INDEX_TARGET, target.column, SchemaConstants.NAME_LENGTH);

--- a/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/entities/SecondaryIndexTest.java
@@ -1715,6 +1715,15 @@ public class SecondaryIndexTest extends CQLTester
         testIndexOnRegularColumnInsertExpiringColumn(true);
     }
 
+    @Test
+    public void testFullIndexOnClusterRingColumn () throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int,ck frozen<list<int>>,value int,PRIMARY KEY(pk, ck)) WITH CLUSTERING ORDER BY (ck DESC)");
+        createIndex("CREATE INDEX ON %s(FULL(ck));");
+        execute("INSERT INTO %s (pk,ck,value) VALUES (1,[1,2,3],4)");
+        assertRows(execute("SELECT pk FROM %S WHERE CK=[1,2,3]"), row(1));
+    }
+
     private void testIndexOnRegularColumnInsertExpiringColumn(boolean flushBeforeUpdate) throws Throwable
     {
         createTable("CREATE TABLE %s (pk int, ck int, a int, b int, PRIMARY KEY (pk, ck))");


### PR DESCRIPTION
Unwrap ReverseType column before performing type checks

1. Adding a private method unwrapType to check the base type of the column.
2. Added additional test cases with name - testFullIndexOnClusterRingColumn.




[Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19889)

