### PR TITLE
[CASSANDRA-19942][4.0] Clean non-used references to values within pooled BTree.FastBuilder

### DIFF
--- a/src/java/org/apache/cassandra/utils/btree/BTree.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTree.java
@@ -2317,7 +2317,7 @@ public class BTree
      * Base class for AbstractFastBuilder.BranchBuilder, LeafBuilder and AbstractFastBuilder,
      * containing shared behaviour and declaring some useful abstract methods.
      */
-    private static abstract class LeafOrBranchBuilder
+    static abstract class LeafOrBranchBuilder
     {
         final int height;
         final LeafOrBranchBuilder child;
@@ -2783,6 +2783,7 @@ public class BTree
 
             Object[] newLeaf = new Object[count | 1];
             System.arraycopy(buffer, 0, newLeaf, 0, count);
+            Arrays.fill(buffer, 0, count, null);
             count = 0;
             return newLeaf;
         }
@@ -3062,6 +3063,8 @@ public class BTree
             {
                 System.arraycopy(buffer, 0, branch, 0, keys);
                 System.arraycopy(buffer, MAX_KEYS, branch, keys, keys + 1);
+                Arrays.fill(buffer, 0, keys, null);
+                Arrays.fill(buffer, MAX_KEYS, MAX_KEYS + keys + 1, null);
             }
             setDrainSizeMap(null, -1, branch, keys);
             return branch;

--- a/test/unit/org/apache/cassandra/utils/btree/BTreeFastBuilderTest.java
+++ b/test/unit/org/apache/cassandra/utils/btree/BTreeFastBuilderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.btree;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.assertj.core.api.Assertions;
+
+@RunWith(Parameterized.class)
+public class BTreeFastBuilderTest
+{
+    @Parameterized.Parameter(0)
+    public int addedElements;
+
+    @Parameterized.Parameters(name = "addedElements={0}")
+    public static List<Object> parameters()
+    {
+        return ImmutableList.of(1,
+                                BTree.MIN_KEYS - 1, BTree.MIN_KEYS, BTree.MIN_KEYS + 1,
+                                BTree.MAX_KEYS - 1, BTree.MAX_KEYS, BTree.MAX_KEYS + 1,
+                                BTree.MAX_KEYS * 100);
+    }
+
+    // we want all references to values cleared within the pooled builder hierarchy to avoid memory leaking
+    @Test
+    public void testPooledBuffersCleanup()
+    {
+        try (BTree.FastBuilder<Object> builder = BTree.fastBuilder())
+        {
+            for (int i = 0; i < addedElements; i++)
+            {
+                builder.add(i);
+            }
+            builder.build();
+        }
+
+        try (BTree.FastBuilder<Object> builder = BTree.fastBuilder())
+        {
+            BTree.LeafOrBranchBuilder builderToCheck = builder;
+            int level = 0;
+            while (builderToCheck != null)
+            {
+                Assertions.assertThat(builderToCheck.buffer)
+                          .as("Failed for buffer on level = " + level)
+                          .containsOnlyNulls();
+                if (builderToCheck.savedBuffer != null)
+                {
+                    Assertions.assertThat(builderToCheck.savedBuffer)
+                              .as("Failed for savedBuffer on level = " + level)
+                              .containsOnlyNulls();
+                }
+                Assertions.assertThat(builderToCheck.savedNextKey).isNull();
+                builderToCheck = builderToCheck.parent;
+                level++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-19942