### PR TITLE
CASSANDRA-19947: Add constraints framework

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Add constraints framework (CASSANDRA-19947)
  * Add table metric PurgeableTombstoneScannedHistogram and a tracing event for scanned purgeable tombstones (CASSANDRA-20132)
  * Make sure we can parse the expanded CQL before writing it to the log or sending it to replicas (CASSANDRA-20218)
  * Add format_bytes and format_time functions (CASSANDRA-19546)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -76,6 +76,9 @@ New features
     metadata. In the first instance, this encompasses cluster membership, token ownership and schema metadata. See
     https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-21%3A+Transactional+Cluster+Metadata for more detail on
     the motivation and design, and see "Upgrading" below for specific instructions on migrating clusters to this system.
+    - CEP-42 Constraints Framework provides flexibility to Cassandra users and operators by providing a set of
+    usable constraints at table level, that will ease validations at application level and protect
+    the Database from misconfigured clients.
     More updates and documentation to follow.
     - New Guardrails added:
       - Whether bulk loading of SSTables is allowed.

--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -60,6 +60,7 @@
 *** xref:cassandra:developing/cql/json.adoc[JSON]
 *** xref:cassandra:developing/cql/security.adoc[Security]
 *** xref:cassandra:developing/cql/triggers.adoc[Triggers]
+*** xref:cassandra:developing/cql/constraints.adoc[Constraints]
 *** xref:cassandra:developing/cql/appendices.adoc[Appendices]
 *** xref:cassandra:developing/cql/changes.adoc[Changes]
 *** xref:cassandra:developing/cql/SASI.adoc[SASI]

--- a/doc/modules/cassandra/pages/developing/cql/constraints.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/constraints.adoc
@@ -1,0 +1,93 @@
+= Constraints
+
+Constraints provide a way of specifying and enforcing conditions at a
+column level in a table schema definition and enforcing them at write time.
+
+== CREATE CONSTRAINT
+
+Constraints can be created within the column definition, or as part
+of the table properties.
+
+The main syntax to define a constraint is as follows:
+
+[source,bnf]
+----
+CREATE TABLE keyspace.table (
+	name text,
+	i int CHECK (condition) (AND (condition))*
+	...,
+
+);
+----
+
+As shown in this syntax, more than one constraint can be defined for a given column using the AND keyword.
+
+== ALTER CONSTRAINT
+
+Altering a constraint is done by following the alter column CQL syntax:
+[source,bnf]
+----
+ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> CHECK <condition>;
+----
+
+== DROP CONSTRAINT
+And DROP can be used to drop constraints for a column as well.
+[source,bnf]
+----
+ALTER TABLE [IF EXISTS] <table> ALTER [IF EXISTS] <column> DROP CHECK;
+----
+
+== AVAILABLE CONSTRAINTS
+
+=== SCALAR CONSTRAINT
+
+Defines a comparator against a numeric type. It support all numeric types supported in Cassandra, with all the regular
+comparators.
+
+For example, we can define constraints that ensure that i is bigger or equal than 100 but smaller than 1000.
+
+[source,bnf]
+----
+CREATE TABLE keyspace.table (
+	name text,
+	i int CHECK i < 1000 AND i > 100
+	...,
+);
+----
+
+Altering that constraint can be done with:
+
+----
+ALTER TABLE keyspace.table ALTER i CHECK i >= 500;
+----
+
+Finally, the constraint can be removed:
+
+----
+ALTER TABLE keyspace.table ALTER i DROP CHECK;
+----
+
+=== LENGTH CONSTRAINT
+
+Defines a condition that checks the length of text or binary type.
+
+For example, we can create a constraint that checks that name can't be longer than 256 characters:
+
+----
+CREATE TABLE keyspace.table (
+	name text CHECK LENGTH(name) < 256
+	...,
+);
+----
+
+Altering that constraint can be done with:
+
+----
+ALTER TABLE keyspace.table ALTER name LENGTH(name) < 512;
+----
+
+Finally, the constraint can be removed:
+
+----
+ALTER TABLE keyspace.table ALTER name DROP CHECK;
+----

--- a/doc/modules/cassandra/pages/developing/cql/index.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/index.adoc
@@ -21,5 +21,6 @@ For that reason, when used in this document, these terms (tables, rows and colum
 * xref:developing/cql/json.adoc[JSON]
 * xref:developing/cql/security.adoc[CQL security]
 * xref:developing/cql/triggers.adoc[Triggers]
+* xref:developing/cql/constraints.adoc[Constraints]
 * xref:developing/cql/appendices.adoc[Appendices]
 * xref:developing/cql/changes.adoc[Changes]

--- a/doc/modules/cassandra/pages/new/index.adoc
+++ b/doc/modules/cassandra/pages/new/index.adoc
@@ -7,6 +7,7 @@ This section covers the new features in Apache Cassandra 5.1.
 
 * https://cwiki.apache.org/confluence/x/FQRACw[ACID Transactions (Accord)]
 * https://cwiki.apache.org/confluence/x/YyD1D[Transactional Cluster Metadata]
+* https://cwiki.apache.org/confluence/x/8IpyEg[Constraints]
 
 
 == New Features in Apache Cassandra 5.0

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -322,7 +322,14 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
 
 <userType> ::= utname=<cfOrKsName> ;
 
-<storageType> ::= ( <simpleStorageType> | <collectionType> | <frozenCollectionType> | <vectorType> | <userType> ) ( <column_mask> )? ;
+<storageType> ::= ( <simpleStorageType> | <collectionType> | <frozenCollectionType> | <vectorType> | <userType> ) ( <constraintsExpr> )? ( <column_mask> )? ;
+
+<constraintsExpr> ::= "CHECK" <constraint> ( "AND" <constraint> )*
+                    ;
+
+<constraint> ::= <cident> <cmp> <term>
+                | <functionArguments> <cmp> <term>
+               ;
 
 <column_mask> ::= "MASKED" "WITH" ( "DEFAULT" | <functionName> <selectionFunctionArguments> );
 
@@ -1463,7 +1470,7 @@ syntax_rules += r'''
                       | "WITH" <cfamProperty> ( "AND" <cfamProperty> )*
                       | "RENAME" ("IF" "EXISTS")? existcol=<cident> "TO" newcol=<cident>
                          ( "AND" existcol=<cident> "TO" newcol=<cident> )*
-                      | "ALTER" ("IF" "EXISTS")? existcol=<cident> ( <column_mask> | "DROP" "MASKED" )
+                      | "ALTER" ("IF" "EXISTS")? existcol=<cident> ( <constraintsExpr> | <column_mask> | "DROP" ( "CHECK" | "MASKED" ) )
                       ;
 
 <alterUserTypeStatement> ::= "ALTER" "TYPE" ("IF" "EXISTS")? ut=<userTypeName>

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -636,7 +636,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions(prefix + ' new_table (col_a ine',
                             immediate='t ')
         self.trycompletions(prefix + ' new_table (col_a int ',
-                            choices=[',', 'MASKED', 'PRIMARY'])
+                            choices=[',', 'CHECK', 'MASKED', 'PRIMARY'])
         self.trycompletions(prefix + ' new_table (col_a int M',
                             immediate='ASKED WITH ')
         self.trycompletions(prefix + ' new_table (col_a int MASKED WITH ',
@@ -1106,7 +1106,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('ALTER TABLE IF EXISTS new_table ADD ', choices=['<new_column_name>', 'IF'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table ADD IF NOT EXISTS ', choices=['<new_column_name>'])
         self.trycompletions('ALTER TABLE new_table ADD IF NOT EXISTS ', choices=['<new_column_name>'])
-        self.trycompletions('ALTER TABLE new_table ADD col int ', choices=[';', 'MASKED', 'static'])
+        self.trycompletions('ALTER TABLE new_table ADD col int ', choices=[';', 'MASKED', 'CHECK', 'static'])
         self.trycompletions('ALTER TABLE new_table ADD col int M', immediate='ASKED WITH ')
         self.trycompletions('ALTER TABLE new_table ADD col int MASKED WITH ',
                             choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
@@ -1116,12 +1116,15 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('ALTER TABLE IF EXISTS new_table DROP ', choices=['IF', '<quotedName>', '<identifier>'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER ', choices=['IF', '<quotedName>', '<identifier>'])
         self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF E', immediate='XISTS ')
-        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col ', choices=['MASKED', 'DROP'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col ', choices=['CHECK', 'MASKED', 'DROP'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col C', immediate='HECK ')
         self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col M', immediate='ASKED WITH ')
         self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col MASKED WITH ',
                             choices=['DEFAULT', self.cqlsh.keyspace + '.', 'system.'],
                             other_choices_ok=True)
-        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col D', immediate='ROP MASKED ;')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col D', immediate='ROP ')
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col DROP ', choices=['CHECK', 'MASKED'])
+        self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col DROP C', immediate='HECK ;')
         self.trycompletions('ALTER TABLE IF EXISTS new_table ALTER IF EXISTS col DROP M', immediate='ASKED ;')
 
     def test_complete_in_alter_type(self):

--- a/src/antlr/Cql.g
+++ b/src/antlr/Cql.g
@@ -38,6 +38,7 @@ import Parser,Lexer;
 
     import org.apache.cassandra.auth.*;
     import org.apache.cassandra.cql3.conditions.*;
+    import org.apache.cassandra.cql3.constraints.*;
     import org.apache.cassandra.cql3.functions.*;
     import org.apache.cassandra.cql3.functions.masking.*;
     import org.apache.cassandra.cql3.restrictions.CustomIndexExpression;

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -129,6 +129,7 @@ K_GROUP:       G R O U P;
 K_CLUSTER:     C L U S T E R;
 K_INTERNALS:   I N T E R N A L S;
 K_ONLY:        O N L Y;
+K_CHECK:       C H E C K;
 
 K_GRANT:       G R A N T;
 K_ALL:         A L L;

--- a/src/java/org/apache/cassandra/cql3/Validation.java
+++ b/src/java/org/apache/cassandra/cql3/Validation.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.cql3;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.cql3.constraints.ConstraintViolationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.serializers.MarshalException;
@@ -62,6 +63,18 @@ public abstract class Validation
         catch (MarshalException e)
         {
             throw new InvalidRequestException(e.getMessage());
+        }
+    }
+
+    public static void checkConstraints(TableMetadata metadata, ByteBuffer key)
+    {
+        try
+        {
+            metadata.partitionKeyType.checkConstraints(key, metadata.partitionKeyConstraints);
+        }
+        catch (ConstraintViolationException e)
+        {
+            throw new InvalidRequestException(e.getMessage(), e);
         }
     }
 }

--- a/src/java/org/apache/cassandra/cql3/constraints/ColumnConstraint.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/ColumnConstraint.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.constraints;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.tcm.serialization.MetadataSerializer;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+/**
+ * Common class for the conditions that a CQL Constraint needs to implement to be integrated in the
+ * CQL Constraints framework, with T as a constraint serializer.
+ */
+public interface ColumnConstraint<T>
+{
+
+    // Enum containing all the possible constraint serializers to help with serialization/deserialization
+    // of constraints.
+    enum ConstraintType
+    {
+        // The order of that enum matters!!
+        // We are serializing its enum position instead of its name.
+        // Changing this enum would affect how that int is interpreted when deserializing.
+        COMPOSED(ColumnConstraints.serializer),
+        FUNCTION(FunctionColumnConstraint.serializer),
+        SCALAR(ScalarColumnConstraint.serializer);
+
+        private final MetadataSerializer<?> serializer;
+
+        ConstraintType(MetadataSerializer<?> serializer)
+        {
+            this.serializer = serializer;
+        }
+
+        public static MetadataSerializer<?> getSerializer(int i)
+        {
+            return ConstraintType.values()[i].serializer;
+        }
+    }
+
+    MetadataSerializer<T> serializer();
+
+    void appendCqlTo(CqlBuilder builder);
+
+    /**
+     * Method that evaluates the condition. It can either succeed or throw a {@link ConstraintViolationException}.
+     *
+     * @param valueType value type of the column value under test
+     * @param columnValue Column value to be evaluated at write time
+     */
+    void evaluate(AbstractType<?> valueType, ByteBuffer columnValue) throws ConstraintViolationException;
+
+    /**
+     * Method to validate the condition. This method is called when creating constraint via CQL.
+     * A {@link InvalidConstraintDefinitionException} is thrown for invalid consrtaint definition.
+     *
+     * @param columnMetadata Metadata of the column in which the constraint is defined.
+     */
+    void validate(ColumnMetadata columnMetadata) throws InvalidConstraintDefinitionException;
+
+    /**
+     * Method to get the Constraint serializer
+     *
+     * @return the Constraint type serializer
+     */
+    ConstraintType getConstraintType();
+}

--- a/src/java/org/apache/cassandra/cql3/constraints/ColumnConstraints.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/ColumnConstraints.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.constraints;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.tcm.serialization.MetadataSerializer;
+import org.apache.cassandra.tcm.serialization.Version;
+
+
+// group of constraints for the column
+public class ColumnConstraints implements ColumnConstraint<ColumnConstraints>
+{
+    public static final Serializer serializer = new Serializer();
+    public static final ColumnConstraints NO_OP = new Noop();
+
+    private final List<ColumnConstraint<?>> constraints;
+
+    public ColumnConstraints(List<ColumnConstraint<?>> constraints)
+    {
+        this.constraints = constraints;
+    }
+
+    @Override
+    public MetadataSerializer<ColumnConstraints> serializer()
+    {
+        return serializer;
+    }
+
+    @Override
+    public void appendCqlTo(CqlBuilder builder)
+    {
+        for (ColumnConstraint<?> constraint : constraints)
+            constraint.appendCqlTo(builder);
+    }
+
+    @Override
+    public void evaluate(AbstractType<?> valueType, ByteBuffer columnValue) throws ConstraintViolationException
+    {
+        for (ColumnConstraint<?> constraint : constraints)
+            constraint.evaluate(valueType, columnValue);
+    }
+
+    public List<ColumnConstraint<?>> getConstraints()
+    {
+        return constraints;
+    }
+
+    public boolean isEmpty()
+    {
+        return constraints.isEmpty();
+    }
+
+    public int getSize()
+    {
+        return constraints.size();
+    }
+
+    // Checks if there is at least one constraint that will perform checks
+    public boolean hasRelevantConstraints()
+    {
+        for (ColumnConstraint c : constraints)
+        {
+            if (c != ColumnConstraints.NO_OP)
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void validate(ColumnMetadata columnMetadata) throws InvalidConstraintDefinitionException
+    {
+        if (!columnMetadata.type.isConstrainable())
+            throw new InvalidConstraintDefinitionException("Constraint cannot be defined on the column "
+                                                           + columnMetadata.name + " of type " + columnMetadata.type.asCQL3Type()
+                                                           + " for the table " + columnMetadata.ksName + "." + columnMetadata.cfName);
+
+        for (ColumnConstraint<?> constraint : constraints)
+            constraint.validate(columnMetadata);
+    }
+
+    @Override
+    public ConstraintType getConstraintType()
+    {
+        return ConstraintType.COMPOSED;
+    }
+
+    private static class Noop extends ColumnConstraints
+    {
+        private Noop()
+        {
+            super(Collections.emptyList());
+        }
+
+        @Override
+        public void validate(ColumnMetadata columnMetadata)
+        {
+            // Do nothing. It is always valid
+        }
+    }
+
+    public final static class Raw
+    {
+        private final List<ColumnConstraint<?>> constraints;
+
+        public Raw(List<ColumnConstraint<?>> constraints)
+        {
+            this.constraints = constraints;
+        }
+
+        public Raw()
+        {
+            this.constraints = Collections.emptyList();
+        }
+
+        public ColumnConstraints prepare()
+        {
+            if (constraints.isEmpty())
+                return NO_OP;
+            return new ColumnConstraints(constraints);
+        }
+    }
+
+    public static class Serializer implements MetadataSerializer<ColumnConstraints>
+    {
+
+        @Override
+        public void serialize(ColumnConstraints columnConstraint, DataOutputPlus out, Version version) throws IOException
+        {
+            out.writeInt(columnConstraint.getSize());
+            for (ColumnConstraint constraint : columnConstraint.getConstraints())
+            {
+                // We serialize the serializer ordinal in the enum to save space
+                out.writeShort(constraint.getConstraintType().ordinal());
+                constraint.serializer().serialize(constraint, out, version);
+            }
+        }
+
+        @Override
+        public ColumnConstraints deserialize(DataInputPlus in, Version version) throws IOException
+        {
+            List<ColumnConstraint<?>> columnConstraints = new ArrayList<>();
+            int numberOfConstraints = in.readInt();
+            for (int i = 0; i < numberOfConstraints; i++)
+            {
+                int serializerPosition = in.readShort();
+                ColumnConstraint<?> constraint = (ColumnConstraint<?>) ConstraintType
+                                                                       .getSerializer(serializerPosition)
+                                                                       .deserialize(in, version);
+                columnConstraints.add(constraint);
+            }
+            return new ColumnConstraints(columnConstraints);
+        }
+
+        @Override
+        public long serializedSize(ColumnConstraints columnConstraint, Version version)
+        {
+            long constraintsSize = TypeSizes.INT_SIZE;
+            for (ColumnConstraint constraint : columnConstraint.getConstraints())
+            {
+                constraintsSize += TypeSizes.SHORT_SIZE;
+                constraintsSize += constraint.serializer().serializedSize(constraint, version);
+            }
+            return constraintsSize;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+
+        if (!(o instanceof ColumnConstraints))
+            return false;
+
+        ColumnConstraints other = (ColumnConstraints) o;
+        return Objects.equals(constraints, other.constraints);
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/constraints/ConstraintFunction.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/ConstraintFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.constraints;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.schema.ColumnMetadata;
+
+/**
+ * Interface to be implemented by functions that are executed as part of CQL constraints.
+ */
+public interface ConstraintFunction
+{
+    /**
+     * @return the function name to be executed.
+     */
+    String getName();
+
+    /**
+     * Method that performs the actual condition test, executed during the write path.
+     * It the test is not successful, it throws a {@link ConstraintViolationException}.
+     */
+    void evaluate(AbstractType<?> valueType, Operator relationType, String term, ByteBuffer columnValue) throws ConstraintViolationException;
+
+    /**
+     * Method that validates that a condition is valid. This method is called when the CQL constraint is created to determine
+     * if the CQL statement is valid or needs to be rejected as invalid throwing a {@link InvalidConstraintDefinitionException}
+     */
+    void validate(ColumnMetadata columnMetadata) throws InvalidConstraintDefinitionException;
+}

--- a/src/java/org/apache/cassandra/cql3/constraints/ConstraintViolationException.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/ConstraintViolationException.java
@@ -16,23 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.distributed.test.cdc;
+package org.apache.cassandra.cql3.constraints;
 
+import org.apache.cassandra.exceptions.InvalidRequestException;
 
-import org.junit.Test;
-
-
-public class ToggleCDCOnRepairEnabledTest extends ToggleCDCOnRepair
+/**
+ * Thrown to indicate that the CQL operation did not comply with the defined Constraints
+ */
+public class ConstraintViolationException extends InvalidRequestException
 {
-    @Test
-    public void testCDCOnRepairIsEnabled() throws Exception
+    public ConstraintViolationException(String msg)
     {
-        testCDCOnRepairEnabled(true, getRepairEnabledRepairAssertion(), false);
-    }
-
-    @Test
-    public void testCDCOnRepairIsDisabled() throws Exception
-    {
-        testCDCOnRepairEnabled(false, getRepairDisabledRepairAssertion(), false);
+        super(msg);
     }
 }

--- a/src/java/org/apache/cassandra/cql3/constraints/FunctionColumnConstraint.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/FunctionColumnConstraint.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.constraints;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.tcm.serialization.MetadataSerializer;
+import org.apache.cassandra.tcm.serialization.Version;
+import org.apache.cassandra.utils.LocalizeString;
+
+public class FunctionColumnConstraint implements ColumnConstraint<FunctionColumnConstraint>
+{
+    public static final Serializer serializer = new Serializer();
+
+    public final ConstraintFunction function;
+    public final ColumnIdentifier columnName;
+    public final Operator relationType;
+    public final String term;
+
+    public final static class Raw
+    {
+        public final ConstraintFunction function;
+        public final ColumnIdentifier columnName;
+        public final Operator relationType;
+        public final String term;
+
+        public Raw(ColumnIdentifier functionName, ColumnIdentifier columnName, Operator relationType, String term)
+        {
+            this.relationType = relationType;
+            this.columnName = columnName;
+            this.term = term;
+            function = createConstraintFunction(functionName.toCQLString(), columnName);
+        }
+
+        public FunctionColumnConstraint prepare()
+        {
+            return new FunctionColumnConstraint(function, columnName, relationType, term);
+        }
+    }
+
+    private enum Functions
+    {
+        LENGTH(LengthConstraint::new);
+
+        private final java.util.function.Function<ColumnIdentifier, ConstraintFunction> functionCreator;
+
+        Functions(java.util.function.Function<ColumnIdentifier, ConstraintFunction> functionCreator)
+        {
+            this.functionCreator = functionCreator;
+        }
+    }
+
+    private static ConstraintFunction createConstraintFunction(String functionName, ColumnIdentifier columnName)
+    {
+        try
+        {
+            return Functions.valueOf(LocalizeString.toUpperCaseLocalized(functionName)).functionCreator.apply(columnName);
+        }
+        catch (IllegalArgumentException ex)
+        {
+            throw new InvalidConstraintDefinitionException("Unrecognized constraint function: " + functionName);
+        }
+    }
+
+    private FunctionColumnConstraint(ConstraintFunction function, ColumnIdentifier columnName, Operator relationType, String term)
+    {
+        this.function = function;
+        this.columnName = columnName;
+        this.relationType = relationType;
+        this.term = term;
+    }
+
+    @Override
+    public void appendCqlTo(CqlBuilder builder)
+    {
+        builder.append(toString());
+    }
+
+    @Override
+    public MetadataSerializer<FunctionColumnConstraint> serializer()
+    {
+        return serializer;
+    }
+
+    @Override
+    public void evaluate(AbstractType<?> valueType, ByteBuffer columnValue)
+    {
+        function.evaluate(valueType, relationType, term, columnValue);
+    }
+
+    @Override
+    public void validate(ColumnMetadata columnMetadata)
+    {
+        validateArgs(columnMetadata);
+        function.validate(columnMetadata);
+    }
+
+    @Override
+    public ConstraintType getConstraintType()
+    {
+        return ConstraintType.FUNCTION;
+    }
+
+    void validateArgs(ColumnMetadata columnMetadata)
+    {
+        if (!columnMetadata.name.equals(columnName))
+            throw new InvalidConstraintDefinitionException("Function parameter should be the column name");
+    }
+
+    @Override
+    public String toString()
+    {
+        return function.getName() + "(" + columnName + ") " + relationType + " " + term;
+    }
+
+    public static class Serializer implements MetadataSerializer<FunctionColumnConstraint>
+    {
+        @Override
+        public void serialize(FunctionColumnConstraint columnConstraint, DataOutputPlus out, Version version) throws IOException
+        {
+            out.writeUTF(columnConstraint.function.getName());
+            out.writeUTF(columnConstraint.columnName.toCQLString());
+            columnConstraint.relationType.writeTo(out);
+            out.writeUTF(columnConstraint.term);
+        }
+
+        @Override
+        public FunctionColumnConstraint deserialize(DataInputPlus in, Version version) throws IOException
+        {
+            String functionName = in.readUTF();
+            ConstraintFunction function;
+            String columnNameString = in.readUTF();
+            ColumnIdentifier columnName = new ColumnIdentifier(columnNameString, true);
+            try
+            {
+                function = createConstraintFunction(functionName, columnName);
+            }
+            catch (Exception e)
+            {
+                throw new IOException(e);
+            }
+            Operator relationType = Operator.readFrom(in);
+            final String term = in.readUTF();
+            return new FunctionColumnConstraint(function, columnName, relationType, term);
+        }
+
+        @Override
+        public long serializedSize(FunctionColumnConstraint columnConstraint, Version version)
+        {
+            return TypeSizes.sizeof(columnConstraint.function.getClass().getName())
+                   + TypeSizes.sizeof(columnConstraint.columnName.toCQLString())
+                   + TypeSizes.sizeof(columnConstraint.term)
+                   + Operator.serializedSize();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+
+        if (!(o instanceof FunctionColumnConstraint))
+            return false;
+
+        FunctionColumnConstraint other = (FunctionColumnConstraint) o;
+
+        return function.equals(other.function)
+               && columnName.equals(other.columnName)
+               && relationType == other.relationType
+               && term.equals(other.term);
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/constraints/InvalidConstraintDefinitionException.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/InvalidConstraintDefinitionException.java
@@ -16,23 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.cassandra.distributed.test.cdc;
+package org.apache.cassandra.cql3.constraints;
 
+import org.apache.cassandra.exceptions.InvalidRequestException;
 
-import org.junit.Test;
-
-
-public class ToggleCDCOnRepairEnabledTest extends ToggleCDCOnRepair
+/**
+ * Thrown to indicate that the CQL constraint is not valid
+ */
+public class InvalidConstraintDefinitionException extends InvalidRequestException
 {
-    @Test
-    public void testCDCOnRepairIsEnabled() throws Exception
+    public InvalidConstraintDefinitionException(String msg)
     {
-        testCDCOnRepairEnabled(true, getRepairEnabledRepairAssertion(), false);
-    }
-
-    @Test
-    public void testCDCOnRepairIsDisabled() throws Exception
-    {
-        testCDCOnRepairEnabled(false, getRepairDisabledRepairAssertion(), false);
+        super(msg);
     }
 }

--- a/src/java/org/apache/cassandra/cql3/constraints/LengthConstraint.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/LengthConstraint.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.constraints;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.BytesType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+public class LengthConstraint implements ConstraintFunction
+{
+    private static final AbstractType<?>[] SUPPORTED_TYPES = new AbstractType[] { BytesType.instance, UTF8Type.instance, AsciiType.instance };
+
+    public static final String FUNCTION_NAME = "LENGTH";
+
+    private final ColumnIdentifier columnName;
+
+    public LengthConstraint(ColumnIdentifier columnName)
+    {
+        this.columnName = columnName;
+    }
+
+    @Override
+    public String getName()
+    {
+        return FUNCTION_NAME;
+    }
+
+    @Override
+    public void evaluate(AbstractType<?> valueType, Operator relationType, String term, ByteBuffer columnValue)
+    {
+        int valueLength = getValueLength(columnValue, valueType);
+        int sizeConstraint = Integer.parseInt(term);
+
+        ByteBuffer leftOperand = ByteBufferUtil.bytes(valueLength);
+        ByteBuffer rightOperand = ByteBufferUtil.bytes(sizeConstraint);
+
+        if (!relationType.isSatisfiedBy(Int32Type.instance, leftOperand, rightOperand))
+            throw new ConstraintViolationException(columnName + " does not satisfy length constraint. "
+                                                   + valueLength + " should be " + relationType + ' ' + term);
+    }
+
+    @Override
+    public void validate(ColumnMetadata columnMetadata)
+    {
+        boolean supported = false;
+        AbstractType<?> unwrapped = columnMetadata.type.unwrap();
+        for (AbstractType<?> supportedType : SUPPORTED_TYPES)
+        {
+            if (supportedType == unwrapped)
+            {
+                supported = true;
+                break;
+            }
+        }
+
+        if (!supported)
+            throw invalidConstraintDefinitionException(columnMetadata.type);
+    }
+
+    private int getValueLength(ByteBuffer value, AbstractType<?> valueType)
+    {
+        if (valueType.getClass() == BytesType.class)
+        {
+            return value.remaining();
+        }
+
+        if (valueType.getClass() == AsciiType.class || valueType.getClass() == UTF8Type.class)
+            return ((String) valueType.compose(value)).length();
+
+        throw invalidConstraintDefinitionException(valueType);
+    }
+
+    private InvalidConstraintDefinitionException invalidConstraintDefinitionException(AbstractType<?> valueType)
+    {
+        throw new InvalidConstraintDefinitionException("Column type " + valueType.getClass() + " is not supported.");
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+
+        if (!(o instanceof LengthConstraint))
+            return false;
+
+        LengthConstraint other = (LengthConstraint) o;
+
+        return columnName.equals(other.columnName);
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/constraints/ScalarColumnConstraint.java
+++ b/src/java/org/apache/cassandra/cql3/constraints/ScalarColumnConstraint.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3.constraints;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.cql3.Operator;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.ColumnMetadata;
+import org.apache.cassandra.tcm.serialization.MetadataSerializer;
+import org.apache.cassandra.tcm.serialization.Version;
+
+public class ScalarColumnConstraint implements ColumnConstraint<ScalarColumnConstraint>
+{
+    public final ColumnIdentifier param;
+    public final Operator relationType;
+    public final String term;
+
+    public final static Serializer serializer = new Serializer();
+
+    public final static class Raw
+    {
+        public final ColumnIdentifier param;
+        public final Operator relationType;
+        public final String term;
+
+        public Raw(ColumnIdentifier param, Operator relationType, String term)
+        {
+            this.param = param;
+            this.relationType = relationType;
+            this.term = term;
+        }
+
+        public ScalarColumnConstraint prepare()
+        {
+            return new ScalarColumnConstraint(param, relationType, term);
+        }
+    }
+
+    private ScalarColumnConstraint(ColumnIdentifier param, Operator relationType, String term)
+    {
+        this.param = param;
+        this.relationType = relationType;
+        this.term = term;
+    }
+
+    @Override
+    public void evaluate(AbstractType<?> valueType, ByteBuffer columnValue)
+    {
+        ByteBuffer value;
+        try
+        {
+            value = valueType.fromString(term);
+        }
+        catch (NumberFormatException exception)
+        {
+            throw new ConstraintViolationException(param + " and " + term + " need to be numbers.");
+        }
+
+        if (!relationType.isSatisfiedBy(valueType, columnValue, value))
+            throw new ConstraintViolationException("Column value does not satisfy value constraint. "
+                                                   + " It should be " + relationType + " " + term);
+    }
+
+    @Override
+    public void validate(ColumnMetadata columnMetadata) throws InvalidConstraintDefinitionException
+    {
+        if (!columnMetadata.type.isNumber())
+            throw new InvalidConstraintDefinitionException(param + " is not a number");
+    }
+
+    @Override
+    public ConstraintType getConstraintType()
+    {
+        return ConstraintType.SCALAR;
+    }
+
+    @Override
+    public String toString()
+    {
+        return param + " " + relationType + " " + term;
+    }
+
+    @Override
+    public MetadataSerializer<ScalarColumnConstraint> serializer()
+    {
+        return serializer;
+    }
+
+    @Override
+    public void appendCqlTo(CqlBuilder builder)
+    {
+        builder.append(toString());
+    }
+
+    private static class Serializer implements MetadataSerializer<ScalarColumnConstraint>
+    {
+        @Override
+        public void serialize(ScalarColumnConstraint columnConstraint, DataOutputPlus out, Version version) throws IOException
+        {
+            out.writeUTF(columnConstraint.param.toCQLString());
+            columnConstraint.relationType.writeTo(out);
+            out.writeUTF(columnConstraint.term);
+        }
+
+        @Override
+        public ScalarColumnConstraint deserialize(DataInputPlus in, Version version) throws IOException
+        {
+            ColumnIdentifier param = new ColumnIdentifier(in.readUTF(), true);
+            Operator relationType = Operator.readFrom(in);
+            return new ScalarColumnConstraint(param, relationType, in.readUTF());
+        }
+
+        @Override
+        public long serializedSize(ScalarColumnConstraint columnConstraint, Version version)
+        {
+            return TypeSizes.sizeof(columnConstraint.term)
+                   + Operator.serializedSize()
+                   + TypeSizes.sizeof(columnConstraint.param.toString());
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+
+        if (!(o instanceof ScalarColumnConstraint))
+            return false;
+
+        ScalarColumnConstraint other = (ScalarColumnConstraint) o;
+
+        return param.equals(other.param)
+               && relationType == other.relationType
+               && term.equals(other.term);
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.cql3.*;
+import org.apache.cassandra.cql3.constraints.ColumnConstraints;
 import org.apache.cassandra.cql3.functions.masking.ColumnMask;
 import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.marshal.*;
@@ -56,6 +57,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
     private final Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns;
     private final Set<ColumnIdentifier> staticColumns;
     private final List<ColumnIdentifier> partitionKeyColumns;
+    private final Map<ColumnIdentifier, ColumnConstraints> columnConstraints;
     private final List<ColumnIdentifier> clusteringColumns;
 
     private final LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder;
@@ -72,6 +74,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
                                 Set<ColumnIdentifier> staticColumns,
                                 List<ColumnIdentifier> partitionKeyColumns,
                                 List<ColumnIdentifier> clusteringColumns,
+                                Map<ColumnIdentifier, ColumnConstraints> columnConstraints,
                                 LinkedHashMap<ColumnIdentifier, Boolean> clusteringOrder,
                                 TableAttributes attrs,
                                 boolean ifNotExists,
@@ -84,6 +87,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         this.staticColumns = staticColumns;
         this.partitionKeyColumns = partitionKeyColumns;
         this.clusteringColumns = clusteringColumns;
+        this.columnConstraints = columnConstraints;
 
         this.clusteringOrder = clusteringOrder;
         this.attrs = attrs;
@@ -343,13 +347,13 @@ public final class CreateTableStatement extends AlterSchemaStatement
         for (int i = 0; i < partitionKeyColumns.size(); i++)
         {
             ColumnProperties properties = partitionKeyColumnProperties.get(i);
-            builder.addPartitionKeyColumn(partitionKeyColumns.get(i), properties.type, properties.mask);
+            builder.addPartitionKeyColumn(partitionKeyColumns.get(i), properties.type, properties.mask, columnConstraints.get(partitionKeyColumns.get(i)));
         }
 
         for (int i = 0; i < clusteringColumns.size(); i++)
         {
             ColumnProperties properties = clusteringColumnProperties.get(i);
-            builder.addClusteringColumn(clusteringColumns.get(i), properties.type, properties.mask);
+            builder.addClusteringColumn(clusteringColumns.get(i), properties.type, properties.mask, columnConstraints.get(clusteringColumns.get(i)));
         }
 
         if (useCompactStorage)
@@ -360,11 +364,12 @@ public final class CreateTableStatement extends AlterSchemaStatement
         {
             columns.forEach((column, properties) -> {
                 if (staticColumns.contains(column))
-                    builder.addStaticColumn(column, properties.type, properties.mask);
+                    builder.addStaticColumn(column, properties.type, properties.mask, columnConstraints.get(column));
                 else
-                    builder.addRegularColumn(column, properties.type, properties.mask);
+                    builder.addRegularColumn(column, properties.type, properties.mask, columnConstraints.get(column));
             });
         }
+
         return builder;
     }
 
@@ -506,6 +511,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
         private final Map<ColumnIdentifier, ColumnProperties.Raw> rawColumns = new HashMap<>();
         private final Set<ColumnIdentifier> staticColumns = new HashSet<>();
         private final List<ColumnIdentifier> clusteringColumns = new ArrayList<>();
+        private final Map<ColumnIdentifier, ColumnConstraints> columnConstraints = new HashMap<>();
 
         private List<ColumnIdentifier> partitionKeyColumns;
 
@@ -531,6 +537,7 @@ public final class CreateTableStatement extends AlterSchemaStatement
                                             staticColumns,
                                             partitionKeyColumns,
                                             clusteringColumns,
+                                            columnConstraints,
                                             clusteringOrder,
                                             attrs,
                                             ifNotExists,
@@ -559,14 +566,17 @@ public final class CreateTableStatement extends AlterSchemaStatement
             return name.getName();
         }
 
-        public void addColumn(ColumnIdentifier column, CQL3Type.Raw type, boolean isStatic, ColumnMask.Raw mask)
+        public void addColumn(ColumnIdentifier column, CQL3Type.Raw type, boolean isStatic, ColumnMask.Raw mask, ColumnConstraints.Raw constraints)
         {
-
             if (null != rawColumns.put(column, new ColumnProperties.Raw(type, mask)))
                 throw ire("Duplicate column '%s' declaration for table '%s'", column, name);
 
             if (isStatic)
                 staticColumns.add(column);
+            if (null == constraints)
+                columnConstraints.put(column, ColumnConstraints.NO_OP);
+            else
+                columnConstraints.put(column, constraints.prepare());
         }
 
         public void setCompactStorage()

--- a/src/java/org/apache/cassandra/db/ClusteringPrefix.java
+++ b/src/java/org/apache/cassandra/db/ClusteringPrefix.java
@@ -24,6 +24,7 @@ import java.util.function.ToIntFunction;
 
 import org.apache.cassandra.cache.IMeasurableMemory;
 import org.apache.cassandra.config.*;
+import org.apache.cassandra.cql3.constraints.ColumnConstraints;
 import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.CompositeType;
@@ -750,6 +751,11 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
             return false;
 
         return equals(prefix, (ClusteringPrefix<?>) o);
+    }
+
+    default void checkConstraints(int clusterIndex, ClusteringComparator comparator, ColumnConstraints constraints)
+    {
+        comparator.subtype(clusterIndex).checkConstraints(accessor().toBuffer(get(clusterIndex)), constraints);
     }
 
 }

--- a/src/java/org/apache/cassandra/db/Columns.java
+++ b/src/java/org/apache/cassandra/db/Columns.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterators;
 
 import net.nicoulaj.compilecommand.annotations.DontInline;
 import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.constraints.ColumnConstraints;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.rows.ColumnData;
@@ -62,7 +63,8 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                            SetType.getInstance(UTF8Type.instance, true),
                            ColumnMetadata.NO_POSITION,
                            ColumnMetadata.Kind.STATIC,
-                           null);
+                           null,
+                           ColumnConstraints.NO_OP);
 
     public static final ColumnMetadata FIRST_COMPLEX_REGULAR =
         new ColumnMetadata("",
@@ -71,7 +73,8 @@ public class Columns extends AbstractCollection<ColumnMetadata> implements Colle
                            SetType.getInstance(UTF8Type.instance, true),
                            ColumnMetadata.NO_POSITION,
                            ColumnMetadata.Kind.REGULAR,
-                           null);
+                           null,
+                           ColumnConstraints.NO_OP);
 
     private final Object[] columns;
     private final int complexIdx; // Index of the first complex column

--- a/src/java/org/apache/cassandra/db/marshal/MapType.java
+++ b/src/java/org/apache/cassandra/db/marshal/MapType.java
@@ -456,4 +456,10 @@ public class MapType<K, V> extends CollectionType<Map<K, V>>
 
         return getSerializer().getSerializedValue(((Cell<?>) columnData).buffer(), keyOrIndex, getValuesType());
     }
+
+    @Override
+    public boolean isConstrainable()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/db/marshal/ReversedType.java
+++ b/src/java/org/apache/cassandra/db/marshal/ReversedType.java
@@ -244,4 +244,10 @@ public class ReversedType<T> extends AbstractType<T>
     {
         return baseType.unwrap();
     }
+
+    @Override
+    public boolean isConstrainable()
+    {
+        return unwrap().isConstrainable();
+    }
 }

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -616,4 +616,10 @@ public class TupleType extends MultiElementType<ByteBuffer>
     {
         throw new UnsupportedOperationException("Multicell tuples are not supported");
     }
+
+    @Override
+    public boolean isConstrainable()
+    {
+        return false;
+    }
 }

--- a/src/java/org/apache/cassandra/db/marshal/UserType.java
+++ b/src/java/org/apache/cassandra/db/marshal/UserType.java
@@ -618,6 +618,12 @@ public class UserType extends TupleType implements SchemaElement
         return "field " + fieldName(i);
     }
 
+    @Override
+    public boolean isConstrainable()
+    {
+        return false;
+    }
+
     private enum ConflictBehavior
     {
         LOG {

--- a/src/java/org/apache/cassandra/tcm/membership/NodeVersion.java
+++ b/src/java/org/apache/cassandra/tcm/membership/NodeVersion.java
@@ -34,7 +34,7 @@ import static org.apache.cassandra.db.TypeSizes.sizeofUnsignedVInt;
 public class NodeVersion implements Comparable<NodeVersion>
 {
     public static final Serializer serializer = new Serializer();
-    public static final Version CURRENT_METADATA_VERSION = Version.V5;
+    public static final Version CURRENT_METADATA_VERSION = Version.V6;
     public static final NodeVersion CURRENT = new NodeVersion(new CassandraVersion(FBUtilities.getReleaseVersionString()), CURRENT_METADATA_VERSION);
     private static final CassandraVersion SINCE_VERSION = CassandraVersion.CASSANDRA_5_0;
 

--- a/src/java/org/apache/cassandra/tcm/serialization/Version.java
+++ b/src/java/org/apache/cassandra/tcm/serialization/Version.java
@@ -51,6 +51,10 @@ public enum Version
      * - PreInitialize includes datacenter (affects local serialization on first CMS node only)
      */
     V5(5),
+    /**
+     * CEP-42 - Constraints framework. New version due to modifications in table metadata serialization.
+     */
+    V6(6),
 
     UNKNOWN(Integer.MAX_VALUE);
 

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnConstraintsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnConstraintsTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ColumnConstraintsTest extends TestBaseImpl
+{
+    final static Map<String, String> RELATIONS_MAP = Map.of("st", "<",
+                                                           "set", "<=",
+                                                           "et", "=",
+                                                           "net", "!=",
+                                                           "bt", ">",
+                                                           "bet", ">=");
+
+    @Test
+    public void testInvalidConstraintsExceptions() throws IOException
+    {
+        final String tableName = KEYSPACE + ".tbl1";
+
+        try (Cluster cluster = init(Cluster.build(3).start()))
+        {
+            assertThrowsInvalidConstraintException(cluster, String.format("CREATE TABLE %s (pk int, ck1 text CHECK ck1 < 100, ck2 int, v int, " +
+                                                                          "PRIMARY KEY ((pk), ck1, ck2));", tableName),
+                                                   "ck1 is not a number");
+
+            assertThrowsInvalidConstraintException(cluster, String.format("CREATE TABLE %s (pk int, ck1 int CHECK LENGTH(ck1) < 100, ck2 int, v int, " +
+                                                                          "PRIMARY KEY ((pk), ck1, ck2));", tableName),
+                                                   "Column should be of type class org.apache.cassandra.db.marshal.UTF8Type or " +
+                                                   "class org.apache.cassandra.db.marshal.AsciiType but got class org.apache.cassandra.db.marshal.Int32Type");
+        }
+    }
+
+    @Test
+    public void testUpdateConstraint() throws IOException
+    {
+        final String tableName = KEYSPACE + ".tbl1";
+
+        try (Cluster cluster = init(Cluster.build(3).start()))
+        {
+            String createTableStatement = "CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 100, ck2 int, v int, PRIMARY KEY ((pk), ck1, ck2));";
+            cluster.schemaChange(String.format(createTableStatement, tableName));
+
+            String insertStatement = "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 200, 3)";
+
+            cluster.coordinator(1).execute(String.format("ALTER TABLE %s ALTER ck2 CHECK ck2 < 100", tableName), ConsistencyLevel.ALL);
+
+            // Can't insert
+            assertThrowsConstraintViolationException(cluster,
+                                                     String.format(insertStatement, tableName),
+                                                     "ck1 value length should be smaller than 100");
+
+            cluster.coordinator(1).execute(String.format("ALTER TABLE %s ALTER ck2 DROP CHECK", tableName), ConsistencyLevel.ALL);
+
+            // Can insert after droping the constraint
+            cluster.coordinator(1).execute(String.format(insertStatement, tableName), ConsistencyLevel.ALL);
+        }
+    }
+
+    @Test
+    public void testConstraintWithJsonInsert() throws IOException
+    {
+        final String tableName = KEYSPACE + ".tbl1";
+
+        try (Cluster cluster = init(Cluster.build(3).start()))
+        {
+            String createTableStatement = "CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 100, ck2 int, v uuid, PRIMARY KEY ((pk), ck1, ck2));";
+            cluster.schemaChange(String.format(createTableStatement, tableName));
+
+            cluster.coordinator(1).execute(String.format("INSERT INTO %s JSON '{\"pk\" : 1, \"ck1\" : 2, \"ck2\" : 2, \"v\" : \"ac064e40-0417-4a4a-bf53-b7cf145afdc2\" }'", tableName), ConsistencyLevel.ALL);
+
+            assertThrowsConstraintViolationException(cluster,
+                                                     String.format("INSERT INTO %s JSON '{\"pk\" : 1, \"ck1\" : 200, \"ck2\" : 2, \"v\" : \"ac064e40-0417-4a4a-bf53-b7cf145afdc2\" }'", tableName),
+                                                     "ck1 value length should be smaller than 100");
+
+            assertThrowsConstraintViolationException(cluster,
+                                                     String.format("INSERT INTO %s JSON '{\"pk\" : 1, \"ck1\": 100, \"ck2\" : 2, \"v\" : \"ac064e40-0417-4a4a-bf53-b7cf145afdc2\" }'", tableName),
+                                                     "ck1 value length should be smaller than 100");
+        }
+    }
+
+    @Test
+    public void testScalarTableLevelConstraint() throws IOException
+    {
+        Set<String> typesSet = Set.of("int", "double", "float", "decimal");
+
+        try (Cluster cluster = init(Cluster.build(3).start()))
+        {
+            // Create tables
+            for (String type : typesSet)
+            {
+                for (Map.Entry<String, String> relation : RELATIONS_MAP.entrySet())
+                {
+                    String tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, relation.getKey());
+                    String createTableStatementSmallerThan = "CREATE TABLE " + tableName + " (pk int, ck1 " + type + " CHECK ck1 " + relation.getValue() + " 100, ck2 int, v int, PRIMARY KEY ((pk), ck1, ck2));";
+                    cluster.schemaChange(createTableStatementSmallerThan);
+                }
+            }
+
+            for (String type : typesSet)
+            {
+                // st
+                String tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "st");
+
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 2, 3)", tableName), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 200, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 100, 2, 3)", tableName),
+                                                         "ck1 value length be smaller than 100.0");
+
+                // set
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "set");
+
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 2, 3)", tableName), ConsistencyLevel.ALL);
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 100, 2, 3)", tableName), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 200, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+
+                // et
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "et");
+
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 100, 2, 3)", tableName), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 200, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+
+                // net
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "net");
+
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 200, 2, 3)", tableName), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 100, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+
+                // bt
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "bt");
+
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 200, 2, 3)", tableName), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 1, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 100, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+
+                // bet
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "bet");
+
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 200, 2, 3)", tableName), ConsistencyLevel.ALL);
+                cluster.coordinator(1).execute(String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 100, 2, 3)", tableName), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 1, 2, 3)", tableName),
+                                                         "ck1 value should be smaller than 100.0");
+
+            }
+        }
+    }
+
+    @Test
+    public void testLengthTableLevelConstraint() throws IOException
+    {
+        Set<String> typesSet = Set.of("varchar", "text", "blob", "ascii");
+
+        try (Cluster cluster = init(Cluster.build(3).start()))
+        {
+            // Create tables
+            for (String type : typesSet)
+            {
+                for (Map.Entry<String, String> relation : RELATIONS_MAP.entrySet())
+                {
+                    String tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, relation.getKey());
+                    String createTableStatementSmallerThan = "CREATE TABLE " + tableName + " (pk " + type + " CHECK LENGTH(pk) " + relation.getValue() + " 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk), ck1, ck2));";
+                    cluster.schemaChange(createTableStatementSmallerThan);
+                }
+            }
+
+            for (String type : typesSet)
+            {
+                String value = "'%s'";
+                if (type.equals("blob"))
+                    value = "textAsBlob('%s')";
+                // st
+                String tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "st");
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "foo"), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 200, 2, 3)", "fooo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "foooo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                // set
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "set");
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "foo"), ConsistencyLevel.ALL);
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "fooo"), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "foooo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                // et
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "et");
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "fooo"), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "foooo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "fo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                // net
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "net");
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "foooo"), ConsistencyLevel.ALL);
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "foo"), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "fooo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                // bt
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "bt");
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "foooo"), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "fooo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "foo"),
+                                                         "ck1 value length should be smaller than 100");
+
+                // bet
+                tableName = String.format(KEYSPACE + ".%s_tbl1_%s", type, "bet");
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "foooo"), ConsistencyLevel.ALL);
+                cluster.coordinator(1).execute(String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 2, 2, 3)", "fooo"), ConsistencyLevel.ALL);
+
+                assertThrowsConstraintViolationException(cluster,
+                                                         String.format("INSERT INTO " + tableName + " (pk, ck1, ck2, v) VALUES (" + value + ", 100, 2, 3)", "foo"),
+                                                         "ck1 value length should be smaller than 100");
+            }
+        }
+    }
+
+    private void assertThrowsConstraintViolationException(Cluster cluster, String statement, String description)
+    {
+        Assertions.assertThatThrownBy(() -> cluster.coordinator(1).execute(statement, ConsistencyLevel.ALL))
+                  .describedAs(description)
+                  .has(new Condition<Throwable>(t -> t.getClass().getCanonicalName()
+                                                      .equals(InvalidRequestException.class.getCanonicalName()), description));
+    }
+
+    private void assertThrowsInvalidConstraintException(Cluster cluster, String statement, String description)
+    {
+        Assertions.setMaxStackTraceElementsDisplayed(100);
+        assertThatThrownBy(() -> cluster.schemaChange(statement))
+                  .describedAs(description)
+                  .has(new Condition<Throwable>(t -> t.getClass().getCanonicalName()
+                                                      .equals(InvalidRequestException.class.getCanonicalName()), description));
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/cdc/ToggleCDCOnRepair.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/cdc/ToggleCDCOnRepair.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.cdc;
+
+import java.util.function.Consumer;
+
+
+import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.db.commitlog.CommitLogSegment;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
+import static org.apache.cassandra.distributed.shared.AssertUtils.assertTrue;
+import static org.apache.cassandra.distributed.shared.AssertUtils.row;
+
+public abstract class ToggleCDCOnRepair extends TestBaseImpl
+{
+    Consumer<Cluster> getRepairEnabledRepairAssertion()
+    {
+        return cluster -> {
+            cluster.get(2).runOnInstance(() -> {
+                boolean containCDCInLog = CommitLog.instance.segmentManager
+                                          .getActiveSegments()
+                                          .stream()
+                                          .anyMatch(s -> s.getCDCState() == CommitLogSegment.CDCState.CONTAINS);
+                assertTrue("Mutation should be added to commit log when cdc_on_repair_enabled is true",
+                           containCDCInLog);
+            });
+        };
+    }
+
+    Consumer<Cluster> getRepairDisabledRepairAssertion()
+    {
+        return cluster -> {
+            cluster.get(2).runOnInstance(() -> {
+                boolean containCDCInLog = CommitLog.instance.segmentManager
+                                          .getActiveSegments()
+                                          .stream()
+                                          .allMatch(s -> s.getCDCState() != CommitLogSegment.CDCState.CONTAINS);
+                assertTrue("No mutation should be added to commit log when cdc_on_repair_enabled is false",
+                           containCDCInLog);
+            });
+        };
+    }
+
+    // test helper to repair data between nodes when cdc_on_repair_enabled is on or off.
+    void testCDCOnRepairEnabled(boolean enabled, Consumer<Cluster> assertion, boolean constraintsEnabled) throws Exception
+    {
+        try (Cluster cluster = init(Cluster.build(2)
+                                           .withConfig(c -> c.set("cdc_enabled", true)
+                                                             .set("cdc_on_repair_enabled", enabled)
+                                                             .with(Feature.NETWORK)
+                                                             .with(Feature.GOSSIP))
+                                           .start()))
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (k INT PRIMARY KEY, v INT) WITH cdc=true"));
+
+            // Data only in node1
+            cluster.get(1).executeInternal(withKeyspace("INSERT INTO %s.tbl (k, v) VALUES (1, 1)"));
+
+            if (constraintsEnabled)
+                cluster.schemaChange(withKeyspace("ALTER TABLE %s.tbl ALTER v CHECK v != 1"));
+
+            Object[][] result = cluster.get(1).executeInternal(withKeyspace("SELECT * FROM %s.tbl WHERE k = 1"));
+            assertRows(result, row(1, 1));
+            result = cluster.get(2).executeInternal(withKeyspace("SELECT * FROM %s.tbl WHERE k = 1"));
+            assertRows(result);
+
+            // repair
+            cluster.get(1).flush(KEYSPACE);
+            cluster.get(2).nodetool("repair", KEYSPACE, "tbl");
+
+            // verify node2 now have data
+            result = cluster.get(2).executeInternal(withKeyspace("SELECT * FROM %s.tbl WHERE k = 1"));
+            assertRows(result, row(1, 1));
+
+            assertion.accept(cluster);
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/cdc/ToggleCDCWithConstraintsOnRepairEnabledTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/cdc/ToggleCDCWithConstraintsOnRepairEnabledTest.java
@@ -22,17 +22,17 @@ package org.apache.cassandra.distributed.test.cdc;
 import org.junit.Test;
 
 
-public class ToggleCDCOnRepairEnabledTest extends ToggleCDCOnRepair
+public class ToggleCDCWithConstraintsOnRepairEnabledTest extends ToggleCDCOnRepair
 {
     @Test
-    public void testCDCOnRepairIsEnabled() throws Exception
+    public void testCDCWithConstraintsOnRepairIsEnabled() throws Exception
     {
-        testCDCOnRepairEnabled(true, getRepairEnabledRepairAssertion(), false);
+        testCDCOnRepairEnabled(true, getRepairEnabledRepairAssertion(), true);
     }
 
     @Test
-    public void testCDCOnRepairIsDisabled() throws Exception
+    public void testCDCWithConstraintsOnRepairIsDisabled() throws Exception
     {
-        testCDCOnRepairEnabled(false, getRepairDisabledRepairAssertion(), false);
+        testCDCOnRepairEnabled(false, getRepairDisabledRepairAssertion(), true);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/log/SnapshotTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/SnapshotTest.java
@@ -51,6 +51,7 @@ public class SnapshotTest extends TestBaseImpl
                                              .start()))
         {
             cluster.schemaChange(withKeyspace("create table %s.tbl (id int primary key, x int)"));
+            cluster.schemaChange(withKeyspace("create table %s.tblconstraints (id int primary key, x int check x > 100 and x < 200, v text check LENGTH(v) > 10)"));
             cluster.schemaChange(withKeyspace("CREATE OR REPLACE FUNCTION %s.fLog (input double) CALLED ON NULL INPUT RETURNS double LANGUAGE java AS 'return Double.valueOf(Math.log(input.doubleValue()));';"));
             cluster.schemaChange(withKeyspace("CREATE OR REPLACE FUNCTION %s.avgState ( state tuple<int,bigint>, val int ) CALLED ON NULL INPUT RETURNS tuple<int,bigint> LANGUAGE java AS \n" +
                                               "  'if (val !=null) { state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue()); } return state;'; "));

--- a/test/unit/org/apache/cassandra/contraints/AlterTableWithTableConstraintValidationTest.java
+++ b/test/unit/org/apache/cassandra/contraints/AlterTableWithTableConstraintValidationTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.contraints;
+
+import org.junit.Test;
+
+
+public class AlterTableWithTableConstraintValidationTest extends CqlConstraintValidationTester
+{
+
+    @Test
+    public void testCreateTableWithColumnNamedConstraintDescribeTableNonFunction() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 100, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        execute("ALTER TABLE %s ALTER ck1 DROP CHECK");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int,\n" +
+                                      "    ck2 int,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    @Test
+    public void testCreateTableAddConstraint() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        execute("ALTER TABLE %s ALTER ck1 CHECK ck1 < 100 AND ck1 > 10");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100 AND ck1 > 10,\n" +
+                                      "    ck2 int,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    @Test
+    public void testCreateTableAddMultipleConstraints() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        execute("ALTER TABLE %s ALTER ck1 CHECK ck1 < 100");
+        execute("ALTER TABLE %s ALTER ck2 CHECK ck2 > 10");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100,\n" +
+                                      "    ck2 int CHECK ck2 > 10,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    @Test
+    public void testCreateTableAddMultipleMixedConstraints() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (pk int, ck1 int, ck2 text, v int, PRIMARY KEY ((pk), ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        execute("ALTER TABLE %s ALTER ck1 CHECK ck1 < 100");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100,\n" +
+                                      "    ck2 text,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement));
+
+        execute("ALTER TABLE %s ALTER ck2 CHECK LENGTH(ck2) = 4");
+
+        tableCreateStatement = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100,\n" +
+                                      "    ck2 text CHECK LENGTH(ck2) = 4,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    @Test
+    public void testCreateTableAddAndRemoveConstraint() throws Throwable
+    {
+        String table = createTable("CREATE TABLE %s (pk int, ck1 int, ck2 text, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        execute("ALTER TABLE %s ALTER ck1 CHECK ck1 < 100");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100,\n" +
+                                      "    ck2 text,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement));
+
+        execute("ALTER TABLE %s ALTER ck1 DROP CHECK");
+
+        String tableCreateStatement2 = "CREATE TABLE " + KEYSPACE + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int,\n" +
+                                      "    ck2 text,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet(KEYSPACE, "DESCRIBE TABLE " + KEYSPACE + "." + table),
+                      row(KEYSPACE,
+                          "table",
+                          table,
+                          tableCreateStatement2));
+    }
+
+    @Test
+    public void testAlterWithConstraintsAndCdcEnabled() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text, ck1 int, ck2 int, PRIMARY KEY ((pk),ck1, ck2)) WITH cdc = true;");
+        // It works
+        execute("ALTER TABLE %s ALTER ck1 CHECK ck1 < 100");
+    }
+
+    @Test
+    public void testAlterWithCdcAndPKConstraintsEnabled() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK length(pk) = 100, ck1 int, ck2 int, PRIMARY KEY ((pk), ck1, ck2));");
+        // It works
+        execute("ALTER TABLE %s WITH cdc = true");
+    }
+
+    @Test
+    public void testAlterWithCdcAndRegularConstraintsEnabled() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text, ck1 int CHECK ck1 < 100, ck2 int, PRIMARY KEY (pk));");
+        // It works
+        execute("ALTER TABLE %s WITH cdc = true");
+    }
+
+    @Test
+    public void testAlterWithCdcAndClusteringConstraintsEnabled() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text, ck1 int CHECK ck1 < 100, ck2 int, PRIMARY KEY ((pk), ck1, ck2));");
+        // It works
+        execute("ALTER TABLE %s WITH cdc = true");
+    }
+}

--- a/test/unit/org/apache/cassandra/contraints/ColumnConstraintsTest.java
+++ b/test/unit/org/apache/cassandra/contraints/ColumnConstraintsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.contraints;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.constraints.ColumnConstraint.ConstraintType;
+
+import static org.apache.cassandra.cql3.constraints.ColumnConstraint.ConstraintType.COMPOSED;
+import static org.apache.cassandra.cql3.constraints.ColumnConstraint.ConstraintType.FUNCTION;
+import static org.apache.cassandra.cql3.constraints.ColumnConstraint.ConstraintType.SCALAR;
+import static org.junit.Assert.assertEquals;
+
+public class ColumnConstraintsTest
+{
+    private static final ConstraintType[] EXPECTED_VALUES = { COMPOSED, FUNCTION, SCALAR };
+
+    @Test
+    public void testEnumCodesAndNames()
+    {
+        ConstraintType[] values = ConstraintType.values();
+
+        for (int i = 0; i < values.length; i++)
+        {
+            assertEquals("Column Constraint Serializer mismatch in the enum " + values[i],
+                         EXPECTED_VALUES[i].name(), values[i].name());
+            assertEquals("Column Constraint Serializer mismatch in the enum for value " + values[i],
+                         ConstraintType.getSerializer(EXPECTED_VALUES[i].ordinal()), ConstraintType.getSerializer(i));
+        }
+
+        assertEquals("Column Constraint Serializer enum constants has changed. Update the test.",
+                     EXPECTED_VALUES.length, values.length);
+    }
+}

--- a/test/unit/org/apache/cassandra/contraints/CqlConstraintValidationTester.java
+++ b/test/unit/org/apache/cassandra/contraints/CqlConstraintValidationTester.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.contraints;
+
+import java.util.Map;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.schema.CompactionParams;
+import org.apache.cassandra.transport.ProtocolVersion;
+
+public abstract class CqlConstraintValidationTester extends CQLTester
+{
+    ResultSet executeDescribeNet(String cql) throws Throwable
+    {
+        return executeDescribeNet(null, cql);
+    }
+
+    ResultSet executeDescribeNet(String useKs, String cql) throws Throwable
+    {
+        return executeNetWithPaging(getProtocolVersion(useKs), cql, useKs, 3);
+    }
+
+    private ProtocolVersion getProtocolVersion(String useKs) throws Throwable
+    {
+        // We're using a trick here to distinguish driver sessions with a "USE keyspace" and without:
+        // As different ProtocolVersions use different driver instances, we use different ProtocolVersions
+        // for the with and without "USE keyspace" cases.
+
+        ProtocolVersion v = useKs != null ? ProtocolVersion.CURRENT : ProtocolVersion.V6;
+
+        if (useKs != null)
+            executeNet(v, "USE " + useKs);
+        return v;
+    }
+
+    static String tableParametersCql()
+    {
+        return "additional_write_policy = '99p'\n" +
+               "    AND allow_auto_snapshot = true\n" +
+               "    AND bloom_filter_fp_chance = 0.01\n" +
+               "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n" +
+               "    AND cdc = false\n" +
+               "    AND comment = ''\n" +
+               "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
+               "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
+               "    AND memtable = 'default'\n" +
+               "    AND crc_check_chance = 1.0\n" +
+               "    AND default_time_to_live = 0\n" +
+               "    AND extensions = {}\n" +
+               "    AND gc_grace_seconds = 864000\n" +
+               "    AND incremental_backups = true\n" +
+               "    AND max_index_interval = 2048\n" +
+               "    AND memtable_flush_period_in_ms = 0\n" +
+               "    AND min_index_interval = 128\n" +
+               "    AND read_repair = 'BLOCKING'\n" +
+               "    AND speculative_retry = '99p';";
+    }
+
+    private static String cqlQuoted(Map<String, String> map)
+    {
+        return new CqlBuilder().append(map).toString();
+    }
+}

--- a/test/unit/org/apache/cassandra/contraints/CreateTableWithColumnCqlConstraintValidationTest.java
+++ b/test/unit/org/apache/cassandra/contraints/CreateTableWithColumnCqlConstraintValidationTest.java
@@ -1,0 +1,1264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.contraints;
+
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.utils.Generators;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static accord.utils.Property.qt;
+import static org.quicktheories.generators.SourceDSL.doubles;
+import static org.quicktheories.generators.SourceDSL.integers;
+
+@RunWith(Parameterized.class)
+public class CreateTableWithColumnCqlConstraintValidationTest extends CqlConstraintValidationTester
+{
+
+    @Parameterized.Parameter
+    public String order;
+
+    @Parameterized.Parameters()
+    public static Collection<Object[]> generateData()
+    {
+        return Arrays.asList(new Object[][]{
+        { "ASC" },
+        { "DESC" }
+        });
+    }
+
+    @Test
+    public void testCreateTableWithColumnNotNamedConstraintDescribeTableNonFunction() throws Throwable
+    {
+        String table = createTable(KEYSPACE_PER_TEST, "CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 100, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE_PER_TEST + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100,\n" +
+                                      "    ck2 int,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet("DESCRIBE TABLE " + KEYSPACE_PER_TEST + "." + table),
+                      row(KEYSPACE_PER_TEST,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    @Test
+    public void testCreateTableWithColumnMultipleConstraintsDescribeTableNonFunction() throws Throwable
+    {
+        String table = createTable(KEYSPACE_PER_TEST, "CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 100 AND ck1 > 10, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE_PER_TEST + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 int CHECK ck1 < 100 AND ck1 > 10,\n" +
+                                      "    ck2 int,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet("DESCRIBE TABLE " + KEYSPACE_PER_TEST + "." + table),
+                      row(KEYSPACE_PER_TEST,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    @Test
+    public void testCreateTableWithColumnNotNamedConstraintDescribeTableFunction() throws Throwable
+    {
+        String table = createTable(KEYSPACE_PER_TEST, "CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) = 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        String tableCreateStatement = "CREATE TABLE " + KEYSPACE_PER_TEST + "." + table + " (\n" +
+                                      "    pk int,\n" +
+                                      "    ck1 text CHECK LENGTH(ck1) = 4,\n" +
+                                      "    ck2 int,\n" +
+                                      "    v int,\n" +
+                                      "    PRIMARY KEY (pk, ck1, ck2)\n" +
+                                      ") WITH CLUSTERING ORDER BY (ck1 ASC, ck2 ASC)\n" +
+                                      "    AND " + tableParametersCql();
+
+        assertRowsNet(executeDescribeNet("DESCRIBE TABLE " + KEYSPACE_PER_TEST + "." + table),
+                      row(KEYSPACE_PER_TEST,
+                          "table",
+                          table,
+                          tableCreateStatement));
+    }
+
+    // SCALAR
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessThanScalarConstraintInteger() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerThanScalarConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 > 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(5, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(0, 4)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerOrEqualThanScalarConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 >= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessOrEqualThanScalarConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 <= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 4)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(5, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnDifferentThanScalarConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 != 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+        qt().forAll(Generators.toGen(integers().between(5, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 4, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnMultipleScalarConstraints() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 4 AND ck1 >= 2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(2, 3)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(-100, 1)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessThanScalarSmallIntConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 smallint CHECK ck1 < 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerThanScalarSmallIntConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 smallint CHECK ck1 > 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(5, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(0, 4)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerOrEqualThanScalarSmallIntConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 smallint CHECK ck1 >= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessOrEqualThanScalarSmallIntConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 smallint CHECK ck1 <= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 4)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(5, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnDifferentThanScalarSmallIntConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 smallint CHECK ck1 != 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+        qt().forAll(Generators.toGen(integers().between(5, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 4, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnMultipleScalarSmallIntConstraints() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 smallint CHECK ck1 < 4 AND ck1 >= 2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(2, 3)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(-100, 1)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessThanScalarDecimalConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 decimal CHECK ck1 < 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 2, 3)");
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerThanScalarDecimalConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 decimal CHECK ck1 > 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.2)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerOrEqualThanScalarDecimalConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 decimal CHECK ck1 >= 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(4.2, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessOrEqualThanScalarDecimalConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 decimal CHECK ck1 <= 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.2)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnDifferentThanScalarDecimalConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 decimal CHECK ck1 != 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 4.2, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnMultipleScalarDecimalConstraints() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 decimal CHECK ck1 < 4.2 AND ck1 >= 2.1, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(2.1, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(-100, 2)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+        qt().forAll(Generators.toGen(doubles().between(4.2, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessThanScalarDoubleConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 double CHECK ck1 < 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 2, 3)");
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerThanScalarDoubleConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 double CHECK ck1 > 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.2)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerOrEqualThanScalarDoubleConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 double CHECK ck1 >= 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(4.2, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessOrEqualThanScalarDoubleConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 double CHECK ck1 <= 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.2)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnDifferentThanScalarDoubleConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 double CHECK ck1 != 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 4.2, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnMultipleScalarDoubleConstraints() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 double CHECK ck1 < 4.2 AND ck1 >= 2.1, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(2.1, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(-100, 2)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+        qt().forAll(Generators.toGen(doubles().between(4.2, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessThanScalarFloatConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 float CHECK ck1 < 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 2, 3)");
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerThanScalarFloatConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 float CHECK ck1 > 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.2)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnBiggerOrEqualThanScalarFloatConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 float CHECK ck1 >= 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(4.2, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessOrEqualThanScalarFloatConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 float CHECK ck1 <= 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.2)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnDifferentThanScalarFloatConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 float CHECK ck1 != 4.2, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(0, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+        qt().forAll(Generators.toGen(doubles().between(4.3, 100)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 4.2, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnMultipleScalarFloatConstraints() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 float CHECK ck1 < 4.2 AND ck1 >= 2.1, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        qt().forAll(Generators.toGen(doubles().between(2.1, 4.1)))
+            .check(d -> execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(doubles().between(-100, 2)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+        qt().forAll(Generators.toGen(doubles().between(4.2, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    // FUNCTION
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLengthEqualToConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) = 4, ck2 int, v int, PRIMARY KEY ((pk), ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'fooo', 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foo', 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLengthDifferentThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) != 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foo', 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'fooo', 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLengthBiggerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) > 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foo', 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'fooo', 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLengthBiggerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) >= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'fooo', 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foo', 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLengthSmallerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) < 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foo', 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'fooo', 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLengthSmallerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 text CHECK LENGTH(ck1) <= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foo', 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'fooo', 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringBlobColumnLengthEqualToConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 blob CHECK LENGTH(ck1) = 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('fooo'), 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foo'), 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foooo'), 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringBlobColumnLengthDifferentThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 blob CHECK LENGTH(ck1) != 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foo'), 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foooo'), 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('fooo'), 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringBlobColumnLengthBiggerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 blob CHECK LENGTH(ck1) > 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foooo'), 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foo'), 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('fooo'), 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringBlobColumnLengthBiggerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 blob CHECK LENGTH(ck1) >= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foooo'), 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('fooo'), 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foo'), 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringBlobColumnLengthSmallerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 blob CHECK LENGTH(ck1) < 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foo'), 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('fooo'), 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foooo'), 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringBlobColumnLengthSmallerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 blob CHECK LENGTH(ck1) <= 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('foo'), 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, textAsBlob('fooo'), 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 'foooo', 2, 3)");
+    }
+
+
+    @Test
+    public void testCreateTableWithColumnWithPkColumnLengthEqualToConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) = 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 1, 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 1, 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 1, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithPkColumnLengthDifferentThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) != 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 1, 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 1, 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 1, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithPkColumnLengthBiggerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) > 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 1, 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 1, 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 1, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithPkColumnLengthBiggerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) >= 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 1, 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 1, 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 1, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithPkColumnLengthSmallerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) < 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 1, 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 1, 2, 3)");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 1, 2, 3)");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithPkColumnLengthSmallerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) <= 4, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 1, 2, 3)");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 1, 2, 3)");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 1, 2, 3)");
+    }
+
+
+    @Test
+    public void testCreateTableWithColumnWithRegularColumnLengthEqualToConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v text CHECK LENGTH(v) = 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'fooo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foooo')");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithRegularColumnLengthDifferentThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v text CHECK LENGTH(v) != 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foo')");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foooo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'fooo')");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithRegularColumnLengthBiggerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v text CHECK LENGTH(v) > 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foooo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'fooo')");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithRegularColumnLengthBiggerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v text CHECK LENGTH(v) >= 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foooo')");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'fooo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foo')");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithRegularColumnLengthSmallerThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v text CHECK LENGTH(v) < 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'fooo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foooo')");
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithRegularColumnLengthSmallerOrEqualThanConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v text CHECK LENGTH(v) <= 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foo')");
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'fooo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES (1, 2, 3, 'foooo')");
+    }
+
+    @Test
+    public void testCreateTableWithColumnMixedColumnsLengthConstraint() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk text CHECK LENGTH(pk) = 4, ck1 int, ck2 int, v text CHECK LENGTH(v) = 4, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+
+        // Valid
+        execute("INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 2, 3, 'fooo')");
+
+        // Invalid
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 2, 3, 'foo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 2, 3, 'foo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foo', 2, 3, 'fooo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 2, 3, 'fooo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('fooo', 2, 3, 'foooo')");
+        assertInvalidThrow(InvalidRequestException.class, "INSERT INTO %s (pk, ck1, ck2, v) VALUES ('foooo', 2, 3, 'foooo')");
+    }
+
+    @Test
+    public void testCreateTableWithWrongColumnConstraint() throws Throwable
+    {
+        try
+        {
+            createTable("CREATE TABLE %s (pk text, ck1 int CHECK LENGTH(pk) = 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+            fail();
+        }
+        catch (InvalidRequestException e)
+        {
+            assertTrue(e.getCause() instanceof InvalidRequestException);
+            assertTrue(e.getMessage().contains("Error setting schema for test"));
+        }
+    }
+
+    @Test
+    public void testCreateTableWithWrongColumnMultipleConstraint() throws Throwable
+    {
+        try
+        {
+            createTable("CREATE TABLE %s (pk text, ck1 int CHECK LENGTH(pk) = 4 AND ck1 < 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+            fail();
+        }
+        catch (InvalidRequestException e)
+        {
+            assertTrue(e.getCause() instanceof InvalidRequestException);
+            assertTrue(e.getMessage().contains("Error setting schema for test"));
+        }
+    }
+
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnInvalidTypeConstraint() throws Throwable
+    {
+        try
+        {
+            createTable("CREATE TABLE %s (pk int, ck1 int CHECK LENGTH(ck1) = 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+            fail();
+        }
+        catch (InvalidRequestException e)
+        {
+            assertTrue(e.getCause() instanceof InvalidRequestException);
+            assertTrue(e.getMessage().contains("Error setting schema for test"));
+        }
+    }
+
+    @Test
+    public void testCreateTableInvalidFunction() throws Throwable
+    {
+        try
+        {
+            createTable("CREATE TABLE %s (pk text CHECK not_a_function(pk) = 4, ck1 int, ck2 int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");");
+            fail();
+        }
+        catch (InvalidRequestException e)
+        {
+            assertTrue(e.getCause() instanceof InvalidRequestException);
+            assertTrue(e.getMessage().contains("Error setting schema for test"));
+        }
+    }
+
+    @Test
+    public void testCreateTableWithPKConstraintsAndCDCEnabled() throws Throwable
+    {
+        // It works
+        createTable("CREATE TABLE %s (pk text CHECK length(pk) = 4, ck1 int, ck2 int, PRIMARY KEY ((pk), ck1, ck2)) WITH cdc = true;");
+    }
+
+    @Test
+    public void testCreateTableWithClusteringConstraintsAndCDCEnabled() throws Throwable
+    {
+        // It works
+        createTable("CREATE TABLE %s (pk text, ck1 int CHECK ck1 < 100, ck2 int, PRIMARY KEY ((pk), ck1, ck2)) WITH cdc = true;");
+    }
+
+    @Test
+    public void testCreateTableWithRegularConstraintsAndCDCEnabled() throws Throwable
+    {
+        // It works
+        createTable("CREATE TABLE %s (pk text, ck1 int CHECK ck1 < 100, ck2 int, PRIMARY KEY (pk)) WITH cdc = true;");
+    }
+
+    // Copy table with like
+    @Test
+    public void testCreateTableWithColumnWithClusteringColumnLessThanScalarConstraintIntegerOnLikeTable() throws Throwable
+    {
+        createTable(KEYSPACE, "CREATE TABLE %s (pk int, ck1 int CHECK ck1 < 4, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 " + order + ");", "liketabletame");
+
+        execute("create table " + KEYSPACE + ".tb_copy like %s");
+
+        // Valid
+        qt().forAll(Generators.toGen(integers().between(0, 3)))
+            .check(d -> execute("INSERT INTO " + KEYSPACE + ".tb_copy (pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)"));
+
+        // Invalid
+        qt().forAll(Generators.toGen(integers().between(4, 100)))
+            .check(d -> {
+                try
+                {
+                    assertInvalidThrow(InvalidRequestException.class, "INSERT INTO " + KEYSPACE + ".tb_copy(pk, ck1, ck2, v) VALUES (1, " + d + ", 3, 4)");
+                }
+                catch (Throwable e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/AbstractTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/AbstractTypeTest.java
@@ -260,6 +260,18 @@ public class AbstractTypeTest
     }
 
     @Test
+    public void isConstrainedTest()
+    {
+        qt().forAll(genBuilder().build()).checkAssert(type -> {
+            if (type instanceof MapType || type instanceof TupleType || type instanceof AbstractCompositeType)
+                assertThat(type.isConstrainable()).isEqualTo(false);
+            else
+                assertThat(type.isConstrainable()).isEqualTo(true);
+        });
+
+    }
+
+    @Test
     public void unsafeSharedSerializer()
     {
         // For all types, make sure the serializer returned is unique to that type,
@@ -950,7 +962,7 @@ public class AbstractTypeTest
                 assertThat(leftDecomposed.hasRemaining()).describedAs(typeRelDesc(".decompose", left, right)).isEqualTo(rightDecomposed.hasRemaining());
 
                 // serialization compatibility means that we can read a cell written using right's type serializer with left's type serializer;
-                // this additinoally imposes the requirement for storing the buffer lenght in the serialized form if the value is of variable length
+                // this additinoally imposes the requirement for storing the buffer length in the serialized form if the value is of variable length
                 // as well as, either both types serialize into a single or multiple cells
                 if (left.isSerializationCompatibleWith(right))
                 {


### PR DESCRIPTION
Add new Constraints framework as described in CEP-42. This initial Jira ticket includes the core constraints length and numeric. Follow up tickets will include the rest of the constraints described in the CEP.

```
patch by Bernardo Botella; reviewed by <Reviewers> for CASSANDRA-19947

```

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19947)

