### PR TITLE
CASSANDRA-18675: (Accord): C* stores keyspace in Range which will cause ranges to be removed from Accord when DROP KEYSPACE is performed

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterSchemaStatement.java
@@ -160,7 +160,7 @@ abstract public class AlterSchemaStatement implements CQLStatement.SingleKeyspac
         ClusterMetadata metadata = ClusterMetadata.current();
         apply(metadata);
 
-        ClusterMetadata result = Schema.instance.submit(this);
+        ClusterMetadata result = commit(metadata);
 
         KeyspacesDiff diff = Keyspaces.diff(metadata.schema.getKeyspaces(), result.schema.getKeyspaces());
         clientWarnings(diff).forEach(ClientWarn.instance::warn);
@@ -183,6 +183,11 @@ abstract public class AlterSchemaStatement implements CQLStatement.SingleKeyspac
         AccordTopology.awaitTopologyReadiness(diff, result.epoch);
 
         return new ResultMessage.SchemaChange(schemaChangeEvent(diff));
+    }
+
+    protected ClusterMetadata commit(ClusterMetadata metadata)
+    {
+        return Schema.instance.submit(this);
     }
 
     private void validateKeyspaceName()

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -123,6 +123,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             return schema;
         }
 
+        if (table.params.pendingDrop)
+            throw ire("Cannot use ALTER TABLE on a table that is being dropped.");
+
         if (table.isView())
             throw ire("Cannot use ALTER TABLE on a materialized view; use ALTER MATERIALIZED VIEW instead");
 

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -174,6 +174,11 @@ public final class CreateViewStatement extends AlterSchemaStatement
                       viewName, tableName);
         }
 
+        if (table.params.pendingDrop)
+            throw ire("Cannot create materialized view '%s' for base table " +
+                      "'%s' as it is being dropped.",
+                      viewName, tableName);
+
         /*
          * Process SELECT clause
          */

--- a/src/java/org/apache/cassandra/schema/KeyspaceParams.java
+++ b/src/java/org/apache/cassandra/schema/KeyspaceParams.java
@@ -33,7 +33,7 @@ import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.serialization.MetadataSerializer;
 import org.apache.cassandra.tcm.serialization.Version;
 
-import static org.apache.cassandra.tcm.serialization.Version.V2;
+import static org.apache.cassandra.tcm.serialization.Version.MIN_ACCORD_VERSION;
 
 /**
  * An immutable class representing keyspace parameters (durability and replication).
@@ -157,7 +157,7 @@ public final class KeyspaceParams
         {
             ReplicationParams.serializer.serialize(t.replication, out, version);
             out.writeBoolean(t.durableWrites);
-            if (version.isAtLeast(V2))
+            if (version.isAtLeast(MIN_ACCORD_VERSION))
                 FastPathStrategy.serializer.serialize(t.fastPath, out, version);
         }
 
@@ -165,7 +165,7 @@ public final class KeyspaceParams
         {
             ReplicationParams params = ReplicationParams.serializer.deserialize(in, version);
             boolean durableWrites = in.readBoolean();
-            FastPathStrategy fastPath = version.isAtLeast(V2)
+            FastPathStrategy fastPath = version.isAtLeast(MIN_ACCORD_VERSION)
                     ? FastPathStrategy.serializer.deserialize(in, version)
                     : FastPathStrategy.simple();
             return new KeyspaceParams(durableWrites, params, fastPath);
@@ -175,7 +175,7 @@ public final class KeyspaceParams
         {
             return ReplicationParams.serializer.serializedSize(t.replication, version) +
                    TypeSizes.sizeof(t.durableWrites) +
-                   (version.isAtLeast(V2) ? FastPathStrategy.serializer.serializedSize(t.fastPath, version) : 0);
+                   (version.isAtLeast(MIN_ACCORD_VERSION) ? FastPathStrategy.serializer.serializedSize(t.fastPath, version) : 0);
         }
     }
 }

--- a/src/java/org/apache/cassandra/service/accord/AccordSafeCommandStore.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordSafeCommandStore.java
@@ -20,8 +20,11 @@ package org.apache.cassandra.service.accord;
 
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import accord.api.Agent;
 import accord.api.DataStore;
@@ -76,6 +79,12 @@ public class AccordSafeCommandStore extends AbstractSafeCommandStore<AccordSafeC
                                                 AccordCommandStore commandStore)
     {
         return new AccordSafeCommandStore(preLoadContext, commands, timestampsForKey, commandsForKey, commandsForRanges, commandStore);
+    }
+
+    @VisibleForTesting
+    public Set<Key> commandsForKeysKeys()
+    {
+        return commandsForKeys.keySet();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/service/accord/AccordStaleReplicas.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordStaleReplicas.java
@@ -44,7 +44,7 @@ public class AccordStaleReplicas implements MetadataValue<AccordStaleReplicas>
     private final Set<Node.Id> staleIds;
     private final Epoch lastModified;
 
-    AccordStaleReplicas(Set<Node.Id> staleIds, Epoch lastModified)
+    public AccordStaleReplicas(Set<Node.Id> staleIds, Epoch lastModified)
     {
         this.staleIds = staleIds;
         this.lastModified = lastModified;

--- a/src/java/org/apache/cassandra/service/accord/AccordTopology.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordTopology.java
@@ -65,16 +65,17 @@ public class AccordTopology
 
     private static class ShardLookup extends HashMap<accord.primitives.Range, Shard>
     {
-        private Shard createOrReuse(accord.primitives.Range range, SortedArrayList<Node.Id> nodes, Set<Node.Id> fastPathElectorate, Set<Node.Id> joining)
+        private Shard createOrReuse(boolean pendingRemoval, accord.primitives.Range range, SortedArrayList<Node.Id> nodes, Set<Node.Id> fastPathElectorate, Set<Node.Id> joining)
         {
             Shard prev = get(range);
             if (prev != null
+                && prev.pendingRemoval == pendingRemoval
                 && Objects.equals(prev.nodes, nodes)
                 && Objects.equals(prev.fastPathElectorate, fastPathElectorate)
                 && Objects.equals(prev.joining, joining))
                 return prev;
 
-            return new Shard(range, nodes, fastPathElectorate, joining);
+            return new Shard(range, nodes, fastPathElectorate, joining, pendingRemoval);
         }
     }
 
@@ -109,7 +110,7 @@ public class AccordTopology
 
             SortedArrayList<Node.Id> fastPath = strategyFor(metadata).calculateFastPath(nodes, unavailable, dcMap);
 
-            return lookup.createOrReuse(tokenRange, nodes, fastPath, pending);
+            return lookup.createOrReuse(metadata.params.pendingDrop, tokenRange, nodes, fastPath, pending);
         }
 
         private static KeyspaceShard forRange(KeyspaceMetadata keyspace, Range<Token> range, Directory directory, VersionedEndpoints.ForRange reads, VersionedEndpoints.ForRange writes)

--- a/src/java/org/apache/cassandra/service/accord/IAccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/IAccordService.java
@@ -49,6 +49,7 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.IVerbHandler;
 import org.apache.cassandra.net.Message;
+import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.service.accord.api.AccordScheduler;
 import org.apache.cassandra.service.accord.txn.TxnResult;
 import org.apache.cassandra.tcm.Epoch;
@@ -158,4 +159,8 @@ public interface IAccordService
     Long minEpoch(Collection<TokenRange> ranges);
 
     void tryMarkRemoved(Topology topology, Node.Id node);
+    default void awaitTableDrop(TableId id)
+    {
+
+    }
 }

--- a/src/java/org/apache/cassandra/service/accord/fastpath/InheritKeyspaceFastPathStrategy.java
+++ b/src/java/org/apache/cassandra/service/accord/fastpath/InheritKeyspaceFastPathStrategy.java
@@ -28,7 +28,7 @@ import accord.utils.SortedArrays.SortedArrayList;
 
 public class InheritKeyspaceFastPathStrategy implements FastPathStrategy
 {
-    static final FastPathStrategy instance = new InheritKeyspaceFastPathStrategy();
+    public static final FastPathStrategy instance = new InheritKeyspaceFastPathStrategy();
 
     private static final Map<String, String> SCHEMA_PARAMS = ImmutableMap.of(Kind.KEY, Kind.INHERIT_KEYSPACE.name());
 

--- a/src/java/org/apache/cassandra/service/accord/fastpath/ParameterizedFastPathStrategy.java
+++ b/src/java/org/apache/cassandra/service/accord/fastpath/ParameterizedFastPathStrategy.java
@@ -50,8 +50,8 @@ import javax.annotation.Nonnull;
 
 public class ParameterizedFastPathStrategy implements FastPathStrategy
 {
-    static final String SIZE = "size";
-    static final String DCS = "dcs";
+    public static final String SIZE = "size";
+    public static final String DCS = "dcs";
     private static final Joiner DC_JOINER = Joiner.on(',');
     private static final Pattern COMMA_SEPARATOR = Pattern.compile(",");
     private static final Pattern COLON_SEPARATOR = Pattern.compile(":");
@@ -64,7 +64,7 @@ public class ParameterizedFastPathStrategy implements FastPathStrategy
             public void serialize(WeightedDc dc, DataOutputPlus out, Version version) throws IOException
             {
                 out.writeUTF(dc.name);
-                out.writeUnsignedVInt(dc.weight);
+                out.writeUnsignedVInt32(dc.weight);
                 out.writeBoolean(dc.autoWeight);
             }
 
@@ -237,7 +237,7 @@ public class ParameterizedFastPathStrategy implements FastPathStrategy
         return new ConfigurationException(String.format(fmt, args));
     }
 
-    static ParameterizedFastPathStrategy fromMap(Map<String, String> map)
+    public static ParameterizedFastPathStrategy fromMap(Map<String, String> map)
     {
         if (!map.containsKey(SIZE))
             throw cfe("fast_path must be set to 'keyspace' or 'default' or a map defining '%s' and optionally '%s'", SIZE, DCS);

--- a/src/java/org/apache/cassandra/service/accord/fastpath/SimpleFastPathStrategy.java
+++ b/src/java/org/apache/cassandra/service/accord/fastpath/SimpleFastPathStrategy.java
@@ -31,7 +31,7 @@ import accord.utils.SortedArrays.SortedArrayList;
 
 public class SimpleFastPathStrategy implements FastPathStrategy
 {
-    static final SimpleFastPathStrategy instance = new SimpleFastPathStrategy();
+    public static final SimpleFastPathStrategy instance = new SimpleFastPathStrategy();
 
     private static final Map<String, String> SCHEMA_PARAMS = ImmutableMap.of(Kind.KEY, Kind.SIMPLE.name());
 

--- a/src/java/org/apache/cassandra/service/consensus/migration/ConsensusMigrationState.java
+++ b/src/java/org/apache/cassandra/service/consensus/migration/ConsensusMigrationState.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
@@ -204,6 +205,8 @@ public class ConsensusMigrationState implements MetadataValue<ConsensusMigration
 
     public ConsensusMigrationState withMigrationsRemovedFor(Set<TableId> removed)
     {
+        if (tableStates.isEmpty() || Sets.intersection(tableStates.keySet(), removed).isEmpty())
+            return this;
         ImmutableMap.Builder<TableId, TableMigrationState> updated = ImmutableMap.builder();
         putUnchanged(tableStates, updated, removed);
         return new ConsensusMigrationState(lastModified, updated.build());

--- a/src/java/org/apache/cassandra/tcm/CMSOperationsMBean.java
+++ b/src/java/org/apache/cassandra/tcm/CMSOperationsMBean.java
@@ -45,4 +45,5 @@ public interface CMSOperationsMBean
     public boolean cancelInProgressSequences(String sequenceOwner, String expectedSequenceKind);
 
     public void unregisterLeftNodes(List<String> nodeIds);
+    public void resumeDropAccordTable(String tableId);
 }

--- a/src/java/org/apache/cassandra/tcm/MultiStepOperation.java
+++ b/src/java/org/apache/cassandra/tcm/MultiStepOperation.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.tcm.sequences.ProgressBarrier;
 import org.apache.cassandra.tcm.sequences.UnbootstrapAndLeave;
 import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializer;
 import org.apache.cassandra.tcm.serialization.MetadataSerializer;
+import org.apache.cassandra.tcm.sequences.DropAccordTable;
 
 /**
  * Represents a multi-step process performed in order to transition the cluster to some state.
@@ -67,7 +68,8 @@ public abstract class MultiStepOperation<CONTEXT>
         LEAVE(UnbootstrapAndLeave.serializer),
         REMOVE(UnbootstrapAndLeave.serializer),
 
-        RECONFIGURE_CMS(ReconfigureCMS.serializer)
+        RECONFIGURE_CMS(ReconfigureCMS.serializer),
+        DROP_ACCORD_TABLE(DropAccordTable.serializer),
         ;
 
         public final AsymmetricMetadataSerializer<MultiStepOperation<?>, ? extends MultiStepOperation<?>> serializer;

--- a/src/java/org/apache/cassandra/tcm/StubClusterMetadataService.java
+++ b/src/java/org/apache/cassandra/tcm/StubClusterMetadataService.java
@@ -76,7 +76,7 @@ public class StubClusterMetadataService extends ClusterMetadataService
 
     private ClusterMetadata metadata;
 
-    private StubClusterMetadataService(ClusterMetadata initial)
+    protected StubClusterMetadataService(ClusterMetadata initial)
     {
         super(new UniformRangePlacement(),
               MetadataSnapshots.NO_OP,
@@ -107,13 +107,18 @@ public class StubClusterMetadataService extends ClusterMetadataService
     @Override
     public <T1> T1 commit(Transformation transform, CommitSuccessHandler<T1> onSuccess, CommitFailureHandler<T1> onFailure)
     {
-        Transformation.Result result = transform.execute(metadata);
+        Transformation.Result result = execute(transform);
         if (result.isSuccess())
         {
-            metadata = result.success().metadata;
+            setMetadata(result.success().metadata);
             return  onSuccess.accept(result.success().metadata);
         }
         return onFailure.accept(result.rejected().code, result.rejected().reason);
+    }
+
+    protected Transformation.Result execute(Transformation transform)
+    {
+        return transform.execute(metadata());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/tcm/Transformation.java
+++ b/src/java/org/apache/cassandra/tcm/Transformation.java
@@ -45,8 +45,10 @@ import org.apache.cassandra.tcm.transformations.Assassinate;
 import org.apache.cassandra.tcm.transformations.BeginConsensusMigrationForTableAndRange;
 import org.apache.cassandra.tcm.transformations.CancelInProgressSequence;
 import org.apache.cassandra.tcm.transformations.CustomTransformation;
+import org.apache.cassandra.tcm.transformations.FinishDropAccordTable;
 import org.apache.cassandra.tcm.transformations.ForceSnapshot;
 import org.apache.cassandra.tcm.transformations.MaybeFinishConsensusMigrationForTableAndRange;
+import org.apache.cassandra.tcm.transformations.PrepareDropAccordTable;
 import org.apache.cassandra.tcm.transformations.PrepareJoin;
 import org.apache.cassandra.tcm.transformations.PrepareLeave;
 import org.apache.cassandra.tcm.transformations.PrepareMove;
@@ -238,7 +240,8 @@ public interface Transformation
         MAYBE_FINISH_CONSENSUS_MIGRATION_FOR_TABLE_AND_RANGE(37, () -> MaybeFinishConsensusMigrationForTableAndRange.serializer),
         ACCORD_MARK_STALE(38, () -> AccordMarkStale.serializer),
         ACCORD_MARK_REJOINING(39, () -> AccordMarkRejoining.serializer),
-
+        PREPARE_DROP_ACCORD_TABLE(40, () -> PrepareDropAccordTable.serializer),
+        FINISH_DROP_ACCORD_TABLE(41, () -> FinishDropAccordTable.serializer),
         ;
 
         private final Supplier<AsymmetricMetadataSerializer<Transformation, ? extends Transformation>> serializer;

--- a/src/java/org/apache/cassandra/tcm/membership/NodeVersion.java
+++ b/src/java/org/apache/cassandra/tcm/membership/NodeVersion.java
@@ -34,7 +34,7 @@ import static org.apache.cassandra.db.TypeSizes.sizeofUnsignedVInt;
 public class NodeVersion implements Comparable<NodeVersion>
 {
     public static final Serializer serializer = new Serializer();
-    public static final Version CURRENT_METADATA_VERSION = Version.V2;
+    public static final Version CURRENT_METADATA_VERSION = Version.V3;
     public static final NodeVersion CURRENT = new NodeVersion(new CassandraVersion(FBUtilities.getReleaseVersionString()), CURRENT_METADATA_VERSION);
     private static final CassandraVersion SINCE_VERSION = CassandraVersion.CASSANDRA_5_0;
 

--- a/src/java/org/apache/cassandra/tcm/sequences/DropAccordTable.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/DropAccordTable.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm.sequences;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.Keyspaces;
+import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.accord.AccordService;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.ClusterMetadataService;
+import org.apache.cassandra.tcm.Epoch;
+import org.apache.cassandra.tcm.MultiStepOperation;
+import org.apache.cassandra.tcm.Transformation;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializer;
+import org.apache.cassandra.tcm.serialization.MetadataSerializer;
+import org.apache.cassandra.tcm.serialization.Version;
+import org.apache.cassandra.tcm.transformations.FinishDropAccordTable;
+import org.apache.cassandra.utils.JVMStabilityInspector;
+
+import static org.apache.cassandra.tcm.Transformation.Kind.FINISH_DROP_ACCORD_TABLE;
+import static org.apache.cassandra.tcm.sequences.SequenceState.continuable;
+import static org.apache.cassandra.tcm.sequences.SequenceState.error;
+import static org.apache.cassandra.tcm.sequences.SequenceState.halted;
+import static org.apache.cassandra.utils.Clock.Global.nanoTime;
+
+/**
+ * A slightly atypical implementation as it consists of only a single step. To perform the drop of an
+ * Accord table, we first commit a PrepareDropAccordTable transformation. Upon enactement, that
+ * marks the table as pending drop, which blocks any new transactions from being started. It also
+ * instantiates an instance of this operation and adds it to the set of in progress operations.
+ *
+ * The intention is to introduce a barrier which blocks until the Accord service acknowledges that
+ * it was learned of the epoch in which the table was marked for deletion and that all prior transactions
+ * are completed. Once this is complete, we can proceed to actually drop the table. The transformation
+ * which performs that schema modification also removes this MSO from ClusterMetadata's in-flight set.
+ * This obviates the need to 'advance' this MSO in the way that other implementations with more steps do.
+ *
+ */
+public class DropAccordTable extends MultiStepOperation<Epoch>
+{
+    private static final Logger logger = LoggerFactory.getLogger(DropAccordTable.class);
+
+    public static final Serializer serializer = new Serializer();
+
+    public final TableReference table;
+
+    public static DropAccordTable newSequence(TableReference table, Epoch preparedAt)
+    {
+        return new DropAccordTable(table, preparedAt);
+    }
+
+    /**
+     * Used by factory method for external callers and by the serializer.
+     * We don't need to include the serialized FinishDropAccordTable step in the serialization
+     * of the MSO itself because they have no parameters other than the table reference and so
+     * we can just construct a new one when we execute it
+     */
+    private DropAccordTable(TableReference table, Epoch latestModification)
+    {
+        super(0, latestModification);
+        this.table = table;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DropAccordTable that = (DropAccordTable) o;
+        return latestModification.equals(that.latestModification)
+               && table.equals(that.table);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(latestModification, table);
+    }
+
+    @Override
+    public Kind kind()
+    {
+        return Kind.DROP_ACCORD_TABLE;
+    }
+
+    @Override
+    protected SequenceKey sequenceKey()
+    {
+        return table;
+    }
+
+    @Override
+    public MetadataSerializer<? extends SequenceKey> keySerializer()
+    {
+        return TableReference.serializer;
+    }
+
+    @Override
+    public Transformation.Kind nextStep()
+    {
+        return FINISH_DROP_ACCORD_TABLE;
+    }
+
+    @Override
+    public SequenceState executeNext()
+    {
+        try
+        {
+            SequenceState failure = awaitSafeFromAccord();
+            if (failure != null) return failure;
+        }
+        catch (Throwable t)
+        {
+            JVMStabilityInspector.inspectThrowable(t);
+            logger.warn("Exception while waiting for Accord service to notify all table txns are complete", t);
+            // this is actually continuable as we can simply retry
+            return continuable();
+        }
+        try
+        {
+            // Now we're satisfied that all Accord txns have finished for the table,
+            // go ahead and actually drop it
+            ClusterMetadataService.instance().commit(new FinishDropAccordTable(table));
+            return continuable();
+        }
+        catch (Throwable t)
+        {
+            JVMStabilityInspector.inspectThrowable(t);
+            logger.warn("Exception committing finish_drop_accord_table. " +
+                        "Accord service has acknowledged the operation but table remains present in schema", t);
+            return halted();
+        }
+    }
+
+    private SequenceState awaitSafeFromAccord() throws ExecutionException, InterruptedException
+    {
+        // make sure that Accord sees the current epoch, which must necessarily follow the
+        // one which marked the table as pending drop
+        ClusterMetadata metadata = ClusterMetadata.current();
+        // just for the sake of paranoia, assert that the table is actually marked as being dropped
+        if (!verifyTableMarked(metadata.schema.getKeyspaces()))
+            return error(new IllegalStateException(String.format("Table %s is in an invalid state to be dropped", table)));
+
+        long startNanos = nanoTime();
+        AccordService.instance().epochReady(metadata.epoch).get();
+        long epochEndNanos = nanoTime();
+
+        // As of this writing this logic is based off ExclusiveSyncPoints which is a bit heavy weight for what is needed, this could cause timeouts for clusters that have a lot of data.
+        // There are retries baked into this call, but trying to handle timeouts more broadly is put on hold as there is active work to define a EpochSyncPoint that should be far cheaper
+        // which would avoid the timeout issues
+        // NOTE: ExclusiveSyncPoint must find all keys in the range, then make sure nothing is blocking them... this causes a lot of IO.  EpochSyncPoint just needs to validate that the last txn processed is in the newer epoch, this can work with in-memory state.
+        AccordService.instance().awaitTableDrop(table.id);
+        long awaitEndNanos = nanoTime();
+        logger.info("Wait for Accord to see the drop table was success.  " +
+                    "Took {} to wait for Accord to learn about the change, then {} to process everything",
+                    Duration.ofNanos(epochEndNanos - startNanos), Duration.ofNanos(awaitEndNanos - epochEndNanos));
+        return null;
+    }
+
+    private boolean verifyTableMarked(Keyspaces keyspaces)
+    {
+        TableMetadata tm = keyspaces.getTableOrViewNullable(table.id);
+        if (tm == null)
+        {
+            logger.warn("Unable to drop accord table {}, table not found", table);
+            return false;
+        }
+
+        if (!tm.params.pendingDrop)
+        {
+            logger.warn("Unexpected state, table {} was not marked pending drop", table);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public Transformation.Result applyTo(ClusterMetadata metadata)
+    {
+        // note: that this will apply the finish drop transformation to the supplied metadata. It's
+        // not used to actually execute the MSO, but to determine what the metadata state will/would
+        // be if it were executed.
+        return new FinishDropAccordTable(table).execute(metadata);
+    }
+
+    @Override
+    public DropAccordTable advance(Epoch epoch)
+    {
+        // note: this isn't really used by this MSO impl as it consists of a single step so there's nothing
+        // to advance. An action of the single step is to remove the MSO from the set of in progress sequences
+        return new DropAccordTable(this.table, epoch);
+    }
+
+    @Override
+    public ProgressBarrier barrier()
+    {
+        return ProgressBarrier.immediate();
+    }
+
+    public static class TableReference implements SequenceKey, Comparable<TableReference>
+    {
+        public static final Serializer serializer = new Serializer();
+
+        public final TableId id;
+
+        public TableReference(TableId id)
+        {
+            this.id = id;
+        }
+
+        public static TableReference from(TableMetadata metadata)
+        {
+            return new TableReference(metadata.id);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TableReference that = (TableReference) o;
+            return id.equals(that.id);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(id);
+        }
+
+        @Override
+        public int compareTo(TableReference o)
+        {
+            return id.compareTo(o.id);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "TableReference{id=" + id + '}';
+        }
+
+        public static class Serializer implements MetadataSerializer<TableReference>
+        {
+            @Override
+            public void serialize(TableReference t, DataOutputPlus out, Version version) throws IOException
+            {
+                t.id.serialize(out);
+            }
+
+            @Override
+            public TableReference deserialize(DataInputPlus in, Version version) throws IOException
+            {
+                TableId id = TableId.deserialize(in);
+                return new TableReference(id);
+            }
+
+            @Override
+            public long serializedSize(TableReference t, Version version)
+            {
+                return t.id.serializedSize();
+            }
+        }
+    }
+
+    public static class Serializer implements AsymmetricMetadataSerializer<MultiStepOperation<?>, DropAccordTable>
+    {
+        @Override
+        public void serialize(MultiStepOperation<?> t, DataOutputPlus out, Version version) throws IOException
+        {
+            DropAccordTable plan = (DropAccordTable) t;
+            Epoch.serializer.serialize(plan.latestModification, out, version);
+            // This type of sequence only has a single step so no need to include the index in serde.
+            // Similarly, the only parameter to that single step (FinishDropAccordTable) is the table
+            // reference, so that's all we really need to include in the serialization.
+            TableReference.serializer.serialize(plan.table, out, version);
+        }
+
+        @Override
+        public DropAccordTable deserialize(DataInputPlus in, Version version) throws IOException
+        {
+            Epoch lastModified = Epoch.serializer.deserialize(in, version);
+            TableReference table = TableReference.serializer.deserialize(in, version);
+            return new DropAccordTable(table, lastModified);
+        }
+
+        @Override
+        public long serializedSize(MultiStepOperation<?> t, Version version)
+        {
+            DropAccordTable plan = (DropAccordTable) t;
+            long size = 0;
+            size += Epoch.serializer.serializedSize(plan.latestModification, version);
+            size += TableReference.serializer.serializedSize(plan.table, version);
+            return size;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tcm/sequences/InProgressSequences.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/InProgressSequences.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -59,20 +60,20 @@ public class InProgressSequences implements MetadataValue<InProgressSequences>, 
         this.state = state;
     }
 
-    public static void finishInProgressSequences(MultiStepOperation.SequenceKey sequenceKey)
+    public static ClusterMetadata finishInProgressSequences(MultiStepOperation.SequenceKey sequenceKey)
     {
         ClusterMetadata metadata = ClusterMetadata.current();
         while (true)
         {
             MultiStepOperation<?> sequence = metadata.inProgressSequences.get(sequenceKey);
             if (sequence == null)
-                break;
+                return metadata;
             if (isLeave(sequence))
                 StorageService.instance.maybeInitializeServices();
             if (resume(sequence))
                 metadata = ClusterMetadata.current();
             else
-                return;
+                return metadata;
         }
     }
 
@@ -216,6 +217,11 @@ public class InProgressSequences implements MetadataValue<InProgressSequences>, 
     public Iterator<MultiStepOperation<?>> iterator()
     {
         return state.values().iterator();
+    }
+
+    public ImmutableSet<MultiStepOperation.SequenceKey> keys()
+    {
+        return state.keySet();
     }
 
     public static class Serializer implements MetadataSerializer<InProgressSequences>

--- a/src/java/org/apache/cassandra/tcm/serialization/Version.java
+++ b/src/java/org/apache/cassandra/tcm/serialization/Version.java
@@ -18,7 +18,10 @@
 
 package org.apache.cassandra.tcm.serialization;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.tcm.ClusterMetadata;
@@ -36,12 +39,23 @@ public enum Version
     /**
      *  - Added version to PlacementForRange serializer
      *  - Serialize MemtableParams when serializing TableParams
-     *  - Added AccordFastPath
-     *  - Added AccordStaleReplicas
      */
     V2(2),
 
+    /**
+     *  - Added AccordFastPath
+     *  - Added ConsensusMigrationState
+     *  - Added AccordStaleReplicas
+     *  - TableParam now has pendingDrop (accord table drop is multistep)
+     */
+    V3(3),
+
     UNKNOWN(Integer.MAX_VALUE);
+
+    /**
+     * The version that Accord was added to TCM.
+     */
+    public static final Version MIN_ACCORD_VERSION = V3;
 
     private static Map<Integer, Version> values = new HashMap<>();
     static
@@ -95,5 +109,16 @@ public enum Version
             return v;
 
         throw new IllegalArgumentException("Unsupported metadata version (" + i + ")");
+    }
+
+    public List<Version> greaterThanOrEqual()
+    {
+        Version[] all = Version.values();
+        if (ordinal() == all.length - 1)
+            return Collections.singletonList(this);
+        List<Version> values = new ArrayList<>(all.length - ordinal());
+        for (int i = ordinal(); i < all.length; i++)
+            values.add(all[i]);
+        return values;
     }
 }

--- a/src/java/org/apache/cassandra/tcm/transformations/AlterSchema.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/AlterSchema.java
@@ -248,7 +248,7 @@ public class AlterSchema implements Transformation
         return byReplication;
     }
 
-    private Transformer maybeUpdateConsensusMigrationState(ConsensusMigrationState prev, Transformer next, ImmutableList<KeyspaceDiff> altered, Keyspaces dropped)
+    public static Transformer maybeUpdateConsensusMigrationState(ConsensusMigrationState prev, Transformer next, ImmutableList<KeyspaceDiff> altered, Keyspaces dropped)
     {
         ConsensusMigrationState migrationState = prev;
 

--- a/src/java/org/apache/cassandra/tcm/transformations/FinishDropAccordTable.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/FinishDropAccordTable.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm.transformations;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.DistributedSchema;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.Keyspaces;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.Transformation;
+import org.apache.cassandra.tcm.sequences.DropAccordTable.TableReference;
+import org.apache.cassandra.tcm.sequences.LockedRanges;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializer;
+import org.apache.cassandra.tcm.serialization.Version;
+
+import static org.apache.cassandra.tcm.Transformation.Kind.FINISH_DROP_ACCORD_TABLE;
+
+/**
+ * Dropping an Accord table is a three-step process.
+ * <ol>
+ *     <li>Mark the table as pending drop</li>
+ *     <li>Await all in-flight txns to finish</li>
+ *     <li>Drop the table from schema (this step)</li>
+ * </ol>
+ * <p/>
+ * Hypothetically it is possible that after {1} has been committed, but before {3} is executed
+ * interleaving metadata changes occur. These could include dropping the table's keyspace, or
+ * modifying the transactional mode of the table to make it a non-accord table. Validation
+ * exists to prevent these schema changes from being committed while the drop is in-flight.
+ * However, if something like this did happen, by the time we come to execute this transformation,
+ * there's nothing really to do other than return success (as the table has indeed already been dropped).
+ */
+public class FinishDropAccordTable implements Transformation
+{
+    private static final Logger logger = LoggerFactory.getLogger(FinishDropAccordTable.class);
+
+    public static final Serializer serializer = new Serializer();
+    public final TableReference tableRef;
+
+    public FinishDropAccordTable(TableReference tableRef)
+    {
+        this.tableRef = tableRef;
+    }
+
+    @Override
+    public Kind kind()
+    {
+        return FINISH_DROP_ACCORD_TABLE;
+    }
+
+    @Override
+    public Result execute(ClusterMetadata prev)
+    {
+        // In every case we remove the operation to drop this table from the set of in-flight sequences
+        ClusterMetadata.Transformer proposed = prev.transformer()
+                                                   .with(prev.inProgressSequences.without(tableRef));
+
+        Keyspaces keyspaces = prev.schema.getKeyspaces();
+        TableMetadata table = keyspaces.getTableOrViewNullable(tableRef.id);
+        // Table was already dropped
+        if (table == null)
+        {
+            logger.warn("Table {} was dropped while drop accord table sequence was in flight", tableRef);
+            return Transformation.success(proposed, LockedRanges.AffectedRanges.EMPTY);
+        }
+        KeyspaceMetadata keyspace = keyspaces.getNullable(table.keyspace);
+
+        // Actually drop the table
+        Keyspaces withoutTable = keyspaces.withAddedOrUpdated(keyspace.withSwapped(keyspace.tables.without(table)));
+
+        Keyspaces.KeyspacesDiff diff = Keyspaces.diff(prev.schema.getKeyspaces(), withoutTable);
+
+        proposed = AlterSchema.maybeUpdateConsensusMigrationState(prev.consensusMigrationState, proposed, diff.altered, Keyspaces.NONE);
+
+        proposed = proposed.with(new DistributedSchema(withoutTable));
+        return Transformation.success(proposed, LockedRanges.AffectedRanges.EMPTY);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (!(o instanceof FinishDropAccordTable)) return false;
+
+        FinishDropAccordTable that = (FinishDropAccordTable) o;
+
+        return Objects.equals(tableRef, that.tableRef);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(tableRef);
+    }
+
+    public static class Serializer implements AsymmetricMetadataSerializer<Transformation, FinishDropAccordTable>
+    {
+        @Override
+        public void serialize(Transformation t, DataOutputPlus out, Version version) throws IOException
+        {
+            FinishDropAccordTable plan = (FinishDropAccordTable) t;
+            TableReference.serializer.serialize(plan.tableRef, out, version);
+        }
+
+        @Override
+        public FinishDropAccordTable deserialize(DataInputPlus in, Version version) throws IOException
+        {
+            TableReference table = TableReference.serializer.deserialize(in, version);
+            return new FinishDropAccordTable(table);
+        }
+
+        @Override
+        public long serializedSize(Transformation t, Version version)
+        {
+            FinishDropAccordTable plan = (FinishDropAccordTable) t;
+            return TableReference.serializer.serializedSize(plan.tableRef, version);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tcm/transformations/PrepareDropAccordTable.java
+++ b/src/java/org/apache/cassandra/tcm/transformations/PrepareDropAccordTable.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm.transformations;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.cassandra.exceptions.ExceptionCode;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.DistributedSchema;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.Transformation;
+import org.apache.cassandra.tcm.sequences.DropAccordTable;
+import org.apache.cassandra.tcm.sequences.DropAccordTable.TableReference;
+import org.apache.cassandra.tcm.sequences.LockedRanges;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializer;
+import org.apache.cassandra.tcm.serialization.Version;
+
+public class PrepareDropAccordTable implements Transformation
+{
+    public static final Serializer serializer = new Serializer();
+
+    public final TableReference tableRef;
+
+    public PrepareDropAccordTable(TableReference tableRef)
+    {
+        this.tableRef = tableRef;
+    }
+
+    @Override
+    public Kind kind()
+    {
+        return Kind.PREPARE_DROP_ACCORD_TABLE;
+    }
+
+    @Override
+    public Result execute(ClusterMetadata prev)
+    {
+        TableMetadata metadata = prev.schema.getKeyspaces().getTableOrViewNullable(tableRef.id);
+        if (metadata == null)
+            return new Rejected(ExceptionCode.INVALID, "Table " + tableRef + " is not known");
+        if (!metadata.isAccordEnabled())
+            return new Rejected(ExceptionCode.INVALID, "Table " + metadata + " is not an Accord table and should be dropped normally");
+        if (metadata.params.pendingDrop)
+            return new Rejected(ExceptionCode.INVALID, "Table " + metadata + " is in the process of being dropped");
+
+        KeyspaceMetadata ks = prev.schema.getKeyspaceMetadata(metadata.keyspace);
+        metadata = metadata.unbuild().params(metadata.params.unbuild().pendingDrop(true).build()).build();
+        ks = ks.withSwapped(ks.tables.withSwapped(metadata));
+
+        DropAccordTable operation = DropAccordTable.newSequence(tableRef, prev.nextEpoch());
+        ClusterMetadata.Transformer proposed = prev.transformer()
+                                                   .with(new DistributedSchema(prev.schema.getKeyspaces().withAddedOrUpdated(ks)))
+                                                   .with(prev.inProgressSequences.with(tableRef, operation));
+        return Transformation.success(proposed, LockedRanges.AffectedRanges.EMPTY);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PrepareDropAccordTable that = (PrepareDropAccordTable) o;
+        return tableRef.equals(that.tableRef);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(tableRef);
+    }
+
+    public static class Serializer implements AsymmetricMetadataSerializer<Transformation, PrepareDropAccordTable>
+    {
+        @Override
+        public void serialize(Transformation t, DataOutputPlus out, Version version) throws IOException
+        {
+            PrepareDropAccordTable plan = (PrepareDropAccordTable) t;
+            TableReference.serializer.serialize(plan.tableRef, out, version);
+        }
+
+        @Override
+        public PrepareDropAccordTable deserialize(DataInputPlus in, Version version) throws IOException
+        {
+            TableReference table = TableReference.serializer.deserialize(in, version);
+            return new PrepareDropAccordTable(table);
+        }
+
+        @Override
+        public long serializedSize(Transformation t, Version version)
+        {
+            PrepareDropAccordTable plan = (PrepareDropAccordTable) t;
+            return TableReference.serializer.serializedSize(plan.tableRef, version);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -262,7 +262,8 @@ public class NodeTool
                .withCommand(CMSAdmin.InitializeCMS.class)
                .withCommand(CMSAdmin.ReconfigureCMS.class)
                .withCommand(CMSAdmin.Snapshot.class)
-               .withCommand(CMSAdmin.Unregister.class);
+               .withCommand(CMSAdmin.Unregister.class)
+               .withCommand(CMSAdmin.ResumeDropAccordTable.class);
 
         builder.withGroup("consensus_admin")
             .withDescription("List and mark ranges as migrating between consensus protocols")

--- a/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
@@ -194,4 +194,16 @@ public abstract class CMSAdmin extends NodeTool.NodeToolCmd
             probe.getCMSOperationsProxy().unregisterLeftNodes(nodeIds);
         }
     }
+
+    @Command(name = "resumedropaccordtable", description = "Resume a drop accord table operation which has stalled")
+    public static class ResumeDropAccordTable extends NodeTool.NodeToolCmd
+    {
+        @Arguments(usage = "[tableId]", description = "Table id of the table being dropped")
+        private String tableId;
+        @Override
+        public void execute(NodeProbe probe)
+        {
+            probe.getCMSOperationsProxy().resumeDropAccordTable(tableId);
+        }
+    }
 }

--- a/test/distributed/org/apache/cassandra/distributed/shared/ClusterUtils.java
+++ b/test/distributed/org/apache/cassandra/distributed/shared/ClusterUtils.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
 
 import accord.primitives.TxnId;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.ICluster;
@@ -74,6 +76,8 @@ import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.RequestCallback;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableId;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.ClusterMetadataService;
@@ -1499,6 +1503,12 @@ public class ClusterUtils
                 sb.append(Arrays.asList(row.toObjectArray())).append('\n');
             }
         }
+    }
+
+    public static TableId tableId(Cluster cluster, String ks, String table)
+    {
+        String str = cluster.getFirstRunningInstance().callOnInstance(() -> Schema.instance.getKeyspaceInstance(ks).getColumnFamilyStore(table).getTableId().toString());
+        return TableId.fromUUID(UUID.fromString(str));
     }
 }
 

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordDropKeyspaceTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordDropKeyspaceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.accord;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.schema.TableId;
+
+public class AccordDropKeyspaceTest extends AccordDropTableBase
+{
+    @Test
+    public void dropKeyspace() throws IOException
+    {
+        int examples = 5;
+        int steps = 5;
+        try (Cluster cluster = Cluster.build(3)
+                                      .withoutVNodes()
+                                      .withConfig(c -> c.with(Feature.values())
+                                                        .set("auto_snapshot", false))
+                                      .start())
+        {
+            fixDistributedSchemas(cluster);
+            for (int i = 0; i < examples; i++)
+            {
+                int j = 0;
+                try
+                {
+                    addChaos(cluster, i);
+                    init(cluster);
+                    TableId id = createTable(cluster);
+                    for (j = 0; j < steps; j++)
+                        doTxn(cluster, j);
+                    dropKeyspace(cluster);
+                    validateAccord(cluster, id);
+                }
+                catch (Throwable t)
+                {
+                    throw new AssertionError("Error at example " + i + ", " + j, t);
+                }
+            }
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordDropTableBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordDropTableBase.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.accord;
+
+import java.util.UUID;
+
+import com.google.common.base.Throwables;
+
+import accord.api.Key;
+import accord.local.CommandStores;
+import accord.local.KeyHistory;
+import accord.local.PreLoadContext;
+import accord.local.cfk.CommandsForKey;
+import accord.primitives.Ranges;
+import accord.primitives.TxnId;
+import accord.utils.async.AsyncChains;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.ICoordinator;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.shared.ClusterUtils;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.service.accord.AccordCommandStore;
+import org.apache.cassandra.service.accord.AccordSafeCommandStore;
+import org.apache.cassandra.service.accord.AccordSafeCommandsForKey;
+import org.apache.cassandra.service.accord.AccordService;
+import org.apache.cassandra.service.accord.TokenRange;
+import org.assertj.core.api.Assertions;
+
+import static org.apache.cassandra.service.accord.AccordTestUtils.wrapInTxn;
+
+public class AccordDropTableBase extends TestBaseImpl
+{
+    protected static void addChaos(Cluster cluster, int example)
+    {
+        cluster.filters().reset();
+        cluster.filters().verbs(Verb.ACCORD_APPLY_REQ.id).from(1).to(3).drop();
+    }
+
+    protected static void doTxn(Cluster cluster, int step)
+    {
+        int stepId = step % 3;
+        int partitionId = step % 10;
+        int coordinatorId = (step % 2) + 1; // avoid node3 as it can't get applies from node1, so leads to user errors
+        ICoordinator coordinator = cluster.coordinator(coordinatorId);
+        switch (stepId)
+        {
+            case 0: // insert
+                retry(3, () -> coordinator.executeWithResult(wrapInTxn(withKeyspace("INSERT INTO %s.tbl(pk, v) VALUES (?, ?);")), ConsistencyLevel.ANY, partitionId, step));
+                break;
+            case 1: // insert + read
+                retry(3, () -> coordinator.executeWithResult(wrapInTxn(withKeyspace("UPDATE %s.tbl SET v+=1 WHERE pk=?;")), ConsistencyLevel.ANY, partitionId));
+                break;
+            case 2: // read
+                retry(3, () -> coordinator.executeWithResult(wrapInTxn(withKeyspace("SELECT * FROM %s.tbl WHERE pk=?")), ConsistencyLevel.ANY, partitionId));
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    protected static void retry(int maxAttempts, Runnable fn)
+    {
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                fn.run();
+            }
+            catch (Throwable t)
+            {
+                if (i == (maxAttempts - 1))
+                    throw t;
+            }
+        }
+    }
+
+    protected static TableId createTable(Cluster cluster)
+    {
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl(pk int PRIMARY KEY, v int) WITH transactional_mode='full'"));
+        return ClusterUtils.tableId(cluster, KEYSPACE, "tbl");
+    }
+
+    protected void dropKeyspace(Cluster cluster)
+    {
+        // drop keyspace should be rejected as there is an accord table... so validate that is true then do both
+        try
+        {
+            cluster.schemaChange(withKeyspace("DROP KEYSPACE %s"));
+        }
+        catch (Throwable t)
+        {
+            Assertions.assertThat(Throwables.getRootCause(t))
+                      .hasMessage("Cannot drop keyspace 'distributed_test_keyspace' as it contains accord tables. (distributed_test_keyspace.tbl)");
+        }
+
+        // now do it for real
+        dropTable(cluster);
+        cluster.schemaChange(withKeyspace("DROP KEYSPACE %s"));
+    }
+
+    protected static void dropTable(Cluster cluster)
+    {
+        cluster.schemaChange(withKeyspace("DROP TABLE %s.tbl"));
+    }
+
+    protected static void validateAccord(Cluster cluster, TableId id)
+    {
+        String s = id.toString();
+        for (IInvokableInstance inst : cluster)
+        {
+            inst.runOnInstance(() -> {
+                TableId tableId = TableId.fromUUID(UUID.fromString(s));
+                AccordService accord = (AccordService) AccordService.instance();
+                PreLoadContext ctx = PreLoadContext.contextFor(Ranges.single(TokenRange.fullRange(tableId)), KeyHistory.COMMANDS);
+                CommandStores stores = accord.node().commandStores();
+                for (int storeId : stores.ids())
+                {
+                    AccordCommandStore store = (AccordCommandStore) stores.forId(storeId);
+                    AsyncChains.getUnchecked(store.submit(ctx, input -> {
+                        AccordSafeCommandStore safe = (AccordSafeCommandStore) input;
+                        for (Key key : safe.commandsForKeysKeys())
+                        {
+                            AccordSafeCommandsForKey safeCFK = safe.maybeCommandsForKey(key);
+                            if (safeCFK == null) // we read and found a key, but its null at load time... so ignore it
+                                continue;
+                            CommandsForKey cfk = safeCFK.current();
+                            CommandsForKey.TxnInfo minUndecided = cfk.minUndecided();
+                            if (minUndecided != null)
+                                throw new AssertionError("Undecided txn: " + minUndecided);
+                            TxnId next = cfk.nextWaitingToApply();
+                            if (next != null)
+                                throw new AssertionError("Unapplied txn: " + next);
+                        }
+                        return null;
+                    }));
+                }
+            });
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordDropTableTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordDropTableTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.accord;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.schema.TableId;
+
+public class AccordDropTableTest extends AccordDropTableBase
+{
+    @Test
+    public void dropTable() throws IOException
+    {
+        int examples = 5;
+        int steps = 5;
+        try (Cluster cluster = Cluster.build(3)
+                                      .withoutVNodes()
+                                      .withConfig(c -> c.with(Feature.values())
+                                                       .set("auto_snapshot", false))
+                                      .start())
+        {
+            fixDistributedSchemas(cluster);
+            init(cluster);
+            for (int i = 0; i < examples; i++)
+            {
+                int j = 0;
+                try
+                {
+                    addChaos(cluster, i);
+                    TableId id = createTable(cluster);
+                    for (j = 0; j < steps; j++)
+                        doTxn(cluster, j);
+                    dropTable(cluster);
+                    validateAccord(cluster, id);
+                }
+                catch (Throwable t)
+                {
+                    throw new AssertionError("Error at example " + i + ", " + j, t);
+                }
+            }
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/log/ClusterMetadataTestHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/ClusterMetadataTestHelper.java
@@ -59,6 +59,7 @@ import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.SchemaTransformation;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.accord.AccordStaleReplicas;
+import org.apache.cassandra.service.consensus.migration.ConsensusMigrationState;
 import org.apache.cassandra.tcm.AtomicLongBackedProcessor;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.ClusterMetadataService;
@@ -157,41 +158,22 @@ public class ClusterMetadataTestHelper
                                    AccordFastPath.EMPTY,
                                    LockedRanges.EMPTY,
                                    InProgressSequences.EMPTY,
-                                   null,
+                                   ConsensusMigrationState.EMPTY,
                                    ImmutableMap.of(),
                                    AccordStaleReplicas.EMPTY);
     }
 
     public static ClusterMetadata minimalForTesting(IPartitioner partitioner)
     {
-        return new ClusterMetadata(Epoch.EMPTY,
-                                   partitioner,
-                                   null,
-                                   null,
-                                   null,
-                                   DataPlacements.empty(),
-                                   AccordFastPath.EMPTY,
-                                   null,
-                                   null,
-                                   null,
-                                   ImmutableMap.of(),
-                                   AccordStaleReplicas.EMPTY);
+        return minimalForTesting(Epoch.EMPTY, partitioner);
     }
 
     public static ClusterMetadata minimalForTesting(Keyspaces keyspaces)
     {
-        return new ClusterMetadata(Epoch.EMPTY,
-                                   Murmur3Partitioner.instance,
-                                   new DistributedSchema(keyspaces),
-                                   null,
-                                   null,
-                                   DataPlacements.empty(),
-                                   AccordFastPath.EMPTY,
-                                   null,
-                                   null,
-                                   null,
-                                   ImmutableMap.of(),
-                                   AccordStaleReplicas.EMPTY);
+        return minimalForTesting(Murmur3Partitioner.instance).transformer()
+                                                             .with(new DistributedSchema(keyspaces))
+                                                             .build()
+               .metadata.forceEpoch(Epoch.EMPTY);
     }
 
     public static ClusterMetadataService syncInstanceForTest()

--- a/test/unit/org/apache/cassandra/cql3/PreparedStatementsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PreparedStatementsTest.java
@@ -218,6 +218,7 @@ public class PreparedStatementsTest extends CQLTester
         session.execute(preparedBatch.bind(2, 2, "value2"));
         session.execute(preparedTxn.bind(3, 3, "value3"));
 
+        sessionSchemaUpdate(session, dropTableStatement); // since this is an accord table, need to drop the table before the keyspace
         sessionSchemaUpdate(session, dropKsStatement);
         sessionSchemaUpdate(session, createKsStatement);
         sessionSchemaUpdate(session, createTableStatement);
@@ -229,6 +230,7 @@ public class PreparedStatementsTest extends CQLTester
         session.execute(prepared.bind(1, 1, "value"));
         session.execute(preparedBatch.bind(2, 2, "value2"));
         session.execute(preparedTxn.bind(3, 3, "value3"));
+        sessionSchemaUpdate(session, dropTableStatement); // since this is an accord table, need to drop the table before the keyspace
         sessionSchemaUpdate(session, dropKsStatement);
     }
 
@@ -249,6 +251,7 @@ public class PreparedStatementsTest extends CQLTester
         Session session = sessionNet(version);
         String createTableStatement = "CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".qp_cleanup (a int PRIMARY KEY, b int, c int) WITH transactional_mode='unsafe';";
         String alterTableStatement = "ALTER TABLE " + KEYSPACE + ".qp_cleanup ADD d int;";
+        String dropTableStatement = "DROP TABLE IF EXISTS " + KEYSPACE + ".qp_cleanup;";
 
         sessionSchemaUpdate(session, dropKsStatement);
         sessionSchemaUpdate(session, createKsStatement);
@@ -315,6 +318,7 @@ public class PreparedStatementsTest extends CQLTester
             }
         }
 
+        sessionSchemaUpdate(session, dropTableStatement);
         sessionSchemaUpdate(session, dropKsStatement);
     }
 
@@ -335,6 +339,7 @@ public class PreparedStatementsTest extends CQLTester
         Session session = sessionNet(version);
         String createTableStatement = "CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".qp_cleanup (a int PRIMARY KEY, b int, c int) WITH transactional_mode='unsafe';";
         String alterTableStatement = "ALTER TABLE " + KEYSPACE + ".qp_cleanup ADD d int;";
+        String dropTableStatement = "DROP TABLE IF EXISTS " + KEYSPACE + ".qp_cleanup;";
 
         sessionSchemaUpdate(session, dropKsStatement);
         sessionSchemaUpdate(session, createKsStatement);
@@ -382,6 +387,7 @@ public class PreparedStatementsTest extends CQLTester
             Assertions.assertThat(columnNames(rs)).containsExactlyInAnyOrder("a", "b", "c");
         }
 
+        sessionSchemaUpdate(session, dropTableStatement);
         sessionSchemaUpdate(session, dropKsStatement);
     }
 

--- a/test/unit/org/apache/cassandra/schema/TableParamsTest.java
+++ b/test/unit/org/apache/cassandra/schema/TableParamsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.schema;
+
+import org.junit.Test;
+
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.tcm.membership.NodeVersion;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializers;
+import org.apache.cassandra.utils.CassandraGenerators.TableParamsBuilder;
+import org.apache.cassandra.utils.FailingConsumer;
+import org.quicktheories.core.Gen;
+
+import static org.quicktheories.QuickTheory.qt;
+
+
+public class TableParamsTest
+{
+    @Test
+    public void serdeLatest()
+    {
+        DataOutputBuffer output = new DataOutputBuffer();
+        qt().forAll(tableParams()).checkAssert(FailingConsumer.orFail(params -> {
+            AsymmetricMetadataSerializers.testSerde(output, TableParams.serializer, params, NodeVersion.CURRENT_METADATA_VERSION);
+        }));
+    }
+
+    private static Gen<TableParams> tableParams()
+    {
+        return new TableParamsBuilder()
+               .withKnownMemtables()
+               .withTransactionalMode()
+               .withFastPathStrategy()
+               .build();
+    }
+}

--- a/test/unit/org/apache/cassandra/service/accord/AccordKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/AccordKeyspaceTest.java
@@ -135,7 +135,7 @@ public class AccordKeyspaceTest extends CQLTester.InMemory
     public void findOverlappingKeys()
     {
         var tableIdGen = fromQT(CassandraGenerators.TABLE_ID_GEN);
-        var partitionGen = fromQT(CassandraGenerators.partitioners());
+        var partitionGen = fromQT(CassandraGenerators.partitioners()).map(CassandraGenerators::simplify);
 
         var sstableFormats = DatabaseDescriptor.getSSTableFormats();
         List<String> sstableFormatNames = new ArrayList<>(sstableFormats.keySet());

--- a/test/unit/org/apache/cassandra/service/accord/AccordStaleReplicasTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/AccordStaleReplicasTest.java
@@ -47,7 +47,7 @@ public class AccordStaleReplicasTest
             qt().check(rs -> {
                 Epoch epoch = epochGen.next(rs);
                 Set<Node.Id> nodes = nodesGen.next(rs);
-                AsymmetricMetadataSerializers.testSerde(buffer, AccordStaleReplicas.serializer, new AccordStaleReplicas(nodes, epoch), Version.V2);
+                AsymmetricMetadataSerializers.testSerde(buffer, AccordStaleReplicas.serializer, new AccordStaleReplicas(nodes, epoch), Version.MIN_ACCORD_VERSION);
             });
         }
     }

--- a/test/unit/org/apache/cassandra/service/accord/AccordSyncPropagatorTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/AccordSyncPropagatorTest.java
@@ -58,7 +58,6 @@ import accord.utils.RandomSource;
 import org.apache.cassandra.concurrent.AdaptingScheduledExecutorPlus;
 import org.apache.cassandra.concurrent.ScheduledExecutorPlus;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.exceptions.RequestFailure;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
@@ -70,8 +69,8 @@ import org.apache.cassandra.net.ConnectionType;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessageDelivery;
 import org.apache.cassandra.net.RequestCallback;
-import org.apache.cassandra.tcm.ClusterMetadataService;
-import org.apache.cassandra.tcm.StubClusterMetadataService;
+import org.apache.cassandra.tcm.ValidatingClusterMetadataService;
+import org.apache.cassandra.tcm.serialization.Version;
 import org.apache.cassandra.utils.AccordGenerators;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.concurrent.Future;
@@ -86,9 +85,7 @@ public class AccordSyncPropagatorTest
     public static void setup() throws NoSuchFieldException, IllegalAccessException
     {
         DatabaseDescriptor.daemonInitialization();
-        DatabaseDescriptor.setPartitionerUnsafe(Murmur3Partitioner.instance);
-        ClusterMetadataService.unsetInstance();
-        ClusterMetadataService.setInstance(StubClusterMetadataService.forTesting());
+        ValidatingClusterMetadataService.createAndRegister(Version.MIN_ACCORD_VERSION);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/service/accord/FetchMinEpochTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/FetchMinEpochTest.java
@@ -78,6 +78,7 @@ public class FetchMinEpochTest
     {
         DataOutputBuffer output = new DataOutputBuffer();
         Gen<FetchMinEpoch> gen = fromQT(CassandraGenerators.partitioners())
+                                 .map(CassandraGenerators::simplify)
                                  .flatMap(partitioner ->
                                           Gens.lists(AccordGenerators.range(partitioner)
                                                                      .map(r -> (TokenRange) r))

--- a/test/unit/org/apache/cassandra/service/accord/serializers/AccordRoutingKeyByteSourceTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/AccordRoutingKeyByteSourceTest.java
@@ -49,7 +49,7 @@ public class AccordRoutingKeyByteSourceTest
     @Test
     public void tokenSerde()
     {
-        qt().forAll(fromQT(token())).check(token -> {
+        qt().forAll(fromQT(CassandraGenerators.partitioners().map(CassandraGenerators::simplify).flatMap(CassandraGenerators::token))).check(token -> {
             var serializer = AccordRoutingKeyByteSource.create(token.getPartitioner());
             byte[] min = ByteSourceInverse.readBytes(serializer.minAsComparableBytes());
             byte[] max = ByteSourceInverse.readBytes(serializer.maxAsComparableBytes());

--- a/test/unit/org/apache/cassandra/tcm/ClusterMetadataMetadataKeyTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ClusterMetadataMetadataKeyTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.utils.FBUtilities;
+import org.assertj.core.api.Assertions;
+
+/**
+ * This test is to make sure that the fields of {@link ClusterMetadata} have a matching {@link MetadataKey} and the
+ * utility functions linking key to field are maintained.
+ *
+ * If this test is failing it likely means a new field was added to {@link ClusterMetadata} and {@link MetadataKeys} was
+ * not updated to know about it.
+ */
+public class ClusterMetadataMetadataKeyTest
+{
+    static
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
+    private static final Map<String, Field> NAME_TO_KEY;
+
+    static
+    {
+        ImmutableMap.Builder<String, Field> builder = ImmutableMap.builder();
+        for (Field field : MetadataKeys.class.getDeclaredFields())
+        {
+            if (field.getType() == MetadataKey.class
+                && Modifier.isStatic(field.getModifiers())
+                && Modifier.isPublic(field.getModifiers()))
+                builder.put(field.getName(), field);
+        }
+        NAME_TO_KEY = builder.build();
+    }
+
+    @Test
+    public void metadataKeyExists() throws IllegalAccessException
+    {
+        ClusterMetadata empty = new ClusterMetadata(Murmur3Partitioner.instance);
+        // Theese are fields that should not have MetadataKeys and should be ignored.
+        Set<String> exclude = ImmutableSet.of("metadataIdentifier",
+                                              "epoch",
+                                              "partitioner",
+                                              "extensions");
+        // Mapping of ClusterMetadata field names to MetadataKey name; mapping is only needed if the names don't match.
+        Map<String, String> mapping = ImmutableMap.of("directory", "node_directory",
+                                                      "placements", "data_placements");
+        for (Field field : ClusterMetadata.class.getDeclaredFields())
+        {
+            if (Modifier.isStatic(field.getModifiers())
+                || !Modifier.isPublic(field.getModifiers())
+                || !Modifier.isFinal(field.getModifiers()))
+                continue;
+            String name = field.getName();
+            if (exclude.contains(name)) continue;
+            if (mapping.containsKey(name))
+                name = mapping.get(name);
+            String snakeName = FBUtilities.camelToSnake(name).toUpperCase(Locale.ROOT);
+            Assertions.assertThat(NAME_TO_KEY.keySet())
+                      .describedAs("Unable to locate MetadataKey for %s", snakeName)
+                      .contains(snakeName);
+            MetadataKey expectedKey = (MetadataKey) NAME_TO_KEY.get(snakeName).get(null);
+            if (!MetadataKeys.CORE_METADATA.containsKey(expectedKey))
+                throw new IllegalStateException("MetadataKeys.CORE_METADATA is missing key " + expectedKey + " for field " + name);
+
+            Assertions.assertThat(field.get(empty))
+                      .describedAs("Extraction function does not seem to match the field %s and key %s", name, snakeName)
+                      .isSameAs(MetadataKeys.CORE_METADATA.get(expectedKey).apply(empty));
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/tcm/ClusterMetadataSerializerTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ClusterMetadataSerializerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm;
+
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.service.accord.AccordFastPath;
+import org.apache.cassandra.service.accord.AccordStaleReplicas;
+import org.apache.cassandra.service.consensus.migration.ConsensusMigrationState;
+import org.apache.cassandra.tcm.membership.NodeVersion;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializers;
+import org.apache.cassandra.tcm.serialization.Version;
+import org.apache.cassandra.utils.CassandraGenerators.ClusterMetadataBuilder;
+import org.assertj.core.api.Assertions;
+import org.quicktheories.core.Gen;
+
+import static org.apache.cassandra.utils.FailingConsumer.orFail;
+import static org.quicktheories.QuickTheory.qt;
+
+public class ClusterMetadataSerializerTest
+{
+    static
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
+    @Test
+    public void serdeLatest()
+    {
+        DataOutputBuffer output = new DataOutputBuffer();
+        qt().forAll(new ClusterMetadataBuilder().build()).checkAssert(orFail(cm -> {
+            AsymmetricMetadataSerializers.testSerde(output, ClusterMetadata.serializer, cm, NodeVersion.CURRENT_METADATA_VERSION);
+        }));
+    }
+
+    @Test
+    public void serdeWithoutAccord()
+    {
+        DataOutputBuffer output = new DataOutputBuffer();
+        Gen<ClusterMetadata> gen = new ClusterMetadataBuilder().build().assuming(cm -> {
+            if (!cm.consensusMigrationState.equals(ConsensusMigrationState.EMPTY))
+                return true;
+            if (!cm.accordStaleReplicas.equals(AccordStaleReplicas.EMPTY))
+                return true;
+            if (!cm.accordFastPath.equals(AccordFastPath.EMPTY))
+                return true;
+            return false;
+        });
+        qt().forAll(gen).checkAssert(orFail(cm -> {
+            output.clear();
+            Version version = Version.V2; // this is the version before accord
+            long expectedSize = ClusterMetadata.serializer.serializedSize(cm, version);
+            ClusterMetadata.serializer.serialize(cm, output, version);
+            Assertions.assertThat(output.getLength()).describedAs("The serialized size and bytes written do not match").isEqualTo(expectedSize);
+            DataInputBuffer in = new DataInputBuffer(output.unsafeGetBufferAndFlip(), false);
+            ClusterMetadata read = ClusterMetadata.serializer.deserialize(in, version);
+            Assertions.assertThat(read).isNotEqualTo(cm);
+
+            Assertions.assertThat(read.consensusMigrationState).isEqualTo(ConsensusMigrationState.EMPTY);
+            Assertions.assertThat(read.accordStaleReplicas).isEqualTo(AccordStaleReplicas.EMPTY);
+            Assertions.assertThat(read.accordFastPath).isEqualTo(AccordFastPath.EMPTY);
+        }));
+    }
+}

--- a/test/unit/org/apache/cassandra/tcm/ClusterMetadataTransformationTest.java
+++ b/test/unit/org/apache/cassandra/tcm/ClusterMetadataTransformationTest.java
@@ -275,7 +275,7 @@ public class ClusterMetadataTransformationTest
         // anything modified by in this transformation, and therefore included in the modified keys,
         // should have the same epoch as the CM itself. Anything not modified now must have a strictly
         // earlier epoch
-        for (MetadataKey key : Iterables.concat(MetadataKeys.CORE_METADATA, transformed.metadata.extensions.keySet()))
+        for (MetadataKey key : Iterables.concat(MetadataKeys.CORE_METADATA.keySet(), transformed.metadata.extensions.keySet()))
         {
             MetadataValue<?> value = valueFor(key, transformed.metadata);
             if (transformed.modifiedKeys.contains(key))
@@ -287,7 +287,7 @@ public class ClusterMetadataTransformationTest
 
     private static MetadataValue<?> valueFor(MetadataKey key, ClusterMetadata metadata)
     {
-        if (!MetadataKeys.CORE_METADATA.contains(key))
+        if (!MetadataKeys.CORE_METADATA.containsKey(key))
         {
             assert key instanceof ExtensionKey<?,?>;
             return metadata.extensions.get((ExtensionKey<?, ?>)key);

--- a/test/unit/org/apache/cassandra/tcm/ValidatingClusterMetadataService.java
+++ b/test/unit/org/apache/cassandra/tcm/ValidatingClusterMetadataService.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializer;
+import org.apache.cassandra.tcm.serialization.AsymmetricMetadataSerializers;
+import org.apache.cassandra.tcm.serialization.Version;
+import org.assertj.core.api.Assertions;
+
+public class ValidatingClusterMetadataService extends StubClusterMetadataService
+{
+    private final List<Version> supportedVersions;
+
+    private ValidatingClusterMetadataService(List<Version> supportedVersions)
+    {
+        super(new ClusterMetadata(safeGetPartitioner()));
+        this.supportedVersions = supportedVersions;
+    }
+
+    public static ValidatingClusterMetadataService createAndRegister(Version minVersion)
+    {
+        return createAndRegister(minVersion.greaterThanOrEqual());
+    }
+
+    public static ValidatingClusterMetadataService createAndRegister(List<Version> supportedVersions)
+    {
+        ValidatingClusterMetadataService cms = new ValidatingClusterMetadataService(supportedVersions);
+
+        ClusterMetadataService.unsetInstance();
+        ClusterMetadataService.setInstance(cms);
+        return cms;
+    }
+
+    private static IPartitioner safeGetPartitioner()
+    {
+        IPartitioner partitioner = DatabaseDescriptor.getPartitioner();
+        return partitioner == null ? Murmur3Partitioner.instance : partitioner;
+    }
+
+    private <In, Out> void testSerde(AsymmetricMetadataSerializer<In, Out> serializer, In input)
+    {
+        for (Version version : supportedVersions)
+        {
+            try (DataOutputBuffer buffer = DataOutputBuffer.scratchBuffer.get())
+            {
+                AsymmetricMetadataSerializers.testSerde(buffer, serializer, input, version);
+            }
+            catch (IOException e)
+            {
+                throw new AssertionError(String.format("Serde error for version=%s; input=%s", version, input), e);
+            }
+        }
+    }
+
+    @Override
+    protected Transformation.Result execute(Transformation transform)
+    {
+        Transformation.Result result = super.execute(transform);
+        if (result.isSuccess())
+        {
+            Transformation.Success success = result.success();
+            Assertions.assertThat(success.affectedMetadata)
+                      .describedAs("Affected Metadata keys do not match")
+                      .isEqualTo(MetadataKeys.diffKeys(metadata(), success.metadata));
+        }
+        return result;
+    }
+
+    @Override
+    public <T1> T1 commit(Transformation transform, CommitSuccessHandler<T1> onSuccess, CommitFailureHandler<T1> onFailure)
+    {
+        testSerde(transform.kind().serializer(), transform);
+        return super.commit(transform, onSuccess, onFailure);
+    }
+
+    @Override
+    public void setMetadata(ClusterMetadata metadata)
+    {
+        if (!metadata.epoch.equals(metadata().epoch.nextEpoch()))
+            throw new AssertionError("Epochs were not sequential: expected " + metadata().epoch.nextEpoch() + " but given " + metadata.epoch);
+        testSerde(ClusterMetadata.serializer, metadata);
+        super.setMetadata(metadata);
+    }
+}

--- a/test/unit/org/apache/cassandra/tcm/log/LogListenerNotificationTest.java
+++ b/test/unit/org/apache/cassandra/tcm/log/LogListenerNotificationTest.java
@@ -111,7 +111,7 @@ public class LogListenerNotificationTest
 
     static Set<MetadataKey> affectedMetadata(Random random)
     {
-        List<MetadataKey> src = new ArrayList<>(CORE_METADATA);
+        List<MetadataKey> src = new ArrayList<>(CORE_METADATA.keySet());
         int required = random.nextInt(src.size());
         Set<MetadataKey> keys = new HashSet<>();
         while (keys.size() < required)

--- a/test/unit/org/apache/cassandra/tcm/sequences/DropAccordTableTest.java
+++ b/test/unit/org/apache/cassandra/tcm/sequences/DropAccordTableTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tcm.sequences;
+
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import accord.utils.Gen;
+import accord.utils.Property;
+import accord.utils.Property.Command;
+import accord.utils.RandomSource;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.locator.MetaStrategy;
+import org.apache.cassandra.schema.DistributedSchema;
+import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.KeyspaceParams;
+import org.apache.cassandra.schema.Keyspaces;
+import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.schema.Types;
+import org.apache.cassandra.service.consensus.TransactionalMode;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.ClusterMetadataService;
+import org.apache.cassandra.tcm.MultiStepOperation;
+import org.apache.cassandra.tcm.StubClusterMetadataService;
+import org.apache.cassandra.tcm.ValidatingClusterMetadataService;
+import org.apache.cassandra.tcm.serialization.Version;
+import org.apache.cassandra.tcm.transformations.PrepareDropAccordTable;
+import org.apache.cassandra.tcm.sequences.DropAccordTable.TableReference;
+import org.apache.cassandra.utils.AbstractTypeGenerators;
+import org.apache.cassandra.utils.CassandraGenerators;
+import org.apache.cassandra.utils.CassandraGenerators.TableMetadataBuilder;
+import org.apache.cassandra.utils.Generators;
+import org.assertj.core.api.Assertions;
+import org.quicktheories.generators.SourceDSL;
+
+import static accord.utils.Property.commands;
+import static accord.utils.Property.qt;
+import static accord.utils.Property.stateful;
+import static org.apache.cassandra.utils.CassandraGenerators.TABLE_ID_GEN;
+
+public class DropAccordTableTest
+{
+    static
+    {
+        DatabaseDescriptor.clientInitialization();
+    }
+
+    private static final TransactionalMode[] ACCORD_ENABLED_MODES = Stream.of(TransactionalMode.values())
+                                                                          .filter(t -> t.accordIsEnabled)
+                                                                          .toArray(TransactionalMode[]::new);
+
+    private static final Gen<TableMetadata> TABLE_GEN = Generators.toGen(defaultTableMetadataBuilder().build());
+
+    private static TableMetadataBuilder defaultTableMetadataBuilder()
+    {
+        return new TableMetadataBuilder()
+               .withUseCounter(false)
+               .withPartitioner(Murmur3Partitioner.instance)
+               .withTransactionalMode(SourceDSL.arbitrary().pick(ACCORD_ENABLED_MODES));
+    }
+
+    @Test
+    public void e2e()
+    {
+        qt().check(rs -> {
+            ValidatingClusterMetadataService cms = createCMS();
+            TableMetadata metadata = TABLE_GEN.next(rs);
+            addTable(cms, metadata); // hack this table into the schema...
+
+            TableReference table = TableReference.from(metadata);
+
+            cms.commit(new PrepareDropAccordTable(table));
+
+            // This is only here because "applyTo" is not touched without it...
+            for (KeyspaceMetadata ks : cms.metadata().schema.getKeyspaces())
+                cms.metadata().writePlacementAllSettled(ks);
+
+            Assertions.assertThat(cms.metadata().inProgressSequences.isEmpty()).isFalse();
+            InProgressSequences.finishInProgressSequences(table);
+            Assertions.assertThat(cms.metadata().inProgressSequences.isEmpty()).isTrue();
+
+            // table is dropped
+            Assertions.assertThat(cms.metadata().schema.getTableMetadata(metadata.id)).isNull();
+        });
+    }
+
+    @Test
+    public void multi()
+    {
+        stateful().withExamples(50).withSteps(500).check(commands(() -> State::new)
+                                                        .destroyState(DropAccordTableTest::validate)
+                                                        .add(DropAccordTableTest::addTable)
+                                                        .addIf(s -> !s.aliveTables.isEmpty(), DropAccordTableTest::dropTable)
+                                                        .addIf(s -> !s.cms.metadata().inProgressSequences.isEmpty(), DropAccordTableTest::inProgressSequences)
+                                                        .build());
+    }
+
+    private static void validate(State state)
+    {
+        while (!state.cms.metadata().inProgressSequences.isEmpty())
+        {
+            for (MultiStepOperation<?> opt : state.cms.metadata().inProgressSequences)
+                InProgressSequences.resume(opt);
+        }
+        // all tables are dropped, unless they were never dropped
+        Keyspaces keyspaces = state.cms.metadata().schema.getKeyspaces();
+        for (KeyspaceMetadata k : keyspaces)
+        {
+            if (k.tables.size() == 0) continue;
+            if (k.replicationStrategy instanceof MetaStrategy) continue;
+            for (TableMetadata t : k.tables)
+            {
+                Assertions.assertThat(t.params.pendingDrop).isFalse();
+                Assertions.assertThat(state.aliveTables).contains(t.id);
+            }
+        }
+    }
+
+    private static Command<State, Void, ?> addTable(RandomSource rs, State state)
+    {
+        TableMetadata metadata = Generators.toGen(defaultTableMetadataBuilder()
+                                                  .withKeyspaceName(CassandraGenerators.KEYSPACE_NAME_GEN.assuming(name -> !state.cms.metadata().schema.getKeyspaces().containsKeyspace(name)))
+                                                  .withTableId(TABLE_ID_GEN.assuming(id -> state.cms.metadata().schema.getTableMetadata(id) == null))
+                                                  // other tests better cover serialization so can speed up tests by only doing primitive types
+                                                  .withDefaultTypeGen(CassandraGenerators.TableMetadataBuilder.defaultTypeGen().withTypeKinds(AbstractTypeGenerators.TypeKind.PRIMITIVE))
+                                                  .build())
+                                           .next(rs);
+        return new Property.SimpleCommand<>("Add Table " + metadata, s2 -> {
+            addTable(s2.cms, metadata);
+            s2.aliveTables.add(metadata.id);
+        });
+    }
+
+    private static Command<State, Void, ?> dropTable(RandomSource rs, State state)
+    {
+        TableId id = rs.pickOrderedSet(state.aliveTables);
+        TableMetadata metadata = state.cms.metadata().schema.getTableMetadata(id);
+        return new Property.SimpleCommand<>("Drop Table " + metadata, s2 -> {
+            TableReference table = TableReference.from(metadata);
+
+            s2.cms.commit(new PrepareDropAccordTable(table));
+            s2.aliveTables.remove(id);
+        });
+    }
+
+    private static Command<State, Void, ?> inProgressSequences(RandomSource rs, State state)
+    {
+        ClusterMetadata current = state.cms.metadata();
+        TreeSet<TableReference> pending = new TreeSet<>();
+        for (MultiStepOperation<?> opt : current.inProgressSequences)
+        {
+            if (!(opt instanceof DropAccordTable)) throw new AssertionError("Only DropAccordTable should exist in this test; found " + opt);
+            pending.add(((DropAccordTable) opt).table);
+        }
+        TableReference ref = rs.pickOrderedSet(pending);
+        MultiStepOperation<?> seq = current.inProgressSequences.get(ref);
+        Assertions.assertThat(seq).isNotNull();
+        return new Property.SimpleCommand<>("Progress  for " + ref + ": " + seq.nextStep(), s2 -> InProgressSequences.resume(seq));
+    }
+
+    public static class State
+    {
+        private final StubClusterMetadataService cms;
+        private final TreeSet<TableId> aliveTables = new TreeSet<>();
+
+        public State(RandomSource rs)
+        {
+            // With validation enabled the test runtime is dominated by serialization checks, so enable them rarely
+            // just so tests do run with them, but the whole test runtime isn't serde testing.
+            if (rs.decide(0.01))
+            {
+                cms = ValidatingClusterMetadataService.createAndRegister(Version.MIN_ACCORD_VERSION);
+            }
+            else
+            {
+                cms = StubClusterMetadataService.forTesting(new ClusterMetadata(Murmur3Partitioner.instance));
+                ClusterMetadataService.unsetInstance();
+                ClusterMetadataService.setInstance(cms);
+            }
+        }
+    }
+
+    private static ValidatingClusterMetadataService createCMS()
+    {
+        return ValidatingClusterMetadataService.createAndRegister(Version.MIN_ACCORD_VERSION);
+    }
+
+    private static void addTable(StubClusterMetadataService cms, TableMetadata table)
+    {
+        class Ref { Types types;}
+        // first mock out a keyspace
+        ClusterMetadata prev = cms.metadata();
+        KeyspaceMetadata schema = KeyspaceMetadata.create(table.keyspace, KeyspaceParams.simple(3));
+        Ref ref = new Ref();
+        ref.types = schema.types;
+        CassandraGenerators.visitUDTs(table, udt -> ref.types = ref.types.with(udt.unfreeze()));
+        schema = schema.withSwapped(ref.types);
+        schema = schema.withSwapped(schema.tables.with(table));
+        Keyspaces keyspaces = prev.schema.getKeyspaces().withAddedOrUpdated(schema);
+        ClusterMetadata metadata = prev.transformer().with(new DistributedSchema(keyspaces)).build().metadata;
+        cms.setMetadata(metadata);
+    }
+}

--- a/test/unit/org/apache/cassandra/tcm/transformations/AccordMarkRejoiningTest.java
+++ b/test/unit/org/apache/cassandra/tcm/transformations/AccordMarkRejoiningTest.java
@@ -35,7 +35,7 @@ public class AccordMarkRejoiningTest
     public void shouldSerializeEmpty() throws IOException
     {
         DataOutputBuffer buffer = new DataOutputBuffer();
-        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkRejoining.serializer, new AccordMarkRejoining(Collections.emptySet()), Version.V2);
+        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkRejoining.serializer, new AccordMarkRejoining(Collections.emptySet()), Version.MIN_ACCORD_VERSION);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class AccordMarkRejoiningTest
     {
         DataOutputBuffer buffer = new DataOutputBuffer();
         AccordMarkRejoining markStale = new AccordMarkRejoining(Collections.singleton(NodeId.fromString("1")));
-        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkRejoining.serializer, markStale, Version.V2);
+        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkRejoining.serializer, markStale, Version.MIN_ACCORD_VERSION);
     }
 
     @Test
@@ -51,6 +51,6 @@ public class AccordMarkRejoiningTest
     {
         DataOutputBuffer buffer = new DataOutputBuffer();
         AccordMarkRejoining markStale = new AccordMarkRejoining(ImmutableSet.of(NodeId.fromString("1"), NodeId.fromString("2")));
-        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkRejoining.serializer, markStale, Version.V2);
+        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkRejoining.serializer, markStale, Version.MIN_ACCORD_VERSION);
     }
 }

--- a/test/unit/org/apache/cassandra/tcm/transformations/AccordMarkStaleTest.java
+++ b/test/unit/org/apache/cassandra/tcm/transformations/AccordMarkStaleTest.java
@@ -35,7 +35,7 @@ public class AccordMarkStaleTest
     public void shouldSerializeEmpty() throws IOException
     {
         DataOutputBuffer buffer = new DataOutputBuffer();
-        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkStale.serializer, new AccordMarkStale(Collections.emptySet()), Version.V2);
+        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkStale.serializer, new AccordMarkStale(Collections.emptySet()), Version.MIN_ACCORD_VERSION);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class AccordMarkStaleTest
     {
         DataOutputBuffer buffer = new DataOutputBuffer();
         AccordMarkStale markStale = new AccordMarkStale(Collections.singleton(NodeId.fromString("1")));
-        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkStale.serializer, markStale, Version.V2);
+        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkStale.serializer, markStale, Version.MIN_ACCORD_VERSION);
     }
 
     @Test
@@ -51,6 +51,6 @@ public class AccordMarkStaleTest
     {
         DataOutputBuffer buffer = new DataOutputBuffer();
         AccordMarkStale markStale = new AccordMarkStale(ImmutableSet.of(NodeId.fromString("1"), NodeId.fromString("2")));
-        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkStale.serializer, markStale, Version.V2);
+        AsymmetricMetadataSerializers.testSerde(buffer, AccordMarkStale.serializer, markStale, Version.MIN_ACCORD_VERSION);
     }
 }

--- a/test/unit/org/apache/cassandra/utils/CassandraGeneratorsTest.java
+++ b/test/unit/org/apache/cassandra/utils/CassandraGeneratorsTest.java
@@ -47,7 +47,7 @@ public class CassandraGeneratorsTest
     @Test
     public void partitionerToToken()
     {
-        qt().forAll(Gens.random(), toGen(CassandraGenerators.partitioners()))
+        qt().forAll(Gens.random(), toGen(CassandraGenerators.partitioners().map(CassandraGenerators::simplify)))
             .check((rs, p) -> Assertions.assertThat(toGen(CassandraGenerators.token(p)).next(rs)).isNotNull());
     }
 

--- a/test/unit/org/apache/cassandra/utils/Generators.java
+++ b/test/unit/org/apache/cassandra/utils/Generators.java
@@ -26,8 +26,11 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -483,6 +486,28 @@ public final class Generators
     {
         Set<T> dedup = new HashSet<>();
         return filter(gen, dedup::add);
+    }
+
+    public static <T> Gen<Set<T>> set(Gen<T> gen, Gen<Integer> sizeGen)
+    {
+        return rnd -> {
+            Set<T> set = new HashSet<>();
+            int size = sizeGen.generate(rnd);
+            for (int i = 0; i < size; i++)
+            {
+                while (!set.add(gen.generate(rnd))) {}
+            }
+            return set;
+        };
+    }
+
+    public static <T extends Comparable<T>> Gen<List<T>> uniqueList(Gen<T> gen, Gen<Integer> sizeGen)
+    {
+        return set(gen, sizeGen).map(t -> {
+            List<T> list = new ArrayList<>(t);
+            list.sort(Comparator.naturalOrder());
+            return list;
+        });
     }
 
     public static <T> Gen<T> cached(Gen<T> gen)

--- a/test/unit/org/apache/cassandra/utils/SimulatedMiniCluster.java
+++ b/test/unit/org/apache/cassandra/utils/SimulatedMiniCluster.java
@@ -86,6 +86,7 @@ import org.apache.cassandra.tcm.membership.Directory;
 import org.apache.cassandra.tcm.membership.Location;
 import org.apache.cassandra.tcm.membership.NodeAddresses;
 import org.apache.cassandra.tcm.membership.NodeId;
+import org.apache.cassandra.tcm.membership.NodeVersion;
 import org.apache.cassandra.tcm.ownership.UniformRangePlacement;
 import org.apache.cassandra.tcm.transformations.PrepareJoin;
 import org.mockito.Mockito;
@@ -231,9 +232,10 @@ public class SimulatedMiniCluster
         }
         else
         {
-            notifyMetadataChange(current.forceEpoch(current.epoch.nextEpoch())
-                                        .withDirectory(current.directory.with(new NodeAddresses(node.hostId, node.broadcastAddressAndPort, node.broadcastAddressAndPort, node.broadcastAddressAndPort),
-                                                                              new Location(node.dc, node.rack))));
+            notifyMetadataChange(current.transformer().register(new NodeAddresses(node.hostId, node.broadcastAddressAndPort, node.broadcastAddressAndPort, node.broadcastAddressAndPort),
+                                                                new Location(node.dc, node.rack),
+                                                                NodeVersion.CURRENT)
+                                        .build().metadata);
         }
     }
 


### PR DESCRIPTION
Accord PR: https://github.com/apache/cassandra-accord/pull/125