### PR TITLE
CASSANDRA-19958 Assign a separate queue for Hints which is different from Mutation queue

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+ * Assign a separate queue for Hints which is different from Mutation queue (CASSANDRA-19958)
+
 4.1.8
 Merged from 4.0:
  * Fix text containing "/*" being interpreted as multiline comment in cqlsh (CASSANDRA-17667)

--- a/src/java/org/apache/cassandra/concurrent/Stage.java
+++ b/src/java/org/apache/cassandra/concurrent/Stage.java
@@ -55,6 +55,7 @@ public enum Stage
     INTERNAL_RESPONSE (false, "InternalResponseStage", "internal", FBUtilities::getAvailableProcessors,             null,                                            Stage::multiThreadedStage),
     IMMEDIATE         (false, "ImmediateStage",        "internal", () -> 0,                                         null,                                            Stage::immediateExecutor),
     PAXOS_REPAIR      (false, "PaxosRepairStage",      "internal", FBUtilities::getAvailableProcessors,             null,                                            Stage::multiThreadedStage),
+    HINT              (true,  "HintStage",             "request",  DatabaseDescriptor::getConcurrentHints,          DatabaseDescriptor::setConcurrentHints,          Stage::multiThreadedLowSignalStage),
     ;
 
     public final String jmxName;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -164,6 +164,7 @@ public class Config
 
     public int concurrent_reads = 32;
     public int concurrent_writes = 32;
+    public int concurrent_hints = 32;
     public int concurrent_counter_writes = 32;
     public int concurrent_materialized_view_writes = 32;
     public int available_processors = -1;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -4536,4 +4536,18 @@ public class DatabaseDescriptor
     {
         conf.reject_out_of_token_range_requests = enabled;
     }
+
+    public static int getConcurrentHints()
+    {
+        return conf.concurrent_hints;
+    }
+
+    public static void setConcurrentHints(int concurrent_hints)
+    {
+        if (concurrent_hints < 0)
+        {
+            throw new IllegalArgumentException("Concurrent hints must be non-negative");
+        }
+        conf.concurrent_hints = concurrent_hints;
+    }
 }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -2762,7 +2762,7 @@ public class StorageProxy implements StorageProxyMBean
         StorageMetrics.totalHintsInProgress.inc(runnable.targets.size());
         for (Replica target : runnable.targets)
             getHintsInProgressFor(target.endpoint()).incrementAndGet();
-        return (Future<Void>) Stage.MUTATION.submit(runnable);
+        return (Future<Void>) Stage.HINT.submit(runnable);
     }
 
     public Long getRpcTimeout() { return DatabaseDescriptor.getRpcTimeout(MILLISECONDS); }


### PR DESCRIPTION
Assign a separate queue for Hints which is different from Mutation queue

Cassandra uses the same queue (Stage.MUTATION) to process local mutations as well as local hints writing. [CASSANDRA-19534](https://issues.apache.org/jira/browse/CASSANDRA-19534) has enhanced and added timeouts for local mutations, but local hint writing does not honor that timeout by design as it honors a different timeout, i.e. max_hint_window_in_ms
More details with reproducible steps: https://issues.apache.org/jira/browse/CASSANDRA-19958


The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19958)

