### PR TITLE
CASSANDRA-14098: integer overflow fix

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3556,11 +3556,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     static int calculateSplitCount(int keysPerSplit, long totalRowCountEstimate, int numberOfKeys)
     {
         int minSamplesPerSplit = 4;
-        int maxSplitCount = numberOfKeys / minSamplesPerSplit + 1;
-        int calculatedSplitCount = (int) (totalRowCountEstimate / keysPerSplit);
-        int splitCountMaxOrLess = Math.min(maxSplitCount, calculatedSplitCount);
-        int splitCountOneOrHigher = Math.max(1, splitCountMaxOrLess);
-        return splitCountOneOrHigher;
+        long maxSplitCount = numberOfKeys / minSamplesPerSplit + 1;
+        long calculatedSplitCount = totalRowCountEstimate / keysPerSplit;
+        int splitCountWithLimit = (int) Math.min(maxSplitCount, calculatedSplitCount);
+        return Math.max(1, splitCountWithLimit);
     }
 
     private List<Pair<Range<Token>, Long>> getSplits(List<Token> tokens, int splitCount, ColumnFamilyStore cfs)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3546,6 +3546,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
         long totalRowCountEstimate = cfs.estimatedKeysForRange(range);
 
+        // splitCount should be much smaller than number of key samples, to avoid huge sampling error
         int splitCount = calculateSplitCount(keysPerSplit, totalRowCountEstimate, keys.size());
 
         List<Token> tokens = keysToTokens(range, keys);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3557,8 +3557,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     {
         int minSamplesPerSplit = 4;
         long maxSplitCount = numberOfKeys / minSamplesPerSplit + 1;
-        long calculatedSplitCount = totalRowCountEstimate / keysPerSplit;
-        int splitCountWithLimit = (int) Math.min(maxSplitCount, calculatedSplitCount);
+        long splitCount = totalRowCountEstimate / keysPerSplit;
+        int splitCountWithLimit = (int) Math.min(maxSplitCount, splitCount);
         return Math.max(1, splitCountWithLimit);
     }
 

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3557,11 +3557,10 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     {
         int minSamplesPerSplit = 4;
         int maxSplitCount = numberOfKeys / minSamplesPerSplit + 1;
-        int splitCount = Math.max(1,
-                                  Math.min(
-                                  maxSplitCount,
-                                  (int) (totalRowCountEstimate / keysPerSplit)));
-        return splitCount;
+        int calculatedSplitCount = (int) (totalRowCountEstimate / keysPerSplit);
+        int splitCountMaxOrLess = Math.min(maxSplitCount, calculatedSplitCount);
+        int splitCountOneOrHigher = Math.max(1, splitCountMaxOrLess);
+        return splitCountOneOrHigher;
     }
 
     private List<Pair<Range<Token>, Long>> getSplits(List<Token> tokens, int splitCount, ColumnFamilyStore cfs)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3555,7 +3555,6 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     static int calculateSplitCount(int keysPerSplit, long totalRowCountEstimate, int numberOfKeys)
     {
-        // splitCount should be much smaller than number of key samples, to avoid huge sampling error
         int minSamplesPerSplit = 4;
         int maxSplitCount = numberOfKeys / minSamplesPerSplit + 1;
         int splitCount = Math.max(1,

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3546,13 +3546,22 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
         long totalRowCountEstimate = cfs.estimatedKeysForRange(range);
 
-        // splitCount should be much smaller than number of key samples, to avoid huge sampling error
-        int minSamplesPerSplit = 4;
-        int maxSplitCount = keys.size() / minSamplesPerSplit + 1;
-        int splitCount = Math.max(1, Math.min(maxSplitCount, (int)(totalRowCountEstimate / keysPerSplit)));
+        int splitCount = calculateSplitCount(keysPerSplit, totalRowCountEstimate, keys.size());
 
         List<Token> tokens = keysToTokens(range, keys);
         return getSplits(tokens, splitCount, cfs);
+    }
+
+    static int calculateSplitCount(int keysPerSplit, long totalRowCountEstimate, int numberOfKeys)
+    {
+        // splitCount should be much smaller than number of key samples, to avoid huge sampling error
+        int minSamplesPerSplit = 4;
+        int maxSplitCount = numberOfKeys / minSamplesPerSplit + 1;
+        int splitCount = Math.max(1,
+                                  Math.min(
+                                  maxSplitCount,
+                                  (int) (totalRowCountEstimate / keysPerSplit)));
+        return splitCount;
     }
 
     private List<Pair<Range<Token>, Long>> getSplits(List<Token> tokens, int splitCount, ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -325,6 +325,13 @@ public class StorageServiceTest extends TestBaseImpl
     }
 
     @Test
+    public void calculateSplitCount_ZeroRowCount_ReturnsMinimumOfOne()
+    {
+        int result = StorageService.calculateSplitCount(1, 0, 40);
+        assertEquals(1, result);
+    }
+
+    @Test
     public void calculateSplitCount_ForLargeRowCount_LimitsResult()
     {
         int result = StorageService.calculateSplitCount(2, 100, 40);

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -316,4 +316,25 @@ public class StorageServiceTest extends TestBaseImpl
             assertEquals("Cannot specify tokens without keyspace.", ex.getMessage());
         }
     }
+
+    @Test
+    public void calculateSplitCountHappyPath()
+    {
+        int result = StorageService.calculateSplitCount(2, 4, 40);
+        assertEquals(2, result);
+    }
+
+    @Test
+    public void calculateSplitCountForMin()
+    {
+        int result = StorageService.calculateSplitCount(2, 100, 40);
+        assertEquals(11, result);
+    }
+
+    @Test
+    public void calculateSplitCountForMaxWithOverflow()
+    {
+        int result = StorageService.calculateSplitCount(1, Long.MAX_VALUE, 4);
+        assertEquals(1, result);
+    }
 }

--- a/test/unit/org/apache/cassandra/service/StorageServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/StorageServiceTest.java
@@ -318,23 +318,37 @@ public class StorageServiceTest extends TestBaseImpl
     }
 
     @Test
-    public void calculateSplitCountHappyPath()
+    public void calculateSplitCount_SmallRowCount_NotLimited()
     {
-        int result = StorageService.calculateSplitCount(2, 4, 40);
-        assertEquals(2, result);
+        int result = StorageService.calculateSplitCount(2, 8, 40);
+        assertEquals(4, result);
     }
 
     @Test
-    public void calculateSplitCountForMin()
+    public void calculateSplitCount_ForLargeRowCount_LimitsResult()
     {
         int result = StorageService.calculateSplitCount(2, 100, 40);
         assertEquals(11, result);
     }
 
     @Test
-    public void calculateSplitCountForMaxWithOverflow()
+    public void calculateSplitCount_ForMaxIntegerRowCount_LimitsResult()
+    {
+        int result = StorageService.calculateSplitCount(1, Integer.MAX_VALUE, 4);
+        assertEquals(2, result);
+    }
+
+    @Test
+    public void calculateSplitCount_ForOverflowingRowCount_LimitsResult()
+    {
+        int result = StorageService.calculateSplitCount(1, Integer.MAX_VALUE + 1L, 4);
+        assertEquals(2, result);
+    }
+
+    @Test
+    public void calculateSplitCount_ForMaxLongRowCount_LimitsResult()
     {
         int result = StorageService.calculateSplitCount(1, Long.MAX_VALUE, 4);
-        assertEquals(1, result);
+        assertEquals(2, result);
     }
 }


### PR DESCRIPTION
* Fixes https://issues.apache.org/jira/browse/CASSANDRA-14098 in a similar way as the provided patch. The split count will now be correct for larger numbers of rows, where before it was calculated as 1 because of an interaction between the integer overflow from the long input and the Math.max that follows it.
* Also refactored and added tests, some of which fail on the current code because of the integer overflow. They all pass in the branch.

Co-Authored-By: @lexler 

