### PR TITLE
CASSANDRA-19984 Enables IAuthenticator's to return own AuthenticateMessage (5.0)

### DIFF
--- a/src/java/org/apache/cassandra/auth/IAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/IAuthenticator.java
@@ -24,6 +24,8 @@ import java.util.Set;
 
 import org.apache.cassandra.exceptions.AuthenticationException;
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.transport.messages.AuthenticateMessage;
 
 public interface IAuthenticator
 {
@@ -53,6 +55,17 @@ public interface IAuthenticator
      * For example, use this method to create any required keyspaces/column families.
      */
     void setup();
+
+    /**
+     * Allows custom authenticators to return their own {@link AuthenticateMessage} based on
+     * {@link ClientState} information. For example, this allows returning the FQCN of a driver's
+     * known authenticator (e.g. "com.datastax.bdp.cassandra.auth.DseAuthenticator") to enable
+     * SASL scheme negotiation.
+     */
+    default AuthenticateMessage getAuthenticateMessage(ClientState clientState)
+    {
+        return new AuthenticateMessage(getClass().getName());
+    }
 
     /**
      * Provide a SASL handler to perform authentication for an single connection. SASL

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.cassandra.auth.IAuthenticator;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
@@ -118,8 +119,9 @@ public class StartupMessage extends Message.Request
             clientState.setDriverVersion(options.get(DRIVER_VERSION));
         }
 
-        if (DatabaseDescriptor.getAuthenticator().requireAuthentication())
-            return new AuthenticateMessage(DatabaseDescriptor.getAuthenticator().getClass().getName());
+        IAuthenticator authenticator = DatabaseDescriptor.getAuthenticator();
+        if (authenticator.requireAuthentication())
+            return authenticator.getAuthenticateMessage(clientState);
         else
             return new ReadyMessage();
     }

--- a/test/unit/org/apache/cassandra/auth/CustomAuthenticatorTest.java
+++ b/test/unit/org/apache/cassandra/auth/CustomAuthenticatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.auth;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.cassandra.exceptions.AuthenticationException;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.transport.messages.AuthenticateMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class CustomAuthenticatorTest
+{
+    private static final String CUSTOM_AUTHENTICATOR_FQCN = "com.example.auth.CustomAuthenticator";
+
+    @Test
+    public void testCustomAuthenticator()
+    {
+        IAuthenticator authenticator = new CustomAuthenticator();
+
+        AuthenticateMessage message = authenticator.getAuthenticateMessage(ClientState.forInternalCalls());
+
+        assertThat(message.authenticator).isNotEqualTo(authenticator.getClass().getName());
+        assertThat(message.authenticator).isEqualTo(CUSTOM_AUTHENTICATOR_FQCN);
+    }
+
+    private static class CustomAuthenticator implements IAuthenticator
+    {
+        @Override
+        public boolean requireAuthentication()
+        {
+            return false;
+        }
+
+        @Override
+        public Set<? extends IResource> protectedResources()
+        {
+            return Set.of();
+        }
+
+        @Override
+        public void validateConfiguration() throws ConfigurationException {}
+
+        @Override
+        public void setup() {}
+
+        @Override
+        public AuthenticateMessage getAuthenticateMessage(ClientState clientState)
+        {
+            return new AuthenticateMessage(CUSTOM_AUTHENTICATOR_FQCN);
+        }
+
+
+        @Override
+        public SaslNegotiator newSaslNegotiator(InetAddress clientAddress)
+        {
+            return null;
+        }
+
+        @Override
+        public AuthenticatedUser legacyAuthenticate(Map<String, String> credentials) throws AuthenticationException
+        {
+            return null;
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/auth/PasswordAuthenticatorTest.java
+++ b/test/unit/org/apache/cassandra/auth/PasswordAuthenticatorTest.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.exceptions.AuthenticationException;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.transport.messages.AuthenticateMessage;
 
 import static org.apache.cassandra.auth.AuthTestUtils.ALL_ROLES;
 import static org.apache.cassandra.auth.CassandraRoleManager.DEFAULT_SUPERUSER_PASSWORD;
@@ -47,6 +48,7 @@ import static org.apache.cassandra.auth.CassandraRoleManager.getGensaltLogRounds
 import static org.apache.cassandra.auth.PasswordAuthenticator.SaslNegotiator;
 import static org.apache.cassandra.auth.PasswordAuthenticator.checkpw;
 import static org.apache.cassandra.config.CassandraRelevantProperties.AUTH_BCRYPT_GENSALT_LOG2_ROUNDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -197,5 +199,12 @@ public class PasswordAuthenticatorTest extends CQLTester
     {
         Map<String, String> cacheEntries = authenticator.bulkLoader().get();
         assertTrue(cacheEntries.isEmpty());
+    }
+
+    @Test
+    public void testDefaultAuthenticateMessage()
+    {
+        AuthenticateMessage authenticateMessage = authenticator.getAuthenticateMessage(null);
+        assertThat(authenticateMessage.authenticator).isEqualTo(PasswordAuthenticator.class.getName());
     }
 }


### PR DESCRIPTION
Allows implementations of `IAuthenticator` to control what is sent back to clients by returning their own `AuthenticateMessage`.
This enables, for instance, a custom authenticator to emulate a known implementation (e.g. `com.datastax.bdp.cassandra.auth.DseAuthenticator` which enables SASL scheme negotiation) or different ones depending on client state information (e.g. driver name and version).

-----

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

