### PR TITLE
[CASSANDRA-19991][5.0] Fix flaky TopPartitionsTest#testServiceTopPartitionsSingleTable

### DIFF
--- a/src/java/org/apache/cassandra/metrics/Sampler.java
+++ b/src/java/org/apache/cassandra/metrics/Sampler.java
@@ -97,7 +97,7 @@ public abstract class Sampler<T>
     MonotonicClock clock = MonotonicClock.Global.approxTime;
 
     @VisibleForTesting
-    static final ExecutorPlus samplerExecutor = executorFactory()
+    public static final ExecutorPlus samplerExecutor = executorFactory()
             .withJmxInternal()
             .configureSequential("Sampler")
             .withQueueLimit(1000)

--- a/test/unit/org/apache/cassandra/Util.java
+++ b/test/unit/org/apache/cassandra/Util.java
@@ -143,6 +143,7 @@ import org.apache.cassandra.utils.FilterFactory;
 import org.apache.cassandra.utils.OutputHandler;
 import org.apache.cassandra.utils.Throwables;
 import org.awaitility.Awaitility;
+import org.hamcrest.Matcher;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.defaultanswers.ForwardsInvocations;
 
@@ -692,11 +693,16 @@ public class Util
 
     public static <T> void spinAssertEquals(String message, T expected, Supplier<? extends T> actualSupplier, long timeout, TimeUnit timeUnit)
     {
+        spinAssert(message, equalTo(expected), actualSupplier, timeout, timeUnit);
+    }
+
+    public static <T> void spinAssert(String message, Matcher<T> matcher, Supplier<? extends T> actualSupplier, long timeout, TimeUnit timeUnit)
+    {
         Awaitility.await()
                   .pollInterval(Duration.ofMillis(100))
                   .pollDelay(0, TimeUnit.MILLISECONDS)
                   .atMost(timeout, timeUnit)
-                  .untilAsserted(() -> assertThat(message, actualSupplier.get(), equalTo(expected)));
+                  .untilAsserted(() -> assertThat(message, actualSupplier.get(), matcher));
     }
 
     public static void joinThread(Thread thread) throws InterruptedException

--- a/test/unit/org/apache/cassandra/tools/TopPartitionsTest.java
+++ b/test/unit/org/apache/cassandra/tools/TopPartitionsTest.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.Util;
 
 import static java.lang.String.format;
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -93,10 +94,16 @@ public class TopPartitionsTest
     @Test
     public void testServiceTopPartitionsSingleTable() throws Exception
     {
-        ColumnFamilyStore.getIfExists("system", "local").beginLocalSampling("READS", 5, 240000);
+        ColumnFamilyStore columnFamilyStore = ColumnFamilyStore.getIfExists("system", "local");
+        String samplerName = "READS";
+        long executedBefore = Sampler.samplerExecutor.getCompletedTaskCount();
+        columnFamilyStore.beginLocalSampling(samplerName, 5, 240_000);
+
         String req = "SELECT * FROM system.%s WHERE key='%s'";
         executeInternal(format(req, SystemKeyspace.LOCAL, SystemKeyspace.LOCAL));
-        List<CompositeData> result = ColumnFamilyStore.getIfExists("system", "local").finishLocalSampling("READS", 5);
+        ensureThatSamplerExecutorProcessedAllSamples(executedBefore);
+
+        List<CompositeData> result = columnFamilyStore.finishLocalSampling(samplerName, 5);
         assertEquals("If this failed you probably have to raise the beginLocalSampling duration", 1, result.size());
     }
 
@@ -119,13 +126,14 @@ public class TopPartitionsTest
         executeInternal(format("DELETE FROM %s.%s WHERE k='a' AND c='a'", KEYSPACE, TABLE));
         cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
 
+        long executedBefore = Sampler.samplerExecutor.getCompletedTaskCount();
         // test multi-partition read
         cfs.beginLocalSampling("READ_ROW_COUNT", count, 240000);
         cfs.beginLocalSampling("READ_TOMBSTONE_COUNT", count, 240000);
         cfs.beginLocalSampling("READ_SSTABLE_COUNT", count, 240000);
 
         executeInternal(format("SELECT * FROM %s.%s", KEYSPACE, TABLE));
-        Thread.sleep(2000); // simulate waiting before finishing sampling
+        ensureThatSamplerExecutorProcessedAllSamples(executedBefore);
 
         List<CompositeData> rowCounts = cfs.finishLocalSampling("READ_ROW_COUNT", count);
         List<CompositeData> tsCounts = cfs.finishLocalSampling("READ_TOMBSTONE_COUNT", count);
@@ -152,6 +160,7 @@ public class TopPartitionsTest
         assertEquals("a", tsCounts.get(0).get("value"));
         assertEquals(1, (long) tsCounts.get(0).get("count"));
 
+        executedBefore = Sampler.samplerExecutor.getCompletedTaskCount();
         // test single partition read
         cfs.beginLocalSampling("READ_ROW_COUNT", count, 240000);
         cfs.beginLocalSampling("READ_TOMBSTONE_COUNT", count, 240000);
@@ -160,7 +169,7 @@ public class TopPartitionsTest
         executeInternal(format("SELECT * FROM %s.%s WHERE k='a'", KEYSPACE, TABLE));
         executeInternal(format("SELECT * FROM %s.%s WHERE k='b'", KEYSPACE, TABLE));
         executeInternal(format("SELECT * FROM %s.%s WHERE k='c'", KEYSPACE, TABLE));
-        Thread.sleep(2000); // simulate waiting before finishing sampling
+        ensureThatSamplerExecutorProcessedAllSamples(executedBefore);
 
         rowCounts = cfs.finishLocalSampling("READ_ROW_COUNT", count);
         tsCounts = cfs.finishLocalSampling("READ_TOMBSTONE_COUNT", count);
@@ -222,5 +231,15 @@ public class TopPartitionsTest
 
         assertTrue("When nothing is scheduled, you should be able to stop all scheduled sampling tasks",
                    ss.stopSamplingPartitions(null, null));
+    }
+
+    private static void ensureThatSamplerExecutorProcessedAllSamples(long executedBefore)
+    {
+        Util.spinAssertEquals("samplerExecutor should not have pending tasks",
+                        0, Sampler.samplerExecutor::getPendingTaskCount, 60, TimeUnit.SECONDS);
+        Util.spinAssertEquals("samplerExecutor should not have active tasks",
+                        0, Sampler.samplerExecutor::getActiveTaskCount, 60, TimeUnit.SECONDS);
+        Util.spinAssert("samplerExecutor has not completed any new tasks after beginLocalSampling",
+                              greaterThan(executedBefore), Sampler.samplerExecutor::getCompletedTaskCount, 60, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Ensure that Sampler.samplerExecutor completed sample tasks during a test 
Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-19991