### PR TITLE
CASSANDRA-20000 Enables support for role custom options

### DIFF
--- a/src/java/org/apache/cassandra/auth/AuthKeyspace.java
+++ b/src/java/org/apache/cassandra/auth/AuthKeyspace.java
@@ -55,6 +55,7 @@ public final class AuthKeyspace
 
     public static final String ROLES = "roles";
     public static final String ROLE_MEMBERS = "role_members";
+    public static final String ROLE_OPTIONS = "role_options";
     public static final String ROLE_PERMISSIONS = "role_permissions";
     public static final String RESOURCE_ROLE_INDEX = "resource_role_permissons_index";
     public static final String NETWORK_PERMISSIONS = "network_permissions";
@@ -95,6 +96,14 @@ public final class AuthKeyspace
               + "role text,"
               + "member text,"
               + "PRIMARY KEY(role, member))");
+
+    private static final TableMetadata RoleOptions =
+        parse(ROLE_OPTIONS,
+              "role options lookup table",
+              "CREATE TABLE %s ("
+              + "role text,"
+              + "options map<text, text>,"
+              + "PRIMARY KEY(role))");
 
     private static final TableMetadata RolePermissions =
         parse(ROLE_PERMISSIONS,
@@ -156,7 +165,7 @@ public final class AuthKeyspace
     {
         return KeyspaceMetadata.create(SchemaConstants.AUTH_KEYSPACE_NAME,
                                        KeyspaceParams.simple(Math.max(DEFAULT_RF, DatabaseDescriptor.getDefaultKeyspaceRF())),
-                                       Tables.of(Roles, RoleMembers, RolePermissions,
+                                       Tables.of(Roles, RoleMembers, RoleOptions, RolePermissions,
                                                  ResourceRoleIndex, NetworkPermissions,
                                                  CIDRPermissions, CIDRGroups,
                                                  IdentityToRoles));

--- a/test/unit/org/apache/cassandra/auth/RoleCustomOptionsTest.java
+++ b/test/unit/org/apache/cassandra/auth/RoleCustomOptionsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.auth;
+
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.ResultSet;
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+
+import static org.apache.cassandra.auth.AuthKeyspace.ROLES;
+import static org.apache.cassandra.auth.AuthKeyspace.ROLE_OPTIONS;
+import static org.apache.cassandra.schema.SchemaConstants.AUTH_KEYSPACE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RoleCustomOptionsTest extends CQLTester
+{
+    private static final String TEST_ROLE = "testrole";
+    private static IRoleManager roleManager;
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        ServerTestUtils.daemonInitialization();
+
+        DatabaseDescriptor.setPermissionsValidity(0);
+        DatabaseDescriptor.setRolesValidity(0);
+        DatabaseDescriptor.setCredentialsValidity(0);
+
+        CQLTester.setUpClass();
+        requireAuthentication();
+        requireNetwork();
+
+        roleManager = new AuthTestUtils.LocalCassandraRoleManager();
+        roleManager.setup();
+    }
+
+    @Before
+    @After
+    public void cleanupRoles()
+    {
+        useSuperUser();
+        executeNet(String.format("DELETE FROM %s.%s WHERE role = '%s'", AUTH_KEYSPACE_NAME, ROLES, TEST_ROLE));
+        executeNet(String.format("DELETE FROM %s.%s WHERE role = '%s'", AUTH_KEYSPACE_NAME, ROLE_OPTIONS, TEST_ROLE));
+    }
+
+    @Test
+    public void createRoleWithCustomOptions()
+    {
+        executeNet(String.format("CREATE ROLE %s WITH OPTIONS = { 'option1': 'value1', 'option2': 0 }", TEST_ROLE));
+
+        RoleResource testRole = RoleResource.role(TEST_ROLE);
+        assertThat(roleManager.isExistingRole(testRole)).isTrue();
+
+        Map<String, String> customOptions = roleManager.getCustomOptions(testRole);
+
+        Map<String, String> expectedOptions = Map.of("option1", "value1", "option2", "0");
+        assertThat(customOptions).containsExactlyInAnyOrderEntriesOf(expectedOptions);
+    }
+
+    @Test
+    public void dropRoleWithCustomOptions()
+    {
+        executeNet(String.format("CREATE ROLE %s WITH OPTIONS = { 'option1': 'value1', 'option2': 0 }", TEST_ROLE));
+        executeNet("DROP ROLE testrole");
+
+        assertThat(roleManager.isExistingRole(RoleResource.role(TEST_ROLE))).isFalse();
+
+        assertNoRoleOptionsEntryFor(TEST_ROLE);
+    }
+
+    @Test
+    public void alterRoleReplacesCustomOptions()
+    {
+        executeNet(String.format("CREATE ROLE %s WITH OPTIONS = { 'option1': 'value1' }", TEST_ROLE));
+        executeNet(String.format("ALTER ROLE %s WITH OPTIONS = { 'option2': 'value2' }", TEST_ROLE));
+
+        Map<String, String> customOptions = roleManager.getCustomOptions(RoleResource.role(TEST_ROLE));
+
+        assertThat(customOptions).containsExactlyEntriesOf(Map.of("option2", "value2"));
+    }
+
+    @Test
+    public void alterRoleDeletesCustomOptions()
+    {
+        executeNet(String.format("CREATE ROLE %s WITH OPTIONS = { 'option1': 'value1' }", TEST_ROLE));
+        executeNet(String.format("ALTER ROLE %s WITH OPTIONS = {}", TEST_ROLE));
+
+        Map<String, String> customOptions = roleManager.getCustomOptions(RoleResource.role(TEST_ROLE));
+
+        assertThat(customOptions).isEmpty();
+        assertNoRoleOptionsEntryFor(TEST_ROLE);
+    }
+
+    @Test
+    public void alterRoleInsertsCustomOptions()
+    {
+        executeNet(String.format("CREATE ROLE %s WITH OPTIONS = {}", TEST_ROLE));
+        assertNoRoleOptionsEntryFor(TEST_ROLE);
+
+        executeNet(String.format("ALTER ROLE %s WITH OPTIONS = { 'option1': 'value1' }", TEST_ROLE));
+
+        Map<String, String> customOptions = roleManager.getCustomOptions(RoleResource.role(TEST_ROLE));
+
+        assertThat(customOptions).containsExactlyEntriesOf(Map.of("option1", "value1"));
+    }
+
+    @Test
+    public void alterRoleWithoutModifyingCustomOptions()
+    {
+        executeNet(String.format("CREATE ROLE %s WITH OPTIONS = { 'option1': 'value1' }", TEST_ROLE));
+        executeNet(String.format("ALTER ROLE %s WITH LOGIN = true", TEST_ROLE));
+
+        Map<String, String> customOptions = roleManager.getCustomOptions(RoleResource.role(TEST_ROLE));
+
+        assertThat(customOptions).containsExactlyEntriesOf(Map.of("option1", "value1"));
+    }
+
+    private void assertNoRoleOptionsEntryFor(String roleName)
+    {
+        String query = String.format("SELECT * FROM %s.%s WHERE role = '%s'", AUTH_KEYSPACE_NAME, ROLE_OPTIONS, roleName);
+        ResultSet rows = executeNet(query);
+        assertThat(rows).isEmpty();
+    }
+}


### PR DESCRIPTION
Enables support for role custom options via CREATE, ALTER, and DROP
CQL statements storing those in `system_auth.role_options` table.

-----

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

