### PR TITLE
CASSANDRA-19248: Prevent unnecessary streaming session on joining node during nodetool bootstrap resume.

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1593,20 +1593,27 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return SystemKeyspace.getBootstrapState().name();
     }
 
-    public boolean resumeBootstrap()
-    {
-        if (isBootstrapMode() && SystemKeyspace.bootstrapInProgress())
-        {
-            logger.info("Resuming bootstrap...");
-            resumeBootstrapSequence();
-            return true;
-        }
-        else
-        {
+    public boolean resumeBootstrap() {
+        if (!isBootstrapFailed()) {
+            if (isBootstrapMode()) {
+                logger.warn("Resume bootstrap is requested but node is not in bootstrap mode.");
+                return false;
+            }
+
+            if (SystemKeyspace.bootstrapInProgress()) {
+                logger.warn("Bootstrap is already in progress.");
+                return false;
+            }
+
             logger.info("Resuming bootstrap is requested, but the node is already bootstrapped.");
             return false;
         }
+
+        logger.info("Resuming bootstrap");
+        resumeBootstrapSequence();
+        return true;
     }
+
 
     public void abortBootstrap(String nodeStr, String endpointStr)
     {

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2216,7 +2216,7 @@ public class NodeProbe implements AutoCloseable
             }
             else
             {
-                out.println("Node is already bootstrapped.");
+                out.println("Node is already bootstrapped or bootstrap is in progress.");
             }
         }
         catch (Exception e)


### PR DESCRIPTION
CASSANDRA-19248: Fix unnecessary streaming session on joining node during nodetool bootstrap resume
This commit resolves an issue where invoking "nodetool bootstrap resume" would start an unnecessary streaming session on the joining node.
Additionally, a new test case has been added to validate the fix: BootstrapTest#resumeBootstrapTest.