### PR TITLE
Simulation test fixes

### DIFF
--- a/src/java/org/apache/cassandra/tcm/sequences/BootstrapAndJoin.java
+++ b/src/java/org/apache/cassandra/tcm/sequences/BootstrapAndJoin.java
@@ -353,6 +353,8 @@ public class BootstrapAndJoin extends MultiStepOperation<Epoch>
             logger.info("Resetting bootstrap progress to start fresh");
             SystemKeyspace.resetAvailableStreamedRanges();
         }
+
+        StorageService.instance.repairPaxosForTopologyChange("bootstrap");
         Future<StreamState> bootstrapStream = StorageService.instance.startBootstrap(metadata, beingReplaced, movements, strictMovements);
         try
         {

--- a/test/simulator/main/org/apache/cassandra/simulator/cluster/KeyspaceActions.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/cluster/KeyspaceActions.java
@@ -281,8 +281,8 @@ public class KeyspaceActions extends ClusterActions
                     joined.add(join);
                     joined.remove(leave);
                     left.add(leave);
-                    TokenPlacementModel.ReplicatedRanges placementsAfter = placements(joined, currentRf);
                     nodeLookup.setTokenOf(join, nodeLookup.tokenOf(leave));
+                    TokenPlacementModel.ReplicatedRanges placementsAfter = placements(joined, currentRf);
                     Topology during = recomputeTopology(placementsBefore, placementsAfter);
                     updateTopology(during);
                     Topology after = recomputeTopology(placementsAfter, placementsAfter);

--- a/test/simulator/main/org/apache/cassandra/simulator/cluster/OnClusterJoin.java
+++ b/test/simulator/main/org/apache/cassandra/simulator/cluster/OnClusterJoin.java
@@ -111,7 +111,7 @@ class OnClusterJoin extends OnClusterChangeTopology
 
                 BootstrapAndJoin bootstrapAndJoin = ((BootstrapAndJoin) sequence);
                 assert bootstrapAndJoin.next.ordinal() == kind : String.format("Expected next step to be %s, but got %s", Transformation.Kind.values()[kind], bootstrapAndJoin.next);
-                boolean res = bootstrapAndJoin.finishJoiningRing().executeNext().isContinuable();
+                boolean res = bootstrapAndJoin.executeNext().isContinuable();
                 assert res;
             });
         }


### PR DESCRIPTION
* During replacement, correctly set token on the joining instance
* In bootstrap, we were not correctly stepping through the join operation
* When investigating bootstrap issues, it was found that we were not running repairPaxosForTopologyChange on this path..

Patch by Sam Tunnicliffe; reviewed by Marcus Eriksson for CASSANDRA-19997