### PR TITLE
CASS-20015: Add -H option in the nodetool compactionhistory

### DIFF
--- a/src/java/org/apache/cassandra/io/util/FileUtils.java
+++ b/src/java/org/apache/cassandra/io/util/FileUtils.java
@@ -426,6 +426,14 @@ public final class FileUtils
         }
     }
 
+    public static String stringifyFileSize(long bytes, boolean humanReadable)
+    {
+        if (humanReadable)
+            return stringifyFileSize(bytes);
+        else
+            return Long.toString(bytes);
+    }
+
     public static String stringifyFileSize(double value)
     {
         double d;

--- a/src/java/org/apache/cassandra/tools/nodetool/CompactionHistory.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompactionHistory.java
@@ -34,6 +34,11 @@ public class CompactionHistory extends NodeToolCmd
             description = "Output format (json, yaml)")
     private String outputFormat = "";
 
+    @Option(title = "human_readable",
+    name = {"-H", "--human-readable"},
+    description = "Display bytes in human readable form, i.e. KiB, MiB, GiB, TiB")
+    private boolean humanReadable = false;
+
     @Override
     public void execute(NodeProbe probe)
     {
@@ -41,7 +46,7 @@ public class CompactionHistory extends NodeToolCmd
         {
             throw new IllegalArgumentException("arguments for -F are json,yaml only.");
         }
-        StatsHolder data = new CompactionHistoryHolder(probe);
+        StatsHolder data = new CompactionHistoryHolder(probe, humanReadable);
         StatsPrinter printer = CompactionHistoryPrinter.from(outputFormat);
         printer.print(data, probe.output().out);
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/CompactionHistoryHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/CompactionHistoryHolder.java
@@ -29,16 +29,19 @@ import java.util.Map;
 import java.util.Set;
 import javax.management.openmbean.TabularData;
 
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.tools.NodeProbe;
 
 public class CompactionHistoryHolder implements StatsHolder
 {
     public final NodeProbe probe;
     public List<String> indexNames;
+    private final boolean humanReadable;
 
-    public CompactionHistoryHolder(NodeProbe probe)
+    public CompactionHistoryHolder(NodeProbe probe, boolean humanReadable)
     {
         this.probe = probe;
+        this.humanReadable = humanReadable;
     }
 
     /**
@@ -73,7 +76,7 @@ public class CompactionHistoryHolder implements StatsHolder
             return Long.signum(chr.compactedAt - this.compactedAt);
         }
 
-        private HashMap<String, Object> getAllAsMap()
+        private HashMap<String, Object> getAllAsMap(boolean humanReadable)
         {
             HashMap<String, Object> compaction = new HashMap<>();
             compaction.put("id", this.id);
@@ -82,8 +85,8 @@ public class CompactionHistoryHolder implements StatsHolder
             Instant instant = Instant.ofEpochMilli(this.compactedAt);
             LocalDateTime ldt = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
             compaction.put("compacted_at", ldt.toString());
-            compaction.put("bytes_in", this.bytesIn);
-            compaction.put("bytes_out", this.bytesOut);
+            compaction.put("bytes_in", FileUtils.stringifyFileSize(this.bytesIn, humanReadable));
+            compaction.put("bytes_out", FileUtils.stringifyFileSize(this.bytesOut, humanReadable));
             compaction.put("rows_merged", this.rowMerged);
             compaction.put("compaction_properties", this.compactionProperties);
             return compaction;
@@ -122,7 +125,7 @@ public class CompactionHistoryHolder implements StatsHolder
         Collections.sort(chrList);
         for (CompactionHistoryHolder.CompactionHistoryRow chr : chrList)
         {
-            compactions.add(chr.getAllAsMap());
+            compactions.add(chr.getAllAsMap(humanReadable));
         }
         result.put("CompactionHistory", compactions);
         return result;


### PR DESCRIPTION
**Summary**
This PR introduces a **-H** option to the **nodetool compactionhistory** command Cassandra. The **-H** option formats the output in a human-readable manner, making it easier for users to interpret the data.

More specifically, when the -H option is used, the **bytes_in** and **bytes_out** fields are displayed in a more readable format (e.g., KiB). 

**Testing**
1. Without -H option:
```
Compaction History:
id                                   keyspace_name columnfamily_name   compacted_at            bytes_in bytes_out rows_merged compaction_properties
2a5355b0-90f0-11ef-bf8c-79bcdbb5790b system_schema tables              2024-10-22T20:37:44.986 10526    3985      {2:4, 3:2}  {compaction_type:Compaction}
2a348310-90f0-11ef-bf8c-79bcdbb5790b system_schema keyspaces           2024-10-22T20:37:44.779 808      312       {2:4, 3:2}  {compaction_type:Compaction}
```

2. With -H option:
```
Compaction History:
id                                   keyspace_name columnfamily_name   compacted_at            bytes_in  bytes_out rows_merged compaction_properties
2a5355b0-90f0-11ef-bf8c-79bcdbb5790b system_schema tables              2024-10-22T20:37:44.986 10.28 KiB 3.89 KiB  {2:4, 3:2}  {compaction_type:Compaction}
2a348310-90f0-11ef-bf8c-79bcdbb5790b system_schema keyspaces           2024-10-22T20:37:44.779 808 bytes 312 bytes {2:4, 3:2}  {compaction_type:Compaction}
```

3. With -F json option:
```
{
  "CompactionHistory" : [ {
    "keyspace_name" : "system_schema",
    "bytes_out" : "3985",
    "bytes_in" : "10526",
    "compaction_properties" : "{compaction_type:Compaction}",
    "columnfamily_name" : "tables",
    "rows_merged" : "{2:4, 3:2}",
    "id" : "2a5355b0-90f0-11ef-bf8c-79bcdbb5790b",
    "compacted_at" : "2024-10-22T20:37:44.986"
}
```

4. With -F json -H option:
```
{
  "CompactionHistory" : [ {
    "keyspace_name" : "system_schema",
    "bytes_out" : "3.89 KiB",
    "bytes_in" : "10.28 KiB",
    "compaction_properties" : "{compaction_type:Compaction}",
    "columnfamily_name" : "tables",
    "rows_merged" : "{2:4, 3:2}",
    "id" : "2a5355b0-90f0-11ef-bf8c-79bcdbb5790b",
    "compacted_at" : "2024-10-22T20:37:44.986"
  }, 
```