### PR TITLE
Prevent globbing and word splitting in nodetool

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -59,7 +59,7 @@ JVM_ARGS=""
 SSL_FILE=$HOME/.cassandra/nodetool-ssl.properties
 while true
 do
-  if [ ! $1 ]; then break; fi
+  if [ ! "$1" ]; then break; fi
   case $1 in
     -p)
       JMX_PORT=$2


### PR DESCRIPTION
Missing double quotes for the argument in nodetool. (https://github.com/koalaman/shellcheck/wiki/SC2086)
Missing double quotes might cause a below error:
 nodetool: line 62: [: too many arguments