### PR TITLE
Compares the Gossip endpointState and TokenMetadata cache

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -2698,43 +2698,33 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
         MessagingService.instance().send(message, ep);
     }
 
-    public String compareGossipAndTokenMetadataCache()
+    public Map<String,Pair<String,String>> compareGossipAndTokenMetadata()
     {
-        StringBuilder output = new StringBuilder();
         // local epstate will be part of endpointStateMap
-        List<InetAddressAndPort> endpoints = new ArrayList<>(endpointStateMap.keySet());
-        for (InetAddressAndPort endpoint : endpoints)
+        Map<String,Pair<String,String>> mismatches = new HashMap<>();
+        for (InetAddressAndPort endpoint : endpointStateMap.keySet())
         {
             EndpointState ep = endpointStateMap.get(endpoint);
             // check the status only for NORMAL nodes
             if (ep.isNormalState())
             {
-                Collection<Token> tokensFromStorageServiceCache;
+                List<Token> tokensFromMetadata;
                 try
                 {
-                    tokensFromStorageServiceCache = StorageService.instance.getTokenMetadata().getTokens(endpoint);
+                    tokensFromMetadata = new ArrayList<>(StorageService.instance.getTokenMetadata().getTokens(endpoint));
+                    Collections.sort(tokensFromMetadata);
                 }
                 catch(AssertionError e)
                 {
-                    // if we receive AssertionError then it means that the endpoint is part of Gossip cache
-                    // but StorageService cache does not have the endpoint.
-                    // This should be treated as inconsistency between the StorageService cache and Gossip cache
-                    output.append("TokenMetadata cache is missing information for normal endpoint" + endpoint);
-                    output.append("\n");
-                    continue;
+                    tokensFromMetadata = Collections.EMPTY_LIST;
                 }
-                Collection<Token> tokensFromGossipCache = StorageService.instance.getTokensFor(endpoint);
-                List<Token> c1 = new ArrayList<>(tokensFromStorageServiceCache);
-                List<Token> c2 = new ArrayList<>(tokensFromGossipCache);
-                Collections.sort(c1);
-                Collections.sort(c2);
-                if (!c1.equals(c2))
-                {
-                    output.append(String.format("Gossip and TokenMetadata cache token mismatch for endpoint %s", endpoint.toString()));
-                    output.append("\n");
-                }
+                List<Token> tokensFromGossip = new ArrayList<>(StorageService.instance.getTokensFor(endpoint));
+                Collections.sort(tokensFromGossip);
+
+                if (!tokensFromMetadata.equals(tokensFromGossip))
+                    mismatches.put(endpoint.toString(), Pair.create(tokensFromGossip.toString(), tokensFromMetadata.toString()));
             }
         }
-        return output.toString();
+        return mismatches;
     }
 }

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -2697,4 +2697,44 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
         Message<GossipDigestAck2> message = Message.out(Verb.GOSSIP_DIGEST_ACK2, digestAck2Message);
         MessagingService.instance().send(message, ep);
     }
+
+    public String compareGossipAndTokenMetadataCache()
+    {
+        StringBuilder output = new StringBuilder();
+        // local epstate will be part of endpointStateMap
+        List<InetAddressAndPort> endpoints = new ArrayList<>(endpointStateMap.keySet());
+        for (InetAddressAndPort endpoint : endpoints)
+        {
+            EndpointState ep = endpointStateMap.get(endpoint);
+            // check the status only for NORMAL nodes
+            if (ep.isNormalState())
+            {
+                Collection<Token> tokensFromStorageServiceCache;
+                try
+                {
+                    tokensFromStorageServiceCache = StorageService.instance.getTokenMetadata().getTokens(endpoint);
+                }
+                catch(AssertionError e)
+                {
+                    // if we receive AssertionError then it means that the endpoint is part of Gossip cache
+                    // but StorageService cache does not have the endpoint.
+                    // This should be treated as inconsistency between the StorageService cache and Gossip cache
+                    output.append("TokenMetadata cache is missing information for normal endpoint" + endpoint);
+                    output.append("\n");
+                    continue;
+                }
+                Collection<Token> tokensFromGossipCache = StorageService.instance.getTokensFor(endpoint);
+                List<Token> c1 = new ArrayList<>(tokensFromStorageServiceCache);
+                List<Token> c2 = new ArrayList<>(tokensFromGossipCache);
+                Collections.sort(c1);
+                Collections.sort(c2);
+                if (!c1.equals(c2))
+                {
+                    output.append(String.format("Gossip and TokenMetadata cache token mismatch for endpoint %s", endpoint.toString()));
+                    output.append("\n");
+                }
+            }
+        }
+        return output.toString();
+    }
 }

--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -2698,10 +2698,10 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
         MessagingService.instance().send(message, ep);
     }
 
-    public Map<String,Pair<String,String>> compareGossipAndTokenMetadata()
+    public Map<String,List<String>> compareGossipAndTokenMetadata()
     {
         // local epstate will be part of endpointStateMap
-        Map<String,Pair<String,String>> mismatches = new HashMap<>();
+        Map<String,List<String>> mismatches = new HashMap<>();
         for (InetAddressAndPort endpoint : endpointStateMap.keySet())
         {
             EndpointState ep = endpointStateMap.get(endpoint);
@@ -2722,7 +2722,7 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
                 Collections.sort(tokensFromGossip);
 
                 if (!tokensFromMetadata.equals(tokensFromGossip))
-                    mismatches.put(endpoint.toString(), Pair.create(tokensFromGossip.toString(), tokensFromMetadata.toString()));
+                    mismatches.put(endpoint.toString(), ImmutableList.of(tokensFromGossip.toString(), tokensFromMetadata.toString()));
             }
         }
         return mismatches;

--- a/src/java/org/apache/cassandra/gms/GossiperMBean.java
+++ b/src/java/org/apache/cassandra/gms/GossiperMBean.java
@@ -41,4 +41,5 @@ public interface GossiperMBean
     public boolean getLooseEmptyEnabled();
 
     public void setLooseEmptyEnabled(boolean enabled);
+    public String compareGossipAndTokenMetadataCache();
 }

--- a/src/java/org/apache/cassandra/gms/GossiperMBean.java
+++ b/src/java/org/apache/cassandra/gms/GossiperMBean.java
@@ -21,6 +21,8 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.utils.Pair;
+
 public interface GossiperMBean
 {
     public long getEndpointDowntime(String address) throws UnknownHostException;
@@ -41,5 +43,5 @@ public interface GossiperMBean
     public boolean getLooseEmptyEnabled();
 
     public void setLooseEmptyEnabled(boolean enabled);
-    public String compareGossipAndTokenMetadataCache();
+    public Map<String, Pair<String,String>> compareGossipAndTokenMetadata();
 }

--- a/src/java/org/apache/cassandra/gms/GossiperMBean.java
+++ b/src/java/org/apache/cassandra/gms/GossiperMBean.java
@@ -21,8 +21,6 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.cassandra.utils.Pair;
-
 public interface GossiperMBean
 {
     public long getEndpointDowntime(String address) throws UnknownHostException;
@@ -43,5 +41,10 @@ public interface GossiperMBean
     public boolean getLooseEmptyEnabled();
 
     public void setLooseEmptyEnabled(boolean enabled);
-    public Map<String, Pair<String,String>> compareGossipAndTokenMetadata();
+
+    /** Returns a map of endpoints that don't have matching tokenMetadata to gossip tokens.
+     * Values are lists of fixed size two (as Pair is not jmx safe),
+     * the first is the gossip tokens, the second tokenMetadata).
+     */
+    public Map<String, List<String>> compareGossipAndTokenMetadata();
 }

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -3036,7 +3036,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
             Gossiper.instance.addLocalApplicationState(ApplicationState.RPC_READY, valueFactory.rpcReady(value));
     }
 
-    private Collection<Token> getTokensFor(InetAddressAndPort endpoint)
+    public Collection<Token> getTokensFor(InetAddressAndPort endpoint)
     {
         try
         {

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1724,6 +1724,10 @@ public class NodeProbe implements AutoCloseable
     {
         return ssProxy.getOutOfRangeOperationCounts();
     }
+    public String compareGossipAndTokenMetadataCache()
+    {
+        return gossProxy.compareGossipAndTokenMetadataCache();
+    }
 
     // JMX getters for the o.a.c.metrics API below.
     /**

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -122,7 +122,6 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.cassandra.tools.nodetool.GetTimeout;
 import org.apache.cassandra.utils.NativeLibrary;
-import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SSL_ENABLE;
@@ -1725,7 +1724,7 @@ public class NodeProbe implements AutoCloseable
     {
         return ssProxy.getOutOfRangeOperationCounts();
     }
-    public Map<String, Pair<String,String>> compareGossipAndTokenMetadata()
+    public Map<String, List<String>> compareGossipAndTokenMetadata()
     {
         return gossProxy.compareGossipAndTokenMetadata();
     }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -122,6 +122,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.cassandra.tools.nodetool.GetTimeout;
 import org.apache.cassandra.utils.NativeLibrary;
+import org.apache.cassandra.utils.Pair;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SSL_ENABLE;
@@ -1724,9 +1725,9 @@ public class NodeProbe implements AutoCloseable
     {
         return ssProxy.getOutOfRangeOperationCounts();
     }
-    public String compareGossipAndTokenMetadataCache()
+    public Map<String, Pair<String,String>> compareGossipAndTokenMetadata()
     {
-        return gossProxy.compareGossipAndTokenMetadataCache();
+        return gossProxy.compareGossipAndTokenMetadata();
     }
 
     // JMX getters for the o.a.c.metrics API below.

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -97,6 +97,7 @@ public class NodeTool
                 Assassinate.class,
                 CassHelp.class,
                 CIDRFilteringStats.class,
+                CheckTokenMetadata.class,
                 Cleanup.class,
                 ClearSnapshot.class,
                 ClientStats.class,

--- a/src/java/org/apache/cassandra/tools/nodetool/CheckTokenMetadata.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CheckTokenMetadata.java
@@ -17,13 +17,13 @@
  */
 package org.apache.cassandra.tools.nodetool;
 
+import java.util.List;
 import java.util.Map;
 
 import io.airlift.airline.Command;
 
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
-import org.apache.cassandra.utils.Pair;
 
 @Command(name = "checktokenmetadata", description = "compares the Gossip endpointState and TokenMetadata cache; printing any mismatches found")
 public class CheckTokenMetadata extends NodeToolCmd
@@ -38,12 +38,12 @@ public class CheckTokenMetadata extends NodeToolCmd
          * This command compares the Gossip endpointState and TokenMetadata cache, printing any mismatches found.
          */
         StringBuilder sb = new StringBuilder();
-        Map<String,Pair<String,String>> mismatches = probe.compareGossipAndTokenMetadata();
+        Map<String, List<String>> mismatches = probe.compareGossipAndTokenMetadata();
 
-        for (Map.Entry<String,Pair<String,String>> e : mismatches.entrySet())
+        for (Map.Entry<String,List<String>> e : mismatches.entrySet())
             sb.append("Mismatch on : ").append(e.getKey())
-              .append("\n  Gossip tokens: ").append(e.getValue().left())
-              .append("\n  TokenMetadata: ").append(e.getValue().right()).append('\n');
+              .append("\n  Gossip tokens: ").append(e.getValue().get(0))
+              .append("\n  TokenMetadata: ").append(e.getValue().get(1)).append('\n');
 
         System.out.println(sb);
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/CheckTokenMetadata.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CheckTokenMetadata.java
@@ -17,28 +17,34 @@
  */
 package org.apache.cassandra.tools.nodetool;
 
+import java.util.Map;
+
 import io.airlift.airline.Command;
+
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+import org.apache.cassandra.utils.Pair;
 
-@Command(name = "checktokenmetadata", description = "compares the Gossip endpointState and TokenMetadata cache; returns true if they are in sync, false otherwise")
+@Command(name = "checktokenmetadata", description = "compares the Gossip endpointState and TokenMetadata cache; printing any mismatches found")
 public class CheckTokenMetadata extends NodeToolCmd
 {
     @Override
     public void execute(NodeProbe probe)
     {
-        /** Cassandra maintains the token information in two caches 1) Gossip endpointState 2) TokenMetadata cache
-         * The source of truth is the Gossip endpointState, which then updates the TokenMetadata cache - but there exists no guarantee.
-         * As a result, a wide variety of problems could occur, and one of the problems is a node could see different token ownership
-         * than its peers. This command compares the Gossip endpointState and TokenMetadata cache and returns empty result if they are in sync, mismatche(s) otherwise.
+        /** Cassandra maintains the token information in two places: 1) Gossip endpointState, and 2) TokenMetadata.
+         * The probabilistic view of the cluster is the Gossip endpointState.
+         * This then updates the TokenMetadata, a resulting topology view that's usable by hotpaths (e.g. read and write requests).
+         * Bugs can result in these falling out of sync.
+         * This command compares the Gossip endpointState and TokenMetadata cache, printing any mismatches found.
          */
         StringBuilder sb = new StringBuilder();
-        String mismatches = probe.compareGossipAndTokenMetadataCache();
-        if (!mismatches.isEmpty())
-        {
-            sb.append("Mismatch details:");
-            sb.append(mismatches);
-        }
+        Map<String,Pair<String,String>> mismatches = probe.compareGossipAndTokenMetadata();
+
+        for (Map.Entry<String,Pair<String,String>> e : mismatches.entrySet())
+            sb.append("Mismatch on : ").append(e.getKey())
+              .append("\n  Gossip tokens: ").append(e.getValue().left())
+              .append("\n  TokenMetadata: ").append(e.getValue().right()).append('\n');
+
         System.out.println(sb);
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/CheckTokenMetadata.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CheckTokenMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.airline.Command;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "checktokenmetadata", description = "compares the Gossip endpointState and TokenMetadata cache; returns true if they are in sync, false otherwise")
+public class CheckTokenMetadata extends NodeToolCmd
+{
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        /** Cassandra maintains the token information in two caches 1) Gossip endpointState 2) TokenMetadata cache
+         * The source of truth is the Gossip endpointState, which then updates the TokenMetadata cache - but there exists no guarantee.
+         * As a result, a wide variety of problems could occur, and one of the problems is a node could see different token ownership
+         * than its peers. This command compares the Gossip endpointState and TokenMetadata cache and returns empty result if they are in sync, mismatche(s) otherwise.
+         */
+        StringBuilder sb = new StringBuilder();
+        String mismatches = probe.compareGossipAndTokenMetadataCache();
+        if (!mismatches.isEmpty())
+        {
+            sb.append("Mismatch details:");
+            sb.append(mismatches);
+        }
+        System.out.println(sb);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/Pair.java
+++ b/src/java/org/apache/cassandra/utils/Pair.java
@@ -17,9 +17,11 @@
  */
 package org.apache.cassandra.utils;
 
+import java.io.Serializable;
+
 import com.google.common.base.Objects;
 
-public class Pair<T1, T2>
+public class Pair<T1, T2> implements Serializable
 {
     public final T1 left;
     public final T2 right;

--- a/src/java/org/apache/cassandra/utils/Pair.java
+++ b/src/java/org/apache/cassandra/utils/Pair.java
@@ -17,11 +17,9 @@
  */
 package org.apache.cassandra.utils;
 
-import java.io.Serializable;
-
 import com.google.common.base.Objects;
 
-public class Pair<T1, T2> implements Serializable
+public class Pair<T1, T2>
 {
     public final T1 left;
     public final T2 right;

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -59,7 +59,6 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.assertj.core.api.Assertions;
 import org.quicktheories.core.Gen;
 import org.quicktheories.impl.Constraint;
-import org.apache.cassandra.utils.Pair;
 import static org.apache.cassandra.config.CassandraRelevantProperties.GOSSIP_DISABLE_THREAD_VALIDATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -597,7 +596,7 @@ public class GossiperTest
         host0State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         host1State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         Gossiper.instance.applyStateLocally(ImmutableMap.of(hosts.get(1), host0State));
-        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
+        Map<String, List<String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
@@ -621,7 +620,7 @@ public class GossiperTest
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
         // no impact to the cache if there is no cache coherence
-        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
+        Map<String, List<String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
@@ -650,7 +649,7 @@ public class GossiperTest
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
 
         // Because host1 is not yet "NORMAL", it should be skipped in fixing the caches
-        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
+        Map<String, List<String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         assertNotEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
@@ -669,7 +668,7 @@ public class GossiperTest
         host0State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         host1State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         Gossiper.instance.applyStateLocally(ImmutableMap.of(hosts.get(1), host0State));
-        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
+        Map<String, List<String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         // Gossip tokens should be used as the source of truth in case of a mismtach
         Collection<Token> gossipTokensHost0 = getGossipCacheTokens(0);

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.cassandra.gms;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -38,10 +40,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.commitlog.CommitLog;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.IPartitioner;
 import org.apache.cassandra.dht.RandomPartitioner;
 import org.apache.cassandra.dht.Token;
@@ -59,6 +63,7 @@ import org.quicktheories.impl.Constraint;
 import static org.apache.cassandra.config.CassandraRelevantProperties.GOSSIP_DISABLE_THREAD_VALIDATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -96,6 +101,7 @@ public class GossiperTest
     public void tearDown()
     {
         DatabaseDescriptor.setSeedProvider(originalSeedProvider);
+        Gossiper.instance.endpointStateMap.clear();
     }
 
     @AfterClass
@@ -578,6 +584,127 @@ public class GossiperTest
         };
         return mapGen;
     }
+
+    public void testGossipAndTokenMetadataCacheMismatchExist() throws IOException
+    {
+        SchemaLoader.prepareServer();
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);
+        Gossiper.instance.start(1);
+        EndpointState host0State = Gossiper.instance.getEndpointStateForEndpoint(hosts.get(0));
+        EndpointState host1State = Gossiper.instance.getEndpointStateForEndpoint(hosts.get(1));
+
+        Gossiper.instance.injectApplicationState(hosts.get(1), ApplicationState.RELEASE_VERSION, new VersionedValue.VersionedValueFactory(null).releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
+        host0State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
+        host1State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
+        Gossiper.instance.applyStateLocally(ImmutableMap.of(hosts.get(1), host0State));
+        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        assertTrue(output.isEmpty());
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
+
+        // edit the tokens in the Gossip cache to create a mismatch between the two caches
+        host0State.addApplicationState(ApplicationState.TOKENS, StorageService.instance.valueFactory.tokens(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
+
+        output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        assertEquals("Gossip and TokenMetadata cache token mismatch for endpoint /127.0.0.1:7012\n", output);
+    }
+
+    @Test
+    public void testGossipAndTokenMetadataCacheMismatchDoNotExist() throws IOException
+    {
+        SchemaLoader.prepareServer();
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);
+        Gossiper.instance.start(1);
+
+        Gossiper.instance.injectApplicationState(hosts.get(1), ApplicationState.RELEASE_VERSION, new VersionedValue.VersionedValueFactory(null).releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
+
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
+        // no impact to the cache if there is no cache coherence
+        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        assertTrue(output.isEmpty());
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
+    }
+
+
+    @Test
+    public void testGossipAndTokenMetadataCacheIgnoreNonNormalNode() throws IOException
+    {
+        SchemaLoader.prepareServer();
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);
+        Gossiper.instance.start(1);
+
+        EndpointState host0State = Gossiper.instance.getEndpointStateForEndpoint(hosts.get(0));
+        Gossiper.instance.injectApplicationState(hosts.get(1), ApplicationState.RELEASE_VERSION, new VersionedValue.VersionedValueFactory(null).releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
+
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
+
+        // Change host1's status to non-normal
+        host0State.addApplicationState(ApplicationState.STATUS, StorageService.instance.valueFactory.leaving(new ArrayList<Token>(){{add(new ByteOrderedPartitioner.BytesToken(new byte[]{ 1}));}}));
+        // Now intentionally inject inconsistency between the Gossip cache and storage service cache
+        host0State.addApplicationState(ApplicationState.TOKENS, StorageService.instance.valueFactory.tokens(new ArrayList<Token>(){{add(new ByteOrderedPartitioner.BytesToken(new byte[]{1,2,3}));}}));
+
+        assertNotEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
+
+        // Because host1 is not yet "NORMAL", it should be skipped in fixing the caches
+        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        assertTrue(output.isEmpty());
+        assertNotEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
+        assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
+    }
+
+    @Test
+    public void testCacheMismatchIfTokenMetadataCacheIsMissingTheEndpoint() throws IOException
+    {
+        SchemaLoader.prepareServer();
+        Util.createInitialRing(ss, partitioner, endpointTokens, keyTokens, hosts, hostIds, 2);
+        Gossiper.instance.start(1);
+        EndpointState host0State = Gossiper.instance.getEndpointStateForEndpoint(hosts.get(0));
+        EndpointState host1State = Gossiper.instance.getEndpointStateForEndpoint(hosts.get(1));
+
+        Gossiper.instance.injectApplicationState(hosts.get(1), ApplicationState.RELEASE_VERSION, new VersionedValue.VersionedValueFactory(null).releaseVersion(SystemKeyspace.CURRENT_VERSION.toString()));
+        host0State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
+        host1State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
+        Gossiper.instance.applyStateLocally(ImmutableMap.of(hosts.get(1), host0State));
+        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        assertTrue(output.isEmpty());
+        // Gossip tokens should be used as the source of truth in case of a mismtach
+        Collection<Token> gossipTokensHost0 = getGossipCacheTokens(0);
+        Collection<Token> gossipTokensHost1 = getGossipCacheTokens(1);
+
+        assertEquals(getTokenMetadataCacheTokens(0), getGossipCacheTokens(0));
+        assertEquals(getTokenMetadataCacheTokens(1), getGossipCacheTokens(1));
+
+        // remove the tokens from TokenMetadata cache to create a mismatch between the two caches
+        StorageService.instance.getTokenMetadata().removeEndpoint(hosts.get(0));
+        output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        assertEquals("TokenMetadata cache is missing information for normal endpoint/127.0.0.1:7012\n", output);
+        try
+        {
+            getTokenMetadataCacheTokens(0);
+            fail("Expected AssertionError");
+        }
+        catch (AssertionError e)
+        {
+            assertTrue(e.getMessage().contains("Unable to get tokens for /127.0.0.1:7012; it is not a member"));
+        }
+        assertEquals(getTokenMetadataCacheTokens(1), gossipTokensHost1);
+        assertEquals(getTokenMetadataCacheTokens(1), getGossipCacheTokens(1));
+    }
+
+    private Collection<Token> getTokenMetadataCacheTokens(int hostIndex)
+    {
+        return StorageService.instance.getTokenMetadata().getTokens(hosts.get(hostIndex));
+    }
+
+    private Collection<Token> getGossipCacheTokens(int hostIndex)
+    {
+        return StorageService.instance.getTokensFor(hosts.get(hostIndex));
+    }
+
 
     static class SimpleStateChangeListener implements IEndpointStateChangeSubscriber
     {

--- a/test/unit/org/apache/cassandra/gms/GossiperTest.java
+++ b/test/unit/org/apache/cassandra/gms/GossiperTest.java
@@ -59,7 +59,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.assertj.core.api.Assertions;
 import org.quicktheories.core.Gen;
 import org.quicktheories.impl.Constraint;
-
+import org.apache.cassandra.utils.Pair;
 import static org.apache.cassandra.config.CassandraRelevantProperties.GOSSIP_DISABLE_THREAD_VALIDATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -597,7 +597,7 @@ public class GossiperTest
         host0State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         host1State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         Gossiper.instance.applyStateLocally(ImmutableMap.of(hosts.get(1), host0State));
-        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
@@ -605,8 +605,8 @@ public class GossiperTest
         // edit the tokens in the Gossip cache to create a mismatch between the two caches
         host0State.addApplicationState(ApplicationState.TOKENS, StorageService.instance.valueFactory.tokens(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
 
-        output = Gossiper.instance.compareGossipAndTokenMetadataCache();
-        assertEquals("Gossip and TokenMetadata cache token mismatch for endpoint /127.0.0.1:7012\n", output);
+        output = Gossiper.instance.compareGossipAndTokenMetadata();
+        assertTrue(output.containsKey("/127.0.0.1:7012"));
     }
 
     @Test
@@ -621,7 +621,7 @@ public class GossiperTest
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
         // no impact to the cache if there is no cache coherence
-        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
@@ -650,7 +650,7 @@ public class GossiperTest
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
 
         // Because host1 is not yet "NORMAL", it should be skipped in fixing the caches
-        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         assertNotEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(0)), StorageService.instance.getTokensFor(hosts.get(0)));
         assertEquals(StorageService.instance.getTokenMetadata().getTokens(hosts.get(1)), StorageService.instance.getTokensFor(hosts.get(1)));
@@ -669,7 +669,7 @@ public class GossiperTest
         host0State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         host1State.addApplicationState(ApplicationState.STATUS_WITH_PORT, StorageService.instance.valueFactory.normal(new ArrayList<Token>(){{add(DatabaseDescriptor.getPartitioner().getRandomToken());}}));
         Gossiper.instance.applyStateLocally(ImmutableMap.of(hosts.get(1), host0State));
-        String output = Gossiper.instance.compareGossipAndTokenMetadataCache();
+        Map<String, Pair<String,String>> output = Gossiper.instance.compareGossipAndTokenMetadata();
         assertTrue(output.isEmpty());
         // Gossip tokens should be used as the source of truth in case of a mismtach
         Collection<Token> gossipTokensHost0 = getGossipCacheTokens(0);
@@ -680,8 +680,8 @@ public class GossiperTest
 
         // remove the tokens from TokenMetadata cache to create a mismatch between the two caches
         StorageService.instance.getTokenMetadata().removeEndpoint(hosts.get(0));
-        output = Gossiper.instance.compareGossipAndTokenMetadataCache();
-        assertEquals("TokenMetadata cache is missing information for normal endpoint/127.0.0.1:7012\n", output);
+        output = Gossiper.instance.compareGossipAndTokenMetadata();
+        assertTrue(output.containsKey("/127.0.0.1:7012"));
         try
         {
             getTokenMetadataCacheTokens(0);


### PR DESCRIPTION
```
Cassandra keeps token-ownership in two separate caches. 1) Gossip endpointState 2) TokenMetadata cache. These two caches could go out of sync, and if they go, it creates a catastrophic impact on workloads. Currently, no mechanism in Cassandra exist that detects and fixes these two caches. This PR improves these two caches.

Details: As we know, Cassandra exchanges important topology and token-ownership-related details over Gossip. Cassandra internally maintains the following two separate caches that have the token ownership information maintained: 1) Gossip endpointState 2) TokenMetadata cache. The first Gossip cache is updated on a node, followed by the storage service cache. In the hot path, ownership is calculated from the storage service cache. Since two separate caches maintain the same information, then inconsistencies are bound to happen. It could be very well feasible that the Gossip cache has up-to-date ownership of the Cassandra cluster, but the service cache does not, and in that scenario, inconsistent data will be served to the user.
```
**Long-term solution**
We are going with the long-term transactional metadata (https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-21) to handle such inconsistencies, and that’s the right thing to do.

**Short-term solution**
But CEP-21 might take some time, and until then, there is a need to detect such inconsistencies. Hence this PR extends the support for a new _nodetool_ command that does the comparison. 


The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-18758)