### PR TITLE
Cassandra-20025 IN Clauses in SAI AND queries

### DIFF
--- a/doc/modules/cassandra/partials/sai/supported-query-operators-list.adoc
+++ b/doc/modules/cassandra/partials/sai/supported-query-operators-list.adoc
@@ -4,6 +4,6 @@ ifeval::["{evalproduct}" == "dse"]
 * Strings: `=`, `CONTAINS`, `CONTAINS KEY`, `AND`
 endif::[]
 ifeval::["{evalproduct}" != "dse"]
-* Numerics: `=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `IN`
-* Strings: `=`, `CONTAINS`, `CONTAINS KEY`, `AND`, `OR`, `IN`
+* Numerics: `=`, `<`, `>`, `<=`, `>=`, `AND`
+* Strings: `=`, `CONTAINS`, `CONTAINS KEY`, `AND`
 endif::[]

--- a/src/java/org/apache/cassandra/index/sai/plan/Expression.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/Expression.java
@@ -79,7 +79,7 @@ public abstract class Expression
 
     public enum IndexOperator
     {
-        EQ, RANGE, CONTAINS_KEY, CONTAINS_VALUE, ANN;
+        EQ, RANGE, CONTAINS_KEY, CONTAINS_VALUE, ANN, IN;
 
         public static IndexOperator valueOf(Operator operator)
         {
@@ -103,6 +103,9 @@ public abstract class Expression
 
                 case ANN:
                     return ANN;
+
+                case IN:
+                    return IN;
 
                 default:
                     return null;
@@ -169,6 +172,7 @@ public abstract class Expression
             case EQ:
             case CONTAINS:
             case CONTAINS_KEY:
+            case IN:
                 lower = new Bound(value, indexTermType, true);
                 upper = lower;
                 operator = IndexOperator.valueOf(op);
@@ -223,8 +227,8 @@ public abstract class Expression
                 Value first = new Value(buffers.get(0), indexTermType);
                 Value second = new Value(buffers.get(1), indexTermType);
 
-                // SimpleRestriction#addToRowFilter() ensures correct bounds ordering, but SAI enforces a non-arbitrary 
-                // ordering between IPv4 and IPv6 addresses, so correction may still be necessary. 
+                // SimpleRestriction#addToRowFilter() ensures correct bounds ordering, but SAI enforces a non-arbitrary
+                // ordering between IPv4 and IPv6 addresses, so correction may still be necessary.
                 boolean outOfOrder = indexTermType.compare(first.encoded, second.encoded) > 0;
                 lower = new Bound(outOfOrder ? second : first, true);
                 upper = new Bound(outOfOrder ? first : second, true);
@@ -236,6 +240,7 @@ public abstract class Expression
                 lower = new Bound(value, indexTermType, true);
                 upper = lower;
                 break;
+
             default:
                 throw new IllegalArgumentException("Index does not support the " + op + " operator");
         }
@@ -274,6 +279,9 @@ public abstract class Expression
                 // in case of EQ lower == upper
                 if (operator == IndexOperator.EQ || operator == IndexOperator.CONTAINS_KEY || operator == IndexOperator.CONTAINS_VALUE)
                     return cmp == 0;
+
+                if (operator == IndexOperator.IN)
+                    return termMatches(value.raw, lower.value.raw);
 
                 if (cmp > 0 || (cmp == 0 && !lowerInclusive))
                     return false;
@@ -334,6 +342,17 @@ public abstract class Expression
                 break;
             case RANGE:
                 isMatch = isLowerSatisfiedBy(term) && isUpperSatisfiedBy(term);
+                break;
+            case IN:
+                ListType<?> type = ListType.getInstance(indexTermType.columnMetadata().type, true);
+                List<? extends ByteBuffer> buffers = type.unpack(requestedValue);
+                for (ByteBuffer value : buffers)
+                {
+                    if (indexTermType.compare(term, value) == 0)
+                    {
+                        return true;
+                    }
+                }
                 break;
         }
         return isMatch;

--- a/src/java/org/apache/cassandra/index/sai/utils/IndexTermType.java
+++ b/src/java/org/apache/cassandra/index/sai/utils/IndexTermType.java
@@ -566,7 +566,8 @@ public class IndexTermType
             operator == Operator.LIKE_CONTAINS ||
             operator == Operator.LIKE_PREFIX ||
             operator == Operator.LIKE_MATCHES ||
-            operator == Operator.LIKE_SUFFIX) return false;
+            operator == Operator.LIKE_SUFFIX ||
+            operator == Operator.IN) return false;
 
         // ANN is only supported against vectors, and vector indexes only support ANN
         if (operator == Operator.ANN)

--- a/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/AllowFilteringTest.java
@@ -296,6 +296,91 @@ public class AllowFilteringTest extends SAITester
         test("SELECT * FROM %s WHERE v1=0 AND v2=0 AND k1=0 AND k2=0 AND (c1, c2, c3, c4) = (0, 0, 0, 0) AND v3=0", true);
     }
 
+    @Test
+    public void testAllowFilteringTextWithINClause ()
+    {
+        createTable("CREATE TABLE %S (k1 TEXT, k2 TEXT, k3 TEXT, PRIMARY KEY(k1))");
+        createIndex("CREATE INDEX ON %s(K2) USING 'sai'");
+
+        execute("INSERT INTO %s (k1,k2,k3) VALUES ('s1','s11','s111')");
+        execute("INSERT INTO %s (k1,k2,k3) VALUES ('s2','s11','s11')");
+        execute("INSERT INTO %s (k1,k2,k3) VALUES ('s3','s22','s111')");
+        execute("INSERT INTO %s (k1,k2,k3) VALUES ('s4','s22','s111')");
+        execute("INSERT INTO %s (k1,k2,k3) VALUES ('s5','s31','s111')");
+
+        assertRowCount(execute("SELECT * FROM %s WHERE k2='s11' AND k3 IN ('s11','s111') ALLOW FILTERING"),2);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2='s22' AND k3 IN ('s111','s111') ALLOW FILTERING"), 2);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2='s22' AND k3 IN ('s','s1') ALLOW FILTERING"), 0);
+        // To test if an IN clause without an AND condition does not create a query plan and works as expected.
+        assertRowCount(execute("SELECT * FROM %s WHERE k2 IN ('s11','s22') ALLOW FILTERING"), 4);
+
+    }
+
+    @Test
+    public void testAllowFilteringIntWithINClause ()
+    {
+        createTable("CREATE TABLE %S (k1 text, k2 int, k3 int, PRIMARY KEY(k1))");
+        createIndex("CREATE INDEX ON %s(K2) USING 'sai'");
+
+        execute("insert into %s (k1,k2,k3) values ('s1',11,1)");
+        execute("insert into %s (k1,k2,k3) values ('s2',11,11)");
+        execute("insert into %s (k1,k2,k3) values ('s3',11,111)");
+        execute("insert into %s (k1,k2,k3) values ('s4',22,1)");
+        execute("insert into %s (k1,k2,k3) values ('s5',22,11)");
+        execute("insert into %s (k1,k2,k3) values ('s6',22,111)");
+
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=11 AND k3 IN (1,11,111) ALLOW FILTERING"),3);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=22 AND k3 IN (1,11,111) ALLOW FILTERING"),3);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=22 AND k3 IN (101,102) ALLOW FILTERING"),0);
+        // To test if an IN clause without an AND condition does not create a query plan and works as expected.
+        assertRowCount(execute("SELECT * FROM %s WHERE k2 IN (11,22) ALLOW FILTERING"), 6);
+
+    }
+
+    @Test
+    public void testAllowFilteringBigIntWithINClause ()
+    {
+            createTable("CREATE TABLE %S (k1 text, k2 bigint, k3 bigint, PRIMARY KEY(k1))");
+            createIndex("CREATE INDEX ON %s(K2) USING 'sai'");
+
+            execute("insert into %s (k1, k2, k3) values ('s1', 1001, 100)");
+            execute("insert into %s (k1, k2, k3) values ('s2', 1001, 200)");
+            execute("insert into %s (k1, k2, k3) values ('s3', 1001, 300)");
+            execute("insert into %s (k1, k2, k3) values ('s4', 2002, 100)");
+            execute("insert into %s (k1, k2, k3) values ('s5', 2002, 200)");
+            execute("insert into %s (k1, k2, k3) values ('s6', 2002, 300)");
+
+            assertRowCount(execute("SELECT * FROM %s WHERE k2=1001 AND k3 IN (100, 200, 300) ALLOW FILTERING"), 3);
+            assertRowCount(execute("SELECT * FROM %s WHERE k2=2002 AND k3 IN (100, 200, 300) ALLOW FILTERING"), 3);
+            assertRowCount(execute("SELECT * FROM %s WHERE k2=2002 AND k3 IN (101, 201, 301) ALLOW FILTERING"), 0);
+        // To test if an IN clause without an AND condition does not create a query plan and works as expected.
+            assertRowCount(execute("SELECT * FROM %s WHERE k2 IN (1001,2002) ALLOW FILTERING"), 6);
+
+    }
+
+    @Test
+    public void testAllowFilteringBigDecimalWithINClause()
+    {
+        createTable("CREATE TABLE %S (k1 text, k2 decimal, k3 decimal, PRIMARY KEY(k1))");
+        createIndex("CREATE INDEX ON %s(K2) USING 'sai'");
+
+        execute("insert into %s (k1, k2, k3) values ('s1', 1.1, 1.11)");
+        execute("insert into %s (k1, k2, k3) values ('s2', 1.1, 1.12)");
+        execute("insert into %s (k1, k2, k3) values ('s3', 1.1, 1.13)");
+        execute("insert into %s (k1, k2, k3) values ('s4', 2.2, 1.11)");
+        execute("insert into %s (k1, k2, k3) values ('s5', 2.2, 1.12)");
+        execute("insert into %s (k1, k2, k3) values ('s6', 2.2, 1.13)");
+
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=1.1 AND k3 IN (1.11, 1.12, 1.13) ALLOW FILTERING"), 3);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=2.2 AND k3 IN (1.11, 1.12, 1.13) ALLOW FILTERING"), 3);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=2.2 AND k3 IN (1.21, 1.22, 1.13) ALLOW FILTERING"), 1);
+        assertRowCount(execute("SELECT * FROM %s WHERE k2=2.2 AND k3 IN (1.21, 1.22, 1.23) ALLOW FILTERING"), 0);
+        // To test if an IN clause without an AND condition does not create a query plan and works as expected.
+        assertRowCount(execute("SELECT * FROM %s WHERE k2 IN (1.1,2.2) ALLOW FILTERING"), 6);
+    }
+
+
+
     private void test(String query, boolean requiresAllowFiltering) throws Throwable
     {
         if (requiresAllowFiltering)
@@ -305,4 +390,5 @@ public class AllowFilteringTest extends SAITester
 
         assertNotNull(execute(query + " ALLOW FILTERING"));
     }
+
 }


### PR DESCRIPTION
CASSANDRA-20025: Add support for IN clauses in SAI AND queries

1. Extended Expression.java to support IN clauses in Storage-Attached Indexes (SAI).
2. Added a test case to evaluate it.