### PR TITLE
CASSANDRA-18526: Fixing Encoding of Tuples with String types

### DIFF
--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -170,7 +170,6 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         {
             if (input.charAt(i) != ':' || (i > 0 && input.charAt(i-1) == '\\'))
                 continue;
-
             res.add(input.substring(prev, i));
             prev = i + 1;
         }

--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -170,6 +170,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         {
             if (input.charAt(i) != ':' || (i > 0 && input.charAt(i-1) == '\\'))
                 continue;
+            
             res.add(input.substring(prev, i));
             prev = i + 1;
         }

--- a/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
+++ b/src/java/org/apache/cassandra/db/marshal/AbstractCompositeType.java
@@ -170,7 +170,7 @@ public abstract class AbstractCompositeType extends AbstractType<ByteBuffer>
         {
             if (input.charAt(i) != ':' || (i > 0 && input.charAt(i-1) == '\\'))
                 continue;
-            
+
             res.add(input.substring(prev, i));
             prev = i + 1;
         }

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -56,6 +56,10 @@ public class TupleType extends AbstractType<ByteBuffer>
     private static final Pattern AT_PAT = Pattern.compile(AT);
     private static final String ESCAPED_AT = "\\\\@";
     private static final Pattern ESCAPED_AT_PAT = Pattern.compile(ESCAPED_AT);
+    private static final String BACKSLASH = "\\\\";
+    private static final Pattern BACKSLASH_PAT = Pattern.compile(BACKSLASH);
+    private static final String ESCAPED_BACKSLASH = "\\\\\\\\\\$";
+    private static final Pattern ESCAPED_BACKSLASH_PAT = Pattern.compile(ESCAPED_BACKSLASH);
     
     protected final List<AbstractType<?>> types;
 
@@ -396,7 +400,8 @@ public class TupleType extends AbstractType<ByteBuffer>
             V field = accessor.slice(input, offset, size);
             offset += size;
             // We use ':' as delimiter, and @ to represent null, so escape them in the generated string
-            String fld = COLON_PAT.matcher(type.getString(field, accessor)).replaceAll(ESCAPED_COLON);
+            String fld = BACKSLASH_PAT.matcher(type.getString(field, accessor)).replaceAll(ESCAPED_BACKSLASH);
+            fld = COLON_PAT.matcher(fld).replaceAll(ESCAPED_COLON);
             fld = AT_PAT.matcher(fld).replaceAll(ESCAPED_AT);
             sb.append(fld);
         }
@@ -421,8 +426,10 @@ public class TupleType extends AbstractType<ByteBuffer>
                 continue;
 
             AbstractType<?> type = type(i);
+            fieldString = ESCAPED_BACKSLASH_PAT.matcher(fieldString).replaceAll(BACKSLASH);
             fieldString = ESCAPED_COLON_PAT.matcher(fieldString).replaceAll(COLON);
             fieldString = ESCAPED_AT_PAT.matcher(fieldString).replaceAll(AT);
+
             fields[i] = type.fromString(fieldString);
         }
         return buildValue(fields);

--- a/src/java/org/apache/cassandra/db/marshal/TupleType.java
+++ b/src/java/org/apache/cassandra/db/marshal/TupleType.java
@@ -58,7 +58,7 @@ public class TupleType extends AbstractType<ByteBuffer>
     private static final Pattern ESCAPED_AT_PAT = Pattern.compile(ESCAPED_AT);
     private static final String BACKSLASH = "\\\\";
     private static final Pattern BACKSLASH_PAT = Pattern.compile(BACKSLASH);
-    private static final String ESCAPED_BACKSLASH = "\\\\\\\\\\$";
+    private static final String ESCAPED_BACKSLASH = "\\\\\\$";
     private static final Pattern ESCAPED_BACKSLASH_PAT = Pattern.compile(ESCAPED_BACKSLASH);
     
     protected final List<AbstractType<?>> types;

--- a/test/unit/org/apache/cassandra/db/marshal/AbstractTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/AbstractTypeTest.java
@@ -472,7 +472,7 @@ public class AbstractTypeTest
             for (AbstractType<?> e : tt.subTypes())
             {
                 AbstractType<?> unwrap = e.unwrap();
-                if (unwrap instanceof StringType || unwrap instanceof TupleType)
+                if (unwrap instanceof TupleType)
                     return true;
             }
         }


### PR DESCRIPTION
TupleType getString and fromString are not safe with string types

TupleType getString and fromString currently break if it contains string types ending with a backslash. This escapes the colon used as a delimiter between the values in the tuple. To get around this I propose escaping backslashes in tuples with '\$' so that the delimiter colons will not be escaped. 

patch by rwelgosh; for CASSANDRA-18526

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-18526)