### PR TITLE
[CASSANDRA-20052][4.1] Introduce CQL message limits in V5 protocol logic

### DIFF
--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -270,7 +270,6 @@ public class Config
     @Replaces(oldName = "native_transport_max_frame_size_in_mb", converter = Converters.MEBIBYTES_DATA_STORAGE_INT, deprecated = true)
     public DataStorageSpec.IntMebibytesBound native_transport_max_frame_size = new DataStorageSpec.IntMebibytesBound("16MiB");
     public volatile DataStorageSpec.LongBytesBound native_transport_max_message_size = null;
-    public volatile DataStorageSpec.LongBytesBound native_transport_max_auth_message_size = new DataStorageSpec.LongBytesBound("128KiB");
     /** do bcrypt hashing in a limited pool to prevent cpu load spikes; 0 means that all requests will go to default request executor**/
     public int native_transport_max_auth_threads = 0;
     public volatile long native_transport_max_concurrent_connections = -1L;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -269,6 +269,8 @@ public class Config
     public int native_transport_max_threads = 128;
     @Replaces(oldName = "native_transport_max_frame_size_in_mb", converter = Converters.MEBIBYTES_DATA_STORAGE_INT, deprecated = true)
     public DataStorageSpec.IntMebibytesBound native_transport_max_frame_size = new DataStorageSpec.IntMebibytesBound("16MiB");
+    public volatile DataStorageSpec.LongBytesBound native_transport_max_message_size = null;
+    public volatile DataStorageSpec.LongBytesBound native_transport_max_auth_message_size = new DataStorageSpec.LongBytesBound("128KiB");
     /** do bcrypt hashing in a limited pool to prevent cpu load spikes; 0 means that all requests will go to default request executor**/
     public int native_transport_max_auth_threads = 0;
     public volatile long native_transport_max_concurrent_connections = -1L;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -579,11 +579,6 @@ public class DatabaseDescriptor
             conf.native_transport_max_request_data_in_flight_per_ip = new DataStorageSpec.LongBytesBound(Runtime.getRuntime().maxMemory() / 40);
         }
 
-        if (conf.native_transport_max_message_size == null)
-        {
-            conf.native_transport_max_message_size = conf.native_transport_max_request_data_in_flight_per_ip;
-        }
-
         if (conf.native_transport_rate_limiting_enabled)
             logger.info("Native transport rate-limiting enabled at {} requests/second.", conf.native_transport_max_requests_per_second);
         else
@@ -826,6 +821,25 @@ public class DatabaseDescriptor
             conf.max_mutation_size = new DataStorageSpec.IntKibibytesBound(conf.commitlog_segment_size.toKibibytes() / 2);
         else if (conf.commitlog_segment_size.toKibibytes() < 2 * conf.max_mutation_size.toKibibytes())
             throw new ConfigurationException("commitlog_segment_size must be at least twice the size of max_mutation_size / 1024", false);
+
+        if (conf.native_transport_max_message_size == null)
+        {
+            conf.native_transport_max_message_size = new DataStorageSpec.LongBytesBound(
+            Math.min(conf.max_mutation_size.toBytes(),
+                     Math.min(
+                        conf.native_transport_max_request_data_in_flight.toBytes(),
+                        conf.native_transport_max_request_data_in_flight_per_ip.toBytes()
+                     )
+            ));
+        } else {
+            long maxCqlMessageSize = conf.native_transport_max_message_size.toBytes();
+            if (maxCqlMessageSize > conf.native_transport_max_request_data_in_flight.toBytes())
+                throw new ConfigurationException("native_transport_max_message_size must no exceed native_transport_max_request_data_in_flight", false);
+
+            if (maxCqlMessageSize > conf.native_transport_max_request_data_in_flight_per_ip.toBytes())
+                throw new ConfigurationException("native_transport_max_message_size must no exceed native_transport_max_request_data_in_flight_per_ip", false);
+
+        }
 
         // native transport encryption options
         if (conf.client_encryption_options != null)

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -828,14 +828,16 @@ public class DatabaseDescriptor
         if (conf.native_transport_max_message_size == null)
         {
             conf.native_transport_max_message_size = new DataStorageSpec.LongBytesBound(calculateDefaultNativeTransportMaxMessageSizeInBytes());
-        } else {
+        }
+        else
+        {
             nativeTransportMaxMessageSizeConfiguredExplicitly = true;
             long maxCqlMessageSize = conf.native_transport_max_message_size.toBytes();
             if (maxCqlMessageSize > conf.native_transport_max_request_data_in_flight.toBytes())
-                throw new ConfigurationException("native_transport_max_message_size must no exceed native_transport_max_request_data_in_flight", false);
+                throw new ConfigurationException("native_transport_max_message_size must not exceed native_transport_max_request_data_in_flight", false);
 
             if (maxCqlMessageSize > conf.native_transport_max_request_data_in_flight_per_ip.toBytes())
-                throw new ConfigurationException("native_transport_max_message_size must no exceed native_transport_max_request_data_in_flight_per_ip", false);
+                throw new ConfigurationException("native_transport_max_message_size must not exceed native_transport_max_request_data_in_flight_per_ip", false);
 
         }
         nativeTransportMaxMessageSizeInBytes = conf.native_transport_max_message_size.toBytes();

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -153,6 +153,9 @@ public class DatabaseDescriptor
     private static long counterCacheSizeInMiB;
     private static long indexSummaryCapacityInMiB;
 
+    private static volatile long nativeTransportMaxMessageSizeInBytes;
+    private static volatile boolean nativeTransportMaxMessageSizeConfiguredExplicitly;
+
     private static String localDC;
     private static Comparator<Replica> localComparator;
     private static EncryptionContext encryptionContext;
@@ -824,14 +827,9 @@ public class DatabaseDescriptor
 
         if (conf.native_transport_max_message_size == null)
         {
-            conf.native_transport_max_message_size = new DataStorageSpec.LongBytesBound(
-            Math.min(conf.max_mutation_size.toBytes(),
-                     Math.min(
-                        conf.native_transport_max_request_data_in_flight.toBytes(),
-                        conf.native_transport_max_request_data_in_flight_per_ip.toBytes()
-                     )
-            ));
+            conf.native_transport_max_message_size = new DataStorageSpec.LongBytesBound(calculateDefaultNativeTransportMaxMessageSizeInBytes());
         } else {
+            nativeTransportMaxMessageSizeConfiguredExplicitly = true;
             long maxCqlMessageSize = conf.native_transport_max_message_size.toBytes();
             if (maxCqlMessageSize > conf.native_transport_max_request_data_in_flight.toBytes())
                 throw new ConfigurationException("native_transport_max_message_size must no exceed native_transport_max_request_data_in_flight", false);
@@ -840,6 +838,7 @@ public class DatabaseDescriptor
                 throw new ConfigurationException("native_transport_max_message_size must no exceed native_transport_max_request_data_in_flight_per_ip", false);
 
         }
+        nativeTransportMaxMessageSizeInBytes = conf.native_transport_max_message_size.toBytes();
 
         // native transport encryption options
         if (conf.client_encryption_options != null)
@@ -2769,24 +2768,26 @@ public class DatabaseDescriptor
 
     public static long getNativeTransportMaxMessageSizeInBytes()
     {
-        return conf.native_transport_max_message_size.toBytes();
+        // the value of native_transport_max_message_size in bytes is cached
+        // to avoid conversion overhead during a parsing of each incoming CQL message
+        return nativeTransportMaxMessageSizeInBytes;
     }
 
     @VisibleForTesting
     public static void setNativeTransportMaxMessageSizeInBytes(long maxMessageSizeInBytes)
     {
         conf.native_transport_max_message_size = new DataStorageSpec.LongBytesBound(maxMessageSizeInBytes);
+        nativeTransportMaxMessageSizeInBytes = conf.native_transport_max_message_size.toBytes();
     }
 
-    public static long getNativeTransportMaxAuthMessageSizeInBytes()
+    private static long calculateDefaultNativeTransportMaxMessageSizeInBytes()
     {
-        return conf.native_transport_max_auth_message_size.toBytes();
-    }
-
-    @VisibleForTesting
-    public static void setNativeTransportMaxAuthMessageSizeInBytes(long maxAuthMessageSizeInBytes)
-    {
-        conf.native_transport_max_auth_message_size = new DataStorageSpec.LongBytesBound(maxAuthMessageSizeInBytes);
+        return Math.min(conf.max_mutation_size.toBytes(),
+                   Math.min(
+                   conf.native_transport_max_request_data_in_flight.toBytes(),
+                   conf.native_transport_max_request_data_in_flight_per_ip.toBytes()
+                   )
+        );
     }
 
     public static Config.PaxosVariant getPaxosVariant()
@@ -2915,6 +2916,10 @@ public class DatabaseDescriptor
             maxRequestDataInFlightInBytes = Runtime.getRuntime().maxMemory() / 40;
 
         conf.native_transport_max_request_data_in_flight_per_ip = new DataStorageSpec.LongBytesBound(maxRequestDataInFlightInBytes);
+        long newNativeTransportMaxMessageSizeInBytes = nativeTransportMaxMessageSizeConfiguredExplicitly
+                                                       ? Math.min(maxRequestDataInFlightInBytes, getNativeTransportMaxMessageSizeInBytes())
+                                                       : calculateDefaultNativeTransportMaxMessageSizeInBytes();
+        setNativeTransportMaxMessageSizeInBytes(newNativeTransportMaxMessageSizeInBytes);
     }
 
     public static long getNativeTransportMaxRequestDataInFlightInBytes()
@@ -2928,6 +2933,10 @@ public class DatabaseDescriptor
             maxRequestDataInFlightInBytes = Runtime.getRuntime().maxMemory() / 10;
 
         conf.native_transport_max_request_data_in_flight = new DataStorageSpec.LongBytesBound(maxRequestDataInFlightInBytes);
+        long newNativeTransportMaxMessageSizeInBytes = nativeTransportMaxMessageSizeConfiguredExplicitly
+                                                       ? Math.min(maxRequestDataInFlightInBytes, getNativeTransportMaxMessageSizeInBytes())
+                                                       : calculateDefaultNativeTransportMaxMessageSizeInBytes();
+        setNativeTransportMaxMessageSizeInBytes(newNativeTransportMaxMessageSizeInBytes);
     }
 
     public static int getNativeTransportMaxRequestsPerSecond()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -579,6 +579,11 @@ public class DatabaseDescriptor
             conf.native_transport_max_request_data_in_flight_per_ip = new DataStorageSpec.LongBytesBound(Runtime.getRuntime().maxMemory() / 40);
         }
 
+        if (conf.native_transport_max_message_size == null)
+        {
+            conf.native_transport_max_message_size = conf.native_transport_max_request_data_in_flight_per_ip;
+        }
+
         if (conf.native_transport_rate_limiting_enabled)
             logger.info("Native transport rate-limiting enabled at {} requests/second.", conf.native_transport_max_requests_per_second);
         else
@@ -2746,6 +2751,28 @@ public class DatabaseDescriptor
     public static long getNativeTransportMaxRequestDataInFlightPerIpInBytes()
     {
         return conf.native_transport_max_request_data_in_flight_per_ip.toBytes();
+    }
+
+    public static long getNativeTransportMaxMessageSizeInBytes()
+    {
+        return conf.native_transport_max_message_size.toBytes();
+    }
+
+    @VisibleForTesting
+    public static void setNativeTransportMaxMessageSizeInBytes(long maxMessageSizeInBytes)
+    {
+        conf.native_transport_max_message_size = new DataStorageSpec.LongBytesBound(maxMessageSizeInBytes);
+    }
+
+    public static long getNativeTransportMaxAuthMessageSizeInBytes()
+    {
+        return conf.native_transport_max_auth_message_size.toBytes();
+    }
+
+    @VisibleForTesting
+    public static void setNativeTransportMaxAuthMessageSizeInBytes(long maxAuthMessageSizeInBytes)
+    {
+        conf.native_transport_max_auth_message_size = new DataStorageSpec.LongBytesBound(maxAuthMessageSizeInBytes);
     }
 
     public static Config.PaxosVariant getPaxosVariant()

--- a/src/java/org/apache/cassandra/exceptions/OversizedCQLMessageException.java
+++ b/src/java/org/apache/cassandra/exceptions/OversizedCQLMessageException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+
+public class OversizedCQLMessageException extends InvalidRequestException
+{
+    public OversizedCQLMessageException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/java/org/apache/cassandra/net/AbstractMessageHandler.java
+++ b/src/java/org/apache/cassandra/net/AbstractMessageHandler.java
@@ -562,7 +562,7 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
             return size == received;
         }
 
-        private void onIntactFrame(IntactFrame frame)
+        protected void onIntactFrame(IntactFrame frame)
         {
             boolean expires = approxTime.isAfter(expiresAtNanos);
             if (!isExpired && !isCorrupt)
@@ -578,7 +578,7 @@ public abstract class AbstractMessageHandler extends ChannelInboundHandlerAdapte
             isExpired |= expires;
         }
 
-        private void onCorruptFrame()
+        protected void onCorruptFrame()
         {
             if (!isExpired && !isCorrupt)
                 releaseBuffersAndCapacity(); // release resources once we transition from normal state to corrupt

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -82,6 +82,10 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
     public static final int LARGE_MESSAGE_THRESHOLD = FrameEncoder.Payload.MAX_SIZE - 1;
     public static final TimeUnit RATE_LIMITER_DELAY_UNIT = TimeUnit.NANOSECONDS;
 
+    static final String MULTI_FRAME_AUTH_ERROR_MESSAGE_PREFIX = "The connection is not yet in a valid state " +
+                                                                "to process multi frame CQL Messages, usually this" +
+                                                                "means that authentication is still pending. ";
+
     private final QueueBackpressure queueBackpressure;
     private final Envelope.Decoder envelopeDecoder;
     private final Message.Decoder<M> messageDecoder;
@@ -531,8 +535,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
                 // clients. In this case, we raise a fatal error and close the connection so it does
                 // not make sense to continue processing subsequent frames
                 handleError(ProtocolException.toFatalException(new OversizedAuthMessageException(
-                            "The connection is not yet in a valid state to process multi frame CQL Messages, usually this" +
-                            "means that authentication is still pending. " +
+                            MULTI_FRAME_AUTH_ERROR_MESSAGE_PREFIX +
                             "type = " + header.type + ", size = " + header.bodySizeInBytes)));
                 ClientMetrics.instance.markRequestDiscarded();
                 return false;
@@ -784,6 +787,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             this.tooBig = true;
         }
 
+        @Override
         protected void onIntactFrame(IntactFrame frame)
         {
             if (tooBig || overload != Overload.NONE)
@@ -794,6 +798,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
                 super.onIntactFrame(frame);
         }
 
+        @Override
         protected void onCorruptFrame()
         {
             if (!isExpired && !isCorrupt && !tooBig)
@@ -807,6 +812,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
         }
 
 
+        @Override
         protected void onComplete()
         {
             if (tooBig)
@@ -822,6 +828,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
                 processRequest(assembleFrame(), backpressure);
         }
 
+        @Override
         protected void abort()
         {
             if (!isCorrupt && !tooBig && overload == Overload.NONE)

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -94,6 +94,8 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
     long channelPayloadBytesInFlight;
     private int consecutiveMessageErrors = 0;
 
+    private final ServerConnection serverConnection;
+
     interface MessageConsumer<M extends Message>
     {
         void dispatch(Channel channel, M message, Dispatcher.FlushItemConverter toFlushItem, Overload backpressure);
@@ -106,6 +108,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
     }
 
     CQLMessageHandler(Channel channel,
+                      ServerConnection serverConnection,
                       ProtocolVersion version,
                       FrameDecoder decoder,
                       Envelope.Decoder envelopeDecoder,
@@ -128,6 +131,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
               resources.endpointWaitQueue(),
               resources.globalWaitQueue(),
               onClosed);
+        this.serverConnection = serverConnection;
         this.envelopeDecoder    = envelopeDecoder;
         this.messageDecoder     = messageDecoder;
         this.payloadAllocator   = payloadAllocator;
@@ -182,6 +186,8 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
 
         // max CQL message size defaults to 256mb, so should be safe to downcast
         int messageSize = Ints.checkedCast(header.bodySizeInBytes);
+        if (messageTooBig(messageSize))
+            return false;
 
         Overload backpressure = Overload.NONE;
         if (throwOnOverload)
@@ -517,6 +523,9 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             Envelope.Header header = extracted.header();
             // max CQL message size defaults to 256mb, so should be safe to downcast
             int messageSize = Ints.checkedCast(header.bodySizeInBytes);
+            if (messageTooBig(messageSize))
+                return false;
+
             receivedBytes += buf.remaining();
             
             LargeMessage largeMessage = new LargeMessage(header);
@@ -760,5 +769,36 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             if (!isCorrupt)
                 releaseBuffersAndCapacity(); // release resources if in normal state when abort() is invoked
         }
+    }
+
+    static class OversizedCQLMessageException extends ProtocolException
+    {
+        OversizedCQLMessageException(String message)
+        {
+            super(message);
+        }
+    }
+
+    private boolean messageTooBig(int messageSize)
+    {
+        boolean authInProgress = serverConnection != null && serverConnection.stage() != ConnectionStage.READY;
+        if (authInProgress && messageSize > DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes())
+        {
+            handleError(ProtocolException.toFatalException(new OversizedCQLMessageException(
+                        "Auth CQL Message of size " + messageSize + " bytes exceeds allowed maximum of "
+                        + DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes() + " bytes"))
+            );
+            return true;
+        }
+
+        if (messageSize > DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes())
+        {
+            handleError(ProtocolException.toFatalException(new OversizedCQLMessageException(
+                "CQL Message of size " + messageSize + " bytes exceeds allowed maximum of "
+                 + DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes() + " bytes"))
+            );
+            return true;
+        }
+        return false;
     }
 }

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -524,10 +524,16 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             int messageSize = Ints.checkedCast(header.bodySizeInBytes);
             receivedBytes += buf.remaining();
 
-            if (isItLargeMessageSentDuringAuth(header))
+            if (serverConnection != null && serverConnection.stage() != ConnectionStage.READY)
             {
-                // we raise a fatal error and close the connection,
-                // so it does not make sense to continue frames processing
+                // Disallow any multiframe messages before the connection reaches the READY state.
+                // This guards against being swamped with oversize messages from unauthenticated
+                // clients. In this case, we raise a fatal error and close the connection so it does
+                // not make sense to continue processing subsequent frames
+                handleError(ProtocolException.toFatalException(new OversizedAuthMessageException(
+                            "The connection is not yet in a valid state to process multi frame CQL Messages, usually this" +
+                            "means that authentication is still pending. " +
+                            "type = " + header.type + ", size = " + header.bodySizeInBytes)));
                 ClientMetrics.instance.markRequestDiscarded();
                 return false;
             }
@@ -839,19 +845,5 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
         {
             super(message);
         }
-    }
-
-    private boolean isItLargeMessageSentDuringAuth(Envelope.Header header)
-    {
-        boolean authInProgress = serverConnection != null && serverConnection.stage() != ConnectionStage.READY;
-        if (authInProgress)
-        {
-            handleError(ProtocolException.toFatalException(new OversizedAuthMessageException(
-                        "A large multi-frame CQL Message is sent during authentication stage, " +
-                        "type = " + header.type + ", size = " + header.bodySizeInBytes))
-            );
-            return true;
-        }
-        return false;
     }
 }

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -31,6 +31,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.OversizedCQLMessageException;
 import org.apache.cassandra.metrics.ClientMessageSizeMetrics;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.AbstractMessageHandler;
@@ -80,6 +81,9 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
 
     public static final int LARGE_MESSAGE_THRESHOLD = FrameEncoder.Payload.MAX_SIZE - 1;
     public static final TimeUnit RATE_LIMITER_DELAY_UNIT = TimeUnit.NANOSECONDS;
+
+    public static final long MAX_CQL_MESSAGE_SIZE = DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes();
+    public static final long MAX_CQL_AUTH_MESSAGE_SIZE = DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes();
 
     private final QueueBackpressure queueBackpressure;
     private final Envelope.Decoder envelopeDecoder;
@@ -186,8 +190,13 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
 
         // max CQL message size defaults to 256mb, so should be safe to downcast
         int messageSize = Ints.checkedCast(header.bodySizeInBytes);
-        if (messageTooBig(messageSize))
+        if (authMessageTooBig(messageSize))
+        {
+            // we raise a fatal error and close the connection,
+            // so it does not make sense to continue frames processing
+            ClientMetrics.instance.markRequestDiscarded();
             return false;
+        }
 
         Overload backpressure = Overload.NONE;
         if (throwOnOverload)
@@ -523,14 +532,24 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             Envelope.Header header = extracted.header();
             // max CQL message size defaults to 256mb, so should be safe to downcast
             int messageSize = Ints.checkedCast(header.bodySizeInBytes);
-            if (messageTooBig(messageSize))
-                return false;
-
             receivedBytes += buf.remaining();
+
+            if (authMessageTooBig(messageSize))
+            {
+                // we raise a fatal error and close the connection,
+                // so it does not make sense to continue frames processing
+                ClientMetrics.instance.markRequestDiscarded();
+                return false;
+            }
             
             LargeMessage largeMessage = new LargeMessage(header);
-
-            if (throwOnOverload)
+            if (messageSize > MAX_CQL_MESSAGE_SIZE)
+            {
+                ClientMetrics.instance.markRequestDiscarded();
+                // Mark as too big so that discard the message after consuming any subsequent frames
+                largeMessage.markTooBig();
+            }
+            else if (throwOnOverload)
             {
                 if (!acquireCapacity(header, endpointReserve, globalReserve))
                 {
@@ -576,9 +595,9 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
                     }
                 }
             }
-            else
+            else // throwOnOverload = false
             {
-                if (acquireCapacity(header, endpointReserve, globalReserve))
+                if (acquireCapacityAndQueueOnFailure(header, endpointReserve, globalReserve))
                 {
                     long delay = -1;
                     Overload backpressure = Overload.NONE;
@@ -614,7 +633,14 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
                 }
                 else
                 {
-                    noSpamLogger.error("Could not aquire capacity while processing native protocol message");
+                    // we checked previously that messageSize <= native_transport_max_message_size
+                    // and native_transport_max_message_size <= native_transport_max_request_data_in_flight
+                    // and native_transport_max_message_size <= native_transport_max_request_data_in_flight_per_ip
+                    // so, a starvation is not possible for the following case:
+                    // a connection is blocked forever if somebody tries to send a single too big message > total rate limiting capacity.
+                    // Once other messages in the same or other CQL connections are processed and capacity is returned to the limits
+                    // we have enough capacity to acquire it for the current large message.
+                    return false;
                 }
             }
 
@@ -721,6 +747,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
 
         private Overload overload = Overload.NONE;
         private Overload backpressure = Overload.NONE;
+        private boolean tooBig = false;
 
         private LargeMessage(Envelope.Header header)
         {
@@ -756,9 +783,16 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             this.backpressure = backpressure;
         }
 
+        private void markTooBig()
+        {
+            this.tooBig = true;
+        }
+
         protected void onComplete()
         {
-            if (overload != Overload.NONE)
+            if (tooBig)
+                handleErrorAndRelease(buildOversizedCQLMessageException(header.bodySizeInBytes), header);
+            else if (overload != Overload.NONE)
                 handleErrorAndRelease(buildOverloadedException(endpointReserveCapacity, globalReserveCapacity, overload), header);
             else if (!isCorrupt)
                 processRequest(assembleFrame(), backpressure);
@@ -769,33 +803,31 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             if (!isCorrupt)
                 releaseBuffersAndCapacity(); // release resources if in normal state when abort() is invoked
         }
+
+        private OversizedCQLMessageException buildOversizedCQLMessageException(long messageBodySize)
+        {
+            return new OversizedCQLMessageException("CQL Message of size " + messageBodySize
+                                                    + " bytes exceeds allowed maximum of "
+                                                    + DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes() + " bytes");
+        }
     }
 
-    static class OversizedCQLMessageException extends ProtocolException
+    static class OversizedAuthMessageException extends ProtocolException
     {
-        OversizedCQLMessageException(String message)
+        OversizedAuthMessageException(String message)
         {
             super(message);
         }
     }
 
-    private boolean messageTooBig(int messageSize)
+    private boolean authMessageTooBig(int messageSize)
     {
         boolean authInProgress = serverConnection != null && serverConnection.stage() != ConnectionStage.READY;
-        if (authInProgress && messageSize > DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes())
+        if (authInProgress && messageSize > MAX_CQL_AUTH_MESSAGE_SIZE)
         {
-            handleError(ProtocolException.toFatalException(new OversizedCQLMessageException(
+            handleError(ProtocolException.toFatalException(new OversizedAuthMessageException(
                         "Auth CQL Message of size " + messageSize + " bytes exceeds allowed maximum of "
                         + DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes() + " bytes"))
-            );
-            return true;
-        }
-
-        if (messageSize > DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes())
-        {
-            handleError(ProtocolException.toFatalException(new OversizedCQLMessageException(
-                "CQL Message of size " + messageSize + " bytes exceeds allowed maximum of "
-                 + DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes() + " bytes"))
             );
             return true;
         }

--- a/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
+++ b/src/java/org/apache/cassandra/transport/CQLMessageHandler.java
@@ -82,9 +82,6 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
     public static final int LARGE_MESSAGE_THRESHOLD = FrameEncoder.Payload.MAX_SIZE - 1;
     public static final TimeUnit RATE_LIMITER_DELAY_UNIT = TimeUnit.NANOSECONDS;
 
-    public static final long MAX_CQL_MESSAGE_SIZE = DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes();
-    public static final long MAX_CQL_AUTH_MESSAGE_SIZE = DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes();
-
     private final QueueBackpressure queueBackpressure;
     private final Envelope.Decoder envelopeDecoder;
     private final Message.Decoder<M> messageDecoder;
@@ -190,13 +187,6 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
 
         // max CQL message size defaults to 256mb, so should be safe to downcast
         int messageSize = Ints.checkedCast(header.bodySizeInBytes);
-        if (authMessageTooBig(messageSize))
-        {
-            // we raise a fatal error and close the connection,
-            // so it does not make sense to continue frames processing
-            ClientMetrics.instance.markRequestDiscarded();
-            return false;
-        }
 
         Overload backpressure = Overload.NONE;
         if (throwOnOverload)
@@ -534,7 +524,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             int messageSize = Ints.checkedCast(header.bodySizeInBytes);
             receivedBytes += buf.remaining();
 
-            if (authMessageTooBig(messageSize))
+            if (isItLargeMessageSentDuringAuth(header))
             {
                 // we raise a fatal error and close the connection,
                 // so it does not make sense to continue frames processing
@@ -543,7 +533,7 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             }
             
             LargeMessage largeMessage = new LargeMessage(header);
-            if (messageSize > MAX_CQL_MESSAGE_SIZE)
+            if (messageSize > DatabaseDescriptor.getNativeTransportMaxMessageSizeInBytes())
             {
                 ClientMetrics.instance.markRequestDiscarded();
                 // Mark as too big so that discard the message after consuming any subsequent frames
@@ -788,20 +778,51 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
             this.tooBig = true;
         }
 
+        protected void onIntactFrame(IntactFrame frame)
+        {
+            if (tooBig || overload != Overload.NONE)
+                // we do not want to add the frame to buffers (to not consume a lot of memory and throw it away later
+                // we also do not want to release capacity because we haven't accuired it
+                frame.consume();
+            else
+                super.onIntactFrame(frame);
+        }
+
+        protected void onCorruptFrame()
+        {
+            if (!isExpired && !isCorrupt && !tooBig)
+            {
+                releaseBuffers(); // release resources once we transition from normal state to corrupt
+                if (overload != Overload.BYTES_IN_FLIGHT)
+                    releaseCapacity(size);
+            }
+            isCorrupt = true;
+            isExpired |= approxTime.isAfter(expiresAtNanos);
+        }
+
+
         protected void onComplete()
         {
             if (tooBig)
-                handleErrorAndRelease(buildOversizedCQLMessageException(header.bodySizeInBytes), header);
+                // we haven't accuired a capacity for too big messages to release it
+                handleError(buildOversizedCQLMessageException(header.bodySizeInBytes), header);
             else if (overload != Overload.NONE)
-                handleErrorAndRelease(buildOverloadedException(endpointReserveCapacity, globalReserveCapacity, overload), header);
+                if (overload == Overload.BYTES_IN_FLIGHT)
+                    // we haven't accuired a capacity successfully to release it
+                    handleError(buildOverloadedException(endpointReserveCapacity, globalReserveCapacity, overload), header);
+                else
+                    handleErrorAndRelease(buildOverloadedException(endpointReserveCapacity, globalReserveCapacity, overload), header);
             else if (!isCorrupt)
                 processRequest(assembleFrame(), backpressure);
         }
 
         protected void abort()
         {
-            if (!isCorrupt)
-                releaseBuffersAndCapacity(); // release resources if in normal state when abort() is invoked
+            if (!isCorrupt && !tooBig && overload == Overload.NONE)
+                releaseBuffers();
+
+            if (overload == Overload.NONE || overload == Overload.BYTES_IN_FLIGHT)
+                releaseCapacity(size);
         }
 
         private OversizedCQLMessageException buildOversizedCQLMessageException(long messageBodySize)
@@ -820,14 +841,14 @@ public class CQLMessageHandler<M extends Message> extends AbstractMessageHandler
         }
     }
 
-    private boolean authMessageTooBig(int messageSize)
+    private boolean isItLargeMessageSentDuringAuth(Envelope.Header header)
     {
         boolean authInProgress = serverConnection != null && serverConnection.stage() != ConnectionStage.READY;
-        if (authInProgress && messageSize > MAX_CQL_AUTH_MESSAGE_SIZE)
+        if (authInProgress)
         {
             handleError(ProtocolException.toFatalException(new OversizedAuthMessageException(
-                        "Auth CQL Message of size " + messageSize + " bytes exceeds allowed maximum of "
-                        + DatabaseDescriptor.getNativeTransportMaxAuthMessageSizeInBytes() + " bytes"))
+                        "A large multi-frame CQL Message is sent during authentication stage, " +
+                        "type = " + header.type + ", size = " + header.bodySizeInBytes))
             );
             return true;
         }

--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -38,6 +38,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.unix.Errors;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.exceptions.OversizedCQLMessageException;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.transport.messages.ErrorMessage;
@@ -128,6 +129,10 @@ public class ExceptionHandlers
         else if (Throwables.anyCauseMatches(cause, t -> t instanceof OverloadedException))
         {
             // Once the threshold for overload is breached, it will very likely spam the logs...
+            NoSpamLogger.log(logger, NoSpamLogger.Level.INFO, 1, TimeUnit.MINUTES, cause.getMessage());
+        }
+        else if (Throwables.anyCauseMatches(cause, t -> t instanceof OversizedCQLMessageException))
+        {
             NoSpamLogger.log(logger, NoSpamLogger.Level.INFO, 1, TimeUnit.MINUTES, cause.getMessage());
         }
         else if (Throwables.anyCauseMatches(cause, t -> t instanceof Errors.NativeIoException))

--- a/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
+++ b/src/java/org/apache/cassandra/transport/InitialConnectionHandler.java
@@ -104,6 +104,7 @@ public class InitialConnectionHandler extends ByteToMessageDecoder
                         attrConn.set(connection);
                     }
                     assert connection instanceof ServerConnection;
+                    ServerConnection serverConnection = (ServerConnection) connection;
 
                     StartupMessage startup = (StartupMessage) Message.Decoder.decodeMessage(ctx.channel(), inbound);
                     InetAddress remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress();
@@ -120,7 +121,7 @@ public class InitialConnectionHandler extends ByteToMessageDecoder
                             if (future.isSuccess())
                             {
                                 logger.trace("Response to STARTUP sent, configuring pipeline for {}", inbound.header.version);
-                                configurator.configureModernPipeline(ctx, allocator, inbound.header.version, startup.options);
+                                configurator.configureModernPipeline(ctx, serverConnection, allocator, inbound.header.version, startup.options);
                                 allocator.release(inbound.header.bodySizeInBytes);
                             }
                             else

--- a/src/java/org/apache/cassandra/transport/PipelineConfigurator.java
+++ b/src/java/org/apache/cassandra/transport/PipelineConfigurator.java
@@ -270,6 +270,7 @@ public class PipelineConfigurator
     }
 
     public void configureModernPipeline(ChannelHandlerContext ctx,
+                                        ServerConnection serverConnection,
                                         ClientResourceLimits.Allocator resourceAllocator,
                                         ProtocolVersion version,
                                         Map<String, String> options)
@@ -311,6 +312,7 @@ public class PipelineConfigurator
         CQLMessageHandler.MessageConsumer<Message.Request> messageConsumer = messageConsumer();
         CQLMessageHandler<Message.Request> processor =
             new CQLMessageHandler<>(ctx.channel(),
+                                    serverConnection,
                                     version,
                                     frameDecoder,
                                     envelopeDecoder,

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -504,6 +504,7 @@ public class SimpleClient implements Closeable
 
             CQLMessageHandler<Message.Response> processor =
                 new CQLMessageHandler<Message.Response>(ctx.channel(),
+                                        null,
                                         version,
                                         frameDecoder,
                                         envelopeDecoder,

--- a/test/unit/org/apache/cassandra/transport/AuthMessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/AuthMessageSizeLimitTest.java
@@ -18,10 +18,6 @@
 
 package org.apache.cassandra.transport;
 
-import java.io.IOException;
-
-import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,29 +27,17 @@ import com.datastax.driver.core.EndPoint;
 import com.datastax.driver.core.PlainTextAuthProvider;
 import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.transport.messages.AuthResponse;
 import org.apache.cassandra.transport.messages.QueryMessage;
+import org.assertj.core.api.Assertions;
 
-public class AuthMessageSizeLimitTest extends CQLTester
+public class AuthMessageSizeLimitTest extends NativeProtocolLimitsTest
 {
     private static final int TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE = 2 * FrameEncoder.Payload.MAX_SIZE;
 
     // set MAX_CQL_MESSAGE_SIZE bigger than TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE to ensure what the auth message size check is more restrictive
     private static final int MAX_CQL_MESSAGE_SIZE = TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE * 2;
-
-    private static final QueryOptions V5_DEFAULT_OPTIONS =
-    QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
-                        QueryOptions.DEFAULT.getValues(),
-                        QueryOptions.DEFAULT.skipMetadata(),
-                        QueryOptions.DEFAULT.getPageSize(),
-                        QueryOptions.DEFAULT.getPagingState(),
-                        QueryOptions.DEFAULT.getSerialConsistency(),
-                        ProtocolVersion.V5,
-                        KEYSPACE);
 
     @BeforeClass
     public static void setUp()
@@ -73,36 +57,6 @@ public class AuthMessageSizeLimitTest extends CQLTester
         ClientResourceLimits.setEndpointLimit(MAX_CQL_MESSAGE_SIZE);
     }
 
-    @After
-    public void dropCreatedTable()
-    {
-        try
-        {
-            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".test_table");
-        }
-        catch (Throwable t)
-        {
-            // ignore
-        }
-    }
-
-    @SuppressWarnings({"resource", "SameParameterValue"})
-    private SimpleClient client()
-    {
-        try
-        {
-            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
-                               .protocolVersion(ProtocolVersion.V5)
-                               .useBeta()
-                               .build()
-                               .connect(false, false);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error initializing client", e);
-        }
-    }
-
     @Test
     public void sendSmallAuthMessage()
     {
@@ -110,13 +64,10 @@ public class AuthMessageSizeLimitTest extends CQLTester
                {
                    AuthResponse authResponse = createAuthMessage("cassandra", "cassandra");
                    client.execute(authResponse);
-
-                   QueryMessage createTableMessage = new QueryMessage("CREATE TABLE test_table (pk int PRIMARY KEY, v text)",
-                                                                V5_DEFAULT_OPTIONS);
-                   client.execute(createTableMessage);
+                   createTable(client);
 
                    int valueLessThanMessageMaxSize = MAX_CQL_MESSAGE_SIZE - 500;
-                   QueryMessage queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
+                   QueryMessage queryMessage = queryMessage(valueLessThanMessageMaxSize);
                    client.execute(queryMessage);
                }
         );
@@ -128,41 +79,16 @@ public class AuthMessageSizeLimitTest extends CQLTester
         doTest((client) ->
                {
                    AuthResponse authResponse = createAuthMessage("cassandra", createIncorrectLongPassword(TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE));
-                   try
-                   {
-                       client.execute(authResponse);
-                   } catch (RuntimeException e) {
-                       // ProtocolException: Auth CQL Message of size 262159 bytes exceeds allowed maximum of 130072 bytes
-                       Assert.assertTrue(e.getCause() instanceof ProtocolException);
-                   }
+                   Assertions.assertThatThrownBy(() -> client.execute(authResponse))
+                             .hasCauseInstanceOf(ProtocolException.class)
+                             .hasMessageContaining(CQLMessageHandler.MULTI_FRAME_AUTH_ERROR_MESSAGE_PREFIX);
                    Util.spinAssertEquals(false, () -> client.connection.channel().isOpen(), 10);
-
                }
         );
     }
 
-    private void doTest(TestLogic testLogic)
+    private static String createIncorrectLongPassword(int length)
     {
-        try (SimpleClient client = client())
-        {
-            testLogic.run(client);
-        }
-    }
-    private interface TestLogic
-    {
-        void run(SimpleClient simpleClient);
-    }
-
-    private QueryMessage createQueryMessage(int valueSize)
-    {
-        StringBuilder query = new StringBuilder("INSERT INTO test_table (pk, v) VALUES (1, '");
-        for (int i = 0; i < valueSize; i++)
-            query.append('a');
-        query.append("')");
-        return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);
-    }
-
-    private static String createIncorrectLongPassword(int length) {
         StringBuilder password = new StringBuilder(length);
         for (int i = 0; i < length; i++)
             password.append('a');

--- a/test/unit/org/apache/cassandra/transport/AuthMessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/AuthMessageSizeLimitTest.java
@@ -40,11 +40,6 @@ import org.apache.cassandra.transport.messages.QueryMessage;
 
 public class AuthMessageSizeLimitTest extends CQLTester
 {
-    // set MAX_CQL_AUTH_MESSAGE_SIZE less than a frame size to be able to test both decoding options on a server side:
-    // - org.apache.cassandra.transport.CQLMessageHandler.processOneContainedMessage
-    // - org.apache.cassandra.transport.CQLMessageHandler.processFirstFrameOfLargeMessage
-    private static final int MAX_CQL_AUTH_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 1000;
-    private static final int TOO_BIG_SINGLE_FRAME_AUTH_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 500;
     private static final int TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE = 2 * FrameEncoder.Payload.MAX_SIZE;
 
     // set MAX_CQL_MESSAGE_SIZE bigger than TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE to ensure what the auth message size check is more restrictive
@@ -67,8 +62,6 @@ public class AuthMessageSizeLimitTest extends CQLTester
         DatabaseDescriptor.setNativeTransportMaxRequestDataInFlightPerIpInBytes(MAX_CQL_MESSAGE_SIZE);
         DatabaseDescriptor.setNativeTransportConcurrentRequestDataInFlightInBytes(MAX_CQL_MESSAGE_SIZE);
         DatabaseDescriptor.setNativeTransportMaxMessageSizeInBytes(MAX_CQL_MESSAGE_SIZE);
-        DatabaseDescriptor.setNativeTransportMaxAuthMessageSizeInBytes(MAX_CQL_AUTH_MESSAGE_SIZE);
-
         requireNetwork();
         requireAuthentication();
     }
@@ -125,25 +118,6 @@ public class AuthMessageSizeLimitTest extends CQLTester
                    int valueLessThanMessageMaxSize = MAX_CQL_MESSAGE_SIZE - 500;
                    QueryMessage queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
                    client.execute(queryMessage);
-               }
-        );
-    }
-
-    @Test
-    public void sendTooBigAuthSingleFrameMessage()
-    {
-        doTest((client) ->
-               {
-                   AuthResponse authResponse = createAuthMessage("cassandra", createIncorrectLongPassword(TOO_BIG_SINGLE_FRAME_AUTH_MESSAGE_SIZE));
-                   try
-                   {
-                       client.execute(authResponse);
-                   } catch (RuntimeException e) {
-                       // ProtocolException: Auth CQL Message of size 130587 bytes exceeds allowed maximum of 130072 bytes
-                       Assert.assertTrue(e.getCause() instanceof ProtocolException);
-                   }
-                   Util.spinAssertEquals(false, () -> client.connection.channel().isOpen(), 10);
-
                }
         );
     }

--- a/test/unit/org/apache/cassandra/transport/AuthMessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/AuthMessageSizeLimitTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.Authenticator;
+import com.datastax.driver.core.EndPoint;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.net.FrameEncoder;
+import org.apache.cassandra.transport.messages.AuthResponse;
+import org.apache.cassandra.transport.messages.QueryMessage;
+
+public class AuthMessageSizeLimitTest extends CQLTester
+{
+    // set MAX_CQL_AUTH_MESSAGE_SIZE less than a frame size to be able to test both decoding options on a server side:
+    // - org.apache.cassandra.transport.CQLMessageHandler.processOneContainedMessage
+    // - org.apache.cassandra.transport.CQLMessageHandler.processFirstFrameOfLargeMessage
+    private static final int MAX_CQL_AUTH_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 1000;
+    private static final int TOO_BIG_SINGLE_FRAME_AUTH_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 500;
+    private static final int TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE = 2 * FrameEncoder.Payload.MAX_SIZE;
+
+    // set MAX_CQL_MESSAGE_SIZE bigger than TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE to ensure what the auth message size check is more restrictive
+    private static final int MAX_CQL_MESSAGE_SIZE = TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE * 2;
+
+    private static final QueryOptions V5_DEFAULT_OPTIONS =
+    QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
+                        QueryOptions.DEFAULT.getValues(),
+                        QueryOptions.DEFAULT.skipMetadata(),
+                        QueryOptions.DEFAULT.getPageSize(),
+                        QueryOptions.DEFAULT.getPagingState(),
+                        QueryOptions.DEFAULT.getSerialConsistency(),
+                        ProtocolVersion.V5,
+                        KEYSPACE);
+
+    @BeforeClass
+    public static void setUp()
+    {
+        DatabaseDescriptor.setNativeTransportReceiveQueueCapacityInBytes(1);
+        DatabaseDescriptor.setNativeTransportMaxRequestDataInFlightPerIpInBytes(MAX_CQL_MESSAGE_SIZE);
+        DatabaseDescriptor.setNativeTransportConcurrentRequestDataInFlightInBytes(MAX_CQL_MESSAGE_SIZE);
+        DatabaseDescriptor.setNativeTransportMaxMessageSizeInBytes(MAX_CQL_MESSAGE_SIZE);
+        DatabaseDescriptor.setNativeTransportMaxAuthMessageSizeInBytes(MAX_CQL_AUTH_MESSAGE_SIZE);
+
+        requireNetwork();
+        requireAuthentication();
+    }
+
+    @Before
+    public void setLimits()
+    {
+        ClientResourceLimits.setGlobalLimit(MAX_CQL_MESSAGE_SIZE);
+        ClientResourceLimits.setEndpointLimit(MAX_CQL_MESSAGE_SIZE);
+    }
+
+    @After
+    public void dropCreatedTable()
+    {
+        try
+        {
+            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".test_table");
+        }
+        catch (Throwable t)
+        {
+            // ignore
+        }
+    }
+
+    @SuppressWarnings({"resource", "SameParameterValue"})
+    private SimpleClient client()
+    {
+        try
+        {
+            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
+                               .protocolVersion(ProtocolVersion.V5)
+                               .useBeta()
+                               .build()
+                               .connect(false, false);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error initializing client", e);
+        }
+    }
+
+    @Test
+    public void sendSmallAuthMessage()
+    {
+        doTest((client) ->
+               {
+                   AuthResponse authResponse = createAuthMessage("cassandra", "cassandra");
+                   client.execute(authResponse);
+
+                   QueryMessage createTableMessage = new QueryMessage("CREATE TABLE test_table (pk int PRIMARY KEY, v text)",
+                                                                V5_DEFAULT_OPTIONS);
+                   client.execute(createTableMessage);
+
+                   int valueLessThanMessageMaxSize = MAX_CQL_MESSAGE_SIZE - 500;
+                   QueryMessage queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
+                   client.execute(queryMessage);
+               }
+        );
+    }
+
+    @Test
+    public void sendTooBigAuthSingleFrameMessage()
+    {
+        doTest((client) ->
+               {
+                   AuthResponse authResponse = createAuthMessage("cassandra", createIncorrectLongPassword(TOO_BIG_SINGLE_FRAME_AUTH_MESSAGE_SIZE));
+                   try
+                   {
+                       client.execute(authResponse);
+                   } catch (RuntimeException e) {
+                       // ProtocolException: Auth CQL Message of size 130587 bytes exceeds allowed maximum of 130072 bytes
+                       Assert.assertTrue(e.getCause() instanceof ProtocolException);
+                   }
+                   Util.spinAssertEquals(false, () -> client.connection.channel().isOpen(), 10);
+
+               }
+        );
+    }
+
+    @Test
+    public void sendTooBigAuthMultiFrameMessage()
+    {
+        doTest((client) ->
+               {
+                   AuthResponse authResponse = createAuthMessage("cassandra", createIncorrectLongPassword(TOO_BIG_MULTI_FRAME_AUTH_MESSAGE_SIZE));
+                   try
+                   {
+                       client.execute(authResponse);
+                   } catch (RuntimeException e) {
+                       // ProtocolException: Auth CQL Message of size 262159 bytes exceeds allowed maximum of 130072 bytes
+                       Assert.assertTrue(e.getCause() instanceof ProtocolException);
+                   }
+                   Util.spinAssertEquals(false, () -> client.connection.channel().isOpen(), 10);
+
+               }
+        );
+    }
+
+    private void doTest(TestLogic testLogic)
+    {
+        try (SimpleClient client = client())
+        {
+            testLogic.run(client);
+        }
+    }
+    private interface TestLogic
+    {
+        void run(SimpleClient simpleClient);
+    }
+
+    private QueryMessage createQueryMessage(int valueSize)
+    {
+        StringBuilder query = new StringBuilder("INSERT INTO test_table (pk, v) VALUES (1, '");
+        for (int i = 0; i < valueSize; i++)
+            query.append('a');
+        query.append("')");
+        return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);
+    }
+
+    private static String createIncorrectLongPassword(int length) {
+        StringBuilder password = new StringBuilder(length);
+        for (int i = 0; i < length; i++)
+            password.append('a');
+        return password.toString();
+    }
+
+    private AuthResponse createAuthMessage(String username, String password)
+    {
+        PlainTextAuthProvider authProvider = new PlainTextAuthProvider(username, password);
+        Authenticator authenticator = authProvider.newAuthenticator((EndPoint) null, null);
+        return new AuthResponse(authenticator.initialResponse());
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
@@ -65,6 +65,8 @@ public class ClientResourceLimitsTest extends CQLTester
                             ProtocolVersion.V5,
                             KEYSPACE);
 
+    private long emulatedUsedCapacity;
+
     @BeforeClass
     public static void setUp()
     {
@@ -92,6 +94,10 @@ public class ClientResourceLimitsTest extends CQLTester
     @After
     public void dropCreatedTable()
     {
+        if (emulatedUsedCapacity > 0)
+        {
+            releaseEmulatedCapacity(emulatedUsedCapacity);
+        }
         try
         {
             QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".atable");
@@ -135,6 +141,23 @@ public class ClientResourceLimitsTest extends CQLTester
         {
            throw new RuntimeException("Error initializing client", e);
         }
+    }
+
+    private void emulateInFlightConcurrentMessage(long length)
+    {
+        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
+        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
+        resourceProvider.globalLimit().allocate(length);
+        resourceProvider.endpointLimit().allocate(length);
+        emulatedUsedCapacity += length;
+    }
+
+    private void releaseEmulatedCapacity(long length)
+    {
+        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
+        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
+        resourceProvider.globalLimit().release(length);
+        resourceProvider.endpointLimit().release(length);
     }
 
     @Test
@@ -261,7 +284,11 @@ public class ClientResourceLimitsTest extends CQLTester
     {
         // Bump the per-endpoint limit to make sure we exhaust the global
         ClientResourceLimits.setEndpointLimit(HIGH_LIMIT);
-        testOverloadedException(() -> client(true, Ints.checkedCast(LOW_LIMIT / 2)));
+        // test massage = 2/3 x
+        // emulated concurrent message = 2/3 x
+        // test massage + emulated concurrent message = 4/3 x > x set as a global limit
+        emulateInFlightConcurrentMessage(LOW_LIMIT * 2 / 3);
+        testOverloadedException(() -> client(true, Ints.checkedCast(LOW_LIMIT / 2)), LOW_LIMIT * 2 / 3);
     }
 
     @Test
@@ -269,10 +296,19 @@ public class ClientResourceLimitsTest extends CQLTester
     {
         // Make sure we can only exceed the per-endpoint limit
         ClientResourceLimits.setGlobalLimit(HIGH_LIMIT);
-        testOverloadedException(() -> client(true, Ints.checkedCast(LOW_LIMIT / 2)));
+        // test massage = 2/3 x
+        // emulated concurrent message = 2/3 x
+        // test massage + emulated concurrent message = 4/3 x > x set as an endpoint limit
+        emulateInFlightConcurrentMessage(LOW_LIMIT * 2 / 3);
+        testOverloadedException(() -> client(true, Ints.checkedCast(LOW_LIMIT / 2)), LOW_LIMIT * 2 / 3);
     }
 
     private void testOverloadedException(Supplier<SimpleClient> clientSupplier)
+    {
+        testOverloadedException(clientSupplier, LOW_LIMIT * 2);
+    }
+
+    private void testOverloadedException(Supplier<SimpleClient> clientSupplier, long limit)
     {
         try (SimpleClient client = clientSupplier.get())
         {
@@ -280,7 +316,7 @@ public class ClientResourceLimitsTest extends CQLTester
                                                          V5_DEFAULT_OPTIONS);
             client.execute(queryMessage);
 
-            queryMessage = queryMessage();
+            queryMessage = queryMessage(limit);
             try
             {
                 client.execute(queryMessage);
@@ -295,8 +331,13 @@ public class ClientResourceLimitsTest extends CQLTester
 
     private QueryMessage queryMessage()
     {
+        return queryMessage(LOW_LIMIT * 2);
+    }
+
+    private QueryMessage queryMessage(long parameterLength)
+    {
         StringBuilder query = new StringBuilder("INSERT INTO atable (pk, v) VALUES (1, '");
-        for (int i=0; i < LOW_LIMIT * 2; i++)
+        for (int i=0; i < parameterLength; i++)
             query.append('a');
         query.append("')");
         return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);

--- a/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
@@ -284,9 +284,9 @@ public class ClientResourceLimitsTest extends CQLTester
     {
         // Bump the per-endpoint limit to make sure we exhaust the global
         ClientResourceLimits.setEndpointLimit(HIGH_LIMIT);
-        // test massage = 2/3 x
+        // test message = 2/3 x
         // emulated concurrent message = 2/3 x
-        // test massage + emulated concurrent message = 4/3 x > x set as a global limit
+        // test message + emulated concurrent message = 4/3 x > x set as a global limit
         emulateInFlightConcurrentMessage(LOW_LIMIT * 2 / 3);
         testOverloadedException(() -> client(true, Ints.checkedCast(LOW_LIMIT / 2)), LOW_LIMIT * 2 / 3);
     }
@@ -296,9 +296,9 @@ public class ClientResourceLimitsTest extends CQLTester
     {
         // Make sure we can only exceed the per-endpoint limit
         ClientResourceLimits.setGlobalLimit(HIGH_LIMIT);
-        // test massage = 2/3 x
+        // test message = 2/3 x
         // emulated concurrent message = 2/3 x
-        // test massage + emulated concurrent message = 4/3 x > x set as an endpoint limit
+        // test message + emulated concurrent message = 4/3 x > x set as an endpoint limit
         emulateInFlightConcurrentMessage(LOW_LIMIT * 2 / 3);
         testOverloadedException(() -> client(true, Ints.checkedCast(LOW_LIMIT / 2)), LOW_LIMIT * 2 / 3);
     }

--- a/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/ClientResourceLimitsTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.transport;
 
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -32,9 +31,6 @@ import org.apache.cassandra.service.StorageService;
 import org.junit.*;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.virtual.*;
@@ -50,20 +46,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ClientResourceLimitsTest extends CQLTester
+public class ClientResourceLimitsTest extends NativeProtocolLimitsTest
 {
     private static final long LOW_LIMIT = 600L;
     private static final long HIGH_LIMIT = 5000000000L;
-
-    private static final QueryOptions V5_DEFAULT_OPTIONS = 
-        QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
-                            QueryOptions.DEFAULT.getValues(),
-                            QueryOptions.DEFAULT.skipMetadata(),
-                            QueryOptions.DEFAULT.getPageSize(),
-                            QueryOptions.DEFAULT.getPagingState(),
-                            QueryOptions.DEFAULT.getSerialConsistency(),
-                            ProtocolVersion.V5,
-                            KEYSPACE);
 
     private long emulatedUsedCapacity;
 
@@ -91,75 +77,6 @@ public class ClientResourceLimitsTest extends CQLTester
         ClientResourceLimits.setEndpointLimit(LOW_LIMIT);
     }
 
-    @After
-    public void dropCreatedTable()
-    {
-        if (emulatedUsedCapacity > 0)
-        {
-            releaseEmulatedCapacity(emulatedUsedCapacity);
-        }
-        try
-        {
-            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".atable");
-        }
-        catch (Throwable t)
-        {
-            // ignore
-        }
-    }
-
-    @SuppressWarnings("resource")
-    private SimpleClient client(boolean throwOnOverload)
-    {
-        try
-        {
-            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
-                               .protocolVersion(ProtocolVersion.V5)
-                               .useBeta()
-                               .build()
-                               .connect(false, throwOnOverload);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error initializing client", e);
-        }
-    }
-
-    @SuppressWarnings({"resource", "SameParameterValue"})
-    private SimpleClient client(boolean throwOnOverload, int largeMessageThreshold)
-    {
-        try
-        {
-            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
-                               .protocolVersion(ProtocolVersion.V5)
-                               .useBeta()
-                               .largeMessageThreshold(largeMessageThreshold)
-                               .build()
-                               .connect(false, throwOnOverload);
-        }
-        catch (IOException e)
-        {
-           throw new RuntimeException("Error initializing client", e);
-        }
-    }
-
-    private void emulateInFlightConcurrentMessage(long length)
-    {
-        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
-        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
-        resourceProvider.globalLimit().allocate(length);
-        resourceProvider.endpointLimit().allocate(length);
-        emulatedUsedCapacity += length;
-    }
-
-    private void releaseEmulatedCapacity(long length)
-    {
-        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
-        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
-        resourceProvider.globalLimit().release(length);
-        resourceProvider.endpointLimit().release(length);
-    }
-
     @Test
     public void testQueryExecutionWithThrowOnOverload()
     {
@@ -176,10 +93,8 @@ public class ClientResourceLimitsTest extends CQLTester
     {
         try (SimpleClient client = client(throwOnOverload))
         {
-            QueryMessage queryMessage = new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)",
-                                                         V5_DEFAULT_OPTIONS);
-            client.execute(queryMessage);
-            queryMessage = new QueryMessage("SELECT * FROM atable", V5_DEFAULT_OPTIONS);
+            createTable(client);
+            QueryMessage queryMessage = new QueryMessage("SELECT * FROM atable", queryOptions());
             client.execute(queryMessage);
         }
     }
@@ -212,7 +127,7 @@ public class ClientResourceLimitsTest extends CQLTester
         {
             // The first query does not trigger backpressure/pause the connection:
             QueryMessage queryMessage = 
-                    new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)", V5_DEFAULT_OPTIONS);
+                    new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)", queryOptions());
             Message.Response belowThresholdResponse = client.execute(queryMessage);
             assertEquals(0, getPausedConnectionsGauge().getValue().intValue());
             assertNoWarningContains(belowThresholdResponse, "bytes in flight");
@@ -312,11 +227,9 @@ public class ClientResourceLimitsTest extends CQLTester
     {
         try (SimpleClient client = clientSupplier.get())
         {
-            QueryMessage queryMessage = new QueryMessage("CREATE TABLE atable (pk int PRIMARY KEY, v text)",
-                                                         V5_DEFAULT_OPTIONS);
-            client.execute(queryMessage);
+            createTable(client);
 
-            queryMessage = queryMessage(limit);
+            QueryMessage queryMessage = queryMessage(limit);
             try
             {
                 client.execute(queryMessage);
@@ -332,15 +245,6 @@ public class ClientResourceLimitsTest extends CQLTester
     private QueryMessage queryMessage()
     {
         return queryMessage(LOW_LIMIT * 2);
-    }
-
-    private QueryMessage queryMessage(long parameterLength)
-    {
-        StringBuilder query = new StringBuilder("INSERT INTO atable (pk, v) VALUES (1, '");
-        for (int i=0; i < parameterLength; i++)
-            query.append('a');
-        query.append("')");
-        return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);
     }
 
     @Test
@@ -382,7 +286,7 @@ public class ClientResourceLimitsTest extends CQLTester
             VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(table, ImmutableList.of(vt1)));
 
             final QueryMessage queryMessage = new QueryMessage(String.format("SELECT * FROM %s.%s", table, table),
-                                                               V5_DEFAULT_OPTIONS);
+                                                               queryOptions());
             try
             {
                 Thread tester = new Thread(() -> client.execute(queryMessage));
@@ -408,8 +312,9 @@ public class ClientResourceLimitsTest extends CQLTester
         try
         {
             QueryMessage smallMessage = new QueryMessage(String.format("CREATE TABLE %s.atable (pk int PRIMARY KEY, v text)", KEYSPACE),
-                                                         V5_DEFAULT_OPTIONS);
+                                                         queryOptions());
             client.execute(smallMessage);
+            createTable(client);
             try
             {
                 client.execute(queryMessage());

--- a/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.net.FrameEncoder;
+import org.apache.cassandra.transport.messages.QueryMessage;
+
+public class MessageSizeLimitTest extends CQLTester
+{
+    // set MAX_CQL_MESSAGE_SIZE less than a frame size to be able to test both decoding options on a server side:
+    // - org.apache.cassandra.transport.CQLMessageHandler.processOneContainedMessage
+    // - org.apache.cassandra.transport.CQLMessageHandler.processFirstFrameOfLargeMessage
+    private static final int MAX_CQL_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 1000;
+    private static final int TOO_BIG_SINGLE_FRAME_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 500;
+    private static final int TOO_BIG_MULTI_FRAME_MESSAGE_SIZE = 2 * FrameEncoder.Payload.MAX_SIZE;
+
+
+    private static final QueryOptions V5_DEFAULT_OPTIONS =
+    QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
+                        QueryOptions.DEFAULT.getValues(),
+                        QueryOptions.DEFAULT.skipMetadata(),
+                        QueryOptions.DEFAULT.getPageSize(),
+                        QueryOptions.DEFAULT.getPagingState(),
+                        QueryOptions.DEFAULT.getSerialConsistency(),
+                        ProtocolVersion.V5,
+                        KEYSPACE);
+
+    @BeforeClass
+    public static void setUp()
+    {
+        DatabaseDescriptor.setNativeTransportReceiveQueueCapacityInBytes(1);
+        DatabaseDescriptor.setNativeTransportMaxRequestDataInFlightPerIpInBytes(MAX_CQL_MESSAGE_SIZE);
+        DatabaseDescriptor.setNativeTransportConcurrentRequestDataInFlightInBytes(MAX_CQL_MESSAGE_SIZE);
+        DatabaseDescriptor.setNativeTransportMaxMessageSizeInBytes(MAX_CQL_MESSAGE_SIZE);
+
+
+        requireNetwork();
+    }
+
+    @Before
+    public void setLimits()
+    {
+        ClientResourceLimits.setGlobalLimit(MAX_CQL_MESSAGE_SIZE);
+        ClientResourceLimits.setEndpointLimit(MAX_CQL_MESSAGE_SIZE);
+    }
+
+    @After
+    public void dropCreatedTable()
+    {
+        try
+        {
+            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".test_table");
+        }
+        catch (Throwable t)
+        {
+            // ignore
+        }
+    }
+
+    @SuppressWarnings({"resource", "SameParameterValue"})
+    private SimpleClient client()
+    {
+        try
+        {
+            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
+                               .protocolVersion(ProtocolVersion.V5)
+                               .useBeta()
+                               .build()
+                               .connect(false, false);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error initializing client", e);
+        }
+    }
+
+    @Test
+    public void sendMessageWithSizeMoreThanMaxMessageSizeAndLessThanFrameSize()
+    {
+        sendTooBigMessage(TOO_BIG_SINGLE_FRAME_MESSAGE_SIZE);
+    }
+
+    @Test
+    public void sendMessageWithSizeMoreThanMaxMessageSizeAndMoreThanFrameSize()
+    {
+        sendTooBigMessage(TOO_BIG_MULTI_FRAME_MESSAGE_SIZE);
+    }
+
+    private void sendTooBigMessage(int valueSize)
+    {
+        doTest((client) ->
+               {
+                   QueryMessage queryMessage = createQueryMessage(valueSize);
+                   try
+                   {
+                       client.execute(queryMessage);
+                   } catch (RuntimeException e) {
+                       // ProtocolException: CQL Message of size 120070 bytes exceeds allowed maximum of 60000 bytes
+                       Assert.assertTrue(e.getCause() instanceof ProtocolException);
+                   }
+                   Util.spinAssertEquals(false, () -> client.connection.channel().isOpen(), 10);
+
+               }
+        );
+    }
+
+    @Test
+    public void sendMessageWithSizeBelowLimit()
+    {
+        doTest((client) ->
+               {
+                   int valueLessThanMessageMaxSize = MAX_CQL_MESSAGE_SIZE - 500;
+                   QueryMessage queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
+                   client.execute(queryMessage);
+
+                   // run one more time, to validate that the connection is still alive
+                   queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
+                   client.execute(queryMessage);
+               }
+        );
+    }
+
+    private void doTest(TestLogic testLogic)
+    {
+        try (SimpleClient client = client())
+        {
+            QueryMessage queryMessage = new QueryMessage("CREATE TABLE test_table (pk int PRIMARY KEY, v text)",
+                                                         V5_DEFAULT_OPTIONS);
+            client.execute(queryMessage);
+            testLogic.run(client);
+        }
+    }
+    private interface TestLogic
+    {
+        void run(SimpleClient simpleClient);
+    }
+
+    private QueryMessage createQueryMessage(int valueSize)
+    {
+        StringBuilder query = new StringBuilder("INSERT INTO test_table (pk, v) VALUES (1, '");
+        for (int i=0; i < valueSize; i++)
+            query.append('a');
+        query.append("')");
+        return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
@@ -18,38 +18,26 @@
 
 package org.apache.cassandra.transport;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.cql3.QueryOptions;
-import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.transport.messages.QueryMessage;
+import org.assertj.core.api.Assertions;
 
-public class MessageSizeLimitTest extends CQLTester
+public class MessageSizeLimitTest extends NativeProtocolLimitsTest
 {
     private static final int MAX_CQL_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE * 3;
     private static final int TOO_BIG_MESSAGE_SIZE = MAX_CQL_MESSAGE_SIZE * 2;
     private static final int NORMAL_MESSAGE_SIZE = MAX_CQL_MESSAGE_SIZE - 500;
-    private static final QueryOptions V5_DEFAULT_OPTIONS = QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
-                                                                               QueryOptions.DEFAULT.getValues(),
-                                                                               QueryOptions.DEFAULT.skipMetadata(),
-                                                                               QueryOptions.DEFAULT.getPageSize(),
-                                                                               QueryOptions.DEFAULT.getPagingState(),
-                                                                               QueryOptions.DEFAULT.getSerialConsistency(),
-                                                                               ProtocolVersion.V5,
-                                                                               KEYSPACE);
 
     @BeforeClass
     public static void setUp()
@@ -68,52 +56,18 @@ public class MessageSizeLimitTest extends CQLTester
         ClientResourceLimits.setEndpointLimit(MAX_CQL_MESSAGE_SIZE);
     }
 
-    @After
-    public void dropCreatedTable()
-    {
-        try
-        {
-            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".test_table");
-        }
-        catch (Throwable t)
-        {
-            // ignore
-        }
-    }
-
-    @SuppressWarnings({"resource", "SameParameterValue"})
-    private SimpleClient client()
-    {
-        try
-        {
-            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
-                               .protocolVersion(ProtocolVersion.V5)
-                               .useBeta()
-                               .build()
-                               .connect(false, false);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error initializing client", e);
-        }
-    }
-
     @Test
     public void sendMessageWithSizeMoreThanMaxMessageSize()
     {
         runClientLogic((client) ->
                {
-                   try
-                   {
-                       QueryMessage tooBigQueryMessage = createQueryMessage(TOO_BIG_MESSAGE_SIZE);
-                       client.execute(tooBigQueryMessage);
-                   } catch (RuntimeException e) {
-                       // InvalidRequestException: CQL Message of size 524362 bytes exceeds allowed maximum of 262144 bytes
-                       Assert.assertTrue(e.getCause() instanceof InvalidRequestException);
-                   }
+                   QueryMessage tooBigQueryMessage = queryMessage(TOO_BIG_MESSAGE_SIZE);
+                   Assertions.assertThatThrownBy(() -> client.execute(tooBigQueryMessage))
+                             .hasCauseInstanceOf(InvalidRequestException.class);
+                   // InvalidRequestException: CQL Message of size 524362 bytes exceeds allowed maximum of 262144 bytes
 
                    // we send one more message to check that the server continues to process new messages in the opened connection
-                   QueryMessage queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
+                   QueryMessage queryMessage = queryMessage(NORMAL_MESSAGE_SIZE);
                    client.execute(queryMessage);
                }
         );
@@ -148,7 +102,7 @@ public class MessageSizeLimitTest extends CQLTester
     {
         for (int i = 0; i < messagesCount; i++)
         {
-            QueryMessage queryMessage1 = createQueryMessage(messageSize);
+            QueryMessage queryMessage1 = queryMessage(messageSize);
             client.execute(queryMessage1);
         }
     }
@@ -158,45 +112,13 @@ public class MessageSizeLimitTest extends CQLTester
     {
         runClientLogic((client) ->
                {
-                   QueryMessage queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
+                   QueryMessage queryMessage = queryMessage(NORMAL_MESSAGE_SIZE);
                    client.execute(queryMessage);
 
                    // run one more time, to validate that the connection is still alive
-                   queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
+                   queryMessage = queryMessage(NORMAL_MESSAGE_SIZE);
                    client.execute(queryMessage);
                }
         );
-    }
-
-    private void runClientLogic(ClientLogic clientLogic)
-    {
-        runClientLogic(clientLogic, true);
-    }
-
-    private void runClientLogic(ClientLogic clientLogic, boolean createTable)
-    {
-        try (SimpleClient client = client())
-        {
-            if (createTable)
-            {
-                QueryMessage queryMessage = new QueryMessage("CREATE TABLE test_table (pk int PRIMARY KEY, v text)",
-                                                             V5_DEFAULT_OPTIONS);
-                client.execute(queryMessage);
-            }
-            clientLogic.run(client);
-        }
-    }
-    private interface ClientLogic
-    {
-        void run(SimpleClient simpleClient);
-    }
-
-    private QueryMessage createQueryMessage(int valueSize)
-    {
-        StringBuilder query = new StringBuilder("INSERT INTO test_table (pk, v) VALUES (1, '");
-        for (int i=0; i < valueSize; i++)
-            query.append('a');
-        query.append("')");
-        return new QueryMessage(query.toString(), V5_DEFAULT_OPTIONS);
     }
 }

--- a/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
@@ -41,20 +41,15 @@ public class MessageSizeLimitTest extends CQLTester
 {
     private static final int MAX_CQL_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE * 3;
     private static final int TOO_BIG_MESSAGE_SIZE = MAX_CQL_MESSAGE_SIZE * 2;
-
     private static final int NORMAL_MESSAGE_SIZE = MAX_CQL_MESSAGE_SIZE - 500;
-
-
-
-    private static final QueryOptions V5_DEFAULT_OPTIONS =
-    QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
-                        QueryOptions.DEFAULT.getValues(),
-                        QueryOptions.DEFAULT.skipMetadata(),
-                        QueryOptions.DEFAULT.getPageSize(),
-                        QueryOptions.DEFAULT.getPagingState(),
-                        QueryOptions.DEFAULT.getSerialConsistency(),
-                        ProtocolVersion.V5,
-                        KEYSPACE);
+    private static final QueryOptions V5_DEFAULT_OPTIONS = QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
+                                                                               QueryOptions.DEFAULT.getValues(),
+                                                                               QueryOptions.DEFAULT.skipMetadata(),
+                                                                               QueryOptions.DEFAULT.getPageSize(),
+                                                                               QueryOptions.DEFAULT.getPagingState(),
+                                                                               QueryOptions.DEFAULT.getSerialConsistency(),
+                                                                               ProtocolVersion.V5,
+                                                                               KEYSPACE);
 
     @BeforeClass
     public static void setUp()
@@ -63,8 +58,6 @@ public class MessageSizeLimitTest extends CQLTester
         DatabaseDescriptor.setNativeTransportMaxRequestDataInFlightPerIpInBytes(MAX_CQL_MESSAGE_SIZE);
         DatabaseDescriptor.setNativeTransportConcurrentRequestDataInFlightInBytes(MAX_CQL_MESSAGE_SIZE);
         DatabaseDescriptor.setNativeTransportMaxMessageSizeInBytes(MAX_CQL_MESSAGE_SIZE);
-
-
         requireNetwork();
     }
 
@@ -122,7 +115,6 @@ public class MessageSizeLimitTest extends CQLTester
                    // we send one more message to check that the server continues to process new messages in the opened connection
                    QueryMessage queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
                    client.execute(queryMessage);
-
                }
         );
     }

--- a/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageSizeLimitTest.java
@@ -19,6 +19,9 @@
 package org.apache.cassandra.transport;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -26,22 +29,21 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.transport.messages.QueryMessage;
 
 public class MessageSizeLimitTest extends CQLTester
 {
-    // set MAX_CQL_MESSAGE_SIZE less than a frame size to be able to test both decoding options on a server side:
-    // - org.apache.cassandra.transport.CQLMessageHandler.processOneContainedMessage
-    // - org.apache.cassandra.transport.CQLMessageHandler.processFirstFrameOfLargeMessage
-    private static final int MAX_CQL_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 1000;
-    private static final int TOO_BIG_SINGLE_FRAME_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE - 500;
-    private static final int TOO_BIG_MULTI_FRAME_MESSAGE_SIZE = 2 * FrameEncoder.Payload.MAX_SIZE;
+    private static final int MAX_CQL_MESSAGE_SIZE = FrameEncoder.Payload.MAX_SIZE * 3;
+    private static final int TOO_BIG_MESSAGE_SIZE = MAX_CQL_MESSAGE_SIZE * 2;
+
+    private static final int NORMAL_MESSAGE_SIZE = MAX_CQL_MESSAGE_SIZE - 500;
+
 
 
     private static final QueryOptions V5_DEFAULT_OPTIONS =
@@ -104,62 +106,95 @@ public class MessageSizeLimitTest extends CQLTester
     }
 
     @Test
-    public void sendMessageWithSizeMoreThanMaxMessageSizeAndLessThanFrameSize()
+    public void sendMessageWithSizeMoreThanMaxMessageSize()
     {
-        sendTooBigMessage(TOO_BIG_SINGLE_FRAME_MESSAGE_SIZE);
-    }
-
-    @Test
-    public void sendMessageWithSizeMoreThanMaxMessageSizeAndMoreThanFrameSize()
-    {
-        sendTooBigMessage(TOO_BIG_MULTI_FRAME_MESSAGE_SIZE);
-    }
-
-    private void sendTooBigMessage(int valueSize)
-    {
-        doTest((client) ->
+        runClientLogic((client) ->
                {
-                   QueryMessage queryMessage = createQueryMessage(valueSize);
                    try
                    {
-                       client.execute(queryMessage);
+                       QueryMessage tooBigQueryMessage = createQueryMessage(TOO_BIG_MESSAGE_SIZE);
+                       client.execute(tooBigQueryMessage);
                    } catch (RuntimeException e) {
-                       // ProtocolException: CQL Message of size 120070 bytes exceeds allowed maximum of 60000 bytes
-                       Assert.assertTrue(e.getCause() instanceof ProtocolException);
+                       // InvalidRequestException: CQL Message of size 524362 bytes exceeds allowed maximum of 262144 bytes
+                       Assert.assertTrue(e.getCause() instanceof InvalidRequestException);
                    }
-                   Util.spinAssertEquals(false, () -> client.connection.channel().isOpen(), 10);
+
+                   // we send one more message to check that the server continues to process new messages in the opened connection
+                   QueryMessage queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
+                   client.execute(queryMessage);
 
                }
         );
+    }
+
+    @Test(timeout = 30_000)
+    public void checkThatThereIsNoStarvationForMultiFrameMessages() throws InterruptedException
+    {
+        runClientLogic((client) -> {}, true); // to create table
+        AtomicInteger completedSuccessfully = new AtomicInteger(0);
+        int threadsCount = 2;
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < threadsCount; i++)
+        {
+            threads.add(new Thread(() -> runClientLogic((client) -> {
+                    sendMessages(client, 100, NORMAL_MESSAGE_SIZE);
+                    completedSuccessfully.incrementAndGet();
+                }, false))
+            );
+        }
+        for (Thread thread : threads)
+            thread.start();
+
+        for (Thread thread : threads)
+            thread.join();
+
+        Assert.assertEquals("not all messages were sent successfully by all threads",
+                            threadsCount, completedSuccessfully.get());
+    }
+
+    private void sendMessages(SimpleClient client, int messagesCount, int messageSize)
+    {
+        for (int i = 0; i < messagesCount; i++)
+        {
+            QueryMessage queryMessage1 = createQueryMessage(messageSize);
+            client.execute(queryMessage1);
+        }
     }
 
     @Test
     public void sendMessageWithSizeBelowLimit()
     {
-        doTest((client) ->
+        runClientLogic((client) ->
                {
-                   int valueLessThanMessageMaxSize = MAX_CQL_MESSAGE_SIZE - 500;
-                   QueryMessage queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
+                   QueryMessage queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
                    client.execute(queryMessage);
 
                    // run one more time, to validate that the connection is still alive
-                   queryMessage = createQueryMessage(valueLessThanMessageMaxSize);
+                   queryMessage = createQueryMessage(NORMAL_MESSAGE_SIZE);
                    client.execute(queryMessage);
                }
         );
     }
 
-    private void doTest(TestLogic testLogic)
+    private void runClientLogic(ClientLogic clientLogic)
+    {
+        runClientLogic(clientLogic, true);
+    }
+
+    private void runClientLogic(ClientLogic clientLogic, boolean createTable)
     {
         try (SimpleClient client = client())
         {
-            QueryMessage queryMessage = new QueryMessage("CREATE TABLE test_table (pk int PRIMARY KEY, v text)",
-                                                         V5_DEFAULT_OPTIONS);
-            client.execute(queryMessage);
-            testLogic.run(client);
+            if (createTable)
+            {
+                QueryMessage queryMessage = new QueryMessage("CREATE TABLE test_table (pk int PRIMARY KEY, v text)",
+                                                             V5_DEFAULT_OPTIONS);
+                client.execute(queryMessage);
+            }
+            clientLogic.run(client);
         }
     }
-    private interface TestLogic
+    private interface ClientLogic
     {
         void run(SimpleClient simpleClient);
     }

--- a/test/unit/org/apache/cassandra/transport/NativeProtocolLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/NativeProtocolLimitsTest.java
@@ -28,7 +28,7 @@ import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.utils.FBUtilities;
 
-public class NativeProtocolLimitsTest extends CQLTester
+public abstract class NativeProtocolLimitsTest extends CQLTester
 {
     protected final ProtocolVersion version;
 

--- a/test/unit/org/apache/cassandra/transport/NativeProtocolLimitsTest.java
+++ b/test/unit/org/apache/cassandra/transport/NativeProtocolLimitsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.net.FrameEncoder;
+import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.utils.FBUtilities;
+
+public class NativeProtocolLimitsTest extends CQLTester
+{
+    protected final ProtocolVersion version;
+
+    protected long emulatedUsedCapacity;
+
+    public NativeProtocolLimitsTest()
+    {
+        this(ProtocolVersion.V5);
+    }
+
+    public NativeProtocolLimitsTest(ProtocolVersion version)
+    {
+        this.version = version;
+    }
+
+    @After
+    public void dropCreatedTable()
+    {
+        if (emulatedUsedCapacity > 0)
+        {
+            releaseEmulatedCapacity(emulatedUsedCapacity);
+        }
+        try
+        {
+            QueryProcessor.executeOnceInternal("DROP TABLE " + KEYSPACE + ".atable");
+        }
+        catch (Throwable t)
+        {
+            // ignore
+        }
+    }
+
+    public QueryOptions queryOptions()
+    {
+        return QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
+                                   QueryOptions.DEFAULT.getValues(),
+                                   QueryOptions.DEFAULT.skipMetadata(),
+                                   QueryOptions.DEFAULT.getPageSize(),
+                                   QueryOptions.DEFAULT.getPagingState(),
+                                   QueryOptions.DEFAULT.getSerialConsistency(),
+                                   version,
+                                   KEYSPACE);
+    }
+
+    public SimpleClient client()
+    {
+        return client(false);
+    }
+
+    @SuppressWarnings({"resource", "SameParameterValue"})
+    public SimpleClient client(boolean throwOnOverload)
+    {
+        return client(throwOnOverload, FrameEncoder.Payload.MAX_SIZE);
+    }
+
+    @SuppressWarnings({"resource", "SameParameterValue"})
+    public SimpleClient client(boolean throwOnOverload, int largeMessageThreshold)
+    {
+        try
+        {
+            return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
+                               .protocolVersion(version)
+                               .useBeta()
+                               .largeMessageThreshold(largeMessageThreshold)
+                               .build()
+                               .connect(false, throwOnOverload);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Error initializing client", e);
+        }
+    }
+
+    public void runClientLogic(ClientLogic clientLogic)
+    {
+        runClientLogic(clientLogic, true);
+    }
+
+    public void runClientLogic(ClientLogic clientLogic, boolean createTable)
+    {
+        try (SimpleClient client = client())
+        {
+            if (createTable)
+                createTable(client);
+            clientLogic.run(client);
+        }
+    }
+
+    public void createTable(SimpleClient client)
+    {
+        QueryMessage queryMessage = new QueryMessage("CREATE TABLE IF NOT EXISTS " +
+                                                     KEYSPACE + ".atable (pk int PRIMARY KEY, v text)",
+                                                     queryOptions());
+        client.execute(queryMessage);
+    }
+
+    public void doTest(ClientLogic testLogic)
+    {
+        try (SimpleClient client = client())
+        {
+            testLogic.run(client);
+        }
+    }
+    public interface ClientLogic
+    {
+        void run(SimpleClient simpleClient);
+    }
+
+    public QueryMessage queryMessage(long valueSize)
+    {
+        StringBuilder query = new StringBuilder("INSERT INTO " + KEYSPACE + ".atable (pk, v) VALUES (1, '");
+        for (int i = 0; i < valueSize; i++)
+            query.append('a');
+        query.append("')");
+        return new QueryMessage(query.toString(), queryOptions());
+    }
+
+    protected void emulateInFlightConcurrentMessage(long length)
+    {
+        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
+        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
+        resourceProvider.globalLimit().allocate(length);
+        resourceProvider.endpointLimit().allocate(length);
+        emulatedUsedCapacity += length;
+    }
+
+    protected void releaseEmulatedCapacity(long length)
+    {
+        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
+        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
+        resourceProvider.globalLimit().release(length);
+        resourceProvider.endpointLimit().release(length);
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
+++ b/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
@@ -28,7 +28,11 @@ import java.util.stream.Collectors;
 
 import com.codahale.metrics.Meter;
 import com.google.common.base.Ticker;
+
+import org.apache.cassandra.utils.FBUtilities;
 import org.awaitility.Awaitility;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -65,6 +69,8 @@ public class RateLimitingTest extends CQLTester
 
     @Parameterized.Parameter
     public ProtocolVersion version;
+
+    private long emulatedUsedCapacity;
 
     @Parameterized.Parameters(name="{0}")
     public static Collection<Object[]> versions()
@@ -103,6 +109,15 @@ public class RateLimitingTest extends CQLTester
         };
 
         ClientResourceLimits.setGlobalLimit(MAX_LONG_CONFIG_VALUE);
+    }
+
+    @After
+    public void releaseEmulatedCapacity()
+    {
+        if (emulatedUsedCapacity > 0)
+        {
+            releaseEmulatedCapacity(emulatedUsedCapacity);
+        }
     }
 
     @Test
@@ -147,6 +162,7 @@ public class RateLimitingTest extends CQLTester
 
     private void testBytesInFlightOverload(int payloadSize) throws Exception
     {
+        int emulatedConcurrentMessageSize = payloadSize * 3 / 2;
         try (SimpleClient client = client().connect(false, true))
         {
             StorageService.instance.setNativeTransportRateLimitingEnabled(false);
@@ -155,7 +171,11 @@ public class RateLimitingTest extends CQLTester
 
             StorageService.instance.setNativeTransportRateLimitingEnabled(true);
             ClientResourceLimits.GLOBAL_REQUEST_LIMITER.setRate(OVERLOAD_PERMITS_PER_SECOND, ticker);
-            ClientResourceLimits.setGlobalLimit(1);
+            // test massage = 1x
+            // emulated concurrent message = 1.5x
+            // test massage + emulated concurrent message = 2.5x > 2x set as a global limit
+            ClientResourceLimits.setGlobalLimit(payloadSize * 2);
+            emulateInFlightConcurrentMessage(emulatedConcurrentMessageSize);
 
             try
             {
@@ -170,7 +190,7 @@ public class RateLimitingTest extends CQLTester
         finally
         {
             // Sanity check bytes in flight limiter.
-            Awaitility.await().untilAsserted(() -> assertEquals(0, ClientResourceLimits.getCurrentGlobalUsage()));
+            Awaitility.await().untilAsserted(() -> assertEquals(emulatedConcurrentMessageSize, ClientResourceLimits.getCurrentGlobalUsage()));
             StorageService.instance.setNativeTransportRateLimitingEnabled(false);
         }
     }
@@ -327,5 +347,22 @@ public class RateLimitingTest extends CQLTester
         if (metrics.size() != 1)
             fail(String.format("Expected a single registered metric for request dispatched, found %s",metrics.size()));
         return metrics.get(metricName);
+    }
+
+    private void emulateInFlightConcurrentMessage(long length)
+    {
+        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
+        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
+        resourceProvider.globalLimit().allocate(length);
+        resourceProvider.endpointLimit().allocate(length);
+        emulatedUsedCapacity += length;
+    }
+
+    private void releaseEmulatedCapacity(long length)
+    {
+        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
+        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
+        resourceProvider.globalLimit().release(length);
+        resourceProvider.endpointLimit().release(length);
     }
 }

--- a/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
+++ b/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
@@ -171,9 +171,9 @@ public class RateLimitingTest extends CQLTester
 
             StorageService.instance.setNativeTransportRateLimitingEnabled(true);
             ClientResourceLimits.GLOBAL_REQUEST_LIMITER.setRate(OVERLOAD_PERMITS_PER_SECOND, ticker);
-            // test massage = 1x
+            // test message = 1x
             // emulated concurrent message = 1.5x
-            // test massage + emulated concurrent message = 2.5x > 2x set as a global limit
+            // test message + emulated concurrent message = 2.5x > 2x set as a global limit
             ClientResourceLimits.setGlobalLimit(payloadSize * 2);
             emulateInFlightConcurrentMessage(emulatedConcurrentMessageSize);
 

--- a/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
+++ b/test/unit/org/apache/cassandra/transport/RateLimitingTest.java
@@ -29,10 +29,8 @@ import java.util.stream.Collectors;
 import com.codahale.metrics.Meter;
 import com.google.common.base.Ticker;
 
-import org.apache.cassandra.utils.FBUtilities;
 import org.awaitility.Awaitility;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,12 +38,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
-import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.utils.Throwables;
 
 import static org.junit.Assert.assertEquals;
@@ -58,7 +53,7 @@ import static org.apache.cassandra.transport.ProtocolVersion.V4;
 
 @SuppressWarnings("UnstableApiUsage")
 @RunWith(Parameterized.class)
-public class RateLimitingTest extends CQLTester
+public class RateLimitingTest extends NativeProtocolLimitsTest
 {
     public static final String BACKPRESSURE_WARNING_SNIPPET = "Request breached global limit";
     
@@ -67,17 +62,17 @@ public class RateLimitingTest extends CQLTester
 
     private static final long MAX_LONG_CONFIG_VALUE = Long.MAX_VALUE - 1;
 
-    @Parameterized.Parameter
-    public ProtocolVersion version;
-
-    private long emulatedUsedCapacity;
-
     @Parameterized.Parameters(name="{0}")
     public static Collection<Object[]> versions()
     {
         return ProtocolVersion.SUPPORTED.stream()
                                         .map(v -> new Object[]{v})
                                         .collect(Collectors.toList());
+    }
+
+    public RateLimitingTest(ProtocolVersion version)
+    {
+        super(version);
     }
 
     private AtomicLong tick;
@@ -111,14 +106,6 @@ public class RateLimitingTest extends CQLTester
         ClientResourceLimits.setGlobalLimit(MAX_LONG_CONFIG_VALUE);
     }
 
-    @After
-    public void releaseEmulatedCapacity()
-    {
-        if (emulatedUsedCapacity > 0)
-        {
-            releaseEmulatedCapacity(emulatedUsedCapacity);
-        }
-    }
 
     @Test
     public void shouldThrowOnOverloadSmallMessages() throws Exception
@@ -163,11 +150,10 @@ public class RateLimitingTest extends CQLTester
     private void testBytesInFlightOverload(int payloadSize) throws Exception
     {
         int emulatedConcurrentMessageSize = payloadSize * 3 / 2;
-        try (SimpleClient client = client().connect(false, true))
+        try (SimpleClient client = client(true, LARGE_PAYLOAD_THRESHOLD_BYTES))
         {
             StorageService.instance.setNativeTransportRateLimitingEnabled(false);
-            QueryMessage queryMessage = new QueryMessage("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".atable (pk int PRIMARY KEY, v text)", queryOptions());
-            client.execute(queryMessage);
+            createTable(client);
 
             StorageService.instance.setNativeTransportRateLimitingEnabled(true);
             ClientResourceLimits.GLOBAL_REQUEST_LIMITER.setRate(OVERLOAD_PERMITS_PER_SECOND, ticker);
@@ -197,11 +183,10 @@ public class RateLimitingTest extends CQLTester
 
     private void testOverload(int payloadSize, boolean throwOnOverload) throws Exception
     {
-        try (SimpleClient client = client().connect(false, throwOnOverload))
+        try (SimpleClient client = client(throwOnOverload, LARGE_PAYLOAD_THRESHOLD_BYTES))
         {
             StorageService.instance.setNativeTransportRateLimitingEnabled(false);
-            QueryMessage queryMessage = new QueryMessage("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".atable (pk int PRIMARY KEY, v text)", queryOptions());
-            client.execute(queryMessage);
+            createTable(client);
 
             StorageService.instance.setNativeTransportRateLimitingEnabled(true);
             ClientResourceLimits.GLOBAL_REQUEST_LIMITER.setRate(OVERLOAD_PERMITS_PER_SECOND, ticker);
@@ -306,40 +291,6 @@ public class RateLimitingTest extends CQLTester
         assertEquals(dispatchedPrior + 2, getRequestDispatchedMeter().getCount());
     }
 
-    private QueryMessage queryMessage(int length)
-    {
-        StringBuilder query = new StringBuilder("INSERT INTO " + KEYSPACE + ".atable (pk, v) VALUES (1, '");
-        
-        for (int i = 0; i < length; i++)
-        {
-            query.append('a');
-        }
-        
-        query.append("')");
-        return new QueryMessage(query.toString(), queryOptions());
-    }
-
-    private SimpleClient client()
-    {
-        return SimpleClient.builder(nativeAddr.getHostAddress(), nativePort)
-                           .protocolVersion(version)
-                           .useBeta()
-                           .largeMessageThreshold(LARGE_PAYLOAD_THRESHOLD_BYTES)
-                           .build();
-    }
-
-    private QueryOptions queryOptions()
-    {
-        return QueryOptions.create(QueryOptions.DEFAULT.getConsistency(),
-                                   QueryOptions.DEFAULT.getValues(),
-                                   QueryOptions.DEFAULT.skipMetadata(),
-                                   QueryOptions.DEFAULT.getPageSize(),
-                                   QueryOptions.DEFAULT.getPagingState(),
-                                   QueryOptions.DEFAULT.getSerialConsistency(),
-                                   version,
-                                   KEYSPACE);
-    }
-
     protected static Meter getRequestDispatchedMeter()
     {
         String metricName = "org.apache.cassandra.metrics.Client.RequestDispatched";
@@ -347,22 +298,5 @@ public class RateLimitingTest extends CQLTester
         if (metrics.size() != 1)
             fail(String.format("Expected a single registered metric for request dispatched, found %s",metrics.size()));
         return metrics.get(metricName);
-    }
-
-    private void emulateInFlightConcurrentMessage(long length)
-    {
-        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
-        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
-        resourceProvider.globalLimit().allocate(length);
-        resourceProvider.endpointLimit().allocate(length);
-        emulatedUsedCapacity += length;
-    }
-
-    private void releaseEmulatedCapacity(long length)
-    {
-        ClientResourceLimits.Allocator allocator = ClientResourceLimits.getAllocatorForEndpoint(FBUtilities.getJustLocalAddress());
-        ClientResourceLimits.ResourceProvider resourceProvider = new ClientResourceLimits.ResourceProvider.Default(allocator);
-        resourceProvider.globalLimit().release(length);
-        resourceProvider.endpointLimit().release(length);
     }
 }


### PR DESCRIPTION
Add native_transport_max_message_size and native_transport_max_auth_message_size configuration options to limit maximum CQL message size for V5-protocol ore later. 
Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20052
