### PR TITLE
CASSANDRA-20072-trunk: Log client address when detecting unknown exception in client networking

### DIFF
--- a/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
+++ b/src/java/org/apache/cassandra/transport/ExceptionHandlers.java
@@ -148,7 +148,7 @@ public class ExceptionHandlers
         else
         {
             ClientMetrics.instance.markUnknownException();
-            logger.warn("Unknown exception in client networking", cause);
+            logger.warn("Unknown exception in client networking with peer {} {}", clientAddress, cause.getMessage());
         }
     }
 


### PR DESCRIPTION
We are getting hundreds of the below warnings in Cassandra logs: 
```
WARN  [epollEventLoopGroup-5-7] 2024-11-10 00:26:24,296 ExceptionHandlers.java:139 - Unknown exception in client networking
io.netty.channel.StacklessClosedChannelException: null
        at io.netty.channel.AbstractChannel.close(ChannelPromise)(Unknown Source)
```
This means the client dropped the connection abruptly or abnormally. The issue could be a network or application issue on the client side. 
Since there could be many client servers, Cassandra must log the client IP and the port so we can check what's the problem with that server. 
I'll attach the fix for this small change.


The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20072)