### PR TITLE
[CASSANDRA-20074][4.0] AbstractCommitLogService#lastSyncedAt initialized with currentTimeMillis() but later compared and updated with System.nanoTime()

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogService.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogService.java
@@ -45,7 +45,7 @@ public abstract class AbstractCommitLogService
     private volatile boolean shutdown = false;
 
     // all Allocations written before this time will be synced
-    protected volatile long lastSyncedAt = System.currentTimeMillis();
+    protected volatile long lastSyncedAt = MonotonicClock.preciseTime.now();
 
     // counts of total written, and pending, log messages
     private final AtomicLong written = new AtomicLong(0);


### PR DESCRIPTION
AbstractCommitLogService#lastSyncedAt initialized with currentTimeMillis() but later compared and updated with System.nanoTime()

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20074
