### PR TITLE
CASSANDRA-18802: Parallelized UCS compactions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -80,21 +80,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -111,10 +111,10 @@ jobs:
   j17_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -187,21 +187,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -220,7 +220,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -304,21 +304,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -369,21 +369,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -402,7 +402,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -458,21 +458,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -489,10 +489,10 @@ jobs:
   j11_dtests_latest_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -591,21 +591,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -656,21 +656,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -690,7 +690,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -774,21 +774,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -804,10 +804,10 @@ jobs:
   j17_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -882,21 +882,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -912,10 +912,10 @@ jobs:
   j17_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1036,21 +1036,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1066,10 +1066,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1168,21 +1168,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1199,10 +1199,10 @@ jobs:
   j17_cqlsh_dtests_py311_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1277,21 +1277,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1310,7 +1310,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1394,21 +1394,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1428,7 +1428,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1484,21 +1484,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1518,7 +1518,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1602,21 +1602,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1632,10 +1632,10 @@ jobs:
   j11_cqlsh_dtests_py38_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1710,21 +1710,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1744,7 +1744,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1800,21 +1800,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1830,10 +1830,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1908,21 +1908,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -1939,10 +1939,10 @@ jobs:
   j17_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2041,21 +2041,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2071,10 +2071,10 @@ jobs:
   j17_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2195,21 +2195,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2228,7 +2228,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2312,21 +2312,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2346,7 +2346,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2402,21 +2402,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2432,10 +2432,10 @@ jobs:
   j17_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2510,21 +2510,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2540,10 +2540,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2618,21 +2618,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2652,7 +2652,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2708,21 +2708,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2741,7 +2741,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2797,21 +2797,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2831,7 +2831,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2915,21 +2915,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -2948,7 +2948,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3110,21 +3110,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3141,7 +3141,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3195,21 +3195,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3226,10 +3226,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3328,21 +3328,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3359,7 +3359,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3413,21 +3413,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3447,7 +3447,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3503,21 +3503,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3537,7 +3537,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3621,21 +3621,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3652,10 +3652,10 @@ jobs:
   j11_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3754,21 +3754,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3788,7 +3788,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3872,21 +3872,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -3905,7 +3905,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4067,21 +4067,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4173,21 +4173,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4206,7 +4206,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4290,21 +4290,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4324,7 +4324,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4380,21 +4380,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4413,7 +4413,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4497,21 +4497,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4568,21 +4568,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4602,7 +4602,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4658,21 +4658,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4692,7 +4692,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4748,21 +4748,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4851,21 +4851,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4923,21 +4923,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -4957,7 +4957,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5013,21 +5013,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5126,21 +5126,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5160,7 +5160,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5244,21 +5244,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5316,21 +5316,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5350,7 +5350,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5406,21 +5406,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5437,10 +5437,10 @@ jobs:
   j17_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5513,21 +5513,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5543,10 +5543,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5645,21 +5645,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5679,7 +5679,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5763,21 +5763,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5797,7 +5797,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5881,21 +5881,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -5912,10 +5912,10 @@ jobs:
   j17_dtests_latest_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6014,21 +6014,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6047,7 +6047,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6103,21 +6103,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6134,10 +6134,10 @@ jobs:
   j11_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6188,21 +6188,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6219,10 +6219,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6321,21 +6321,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6355,7 +6355,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6411,21 +6411,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6482,21 +6482,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6512,7 +6512,7 @@ jobs:
   j17_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -6566,21 +6566,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6596,10 +6596,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6674,21 +6674,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6708,7 +6708,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6764,21 +6764,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6798,7 +6798,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6854,21 +6854,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -6885,10 +6885,10 @@ jobs:
   j11_cqlsh_dtests_py311_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6963,21 +6963,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7027,21 +7027,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7057,10 +7057,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7135,21 +7135,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7169,7 +7169,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7253,21 +7253,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7283,10 +7283,10 @@ jobs:
   j17_cqlsh_dtests_py38_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7361,21 +7361,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7391,10 +7391,10 @@ jobs:
   j17_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7469,21 +7469,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7502,7 +7502,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7586,21 +7586,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7617,10 +7617,10 @@ jobs:
   j17_dtests_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7693,21 +7693,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7726,7 +7726,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7810,21 +7810,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7881,21 +7881,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -7987,21 +7987,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8021,7 +8021,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8077,21 +8077,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8108,10 +8108,10 @@ jobs:
   j11_dtests_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8162,21 +8162,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8226,21 +8226,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8257,10 +8257,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8311,21 +8311,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8342,10 +8342,10 @@ jobs:
   j17_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8420,21 +8420,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8453,7 +8453,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8537,21 +8537,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8570,7 +8570,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8626,21 +8626,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8656,7 +8656,7 @@ jobs:
   j17_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -8710,21 +8710,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8743,7 +8743,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8799,21 +8799,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8871,21 +8871,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8904,7 +8904,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8960,21 +8960,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -8990,10 +8990,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9044,21 +9044,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -9078,7 +9078,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9134,21 +9134,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -9164,10 +9164,10 @@ jobs:
   j17_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9266,21 +9266,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -9299,7 +9299,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9355,21 +9355,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -9388,7 +9388,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9444,21 +9444,21 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.db.compaction.unified.ShardedCompactionWriterTest,org.apache.cassandra.db.compaction.unified.ParallelizedTasksTest,org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest,org.apache.cassandra.db.compaction.UnifiedCompactionStrategyTest,org.apache.cassandra.db.compaction.TimeWindowCompactionStrategyTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest,org.apache.cassandra.db.compaction.ShardManagerTest,org.apache.cassandra.db.compaction.PendingRepairManagerTest,org.apache.cassandra.db.compaction.PartialCompactionsTest,org.apache.cassandra.db.compaction.LeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.CorruptedSSTablesCompactionsTest,org.apache.cassandra.db.compaction.CompactionTaskTest,org.apache.cassandra.db.compaction.CompactionStrategyManagerPendingRepairTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
-    - REPEATED_UTESTS_LONG: null
+    - REPEATED_UTESTS_LONG: org.apache.cassandra.db.compaction.LongLeveledCompactionStrategyTest,org.apache.cassandra.db.compaction.LongCompactionsTest
     - REPEATED_UTESTS_LONG_COUNT: 100
     - REPEATED_UTESTS_STRESS: null
     - REPEATED_UTESTS_STRESS_COUNT: 500
     - REPEATED_SIMULATOR_DTESTS: null
     - REPEATED_SIMULATOR_DTESTS_COUNT: 500
-    - REPEATED_JVM_DTESTS: null
+    - REPEATED_JVM_DTESTS: org.apache.cassandra.distributed.test.UpgradeSSTablesTest,org.apache.cassandra.distributed.test.PaxosRepairTest,org.apache.cassandra.distributed.test.PaxosRepair2Test
     - REPEATED_JVM_DTESTS_COUNT: 500
     - REPEATED_JVM_UPGRADE_DTESTS: null
     - REPEATED_JVM_UPGRADE_DTESTS_COUNT: 500
-    - REPEATED_DTESTS: null
+    - REPEATED_DTESTS: compaction_test
     - REPEATED_DTESTS_COUNT: 500
     - REPEATED_LARGE_DTESTS: null
     - REPEATED_LARGE_DTESTS_COUNT: 100
@@ -9481,302 +9481,829 @@ workflows:
     - j11_build:
         requires:
         - start_j11_build
+        upstream:
+          start_j11_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j11_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j11_build:
+          - success
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
+        upstream:
+          start_j11_unit_tests_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j11_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests_latest_vnode:
         type: approval
     - j11_jvm_dtests_latest_vnode:
         requires:
         - start_j11_jvm_dtests_latest_vnode
         - j11_build
+        upstream:
+          start_j11_jvm_dtests_latest_vnode:
+          - success
+          j11_build:
+          - success
+    - start_j11_jvm_dtests_repeat:
+        type: approval
+    - j11_jvm_dtests_repeat:
+        requires:
+        - start_j11_jvm_dtests_repeat
+        - j11_build
+        upstream:
+          start_j11_jvm_dtests_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j11_jvm_dtests_latest_vnode_repeat:
+        type: approval
+    - j11_jvm_dtests_latest_vnode_repeat:
+        requires:
+        - start_j11_jvm_dtests_latest_vnode_repeat
+        - j11_build
+        upstream:
+          start_j11_jvm_dtests_latest_vnode_repeat:
+          - success
+          j11_build:
+          - success
     - start_j17_jvm_dtests:
         type: approval
     - j17_jvm_dtests:
         requires:
         - start_j17_jvm_dtests
         - j11_build
+        upstream:
+          start_j17_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j17_jvm_dtests_latest_vnode:
         type: approval
     - j17_jvm_dtests_latest_vnode:
         requires:
         - start_j17_jvm_dtests_latest_vnode
         - j11_build
+        upstream:
+          start_j17_jvm_dtests_latest_vnode:
+          - success
+          j11_build:
+          - success
+    - start_j17_jvm_dtests_repeat:
+        type: approval
+    - j17_jvm_dtests_repeat:
+        requires:
+        - start_j17_jvm_dtests_repeat
+        - j11_build
+        upstream:
+          start_j17_jvm_dtests_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_jvm_dtests_latest_vnode_repeat:
+        type: approval
+    - j17_jvm_dtests_latest_vnode_repeat:
+        requires:
+        - start_j17_jvm_dtests_latest_vnode_repeat
+        - j11_build
+        upstream:
+          start_j17_jvm_dtests_latest_vnode_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_simulator_dtests:
         type: approval
     - j11_simulator_dtests:
         requires:
         - start_j11_simulator_dtests
         - j11_build
+        upstream:
+          start_j11_simulator_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_cython_tests:
         type: approval
     - j11_cqlshlib_cython_tests:
         requires:
         - start_j11_cqlshlib_cython_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_cython_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlshlib_tests:
         type: approval
     - j17_cqlshlib_tests:
         requires:
         - start_j17_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j17_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlshlib_cython_tests:
         type: approval
     - j17_cqlshlib_cython_tests:
         requires:
         - start_j17_cqlshlib_cython_tests
         - j11_build
+        upstream:
+          start_j17_cqlshlib_cython_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_unit_tests:
         type: approval
     - j17_unit_tests:
         requires:
         - start_j17_unit_tests
         - j11_build
+        upstream:
+          start_j17_unit_tests:
+          - success
+          j11_build:
+          - success
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j11_build
+        upstream:
+          start_j17_unit_tests_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_oa:
         type: approval
     - j11_utests_oa:
         requires:
         - start_j11_utests_oa
         - j11_build
+        upstream:
+          start_j11_utests_oa:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_oa_repeat:
+        type: approval
+    - j11_utests_oa_repeat:
+        requires:
+        - start_j11_utests_oa_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_oa_repeat:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_oa:
         type: approval
     - j17_utests_oa:
         requires:
         - start_j17_utests_oa
         - j11_build
+        upstream:
+          start_j17_utests_oa:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_oa_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j11_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_long:
         type: approval
     - j17_utests_long:
         requires:
         - start_j17_utests_long
         - j11_build
+        upstream:
+          start_j17_utests_long:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_long_repeat:
+        type: approval
+    - j11_utests_long_repeat:
+        requires:
+        - start_j11_utests_long_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_long_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_long_repeat:
+        type: approval
+    - j17_utests_long_repeat:
+        requires:
+        - start_j17_utests_long_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_long_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j11_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_cdc:
         type: approval
     - j17_utests_cdc:
         requires:
         - start_j17_utests_cdc
         - j11_build
+        upstream:
+          start_j17_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_cdc_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_cdc_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_j17_utests_compression
         - j11_build
+        upstream:
+          start_j17_utests_compression:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_compression_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_compression_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_latest:
         type: approval
     - j11_utests_latest:
         requires:
         - start_j11_utests_latest
         - j11_build
+        upstream:
+          start_j11_utests_latest:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_latest:
         type: approval
     - j17_utests_latest:
         requires:
         - start_j17_utests_latest
         - j11_build
+        upstream:
+          start_j17_utests_latest:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_latest_repeat:
+        type: approval
+    - j11_utests_latest_repeat:
+        requires:
+        - start_j11_utests_latest_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_latest_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_latest_repeat:
+        type: approval
+    - j17_utests_latest_repeat:
+        requires:
+        - start_j17_utests_latest_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_latest_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j11_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_stress:
         type: approval
     - j17_utests_stress:
         requires:
         - start_j17_utests_stress
         - j11_build
+        upstream:
+          start_j17_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_fqltool:
         type: approval
     - j17_utests_fqltool:
         requires:
         - start_j17_utests_fqltool
         - j11_build
+        upstream:
+          start_j17_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
         requires:
         - start_j17_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j17_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_system_keyspace_directory_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_dtest_jars_build:
         type: approval
     - j11_dtest_jars_build:
         requires:
         - j11_build
         - start_j11_dtest_jars_build
+        upstream:
+          j11_build:
+          - success
+          start_j11_dtest_jars_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j11_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
         - j11_dtest_jars_build
+        upstream:
+          start_jvm_upgrade_dtests:
+          - success
+          j11_dtest_jars_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j11_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_latest:
         type: approval
     - j11_dtests_latest:
         requires:
         - start_j11_dtests_latest
         - j11_build
+        upstream:
+          start_j11_dtests_latest:
+          - success
+          j11_build:
+          - success
+    - start_j11_dtests_latest_repeat:
+        type: approval
+    - j11_dtests_latest_repeat:
+        requires:
+        - start_j11_dtests_latest_repeat
+        - j11_build
+        upstream:
+          start_j11_dtests_latest_repeat:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests:
         type: approval
     - j17_dtests:
         requires:
         - start_j17_dtests
         - j11_build
+        upstream:
+          start_j17_dtests:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_vnode:
         type: approval
     - j17_dtests_vnode:
         requires:
         - start_j17_dtests_vnode
         - j11_build
+        upstream:
+          start_j17_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_latest:
         type: approval
     - j17_dtests_latest:
         requires:
         - start_j17_dtests_latest
         - j11_build
+        upstream:
+          start_j17_dtests_latest:
+          - success
+          j11_build:
+          - success
+    - start_j17_dtests_latest_repeat:
+        type: approval
+    - j17_dtests_latest_repeat:
+        requires:
+        - start_j17_dtests_latest_repeat
+        - j11_build
+        upstream:
+          start_j17_dtests_latest_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j11_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_large_vnode:
         type: approval
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j17_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests_latest:
         type: approval
     - j11_cqlsh_dtests_py38_latest:
         requires:
         - start_j11_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_latest:
         requires:
         - start_j11_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlsh_tests:
         type: approval
     - j17_cqlsh_dtests_py38:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlsh_tests_latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - start_j11_upgrade_dtests:
         type: approval
     - j11_upgrade_dtests:
         requires:
         - start_j11_upgrade_dtests
         - j11_build
+        upstream:
+          start_j11_upgrade_dtests:
+          - success
+          j11_build:
+          - success
+    - start_j11_dtests_repeat:
+        type: approval
+    - j11_dtests_repeat:
+        requires:
+        - start_j11_dtests_repeat
+        - j11_build
+        upstream:
+          start_j11_dtests_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j11_dtests_vnode_repeat:
+        type: approval
+    - j11_dtests_vnode_repeat:
+        requires:
+        - start_j11_dtests_vnode_repeat
+        - j11_build
+        upstream:
+          start_j11_dtests_vnode_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_dtests_repeat:
+        type: approval
+    - j17_dtests_repeat:
+        requires:
+        - start_j17_dtests_repeat
+        - j11_build
+        upstream:
+          start_j17_dtests_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_dtests_vnode_repeat:
+        type: approval
+    - j17_dtests_vnode_repeat:
+        requires:
+        - start_j17_dtests_vnode_repeat
+        - j11_build
+        upstream:
+          start_j17_dtests_vnode_repeat:
+          - success
+          j11_build:
+          - success
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -9784,207 +10311,573 @@ workflows:
     - j11_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j11_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_utests_oa:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_utests_oa_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_utests_oa_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_utests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_utests_latest_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_simulator_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_jvm_dtests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests_latest_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_jvm_dtests_latest_vnode_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_jvm_dtests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_jvm_dtests_latest_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_jvm_dtests_latest_vnode_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_cython_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlshlib_cython_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_utests_oa:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_unit_tests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_utests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_utests_latest_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - j17_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
+    - j11_utests_long_repeat:
+        requires:
+        - start_utests_long
+        - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
+    - j17_utests_long_repeat:
+        requires:
+        - start_utests_long
+        - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - j17_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - j17_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - j17_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - j17_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j11_dtest_jars_build:
         requires:
         - j11_build
         - start_jvm_upgrade_dtests
+        upstream:
+          j11_build:
+          - success
+          start_jvm_upgrade_dtests:
+          - success
     - j11_jvm_upgrade_dtests:
         requires:
         - j11_dtest_jars_build
+        upstream:
+          j11_dtest_jars_build:
+          - success
     - j11_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_dtests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_dtests_vnode_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_dtests_latest_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_dtests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_dtests_vnode_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_dtests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_dtests_latest_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j11_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j11_build:
+          - success
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large
         - j11_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_cqlsh_dtests_latest:
         type: approval
     - j11_cqlsh_dtests_py38_latest:
         requires:
         - start_j11_cqlsh_dtests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_dtests_latest:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_latest:
         requires:
         - start_j11_cqlsh_dtests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_dtests_latest:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j17_cqlsh-dtests-latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j11_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j11_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j11_build:
+          - success
     - start_j11_upgrade_dtests:
         type: approval
     - j11_upgrade_dtests:
         requires:
         - j11_build
         - start_j11_upgrade_dtests
+        upstream:
+          j11_build:
+          - success
+          start_j11_upgrade_dtests:
+          - success
   java17_separate_tests:
     jobs:
     - start_j17_build:
@@ -9992,142 +10885,397 @@ workflows:
     - j17_build:
         requires:
         - start_j17_build
+        upstream:
+          start_j17_build:
+          - success
     - start_j17_unit_tests:
         type: approval
     - j17_unit_tests:
         requires:
         - start_j17_unit_tests
         - j17_build
+        upstream:
+          start_j17_unit_tests:
+          - success
+          j17_build:
+          - success
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j17_build
+        upstream:
+          start_j17_unit_tests_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_jvm_dtests:
         type: approval
     - j17_jvm_dtests:
         requires:
         - start_j17_jvm_dtests
         - j17_build
+        upstream:
+          start_j17_jvm_dtests:
+          - success
+          j17_build:
+          - success
     - start_j17_jvm_dtests_latest_vnode:
         type: approval
     - j17_jvm_dtests_latest_vnode:
         requires:
         - start_j17_jvm_dtests_latest_vnode
         - j17_build
+        upstream:
+          start_j17_jvm_dtests_latest_vnode:
+          - success
+          j17_build:
+          - success
+    - start_j17_jvm_dtests_repeat:
+        type: approval
+    - j17_jvm_dtests_repeat:
+        requires:
+        - start_j17_jvm_dtests_repeat
+        - j17_build
+        upstream:
+          start_j17_jvm_dtests_repeat:
+          - success
+          j17_build:
+          - success
+    - start_j17_jvm_dtests_latest_vnode_repeat:
+        type: approval
+    - j17_jvm_dtests_latest_vnode_repeat:
+        requires:
+        - start_j17_jvm_dtests_latest_vnode_repeat
+        - j17_build
+        upstream:
+          start_j17_jvm_dtests_latest_vnode_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlshlib_tests:
         type: approval
     - j17_cqlshlib_tests:
         requires:
         - start_j17_cqlshlib_tests
         - j17_build
+        upstream:
+          start_j17_cqlshlib_tests:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlshlib_cython_tests:
         type: approval
     - j17_cqlshlib_cython_tests:
         requires:
         - start_j17_cqlshlib_cython_tests
         - j17_build
+        upstream:
+          start_j17_cqlshlib_cython_tests:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests:
         type: approval
     - j17_dtests:
         requires:
         - start_j17_dtests
         - j17_build
+        upstream:
+          start_j17_dtests:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_vnode:
         type: approval
     - j17_dtests_vnode:
         requires:
         - start_j17_dtests_vnode
         - j17_build
+        upstream:
+          start_j17_dtests_vnode:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_latest:
         type: approval
     - j17_dtests_latest:
         requires:
         - start_j17_dtests_latest
         - j17_build
+        upstream:
+          start_j17_dtests_latest:
+          - success
+          j17_build:
+          - success
+    - start_j17_dtests_latest_repeat:
+        type: approval
+    - j17_dtests_latest_repeat:
+        requires:
+        - start_j17_dtests_latest_repeat
+        - j17_build
+        upstream:
+          start_j17_dtests_latest_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j17_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_large_vnode:
         type: approval
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large_vnode
         - j17_build
+        upstream:
+          start_j17_dtests_large_vnode:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlsh_tests:
         type: approval
     - j17_cqlsh_dtests_py38:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlsh-dtests-latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_oa:
         type: approval
     - j17_utests_oa:
         requires:
         - start_j17_utests_oa
         - j17_build
+        upstream:
+          start_j17_utests_oa:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_oa_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_long:
         type: approval
     - j17_utests_long:
         requires:
         - start_j17_utests_long
         - j17_build
+        upstream:
+          start_j17_utests_long:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_long_repeat:
+        type: approval
+    - j17_utests_long_repeat:
+        requires:
+        - start_j17_utests_long_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_long_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_cdc:
         type: approval
     - j17_utests_cdc:
         requires:
         - start_j17_utests_cdc
         - j17_build
+        upstream:
+          start_j17_utests_cdc:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_cdc_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_j17_utests_compression
         - j17_build
+        upstream:
+          start_j17_utests_compression:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_compression_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_latest:
         type: approval
     - j17_utests_latest:
         requires:
         - start_j17_utests_latest
         - j17_build
+        upstream:
+          start_j17_utests_latest:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_latest_repeat:
+        type: approval
+    - j17_utests_latest_repeat:
+        requires:
+        - start_j17_utests_latest_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_latest_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_stress:
         type: approval
     - j17_utests_stress:
         requires:
         - start_j17_utests_stress
         - j17_build
+        upstream:
+          start_j17_utests_stress:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_fqltool:
         type: approval
     - j17_utests_fqltool:
         requires:
         - start_j17_utests_fqltool
         - j17_build
+        upstream:
+          start_j17_utests_fqltool:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
         requires:
         - start_j17_utests_system_keyspace_directory
         - j17_build
+        upstream:
+          start_j17_utests_system_keyspace_directory:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_system_keyspace_directory_repeat:
+          - success
+          j17_build:
+          - success
+    - start_j17_dtests_repeat:
+        type: approval
+    - j17_dtests_repeat:
+        requires:
+        - start_j17_dtests_repeat
+        - j17_build
+        upstream:
+          start_j17_dtests_repeat:
+          - success
+          j17_build:
+          - success
+    - start_j17_dtests_vnode_repeat:
+        type: approval
+    - j17_dtests_vnode_repeat:
+        requires:
+        - start_j17_dtests_vnode_repeat
+        - j17_build
+        upstream:
+          start_j17_dtests_vnode_repeat:
+          - success
+          j17_build:
+          - success
   java17_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10135,101 +11283,280 @@ workflows:
     - j17_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j17_unit_tests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_utests_oa:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_utests_oa_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_unit_tests_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_utests_latest:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_utests_latest_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_jvm_dtests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_jvm_dtests_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_jvm_dtests_latest_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_jvm_dtests_latest_vnode_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlshlib_tests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlshlib_cython_tests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_dtests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_dtests_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_dtests_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_dtests_vnode_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_dtests_latest:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_dtests_latest_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j17_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j17_build:
+          - success
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large
         - j17_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py38:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - start_j17_cqlsh-dtests-latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - start_utests_long:
         type: approval
     - j17_utests_long:
         requires:
         - start_utests_long
         - j17_build
+        upstream:
+          start_utests_long:
+          - success
+          j17_build:
+          - success
+    - j17_utests_long_repeat:
+        requires:
+        - start_utests_long
+        - j17_build
+        upstream:
+          start_utests_long:
+          - success
+          j17_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j17_utests_cdc:
         requires:
         - start_utests_cdc
         - j17_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j17_build:
+          - success
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j17_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j17_build:
+          - success
     - start_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_utests_compression
         - j17_build
+        upstream:
+          start_utests_compression:
+          - success
+          j17_build:
+          - success
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j17_build
+        upstream:
+          start_utests_compression:
+          - success
+          j17_build:
+          - success
     - start_utests_stress:
         type: approval
     - j17_utests_stress:
         requires:
         - start_utests_stress
         - j17_build
+        upstream:
+          start_utests_stress:
+          - success
+          j17_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j17_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j17_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j17_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j17_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j17_build:
+          - success
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j17_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j17_build:
+          - success

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Parallelized UCS compactions (CASSANDRA-18802)
  * Avoid prepared statement invalidation race when committing schema changes (CASSANDRA-20116)
  * Restore optimization in MultiCBuilder around building one clustering (CASSANDRA-20129)
  * Consolidate all snapshot management to SnapshotManager and introduce SnapshotManagerMBean (CASSANDRA-18111)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -92,6 +92,16 @@ New features
     - There is new MBean of name org.apache.cassandra.service.snapshot:type=SnapshotManager which exposes user-facing
       snapshot operations. Snapshot-related methods on StorageServiceMBean are still present and functional
       but marked as deprecated.
+    - The unified compaction strategy will now parallelize individual compactions by splitting operations into separate
+      tasks per output shard. This significantly shortens compaction durations but cannot take advantage of preemptive
+      SSTable opening and thus can be less efficient if the strategy is configured to create large sstables.
+      This functionality is controlled by the parallelize_output_shards compaction option (the default can also be set
+      using -Dunified_compaction.parallelize_output_shards=false/true).
+    - Compaction parallelism for the unified compaction strategy also applies to major compactions. Because the number
+      of shards for a major compaction is usually quite high, this can dramatically improve the duration of major
+      compactions. To avoid the possibility of starving background compactions from resources, the number of threads
+      used for major compactions is limited to half the available compaction threads by default, and can be controlled
+      by a new --jobs / -j option of nodetool compact.
 
 
 Upgrading

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -610,6 +610,7 @@ public enum CassandraRelevantProperties
     UCS_BASE_SHARD_COUNT("unified_compaction.base_shard_count", "4"),
     UCS_MIN_SSTABLE_SIZE("unified_compaction.min_sstable_size", "100MiB"),
     UCS_OVERLAP_INCLUSION_METHOD("unified_compaction.overlap_inclusion_method"),
+    UCS_PARALLELIZE_OUTPUT_SHARDS("unified_compaction.parallelize_output_shards", "true"),
     UCS_SCALING_PARAMETER("unified_compaction.scaling_parameters", "T4"),
     UCS_SSTABLE_GROWTH("unified_compaction.sstable_growth", "0.333"),
     UCS_SURVIVAL_FACTOR("unified_compaction.survival_factor", "1"),

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2208,12 +2208,22 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
 
     public void forceMajorCompaction()
     {
-        forceMajorCompaction(false);
+        forceMajorCompaction(false, -1);
     }
 
     public void forceMajorCompaction(boolean splitOutput)
     {
-        CompactionManager.instance.performMaximal(this, splitOutput);
+        forceMajorCompaction(splitOutput, -1);
+    }
+
+    public void forceMajorCompaction(int permittedParallelism)
+    {
+        forceMajorCompaction(false, permittedParallelism);
+    }
+
+    public void forceMajorCompaction(boolean splitOutput, int permittedParallelism)
+    {
+        CompactionManager.instance.performMaximal(this, splitOutput, permittedParallelism);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
@@ -53,6 +53,15 @@ public interface ColumnFamilyStoreMBean
     public void forceMajorCompaction(boolean splitOutput) throws ExecutionException, InterruptedException;
 
     /**
+     * force a major compaction of this column family
+     *
+     * @param permittedParallelism The maximum number of compaction threads that can be used by the operation.
+     *                             If 0, the operation can use all available threads.
+     *                             If <0, the default parallelism will be used.
+     */
+    public void forceMajorCompaction(int permittedParallelism) throws ExecutionException, InterruptedException;
+
+    /**
      * Forces a major compaction of specified token ranges in this column family.
      * <p>
      * The token ranges will be interpreted as closed intervals to match the closed interval defined by the first and

--- a/src/java/org/apache/cassandra/db/compaction/AbstractStrategyHolder.java
+++ b/src/java/org/apache/cassandra/db/compaction/AbstractStrategyHolder.java
@@ -53,15 +53,15 @@ public abstract class AbstractStrategyHolder
     public static class TaskSupplier implements Comparable<TaskSupplier>
     {
         private final int numRemaining;
-        private final Supplier<AbstractCompactionTask> supplier;
+        private final Supplier<Collection<AbstractCompactionTask>> supplier;
 
-        TaskSupplier(int numRemaining, Supplier<AbstractCompactionTask> supplier)
+        TaskSupplier(int numRemaining, Supplier<Collection<AbstractCompactionTask>> supplier)
         {
             this.numRemaining = numRemaining;
             this.supplier = supplier;
         }
 
-        public AbstractCompactionTask getTask()
+        public Collection<AbstractCompactionTask> getTasks()
         {
             return supplier.get();
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyHolder.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyHolder.java
@@ -106,7 +106,7 @@ public class CompactionStrategyHolder extends AbstractStrategyHolder
     {
         List<TaskSupplier> suppliers = new ArrayList<>(strategies.size());
         for (AbstractCompactionStrategy strategy : strategies)
-            suppliers.add(new TaskSupplier(strategy.getEstimatedRemainingTasks(), () -> strategy.getNextBackgroundTask(gcBefore)));
+            suppliers.add(new TaskSupplier(strategy.getEstimatedRemainingTasks(), () -> strategy.getNextBackgroundTasks(gcBefore)));
 
         return suppliers;
     }
@@ -117,7 +117,7 @@ public class CompactionStrategyHolder extends AbstractStrategyHolder
         List<AbstractCompactionTask> tasks = new ArrayList<>(strategies.size());
         for (AbstractCompactionStrategy strategy : strategies)
         {
-            Collection<AbstractCompactionTask> task = strategy.getMaximalTask(gcBefore, splitOutput);
+            Collection<AbstractCompactionTask> task = strategy.getMaximalTasks(gcBefore, splitOutput);
             if (task != null)
                 tasks.addAll(task);
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompositeCompactionTask.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.utils.Throwables;
+
+/// A composition of several compaction tasks into one. This object executes the given tasks sequentially and
+/// is used to limit the parallelism of some compaction tasks that split into a large number of parallelizable ones
+/// but should not be allowed to take all compaction executor threads.
+public class CompositeCompactionTask extends AbstractCompactionTask
+{
+    @VisibleForTesting
+    final ArrayList<AbstractCompactionTask> tasks;
+
+    public CompositeCompactionTask(AbstractCompactionTask first)
+    {
+        super(first.cfs, first.cfs.getTracker().tryModify(Collections.emptyList(), OperationType.COMPACTION));
+        tasks = new ArrayList<>();
+        addTask(first);
+    }
+
+    /// Add a task to the composition.
+    public CompositeCompactionTask addTask(AbstractCompactionTask task)
+    {
+        tasks.add(task);
+        return this;
+    }
+
+    @Override
+    protected void executeInternal(ActiveCompactionsTracker tracker)
+    {
+        // Run all tasks in sequence, regardless if any of them fail.
+        Throwables.perform(tasks.stream().map(x -> () -> x.execute(tracker)));
+    }
+
+    @Override
+    protected void runMayThrow() throws Exception {
+        throw new IllegalStateException("CompositeCompactionTask should be run through execute");
+    }
+
+    @Override
+    public void rejected()
+    {
+        Throwables.perform(tasks.stream().map(t -> t::rejected), () -> super.rejected());
+    }
+
+    @Override
+    public AbstractCompactionTask setUserDefined(boolean isUserDefined)
+    {
+        for (AbstractCompactionTask task : tasks)
+            task.setUserDefined(isUserDefined);
+        return super.setUserDefined(isUserDefined);
+    }
+
+    @Override
+    public AbstractCompactionTask setCompactionType(OperationType compactionType)
+    {
+        for (AbstractCompactionTask task : tasks)
+            task.setCompactionType(compactionType);
+        return super.setCompactionType(compactionType);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Composite " + tasks;
+    }
+
+    /// Limit the parallelism of a list of compaction tasks by combining them into a smaller number of composite tasks.
+    /// This method assumes that the caller has preference for the tasks to be executed in order close to the order of
+    /// the input list. See [UnifiedCompactionStrategy#getMaximalTasks] for an example of how to use this method.
+    public static List<AbstractCompactionTask> applyParallelismLimit(List<AbstractCompactionTask> tasks, int parallelismLimit)
+    {
+        if (tasks.size() <= parallelismLimit || parallelismLimit <= 0)
+            return tasks;
+
+        List<AbstractCompactionTask> result = new ArrayList<>(parallelismLimit);
+        int taskIndex = 0;
+        for (AbstractCompactionTask task : tasks) {
+            if (result.size() < parallelismLimit)
+                result.add(task);
+            else {
+                result.set(taskIndex, combineTasks(result.get(taskIndex), task));
+                if (++taskIndex == parallelismLimit)
+                    taskIndex = 0;
+            }
+        }
+        return result;
+    }
+
+    /// Make a composite tasks that combines two tasks. If the former is already a composite task, the latter is added
+    /// to it. Otherwise, a new composite task is created.
+    public static CompositeCompactionTask combineTasks(AbstractCompactionTask task1, AbstractCompactionTask task2)
+    {
+        CompositeCompactionTask composite;
+        if (task1 instanceof CompositeCompactionTask)
+            composite = (CompositeCompactionTask) task1;
+        else
+            composite = new CompositeCompactionTask(task1);
+        return composite.addTask(task2);
+    }
+}

--- a/src/java/org/apache/cassandra/db/compaction/PendingRepairHolder.java
+++ b/src/java/org/apache/cassandra/db/compaction/PendingRepairHolder.java
@@ -116,7 +116,7 @@ public class PendingRepairHolder extends AbstractStrategyHolder
     {
         List<TaskSupplier> suppliers = new ArrayList<>(managers.size());
         for (PendingRepairManager manager : managers)
-            suppliers.add(new TaskSupplier(manager.getMaxEstimatedRemainingTasks(), () -> manager.getNextBackgroundTask(gcBefore)));
+            suppliers.add(new TaskSupplier(manager.getMaxEstimatedRemainingTasks(), () -> manager.getNextBackgroundTasks(gcBefore)));
 
         return suppliers;
     }
@@ -156,7 +156,7 @@ public class PendingRepairHolder extends AbstractStrategyHolder
         managers.get(router.getIndexForSSTable(sstable)).addSSTable(sstable);
     }
 
-    AbstractCompactionTask getNextRepairFinishedTask()
+    Collection<AbstractCompactionTask> getNextRepairFinishedTasks()
     {
         List<TaskSupplier> repairFinishedSuppliers = getRepairFinishedTaskSuppliers();
         if (!repairFinishedSuppliers.isEmpty())
@@ -164,9 +164,9 @@ public class PendingRepairHolder extends AbstractStrategyHolder
             Collections.sort(repairFinishedSuppliers);
             for (TaskSupplier supplier : repairFinishedSuppliers)
             {
-                AbstractCompactionTask task = supplier.getTask();
-                if (task != null)
-                    return task;
+                Collection<AbstractCompactionTask> tasks = supplier.getTasks();
+                if (tasks != null && !tasks.isEmpty())
+                    return tasks;
             }
         }
         return null;
@@ -180,7 +180,7 @@ public class PendingRepairHolder extends AbstractStrategyHolder
             int numPending = manager.getNumPendingRepairFinishedTasks();
             if (numPending > 0)
             {
-                suppliers.add(new TaskSupplier(numPending, manager::getNextRepairFinishedTask));
+                suppliers.add(new TaskSupplier(numPending, manager::getNextRepairFinishedTasks));
             }
         }
 

--- a/src/java/org/apache/cassandra/db/compaction/SSTableSplitter.java
+++ b/src/java/org/apache/cassandra/db/compaction/SSTableSplitter.java
@@ -24,13 +24,13 @@ import org.apache.cassandra.db.*;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
 import org.apache.cassandra.db.compaction.writers.MaxSSTableSizeWriter;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 
 public class SSTableSplitter 
 {
     private final SplittingCompactionTask task;
 
-    public SSTableSplitter(ColumnFamilyStore cfs, LifecycleTransaction transaction, int sstableSizeInMB)
+    public SSTableSplitter(ColumnFamilyStore cfs, ILifecycleTransaction transaction, int sstableSizeInMB)
     {
         this.task = new SplittingCompactionTask(cfs, transaction, sstableSizeInMB);
     }
@@ -44,7 +44,7 @@ public class SSTableSplitter
     {
         private final int sstableSizeInMiB;
 
-        public SplittingCompactionTask(ColumnFamilyStore cfs, LifecycleTransaction transaction, int sstableSizeInMB)
+        public SplittingCompactionTask(ColumnFamilyStore cfs, ILifecycleTransaction transaction, int sstableSizeInMB)
         {
             super(cfs, transaction, CompactionManager.NO_GC, false);
             this.sstableSizeInMiB = sstableSizeInMB;
@@ -62,7 +62,7 @@ public class SSTableSplitter
         @Override
         public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs,
                                                               Directories directories,
-                                                              LifecycleTransaction txn,
+                                                              ILifecycleTransaction txn,
                                                               Set<SSTableReader> nonExpiredSSTables)
         {
             return new MaxSSTableSizeWriter(cfs, directories, txn, nonExpiredSSTables, sstableSizeInMiB * 1024L * 1024L, 0, false);

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerDiskAware.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerDiskAware.java
@@ -204,7 +204,7 @@ public class ShardManagerDiskAware extends ShardManagerNoDisks
 
         public int count()
         {
-            return countPerDisk;
+            return countPerDisk * diskBoundaryPositions.length;
         }
 
         /**
@@ -231,7 +231,7 @@ public class ShardManagerDiskAware extends ShardManagerNoDisks
 
         public int shardIndex()
         {
-            return nextShardIndex - 1;
+            return diskIndex * countPerDisk + nextShardIndex - 1;
         }
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/ShardManagerTrivial.java
+++ b/src/java/org/apache/cassandra/db/compaction/ShardManagerTrivial.java
@@ -18,7 +18,10 @@
 
 package org.apache.cassandra.db.compaction;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 import org.apache.cassandra.db.PartitionPosition;
 import org.apache.cassandra.dht.IPartitioner;
@@ -54,12 +57,20 @@ public class ShardManagerTrivial implements ShardManager
     }
 
     @Override
-    public double calculateCombinedDensity(Set<? extends SSTableReader> sstables)
+    public double calculateCombinedDensity(Collection<SSTableReader> sstables)
     {
         double totalSize = 0;
         for (SSTableReader sstable : sstables)
             totalSize += sstable.onDiskLength();
         return totalSize;
+    }
+
+    @Override
+    public <T> List<T> splitSSTablesInShards(Collection<SSTableReader> sstables,
+                                             int numShardsForDensity,
+                                             BiFunction<Collection<SSTableReader>, Range<Token>, T> maker)
+    {
+        return List.of(maker.apply(sstables, new Range<>(partitioner.getMinimumToken(), partitioner.getMinimumToken())));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/SingleSSTableLCSTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/SingleSSTableLCSTask.java
@@ -18,19 +18,14 @@
 
 package org.apache.cassandra.db.compaction;
 
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.cassandra.db.ColumnFamilyStore;
-import org.apache.cassandra.db.Directories;
-import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.StatsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Special compaction task that does not do any compaction, instead it
@@ -51,16 +46,9 @@ public class SingleSSTableLCSTask extends AbstractCompactionTask
     }
 
     @Override
-    public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
-    {
-        throw new UnsupportedOperationException("This method should never be called on SingleSSTableLCSTask");
-    }
-
-    @Override
-    protected int executeInternal(ActiveCompactionsTracker activeCompactions)
+    protected void executeInternal(ActiveCompactionsTracker activeCompactions)
     {
         run();
-        return 1;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/compaction/unified/ShardedCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/ShardedCompactionWriter.java
@@ -28,7 +28,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.compaction.ShardTracker;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.format.SSTableWriter;
 import org.apache.cassandra.utils.FBUtilities;
@@ -47,12 +47,13 @@ public class ShardedCompactionWriter extends CompactionAwareWriter
 
     public ShardedCompactionWriter(ColumnFamilyStore cfs,
                                    Directories directories,
-                                   LifecycleTransaction txn,
+                                   ILifecycleTransaction txn,
                                    Set<SSTableReader> nonExpiredSSTables,
                                    boolean keepOriginals,
+                                   boolean earlyOpenAllowed,
                                    ShardTracker boundaries)
     {
-        super(cfs, directories, txn, nonExpiredSSTables, keepOriginals);
+        super(cfs, directories, txn, nonExpiredSSTables, keepOriginals, earlyOpenAllowed);
 
         this.boundaries = boundaries;
         long totalKeyCount = nonExpiredSSTables.stream()

--- a/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/unified/UnifiedCompactionTask.java
@@ -18,15 +18,20 @@
 
 package org.apache.cassandra.db.compaction.unified;
 
+import java.util.Collection;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.compaction.CompactionTask;
 import org.apache.cassandra.db.compaction.ShardManager;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 /**
@@ -36,26 +41,80 @@ public class UnifiedCompactionTask extends CompactionTask
 {
     private final ShardManager shardManager;
     private final Controller controller;
+    private final Range<Token> operationRange;
+    private final Set<SSTableReader> actuallyCompact;
 
     public UnifiedCompactionTask(ColumnFamilyStore cfs,
                                  UnifiedCompactionStrategy strategy,
-                                 LifecycleTransaction txn,
+                                 ILifecycleTransaction txn,
                                  long gcBefore,
                                  ShardManager shardManager)
+    {
+        this(cfs, strategy, txn, gcBefore, shardManager, null, null);
+    }
+
+    public UnifiedCompactionTask(ColumnFamilyStore cfs,
+                                 UnifiedCompactionStrategy strategy,
+                                 ILifecycleTransaction txn,
+                                 long gcBefore,
+                                 ShardManager shardManager,
+                                 Range<Token> operationRange,
+                                 Collection<SSTableReader> actuallyCompact)
     {
         super(cfs, txn, gcBefore);
         this.controller = strategy.getController();
         this.shardManager = shardManager;
+
+        if (operationRange != null)
+        {
+            assert actuallyCompact != null : "Ranged tasks should use a set of sstables to compact";
+        }
+        this.operationRange = operationRange;
+        // To make sure actuallyCompact tracks any removals from txn.originals(), we intersect the given set with it.
+        // This should not be entirely necessary (as shouldReduceScopeForSpace() is false for ranged tasks), but it
+        // is cleaner to enforce inputSSTables()'s requirements.
+        this.actuallyCompact = actuallyCompact != null ? Sets.intersection(ImmutableSet.copyOf(actuallyCompact),
+                                                                           txn.originals())
+                                                       : txn.originals();
     }
 
     @Override
     public CompactionAwareWriter getCompactionAwareWriter(ColumnFamilyStore cfs,
                                                           Directories directories,
-                                                          LifecycleTransaction txn,
+                                                          ILifecycleTransaction txn,
                                                           Set<SSTableReader> nonExpiredSSTables)
     {
         double density = shardManager.calculateCombinedDensity(nonExpiredSSTables);
         int numShards = controller.getNumShards(density * shardManager.shardSetCoverage());
-        return new ShardedCompactionWriter(cfs, directories, txn, nonExpiredSSTables, keepOriginals, shardManager.boundaries(numShards));
+        // In multi-task operations we need to expire many ranges in a source sstable for early open. Not doable yet.
+        boolean earlyOpenAllowed = tokenRange() == null;
+        return new ShardedCompactionWriter(cfs,
+                                           directories,
+                                           txn,
+                                           nonExpiredSSTables,
+                                           keepOriginals,
+                                           earlyOpenAllowed,
+                                           shardManager.boundaries(numShards));
+    }
+
+    @Override
+    protected Range<Token> tokenRange()
+    {
+        return operationRange;
+    }
+
+    @Override
+    protected boolean shouldReduceScopeForSpace()
+    {
+        // Because parallelized tasks share input sstables, we can't reduce the scope of individual tasks
+        // (as doing that will leave some part of an sstable out of the compaction but still drop the whole sstable
+        // when the task set completes).
+        return tokenRange() == null;
+    }
+
+    @Override
+    protected Set<SSTableReader> inputSSTables()
+    {
+        return actuallyCompact;
     }
 }

--- a/src/java/org/apache/cassandra/db/compaction/writers/DefaultCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/DefaultCompactionWriter.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Directories;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 /**
@@ -37,12 +37,12 @@ public class DefaultCompactionWriter extends CompactionAwareWriter
     protected static final Logger logger = LoggerFactory.getLogger(DefaultCompactionWriter.class);
     private final int sstableLevel;
 
-    public DefaultCompactionWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
+    public DefaultCompactionWriter(ColumnFamilyStore cfs, Directories directories, ILifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
     {
         this(cfs, directories, txn, nonExpiredSSTables, false, 0);
     }
 
-    public DefaultCompactionWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, boolean keepOriginals, int sstableLevel)
+    public DefaultCompactionWriter(ColumnFamilyStore cfs, Directories directories, ILifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, boolean keepOriginals, int sstableLevel)
     {
         super(cfs, directories, txn, nonExpiredSSTables, keepOriginals);
         this.sstableLevel = sstableLevel;

--- a/src/java/org/apache/cassandra/db/compaction/writers/MajorLeveledCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/MajorLeveledCompactionWriter.java
@@ -23,7 +23,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.compaction.LeveledManifest;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
@@ -40,7 +40,7 @@ public class MajorLeveledCompactionWriter extends CompactionAwareWriter
 
     public MajorLeveledCompactionWriter(ColumnFamilyStore cfs,
                                         Directories directories,
-                                        LifecycleTransaction txn,
+                                        ILifecycleTransaction txn,
                                         Set<SSTableReader> nonExpiredSSTables,
                                         long maxSSTableSize)
     {
@@ -49,7 +49,7 @@ public class MajorLeveledCompactionWriter extends CompactionAwareWriter
 
     public MajorLeveledCompactionWriter(ColumnFamilyStore cfs,
                                         Directories directories,
-                                        LifecycleTransaction txn,
+                                        ILifecycleTransaction txn,
                                         Set<SSTableReader> nonExpiredSSTables,
                                         long maxSSTableSize,
                                         boolean keepOriginals)

--- a/src/java/org/apache/cassandra/db/compaction/writers/MaxSSTableSizeWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/MaxSSTableSizeWriter.java
@@ -23,7 +23,7 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.compaction.OperationType;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 public class MaxSSTableSizeWriter extends CompactionAwareWriter
@@ -34,7 +34,7 @@ public class MaxSSTableSizeWriter extends CompactionAwareWriter
 
     public MaxSSTableSizeWriter(ColumnFamilyStore cfs,
                                 Directories directories,
-                                LifecycleTransaction txn,
+                                ILifecycleTransaction txn,
                                 Set<SSTableReader> nonExpiredSSTables,
                                 long maxSSTableSize,
                                 int level)
@@ -44,7 +44,7 @@ public class MaxSSTableSizeWriter extends CompactionAwareWriter
 
     public MaxSSTableSizeWriter(ColumnFamilyStore cfs,
                                 Directories directories,
-                                LifecycleTransaction txn,
+                                ILifecycleTransaction txn,
                                 Set<SSTableReader> nonExpiredSSTables,
                                 long maxSSTableSize,
                                 int level,

--- a/src/java/org/apache/cassandra/db/compaction/writers/SplittingSizeTieredCompactionWriter.java
+++ b/src/java/org/apache/cassandra/db/compaction/writers/SplittingSizeTieredCompactionWriter.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Directories;
-import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 
 /**
@@ -46,12 +46,12 @@ public class SplittingSizeTieredCompactionWriter extends CompactionAwareWriter
     private long currentBytesToWrite;
     private int currentRatioIndex = 0;
 
-    public SplittingSizeTieredCompactionWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
+    public SplittingSizeTieredCompactionWriter(ColumnFamilyStore cfs, Directories directories, ILifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables)
     {
         this(cfs, directories, txn, nonExpiredSSTables, DEFAULT_SMALLEST_SSTABLE_BYTES);
     }
 
-    public SplittingSizeTieredCompactionWriter(ColumnFamilyStore cfs, Directories directories, LifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, long smallestSSTable)
+    public SplittingSizeTieredCompactionWriter(ColumnFamilyStore cfs, Directories directories, ILifecycleTransaction txn, Set<SSTableReader> nonExpiredSSTables, long smallestSSTable)
     {
         super(cfs, directories, txn, nonExpiredSSTables, false);
         this.allSSTables = txn.originals();

--- a/src/java/org/apache/cassandra/db/lifecycle/CompositeLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/CompositeLifecycleTransaction.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.lifecycle;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.utils.TimeUUID;
+
+/// Composite lifecycle transaction. This is a wrapper around a lifecycle transaction that allows for multiple partial
+/// operations that comprise the whole transaction. This is used to parallelize compaction operations over individual
+/// output shards where the compaction sources are shared among the operations; in this case we can only release the
+/// shared sources once all operations are complete.
+///
+/// A composite transaction is initialized with a main transaction that will be used to commit the transaction. Each
+/// part of the composite transaction must be registered with the transaction before it is used. The transaction must
+/// be initialized by calling [#completeInitialization()] before any of the processing is allowed to proceed.
+///
+/// The transaction is considered complete when all parts have been committed or aborted. If any part is aborted, the
+/// whole transaction is also aborted ([PartialLifecycleTransaction] will also throw an exception on other parts when
+/// they access it if the composite is already aborted).
+///
+/// When all parts are committed, the full transaction is applied by performing a checkpoint, obsoletion of the
+/// originals if any of the parts requested it, preparation and commit. This may somewhat violate the rules of
+/// transactions as a part that has been committed may actually have no effect if another part is aborted later.
+/// There are also restrictions on the operations that this model can accept, e.g. replacement of sources and partial
+/// checkpointing are not supported (as they are parts of early open which we don't aim to support at this time),
+/// and we consider that all parts will have the same opinion about the obsoletion of the originals.
+public class CompositeLifecycleTransaction
+{
+    protected static final Logger logger = LoggerFactory.getLogger(CompositeLifecycleTransaction.class);
+
+    final LifecycleTransaction mainTransaction;
+    private final AtomicInteger partsToCommitOrAbort;
+    private volatile boolean obsoleteOriginalsRequested;
+    private volatile boolean wasAborted;
+    private volatile boolean initializationComplete;
+    private volatile int partsCount = 0;
+
+    /// Create a composite transaction wrapper over the given transaction. After construction, the individual parts of
+    /// the operation must be registered using [#register] and the composite sealed by calling [#completeInitialization].
+    /// The composite will then track the state of the parts and commit after all of them have committed (respectively
+    /// abort if one aborts but only after waiting for all the other tasks to complete, successfully or not).
+    ///
+    /// To make it easy to recognize the parts of a composite transaction, the given transaction should have an id with
+    /// sequence number 0, and partial transactions should use the id that [#register] returns.
+    public CompositeLifecycleTransaction(LifecycleTransaction mainTransaction)
+    {
+        this.mainTransaction = mainTransaction;
+        this.partsToCommitOrAbort = new AtomicInteger(0);
+        this.wasAborted = false;
+        this.obsoleteOriginalsRequested = false;
+    }
+
+    /// Register one part of the composite transaction. Every part must register itself before the composite transaction
+    /// is initialized and the parts are allowed to proceed.
+    /// @param part the part to register
+    public TimeUUID register(PartialLifecycleTransaction part)
+    {
+        int index = partsToCommitOrAbort.incrementAndGet();
+        return mainTransaction.opId().withSequence(index);
+    }
+
+    /// Complete the initialization of the composite transaction. This must be called before any of the parts are
+    /// executed.
+    public void completeInitialization()
+    {
+        partsCount = partsToCommitOrAbort.get();
+        initializationComplete = true;
+        if (logger.isTraceEnabled())
+            logger.trace("Composite transaction {} initialized with {} parts.", mainTransaction.opIdString(), partsCount);
+    }
+
+    /// Get the number of parts in the composite transaction. 0 if the transaction is not yet initialized.
+    public int partsCount()
+    {
+        return partsCount;
+    }
+
+    /// Request that the original sstables are obsoleted when the transaction is committed. Note that this class has
+    /// an expectation that all parts will have the same opinion about this, and one request will be sufficient to
+    /// trigger obsoletion.
+    public void requestObsoleteOriginals()
+    {
+        obsoleteOriginalsRequested = true;
+    }
+
+    /// Commit a part of the composite transaction. This will trigger the final commit of the whole transaction if it is
+    /// the last part to complete. A part has to commit or abort exactly once.
+    public void commitPart()
+    {
+        partCommittedOrAborted();
+    }
+
+    /// Signal an abort of one part of the transaction. If this is the last part to signal, the whole transaction will
+    /// now abort. Otherwise the composite transaction will wait for the other parts to complete and will abort the
+    /// composite when they all give their commit or abort signal. A part has to commit or abort exactly once.
+    ///
+    /// [PartialLifecycleTransaction] will attempt to abort other parts sooner by throwing an exception when any of its
+    /// methods are called when the composite transaction is already aborted.
+    public void abortPart()
+    {
+        wasAborted = true;
+        partCommittedOrAborted();
+    }
+
+    boolean wasAborted()
+    {
+        return wasAborted;
+    }
+
+    private void partCommittedOrAborted()
+    {
+        if (!initializationComplete)
+            throw new IllegalStateException("Composite transaction used before initialization is complete.");
+        if (partsToCommitOrAbort.decrementAndGet() == 0)
+        {
+            if (wasAborted)
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("Composite transaction {} with {} parts aborted.",
+                                 mainTransaction.opIdString(),
+                                 partsCount);
+
+                mainTransaction.abort();
+            }
+            else
+            {
+                if (logger.isTraceEnabled())
+                    logger.trace("Composite transaction {} with {} parts completed{}.",
+                                 mainTransaction.opIdString(),
+                                 partsCount,
+                                 obsoleteOriginalsRequested ? " with obsoletion" : "");
+
+                mainTransaction.checkpoint();
+                if (obsoleteOriginalsRequested)
+                    mainTransaction.obsoleteOriginals();
+                mainTransaction.prepareToCommit();
+                mainTransaction.commit();
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/db/lifecycle/LogTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/LogTransaction.java
@@ -134,8 +134,13 @@ class LogTransaction extends Transactional.AbstractTransactional implements Tran
 
     LogTransaction(OperationType opType, Tracker tracker)
     {
+        this(opType, tracker, nextTimeUUID());
+    }
+
+    LogTransaction(OperationType opType, Tracker tracker, TimeUUID id)
+    {
         this.tracker = tracker;
-        this.txnFile = new LogFile(opType, nextTimeUUID());
+        this.txnFile = new LogFile(opType, id);
         this.lock = new Object();
         this.selfRef = new Ref<>(this, new TransactionTidier(txnFile, lock));
 

--- a/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/PartialLifecycleTransaction.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.lifecycle;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.io.sstable.SSTable;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.Throwables;
+import org.apache.cassandra.utils.TimeUUID;
+
+/// Partial lifecycle transaction. This works together with a CompositeLifecycleTransaction to allow for multiple
+/// tasks using a shared transaction to be committed or aborted together. This is used to parallelize compaction
+/// operations over the same sources. See [CompositeLifecycleTransaction] for more details.
+///
+/// This class takes care of synchronizing various operations on the shared transaction, making sure that an abort
+/// or commit signal is given exactly once (provided that this partial transaction is closed), and throwing an exception
+/// when progress is made when the transaction was already aborted by another part.
+public class PartialLifecycleTransaction implements ILifecycleTransaction
+{
+    final CompositeLifecycleTransaction composite;
+    final ILifecycleTransaction mainTransaction;
+    final AtomicBoolean committedOrAborted = new AtomicBoolean(false);
+    final TimeUUID id;
+
+    public PartialLifecycleTransaction(CompositeLifecycleTransaction composite)
+    {
+        this.composite = composite;
+        this.mainTransaction = composite.mainTransaction;
+        this.id = composite.register(this);
+    }
+
+    public void checkpoint()
+    {
+        // don't do anything, composite will checkpoint at end
+    }
+
+    private RuntimeException earlyOpenUnsupported()
+    {
+        throw new UnsupportedOperationException("PartialLifecycleTransaction does not support early opening of SSTables");
+    }
+
+    public void update(SSTableReader reader, boolean original)
+    {
+        throwIfCompositeAborted();
+        if (original)
+            throw earlyOpenUnsupported();
+
+        synchronized (mainTransaction)
+        {
+            mainTransaction.update(reader, original);
+        }
+    }
+
+    public void update(Collection<SSTableReader> readers, boolean original)
+    {
+        throwIfCompositeAborted();
+        if (original)
+            throw earlyOpenUnsupported();
+
+        synchronized (mainTransaction)
+        {
+            mainTransaction.update(readers, original);
+        }
+    }
+
+    public SSTableReader current(SSTableReader reader)
+    {
+        synchronized (mainTransaction)
+        {
+            return mainTransaction.current(reader);
+        }
+    }
+
+    public void obsolete(SSTableReader reader)
+    {
+        earlyOpenUnsupported();
+    }
+
+    public void obsoleteOriginals()
+    {
+        composite.requestObsoleteOriginals();
+    }
+
+    public Set<SSTableReader> originals()
+    {
+        return mainTransaction.originals();
+    }
+
+    public boolean isObsolete(SSTableReader reader)
+    {
+        throw earlyOpenUnsupported();
+    }
+
+    private boolean markCommittedOrAborted()
+    {
+        return committedOrAborted.compareAndSet(false, true);
+    }
+
+    /// Commit the transaction part. Because this is a part of a composite transaction, the actual commit will be
+    /// carried out only after all parts have committed.
+    ///
+    ///
+    public Throwable commit(Throwable accumulate)
+    {
+        Throwables.maybeFail(accumulate); // we must be called with a null accumulate
+        if (markCommittedOrAborted())
+            composite.commitPart();
+        else
+            throw new IllegalStateException("Partial transaction already committed or aborted.");
+        return null;
+    }
+
+    public Throwable abort(Throwable accumulate)
+    {
+        Throwables.maybeFail(accumulate); // we must be called with a null accumulate
+        if (markCommittedOrAborted())
+            composite.abortPart();
+        else
+            throw new IllegalStateException("Partial transaction already committed or aborted.");
+        return null;
+    }
+
+    private void throwIfCompositeAborted()
+    {
+        if (composite.wasAborted())
+            throw new AbortedException("Transaction aborted, likely by another partial operation.");
+    }
+
+    public void prepareToCommit()
+    {
+        if (committedOrAborted.get())
+            throw new IllegalStateException("Partial transaction already committed or aborted.");
+
+        throwIfCompositeAborted();
+        // nothing else to do, the composite transaction will perform the preparation when all parts are done
+    }
+
+    public void close()
+    {
+        if (markCommittedOrAborted())   // close should abort if not committed
+            composite.abortPart();
+    }
+
+    public void trackNew(SSTable table)
+    {
+        throwIfCompositeAborted();
+        synchronized (mainTransaction)
+        {
+            mainTransaction.trackNew(table);
+        }
+    }
+
+    public void untrackNew(SSTable table)
+    {
+        synchronized (mainTransaction)
+        {
+            mainTransaction.untrackNew(table);
+        }
+    }
+
+    public OperationType opType()
+    {
+        return mainTransaction.opType();
+    }
+
+    public boolean isOffline()
+    {
+        return mainTransaction.isOffline();
+    }
+
+    @Override
+    public TimeUUID opId()
+    {
+        return id;
+    }
+
+    @Override
+    public String opIdString()
+    {
+        return String.format("%s (%d/%d)", id, id.sequence(), composite.partsCount());
+    }
+
+    @Override
+    public void cancel(SSTableReader removedSSTable)
+    {
+        synchronized (mainTransaction)
+        {
+            mainTransaction.cancel(removedSSTable);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return opIdString();
+    }
+
+    public static class AbortedException extends RuntimeException
+    {
+        public AbortedException(String message)
+        {
+            super(message);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
+++ b/src/java/org/apache/cassandra/db/lifecycle/WrappedLifecycleTransaction.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.TimeUUID;
 
 public class WrappedLifecycleTransaction implements ILifecycleTransaction
 {
@@ -112,5 +113,15 @@ public class WrappedLifecycleTransaction implements ILifecycleTransaction
     public boolean isOffline()
     {
         return delegate.isOffline();
+    }
+
+    public TimeUUID opId()
+    {
+        return delegate.opId();
+    }
+
+    public void cancel(SSTableReader removedSSTable)
+    {
+        delegate.cancel(removedSSTable);
     }
 }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableRewriter.java
@@ -99,7 +99,12 @@ public class SSTableRewriter extends Transactional.AbstractTransactional impleme
 
     public static SSTableRewriter construct(ColumnFamilyStore cfs, ILifecycleTransaction transaction, boolean keepOriginals, long maxAge)
     {
-        return new SSTableRewriter(transaction, maxAge, calculateOpenInterval(cfs.supportsEarlyOpen()), keepOriginals, true);
+        return construct(cfs, transaction, keepOriginals, maxAge, true);
+    }
+
+    public static SSTableRewriter construct(ColumnFamilyStore cfs, ILifecycleTransaction transaction, boolean keepOriginals, long maxAge, boolean earlyOpenAllowed)
+    {
+        return new SSTableRewriter(transaction, maxAge, calculateOpenInterval(earlyOpenAllowed && cfs.supportsEarlyOpen()), keepOriginals, true);
     }
 
     private static long calculateOpenInterval(boolean shouldOpenEarly)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -1019,7 +1019,8 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     {
         if (range == null)
             return getScanner();
-        return getScanner(Collections.singletonList(range));
+        else
+            return getScanner(Collections.singletonList(range));
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2689,6 +2689,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         }
     }
 
+    public void forceKeyspaceCompaction(boolean splitOutput, int parallelism, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException
+    {
+        for (ColumnFamilyStore cfStore : getValidColumnFamilies(true, false, keyspaceName, tableNames))
+        {
+            cfStore.forceMajorCompaction(splitOutput, parallelism);
+        }
+    }
+
     public int relocateSSTables(String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException
     {
         return relocateSSTables(0, keyspaceName, tableNames);

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -375,6 +375,11 @@ public interface StorageServiceMBean extends NotificationEmitter
      */
     public void forceKeyspaceCompaction(boolean splitOutput, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException;
 
+    /**
+     * Forces major compaction of a single keyspace with the given parallelism limit
+     */
+    public void forceKeyspaceCompaction(boolean splitOutput, int parallelism, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException;
+
     /** @deprecated See CASSANDRA-11179 */
     @Deprecated(since = "3.5")
     public int relocateSSTables(String keyspace, String ... cfnames) throws IOException, ExecutionException, InterruptedException;

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -469,6 +469,11 @@ public class NodeProbe implements AutoCloseable
         compactionProxy.forceUserDefinedCompaction(datafiles);
     }
 
+    public void forceKeyspaceCompaction(boolean splitOutput, int parallelism, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException
+    {
+        ssProxy.forceKeyspaceCompaction(splitOutput, parallelism, keyspaceName, tableNames);
+    }
+
     public void forceKeyspaceCompaction(boolean splitOutput, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException
     {
         ssProxy.forceKeyspaceCompaction(splitOutput, keyspaceName, tableNames);

--- a/src/java/org/apache/cassandra/tools/nodetool/Compact.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Compact.java
@@ -50,6 +50,12 @@ public class Compact extends NodeToolCmd
     @Option(title = "partition_key", name = {"--partition"}, description = "String representation of the partition key")
     private String partitionKey = EMPTY;
 
+    @Option(title = "jobs",
+            name = {"-j", "--jobs"},
+            description = "Use -j to specify the maximum number of threads to use for parallel compaction. " +
+                          "If not set, up to half the compaction threads will be used. " +
+                          "If set to 0, the major compaction will use all threads and will not permit other compactions to run until it completes (use with caution).")
+    private Integer parallelism = null;
 
     @Override
     public void execute(NodeProbe probe)
@@ -95,7 +101,10 @@ public class Compact extends NodeToolCmd
                 }
                 else
                 {
-                    probe.forceKeyspaceCompaction(splitOutput, keyspace, tableNames);
+                    if (parallelism != null)
+                        probe.forceKeyspaceCompaction(splitOutput, parallelism, keyspace, tableNames);
+                    else // avoid referring to the new method to work with older versions
+                        probe.forceKeyspaceCompaction(splitOutput, keyspace, tableNames);
                 }
             } catch (Exception e)
             {

--- a/src/java/org/apache/cassandra/utils/Throwables.java
+++ b/src/java/org/apache/cassandra/utils/Throwables.java
@@ -333,4 +333,11 @@ public final class Throwables
         if (!anyCauseMatches(err, cause::isInstance))
             throw new AssertionError("The exception is not caused by " + cause.getName(), err);
     }
+
+    @VisibleForTesting
+    public static void assertAnyCause(Throwable err, Class<? extends Throwable>... causeClasses)
+    {
+        if (Arrays.stream(causeClasses).noneMatch(c -> anyCauseMatches(err, c::isInstance)))
+            throw new AssertionError("The exception is not caused by any of " + Arrays.toString(causeClasses), err);
+    }
 }

--- a/src/java/org/apache/cassandra/utils/TimeUUID.java
+++ b/src/java/org/apache/cassandra/utils/TimeUUID.java
@@ -293,6 +293,25 @@ public class TimeUUID implements Serializable, Comparable<TimeUUID>
         return ballot == null ? "null" : String.format("%s(%d:%s)", kind, ballot.uuidTimestamp(), ballot);
     }
 
+    public int sequence()
+    {
+        return (int) ((lsb >> 48) & 0x0000000000003FFFL);
+    }
+
+    /**
+     * Returns a new TimeUUID with the same data as this one, but with the provided sequence value.
+     *
+     * <b>Warning:</b> the uniqueness of the returned TimeUUID is not guaranteed by this method. Caller must ensure that
+     * the sequence numbers in use are distinct.
+     */
+    public TimeUUID withSequence(long sequence)
+    {
+        long sequenceBits = 0x0000000000003FFFL;
+        long sequenceMask = ~(sequenceBits << 48);
+        final long bits = (sequence & sequenceBits) << 48;
+        return new TimeUUID(uuidTimestamp, lsb() & sequenceMask | bits);
+    }
+
     @Override
     public int compareTo(TimeUUID that)
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/PaxosRepair2Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/PaxosRepair2Test.java
@@ -287,7 +287,7 @@ public class PaxosRepair2Test extends TestBaseImpl
     {
         ColumnFamilyStore paxos = Keyspace.open(SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(SystemKeyspace.PAXOS);
         FBUtilities.waitOnFuture(paxos.forceFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS));
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(paxos, 0, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(paxos, 0, false, 0));
     }
 
     private static Map<Integer, PaxosRow> getPaxosRows()

--- a/test/distributed/org/apache/cassandra/distributed/test/PaxosRepairTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/PaxosRepairTest.java
@@ -597,7 +597,7 @@ public class PaxosRepairTest extends TestBaseImpl
     {
         ColumnFamilyStore paxos = Keyspace.open(SYSTEM_KEYSPACE_NAME).getColumnFamilyStore(SystemKeyspace.PAXOS);
         FBUtilities.waitOnFuture(paxos.forceFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS));
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(paxos, 0, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(paxos, 0, false, 0));
     }
 
     private static Map<Integer, PaxosRow> getPaxosRows()

--- a/test/distributed/org/apache/cassandra/distributed/test/UpgradeSSTablesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/UpgradeSSTablesTest.java
@@ -83,7 +83,7 @@ public class UpgradeSSTablesTest extends TestBaseImpl
 
             Future<?> future = cluster.get(1).asyncAcceptsOnInstance((String ks) -> {
                 ColumnFamilyStore cfs = Keyspace.open(ks).getColumnFamilyStore("tbl");
-                CompactionManager.instance.submitMaximal(cfs, FBUtilities.nowInSeconds(), false, OperationType.COMPACTION);
+                CompactionManager.instance.submitMaximal(cfs, FBUtilities.nowInSeconds(), false, 1, OperationType.COMPACTION);
             }).apply(KEYSPACE);
 
             Assert.assertTrue(cluster.get(1).callOnInstance(() -> CompactionLatchByteman.starting.awaitUninterruptibly(1, TimeUnit.MINUTES)));
@@ -129,7 +129,7 @@ public class UpgradeSSTablesTest extends TestBaseImpl
 
             cluster.get(1).acceptsOnInstance((String ks) -> {
                 ColumnFamilyStore cfs = Keyspace.open(ks).getColumnFamilyStore("tbl");
-                FBUtilities.allOf(CompactionManager.instance.submitMaximal(cfs, FBUtilities.nowInSeconds(), false, OperationType.COMPACTION))
+                FBUtilities.allOf(CompactionManager.instance.submitMaximal(cfs, FBUtilities.nowInSeconds(), false, 1, OperationType.COMPACTION))
                            .awaitUninterruptibly(1, TimeUnit.MINUTES);
 
             }).accept(KEYSPACE);

--- a/test/long/org/apache/cassandra/db/compaction/LongCompactionsTest.java
+++ b/test/long/org/apache/cassandra/db/compaction/LongCompactionsTest.java
@@ -200,7 +200,7 @@ public class LongCompactionsTest
 
         if (cfs.getLiveSSTables().size() > 1)
         {
-            CompactionManager.instance.performMaximal(cfs, false);
+            CompactionManager.instance.performMaximal(cfs);
         }
     }
 }

--- a/test/long/org/apache/cassandra/db/compaction/LongLeveledCompactionStrategyTest.java
+++ b/test/long/org/apache/cassandra/db/compaction/LongLeveledCompactionStrategyTest.java
@@ -99,16 +99,19 @@ public class LongLeveledCompactionStrategyTest
         {
             while (true)
             {
-                final AbstractCompactionTask nextTask = lcs.getNextBackgroundTask(Integer.MIN_VALUE);
-                if (nextTask == null)
+                final var nextTasks = lcs.getNextBackgroundTasks(Integer.MIN_VALUE);
+                if (nextTasks == null || nextTasks.isEmpty())
                     break;
-                tasks.add(new Runnable()
+                for (var nextTask : nextTasks)
                 {
-                    public void run()
+                    tasks.add(new Runnable()
                     {
-                        nextTask.execute(ActiveCompactionsTracker.NOOP);
-                    }
-                });
+                        public void run()
+                        {
+                            nextTask.execute(ActiveCompactionsTracker.NOOP);
+                        }
+                    });
+                }
             }
             if (tasks.isEmpty())
                 break;

--- a/test/microbench/org/apache/cassandra/test/microbench/CachingBenchTest.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/CachingBenchTest.java
@@ -262,7 +262,7 @@ public class CachingBenchTest extends CQLTester
 
         String hashesBefore = getHashes();
         long startTime = currentTimeMillis();
-        CompactionManager.instance.performMaximal(cfs, true);
+        CompactionManager.instance.performMaximal(cfs, true, 0);
         long endTime = currentTimeMillis();
 
         int endRowCount = countRows(cfs);

--- a/test/microbench/org/apache/cassandra/test/microbench/ZeroCopyStreamingBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/ZeroCopyStreamingBench.java
@@ -202,7 +202,7 @@ public class ZeroCopyStreamingBench
                 .applyUnsafe();
             }
             store.forceBlockingFlush(ColumnFamilyStore.FlushReason.USER_FORCED);
-            CompactionManager.instance.performMaximal(store, false);
+            CompactionManager.instance.performMaximal(store);
         }
 
         @TearDown

--- a/test/unit/org/apache/cassandra/cql3/GcCompactionTest.java
+++ b/test/unit/org/apache/cassandra/cql3/GcCompactionTest.java
@@ -232,7 +232,7 @@ public class GcCompactionTest extends CQLTester
 
       assertEquals(0, collected.getSSTableLevel()); // garbagecollect should leave the LCS level where it was
 
-      CompactionManager.instance.performMaximal(cfs, false);
+      CompactionManager.instance.performMaximal(cfs);
 
       assertEquals(1, cfs.getLiveSSTables().size());
       SSTableReader compacted = cfs.getLiveSSTables().iterator().next();

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/CrcCheckChanceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/CrcCheckChanceTest.java
@@ -188,7 +188,7 @@ public class CrcCheckChanceTest extends CQLTester
         }
 
         DatabaseDescriptor.setCompactionThroughputMebibytesPerSec(1);
-        List<? extends Future<?>> futures = CompactionManager.instance.submitMaximal(cfs, CompactionManager.getDefaultGcBefore(cfs, FBUtilities.nowInSeconds()), false);
+        List<? extends Future<?>> futures = CompactionManager.instance.submitMaximal(cfs, CompactionManager.getDefaultGcBefore(cfs, FBUtilities.nowInSeconds()), false, 1);
         execute("DROP TABLE %s");
 
         try

--- a/test/unit/org/apache/cassandra/db/KeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/db/KeyspaceTest.java
@@ -419,7 +419,7 @@ public class KeyspaceTest extends CQLTester
 
         // compact so we have a big row with more than the minimum index count
         if (cfs.getLiveSSTables().size() > 1)
-            CompactionManager.instance.performMaximal(cfs, false);
+            CompactionManager.instance.performMaximal(cfs);
 
         // verify that we do indeed have multiple index entries
         SSTableReader sstable = cfs.getLiveSSTables().iterator().next();

--- a/test/unit/org/apache/cassandra/db/RangeTombstoneTest.java
+++ b/test/unit/org/apache/cassandra/db/RangeTombstoneTest.java
@@ -421,7 +421,7 @@ public class RangeTombstoneTest
                         partition.getRow(Clustering.make(bb(i))).hasLiveData(nowInSec, enforceStrictLiveness));
 
         // Compact everything and re-test
-        CompactionManager.instance.performMaximal(cfs, false);
+        CompactionManager.instance.performMaximal(cfs);
         partition = Util.getOnlyPartitionUnfiltered(Util.cmd(cfs, key).build());
 
         for (int i = 0; i < 5; i++)
@@ -515,7 +515,7 @@ public class RangeTombstoneTest
 
         assertEquals(10, index.rowsInserted.size());
 
-        CompactionManager.instance.performMaximal(cfs, false);
+        CompactionManager.instance.performMaximal(cfs);
 
         // compacted down to single sstable
         assertEquals(1, cfs.getLiveSSTables().size());
@@ -547,7 +547,7 @@ public class RangeTombstoneTest
         assertEquals(2, cfs.getLiveSSTables().size());
 
         // compact down to single sstable
-        CompactionManager.instance.performMaximal(cfs, false);
+        CompactionManager.instance.performMaximal(cfs);
         assertEquals(1, cfs.getLiveSSTables().size());
 
         // test the physical structure of the sstable i.e. rt & columns on disk

--- a/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CancelCompactionsTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Assume;
 import org.junit.Test;
@@ -485,7 +486,7 @@ public class CancelCompactionsTest extends CQLTester
         {
             for (AbstractCompactionStrategy cs : css)
             {
-                ct = cs.getNextBackgroundTask(0);
+                ct = Iterables.getOnlyElement(cs.getNextBackgroundTasks(0), null);
                 if (ct != null)
                     break;
             }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionControllerTest.java
@@ -184,19 +184,19 @@ public class CompactionControllerTest extends SchemaLoader
 
         // the first sstable should be expired because the overlapping sstable is newer and the gc period is later
         long gcBefore = (System.currentTimeMillis() / 1000) + 5;
-        Set<SSTableReader> expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore);
+        Set<SSTableReader> expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, x -> overlapping, gcBefore);
         assertNotNull(expired);
         assertEquals(1, expired.size());
         assertEquals(compacting.iterator().next(), expired.iterator().next());
 
         // however if we add an older mutation to the memtable then the sstable should not be expired
         applyMutation(cfs.metadata(), key, timestamp3);
-        expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore);
+        expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, x -> overlapping, gcBefore);
         assertNotNull(expired);
         assertEquals(0, expired.size());
 
         // Now if we explicitly ask to ignore overlaped sstables, we should get back our expired sstable
-        expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, overlapping, gcBefore, true);
+        expired = CompactionController.getFullyExpiredSSTables(cfs, compacting, x -> overlapping, gcBefore, true);
         assertNotNull(expired);
         assertEquals(1, expired.size());
     }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerPendingRepairTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerPendingRepairTest.java
@@ -253,7 +253,7 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         Assert.assertFalse(sstable.isRepaired());
 
         cfs.getCompactionStrategyManager().enable(); // enable compaction to fetch next background task
-        AbstractCompactionTask compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds());
+        AbstractCompactionTask compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null);
         Assert.assertNotNull(compactionTask);
         Assert.assertSame(PendingRepairManager.RepairFinishedCompactionTask.class, compactionTask.getClass());
 
@@ -294,7 +294,7 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         Assert.assertFalse(sstable.isRepaired());
 
         cfs.getCompactionStrategyManager().enable(); // enable compaction to fetch next background task
-        AbstractCompactionTask compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds());
+        AbstractCompactionTask compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null);
         Assert.assertNotNull(compactionTask);
         Assert.assertSame(PendingRepairManager.RepairFinishedCompactionTask.class, compactionTask.getClass());
 
@@ -348,7 +348,7 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         cfs.getCompactionStrategyManager().enable();
         for (SSTableReader sstable : sstables)
             pendingContains(sstable);
-        AbstractCompactionTask compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds());
+        AbstractCompactionTask compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null);
 
         // Finalize the repair session
         LocalSessionAccessor.finalizeUnsafe(repairID);
@@ -374,13 +374,13 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         System.out.println("*********************************************************************************************");
 
         // Run compaction again. It should pick up the pending repair sstable
-        compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds());
+        compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null);
         if (compactionTask != null)
         {
             Assert.assertSame(PendingRepairManager.RepairFinishedCompactionTask.class, compactionTask.getClass());
             compactionTask.execute(ActiveCompactionsTracker.NOOP);
 
-            while ((compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds())) != null)
+            while ((compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null)) != null)
                 compactionTask.execute(ActiveCompactionsTracker.NOOP);
         }
 
@@ -388,7 +388,7 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         Util.spinAssertEquals(Boolean.FALSE,
                               () -> {
                                   AbstractCompactionTask ctask;
-                                  while ((ctask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds())) != null)
+                                  while ((ctask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null)) != null)
                                       ctask.execute(ActiveCompactionsTracker.NOOP);
 
                                   return hasPendingStrategiesFor(repairID);
@@ -434,7 +434,7 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         Assert.assertFalse(unrepairedContains(sstable));
 
         cfs.getCompactionStrategyManager().enable(); // enable compaction to fetch next background task
-        AbstractCompactionTask compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds());
+        AbstractCompactionTask compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null);
         Assert.assertNotNull(compactionTask);
         Assert.assertSame(PendingRepairManager.RepairFinishedCompactionTask.class, compactionTask.getClass());
 
@@ -465,7 +465,7 @@ public class CompactionStrategyManagerPendingRepairTest extends AbstractPendingR
         Assert.assertFalse(unrepairedContains(sstable));
 
         cfs.getCompactionStrategyManager().enable(); // enable compaction to fetch next background task
-        AbstractCompactionTask compactionTask = csm.getNextBackgroundTask(FBUtilities.nowInSeconds());
+        AbstractCompactionTask compactionTask = Iterables.getOnlyElement(csm.getNextBackgroundTasks(FBUtilities.nowInSeconds()), null);
         Assert.assertNotNull(compactionTask);
         Assert.assertSame(PendingRepairManager.RepairFinishedCompactionTask.class, compactionTask.getClass());
 

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionTaskTest.java
@@ -213,13 +213,13 @@ public class CompactionTaskTest
 
         try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.COMPACTION, sstables))
         {
-            Assert.assertEquals(4, txn.tracker.getView().liveSSTables().size());
+            Assert.assertEquals(4, txn.tracker().getView().liveSSTables().size());
             CompactionTask task = new CompactionTask(cfs, txn, 1000);
             task.execute(null);
 
             // Check that new SSTable was not released
-            Assert.assertEquals(1, txn.tracker.getView().liveSSTables().size());
-            SSTableReader newSSTable = txn.tracker.getView().liveSSTables().iterator().next();
+            Assert.assertEquals(1, txn.tracker().getView().liveSSTables().size());
+            SSTableReader newSSTable = txn.tracker().getView().liveSSTables().iterator().next();
             Assert.assertNotNull(newSSTable.tryRef());
         }
         finally
@@ -233,7 +233,7 @@ public class CompactionTaskTest
     public void testMajorCompactTask()
     {
         //major compact without range/pk specified 
-        CompactionTasks compactionTasks = cfs.getCompactionStrategyManager().getMaximalTasks(Integer.MAX_VALUE, false, OperationType.MAJOR_COMPACTION);
+        CompactionTasks compactionTasks = cfs.getCompactionStrategyManager().getMaximalTasks(Integer.MAX_VALUE, false, Integer.MAX_VALUE, OperationType.MAJOR_COMPACTION);
         Assert.assertTrue(compactionTasks.stream().allMatch(task -> task.compactionType.equals(OperationType.MAJOR_COMPACTION)));
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionsPurgeTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionsPurgeTest.java
@@ -120,7 +120,7 @@ public class CompactionsPurgeTest
         Util.flush(cfs);
 
         // major compact and test that all columns but the resurrected one is completely gone
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Integer.MAX_VALUE, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Long.MAX_VALUE, false, 0));
         cfs.invalidateCachedPartition(dk(key));
 
         ImmutableBTreePartition partition = Util.getOnlyPartitionUnfiltered(Util.cmd(cfs, key).build());
@@ -156,7 +156,7 @@ public class CompactionsPurgeTest
         Util.flush(cfs);
 
         // major compact - tombstones should be purged
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Integer.MAX_VALUE, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Long.MAX_VALUE, false, 0));
 
         // resurrect one column
         RowUpdateBuilder builder = new RowUpdateBuilder(cfs.metadata(), 2, key);
@@ -200,7 +200,7 @@ public class CompactionsPurgeTest
         Util.flush(cfs);
 
         // major compact - tombstones should be purged
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Integer.MAX_VALUE, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Long.MAX_VALUE, false, 0));
 
         // resurrect one column
         RowUpdateBuilder builder = new RowUpdateBuilder(cfs.metadata(), 2, key);
@@ -242,7 +242,7 @@ public class CompactionsPurgeTest
         Util.flush(cfs);
 
         // major compact - tombstones should be purged
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Integer.MAX_VALUE, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Long.MAX_VALUE, false, 0));
 
         // resurrect one column
         RowUpdateBuilder builder = new RowUpdateBuilder(cfs.metadata(), 2, key);
@@ -519,7 +519,7 @@ public class CompactionsPurgeTest
         assertEquals(0, result.size());
 
         // compact the two sstables with a gcBefore that does *not* allow the row tombstone to be purged
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, (int) (System.currentTimeMillis() / 1000) - 10000, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, (int) (System.currentTimeMillis() / 1000) - 10000, false, 0));
 
         // the data should be gone, but the tombstone should still exist
         assertEquals(1, cfs.getLiveSSTables().size());
@@ -539,7 +539,7 @@ public class CompactionsPurgeTest
         Util.flush(cfs);
 
         // compact the two sstables with a gcBefore that *does* allow the row tombstone to be purged
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, (int) (System.currentTimeMillis() / 1000) + 10000, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, (int) (System.currentTimeMillis() / 1000) + 10000, false, 0));
 
         // both the data and the tombstone should be gone this time
         assertEquals(0, cfs.getLiveSSTables().size());

--- a/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/LeveledCompactionStrategyTest.java
@@ -593,7 +593,7 @@ public class LeveledCompactionStrategyTest
         {
             for (AbstractCompactionStrategy strategy : strategies)
             {
-                AbstractCompactionTask task = strategy.getNextBackgroundTask(0);
+                AbstractCompactionTask task = Iterables.getOnlyElement(strategy.getNextBackgroundTasks(0), null);
                 if (task != null)
                 {
                     try
@@ -922,7 +922,7 @@ public class LeveledCompactionStrategyTest
             l0sstables.add(MockSchema.sstable(i, (i + 1) * 1024 * 1024, cfs));
         try (LifecycleTransaction txn = LifecycleTransaction.offline(OperationType.COMPACTION, Iterables.concat(l0sstables, l1sstables)))
         {
-            Set<SSTableReader> nonExpired = Sets.difference(txn.originals(), Collections.emptySet());
+            Set<SSTableReader> nonExpired = new HashSet<>(Sets.difference(txn.originals(), Collections.emptySet()));
             CompactionTask task = new LeveledCompactionTask(cfs, txn, 1, 0, 1024*1024, false);
             SSTableReader lastRemoved = null;
             boolean removed = true;
@@ -974,7 +974,8 @@ public class LeveledCompactionStrategyTest
             for (int i = 0; i < l0sstables.size(); i++)
             {
                 Set<SSTableReader> before = new HashSet<>(txn.originals());
-                removed = task.reduceScopeForLimitedSpace(before, 0);
+                Set<SSTableReader> sources = new HashSet<>(before);
+                removed = task.reduceScopeForLimitedSpace(sources, 0);
                 SSTableReader removedSSTable = Sets.difference(before, txn.originals()).stream().findFirst().orElse(null);
                 if (removed)
                 {

--- a/test/unit/org/apache/cassandra/db/compaction/PartialCompactionsTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/PartialCompactionsTest.java
@@ -98,7 +98,7 @@ public class PartialCompactionsTest extends SchemaLoader
         LimitableDataDirectory.setAvailableSpace(cfs, enoughSpaceForAllButTheLargestSSTable(cfs));
 
         // when - run a compaction where all tombstones have timed out
-        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Integer.MAX_VALUE, false));
+        FBUtilities.waitOnFutures(CompactionManager.instance.submitMaximal(cfs, Integer.MAX_VALUE, false, 0));
 
         // then - the tombstones should not be removed
         assertEquals("live sstables after compaction", 2, cfs.getLiveSSTables().size());

--- a/test/unit/org/apache/cassandra/db/compaction/PendingRepairManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/PendingRepairManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.db.compaction;
 import java.util.Collection;
 import java.util.Collections;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
@@ -152,8 +153,8 @@ public class PendingRepairManagerTest extends AbstractPendingRepairTest
         LocalSessionAccessor.finalizeUnsafe(repairID);
 
         Assert.assertEquals(2, prm.getSessions().size());
-        Assert.assertNull(prm.getNextBackgroundTask(FBUtilities.nowInSeconds()));
-        AbstractCompactionTask compactionTask = prm.getNextRepairFinishedTask();
+        Assert.assertEquals(0, prm.getNextBackgroundTasks(FBUtilities.nowInSeconds()).size());
+        AbstractCompactionTask compactionTask = Iterables.getOnlyElement(prm.getNextRepairFinishedTasks());
         try
         {
             Assert.assertNotNull(compactionTask);
@@ -171,7 +172,7 @@ public class PendingRepairManagerTest extends AbstractPendingRepairTest
     public void getNextBackgroundTaskNoSessions()
     {
         PendingRepairManager prm = csm.getPendingRepairManagers().get(0);
-        Assert.assertNull(prm.getNextBackgroundTask(FBUtilities.nowInSeconds()));
+        Assert.assertEquals(0, prm.getNextBackgroundTasks(FBUtilities.nowInSeconds()).size());
     }
 
     /**
@@ -191,7 +192,7 @@ public class PendingRepairManagerTest extends AbstractPendingRepairTest
         Assert.assertNotNull(prm.get(repairID));
         LocalSessionAccessor.finalizeUnsafe(repairID);
 
-        Assert.assertNull(prm.getNextBackgroundTask(FBUtilities.nowInSeconds()));
+        Assert.assertEquals(0, prm.getNextBackgroundTasks(FBUtilities.nowInSeconds()).size());
 
     }
 
@@ -303,7 +304,7 @@ public class PendingRepairManagerTest extends AbstractPendingRepairTest
         prm.getOrCreate(sstable);
         cfs.truncateBlocking();
         Assert.assertFalse(cfs.getSSTables(SSTableSet.LIVE).iterator().hasNext());
-        Assert.assertNull(cfs.getCompactionStrategyManager().getNextBackgroundTask(0));
+        Assert.assertEquals(0, cfs.getCompactionStrategyManager().getNextBackgroundTasks(0).size());
 
     }
 }

--- a/test/unit/org/apache/cassandra/db/compaction/SingleSSTableLCSTaskTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/SingleSSTableLCSTaskTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Random;
 
+import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
@@ -101,14 +102,14 @@ public class SingleSSTableLCSTaskTest extends CQLTester
         }
         // now we have a bunch of data in L0, first compaction will be a normal one, containing all sstables:
         LeveledCompactionStrategy lcs = (LeveledCompactionStrategy) cfs.getCompactionStrategyManager().getUnrepairedUnsafe().first();
-        AbstractCompactionTask act = lcs.getNextBackgroundTask(0);
+        AbstractCompactionTask act = Iterables.getOnlyElement(lcs.getNextBackgroundTasks(0), null);
         act.execute(ActiveCompactionsTracker.NOOP);
 
         // now all sstables are laid out non-overlapping in L1, this means that the rest of the compactions
         // will be single sstable ones, make sure that we use SingleSSTableLCSTask if singleSSTUplevel is true:
         while (lcs.getEstimatedRemainingTasks() > 0)
         {
-            act = lcs.getNextBackgroundTask(0);
+            act = Iterables.getOnlyElement(lcs.getNextBackgroundTasks(0), null);
             assertEquals(singleSSTUplevel, act instanceof SingleSSTableLCSTask);
             act.execute(ActiveCompactionsTracker.NOOP);
         }

--- a/test/unit/org/apache/cassandra/db/compaction/TTLExpiryTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/TTLExpiryTest.java
@@ -141,7 +141,7 @@ public class TTLExpiryTest
         Set<SSTableReader> expired = CompactionController.getFullyExpiredSSTables(
                 cfs,
                 sstables,
-                Collections.EMPTY_SET,
+                s -> Collections.EMPTY_SET,
                 gcBefore);
         assertEquals(2, expired.size());
 

--- a/test/unit/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/TimeWindowCompactionStrategyTest.java
@@ -297,11 +297,13 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
             twcs.addSSTable(sstable);
 
         twcs.startup();
-        assertNull(twcs.getNextBackgroundTask(nowInSeconds()));
+        long gcBefore1 = nowInSeconds();
+        assertNull(Iterables.<AbstractCompactionTask>getOnlyElement(twcs.getNextBackgroundTasks(gcBefore1), null));
 
         // Wait for the expiration of the first sstable
         Thread.sleep(TimeUnit.SECONDS.toMillis(TTL_SECONDS + 1));
-        AbstractCompactionTask t = twcs.getNextBackgroundTask(nowInSeconds());
+        long gcBefore = nowInSeconds();
+        AbstractCompactionTask t = Iterables.getOnlyElement(twcs.getNextBackgroundTasks(gcBefore), null);
         assertNotNull(t);
         assertEquals(1, Iterables.size(t.transaction.originals()));
         SSTableReader sstable = t.transaction.originals().iterator().next();
@@ -352,11 +354,13 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
             twcs.addSSTable(sstable);
 
         twcs.startup();
-        assertNull(twcs.getNextBackgroundTask(nowInSeconds()));
+        long gcBefore2 = nowInSeconds();
+        assertNull(Iterables.<AbstractCompactionTask>getOnlyElement(twcs.getNextBackgroundTasks(gcBefore2), null));
 
         // Wait for the expiration of the first sstable
         Thread.sleep(TimeUnit.SECONDS.toMillis(TTL_SECONDS + 1));
-        assertNull(twcs.getNextBackgroundTask(nowInSeconds()));
+        long gcBefore1 = nowInSeconds();
+        assertNull(Iterables.<AbstractCompactionTask>getOnlyElement(twcs.getNextBackgroundTasks(gcBefore1), null));
 
         options.put(TimeWindowCompactionStrategyOptions.UNSAFE_AGGRESSIVE_SSTABLE_EXPIRATION_KEY, "true");
         twcs = new TimeWindowCompactionStrategy(cfs, options);
@@ -364,7 +368,8 @@ public class TimeWindowCompactionStrategyTest extends SchemaLoader
             twcs.addSSTable(sstable);
 
         twcs.startup();
-        AbstractCompactionTask t = twcs.getNextBackgroundTask(nowInSeconds());
+        long gcBefore = nowInSeconds();
+        AbstractCompactionTask t = Iterables.getOnlyElement(twcs.getNextBackgroundTasks(gcBefore), null);
         assertNotNull(t);
         assertEquals(1, Iterables.size(t.transaction.originals()));
         SSTableReader sstable = t.transaction.originals().iterator().next();

--- a/test/unit/org/apache/cassandra/db/compaction/unified/BackgroundCompactionTrackingTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/BackgroundCompactionTrackingTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.unified;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.compaction.CompactionInfo;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.TimeUUID;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BMUnitRunner.class)
+@BMUnitConfig(debug=true)
+@BMRule(
+name = "Get stats before task completion",
+targetClass = "org.apache.cassandra.db.compaction.ActiveCompactions",
+targetMethod = "finishCompaction",
+targetLocation = "AT ENTRY",
+action = "org.apache.cassandra.db.compaction.unified.BackgroundCompactionTrackingTest.getStats()"
+)
+public class BackgroundCompactionTrackingTest extends CQLTester
+{
+    // Get rid of commitlog noise
+    @Before
+    public void disableCommitlog()
+    {
+        schemaChange("ALTER KEYSPACE " + KEYSPACE + " WITH durable_writes = false");
+    }
+    @After
+    public void enableCommitlog()
+    {
+        schemaChange("ALTER KEYSPACE " + KEYSPACE + " WITH durable_writes = true");
+    }
+
+    @Test
+    public void testBackgroundCompactionTracking()
+    {
+        testBackgroundCompactionTracking(false, 3);
+    }
+
+    @Test
+    public void testBackgroundCompactionTrackingParallelized()
+    {
+        testBackgroundCompactionTracking(true, 3);
+    }
+
+    public void testBackgroundCompactionTracking(boolean parallelize, int shards)
+    {
+        int bytes_per_row = 5000;
+        int partitions = 5000;
+        int rows_per_partition = 10;
+        long targetSize = 1L * partitions * rows_per_partition * bytes_per_row / shards;
+        CompactionManager.instance.setMaximumCompactorThreads(50);
+        CompactionManager.instance.setCoreCompactorThreads(50);
+        String table = createTable(String.format("CREATE TABLE %%s (k int, t int, v blob, PRIMARY KEY (k, t))" +
+                                                 " with compression = {'enabled': false} " +
+                                                 " and compaction = {" +
+                                                 "'class': 'UnifiedCompactionStrategy', " +
+                                                 "'parallelize_output_shards': '%s', " +
+                                                 "'base_shard_count': %d, " +
+                                                 "'min_sstable_size': '%dB', " + // to disable sharding on flush
+                                                 "'scaling_parameters': 'T4, T7'" +
+                                   "}",
+                                   parallelize, shards, targetSize));
+        ColumnFamilyStore cfs = getColumnFamilyStore(KEYSPACE, table);
+        cfs.disableAutoCompaction();
+
+        for (int iter = 1; iter <= 5; ++iter)
+        {
+            byte [] payload = new byte[bytes_per_row];
+            new Random(42).nextBytes(payload);
+            ByteBuffer b = ByteBuffer.wrap(payload);
+            Set<SSTableReader> before = new HashSet<>(cfs.getLiveSSTables());
+
+            for (int i = 0; i < partitions; i++)
+            {
+                for (int j = 0; j < rows_per_partition; j++)
+                    execute(String.format("INSERT INTO %s.%s(k, t, v) VALUES (?, ?, ?)", KEYSPACE, table), i, j, b);
+
+                if ((i + 1) % ((partitions  + 3) / 4) == 0)
+                    cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+            }
+            cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+            operations = new ArrayList<>();
+            Set<SSTableReader> newSSTables = new HashSet<>(cfs.getLiveSSTables());
+            newSSTables.removeAll(before);
+            long uncompressedSize = newSSTables.stream().mapToLong(SSTableReader::uncompressedLength).sum();
+
+            cfs.enableAutoCompaction(true); // since the trigger is hit, this initiates an L0 compaction
+            cfs.disableAutoCompaction();
+
+            // Check that the background compactions state is correct during the compaction
+            Assert.assertTrue("Byteman rule did not fire", !operations.isEmpty());
+            printStats();
+            int tasks = parallelize ? shards : 1;
+            assertEquals(tasks, operations.size());
+            TimeUUID mainOpId = null;
+            for (int i = 0; i < operations.size(); ++i)
+            {
+                BitSet seqs = new BitSet(shards);
+                int expectedSize = tasks - i;
+                final List<CompactionInfo> ops = getCompactionOps(i, cfs);
+                final int size = ops.size();
+                int finished = tasks - size;
+                assertTrue(size >= expectedSize); // some task may have not managed to close
+                for (var op : ops)
+                {
+                    final TimeUUID opIdSeq0 = op.getTaskId().withSequence(0);
+                    if (mainOpId == null)
+                        mainOpId = opIdSeq0;
+                    else
+                        assertEquals(mainOpId, opIdSeq0);
+                    seqs.set(op.getTaskId().sequence());
+
+                    if (i == 0)
+                        Assert.assertEquals(uncompressedSize * 1.0 / tasks, op.getTotal(), uncompressedSize * 0.03);
+                    assertTrue(op.getCompleted() <= op.getTotal() * 1.03);
+                    if (op.getCompleted() >= op.getTotal() * 0.97)
+                        ++finished;
+                }
+                assertTrue(finished > i);
+                assertEquals(size, seqs.cardinality());
+            }
+            assertEquals(iter * shards, cfs.getLiveSSTables().size());
+
+            // Check that the background compactions state is correct after the compaction
+            operations.clear();
+            getStats();
+            printStats();
+            final List<CompactionInfo> ops = getCompactionOps(0, cfs);
+            assertEquals(0, ops.size());
+        }
+    }
+
+    private static List<CompactionInfo> getCompactionOps(int i, ColumnFamilyStore cfs)
+    {
+        return operations.get(i)
+                         .stream()
+                         .filter(op -> op.getTableMetadata() == cfs.metadata())
+                         .collect(Collectors.toList());
+    }
+
+    private void printStats()
+    {
+        for (int i = 0; i < operations.size(); ++i)
+        {
+            System.out.println(operations.get(i).stream().map(Object::toString).collect(Collectors.joining("\n")));
+        }
+    }
+
+    public static synchronized void getStats()
+    {
+        operations.add(CompactionManager.instance.getSSTableTasks());
+    }
+
+    static List<List<CompactionInfo>> operations;
+}

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ParallelizedTasksTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.unified;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.AbstractCompactionTask;
+import org.apache.cassandra.db.compaction.ActiveCompactionsTracker;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.compaction.ShardManager;
+import org.apache.cassandra.db.compaction.ShardManagerNoDisks;
+import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy;
+import org.apache.cassandra.db.lifecycle.CompositeLifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.lifecycle.PartialLifecycleTransaction;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.concurrent.Transactional;
+import org.mockito.Mockito;
+
+import static org.apache.cassandra.db.ColumnFamilyStore.RING_VERSION_IRRELEVANT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ParallelizedTasksTest extends ShardingTestBase
+{
+    @Before
+    public void before()
+    {
+        // Disabling durable write since we don't care
+        schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes=false");
+        schemaChange(String.format("CREATE TABLE IF NOT EXISTS %s.%s (k int, t int, v blob, PRIMARY KEY (k, t))", KEYSPACE, TABLE));
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+    {
+        QueryProcessor.executeInternal("DROP KEYSPACE IF EXISTS " + KEYSPACE);
+    }
+
+    private ColumnFamilyStore getColumnFamilyStore()
+    {
+        return Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+    }
+
+    @Test
+    public void testOneSSTablePerShard() throws Throwable
+    {
+        int numShards = 5;
+        testParallelized(numShards, PARTITIONS, numShards, true);
+    }
+
+    @Test
+    public void testMultipleInputSSTables() throws Throwable
+    {
+        int numShards = 3;
+        testParallelized(numShards, PARTITIONS, numShards, false);
+    }
+
+    private void testParallelized(int numShards, int rowCount, int numOutputSSTables, boolean compact) throws Throwable
+    {
+        ColumnFamilyStore cfs = getColumnFamilyStore();
+        cfs.disableAutoCompaction();
+
+        populate(rowCount, compact);
+
+        LifecycleTransaction transaction = cfs.getTracker().tryModify(cfs.getLiveSSTables(), OperationType.COMPACTION);
+
+        ShardManager shardManager = new ShardManagerNoDisks(ColumnFamilyStore.fullWeightedRange(RING_VERSION_IRRELEVANT, cfs.getPartitioner()));
+
+        Controller mockController = Mockito.mock(Controller.class);
+        UnifiedCompactionStrategy mockStrategy = Mockito.mock(UnifiedCompactionStrategy.class, Mockito.CALLS_REAL_METHODS);
+        Mockito.when(mockStrategy.getController()).thenReturn(mockController);
+        Mockito.when(mockController.getNumShards(Mockito.anyDouble())).thenReturn(numShards);
+
+        Collection<SSTableReader> sstables = transaction.originals();
+        CompositeLifecycleTransaction compositeTransaction = new CompositeLifecycleTransaction(transaction);
+
+        List<AbstractCompactionTask> tasks = shardManager.splitSSTablesInShards(
+        sstables,
+        numShards,
+        (rangeSSTables, range) ->
+        new UnifiedCompactionTask(cfs,
+                                  mockStrategy,
+                                  new PartialLifecycleTransaction(compositeTransaction),
+                                  0,
+                                  shardManager,
+                                  range,
+                                  rangeSSTables)
+        );
+        compositeTransaction.completeInitialization();
+        assertEquals(numOutputSSTables, tasks.size());
+
+        List<Future<?>> futures = tasks.stream().map(t -> ForkJoinPool.commonPool().submit(() -> t.execute(ActiveCompactionsTracker.NOOP))).collect(Collectors.toList());
+        FBUtilities.waitOnFutures(futures);
+        assertTrue(transaction.state() == Transactional.AbstractTransactional.State.COMMITTED);
+
+        verifySharding(numShards, rowCount, numOutputSSTables, cfs);
+        cfs.truncateBlocking();
+    }
+}

--- a/test/unit/org/apache/cassandra/db/compaction/unified/ShardingTestBase.java
+++ b/test/unit/org/apache/cassandra/db/compaction/unified/ShardingTestBase.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.compaction.unified;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.AbstractCompactionStrategy;
+import org.apache.cassandra.db.compaction.CompactionController;
+import org.apache.cassandra.db.compaction.CompactionIterator;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.db.compaction.ShardManager;
+import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
+import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.io.sstable.format.SSTableReaderWithFilter;
+import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.FilterFactory;
+import org.apache.cassandra.utils.TimeUUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ShardingTestBase extends CQLTester
+{
+    static final String KEYSPACE = "cawt_keyspace";
+    static final String TABLE = "cawt_table";
+
+    static final int ROW_PER_PARTITION = 10;
+    static final int PARTITIONS = 50000;
+
+    @Before
+    public void before()
+    {
+        // Disabling durable write since we don't care
+        schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes=false");
+        schemaChange(String.format("CREATE TABLE IF NOT EXISTS %s.%s (k int, t int, v blob, PRIMARY KEY (k, t))", KEYSPACE, TABLE));
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+    {
+        QueryProcessor.executeInternal("DROP KEYSPACE IF EXISTS " + KEYSPACE);
+    }
+
+    private ColumnFamilyStore getColumnFamilyStore()
+    {
+        return Keyspace.open(KEYSPACE).getColumnFamilyStore(TABLE);
+    }
+
+    void verifySharding(int numShards, int rowCount, int numOutputSSTables, ColumnFamilyStore cfs) throws Throwable
+    {
+        assertEquals(numOutputSSTables, cfs.getLiveSSTables().size());
+
+        long totalOnDiskLength = cfs.getLiveSSTables().stream().mapToLong(SSTableReader::onDiskLength).sum();
+        long totalBFSize = cfs.getLiveSSTables().stream().mapToLong(ShardingTestBase::getFilterSize).sum();
+        long totalKeyCount = cfs.getLiveSSTables().stream().mapToLong(SSTableReader::estimatedKeys).sum();
+        assert totalBFSize > 16 * numOutputSSTables : "Bloom Filter is empty"; // 16 is the size of empty bloom filter
+        for (SSTableReader rdr : cfs.getLiveSSTables())
+        {
+            assertEquals((double) rdr.onDiskLength() / totalOnDiskLength,
+                         (double) getFilterSize(rdr) / totalBFSize, 0.1);
+            assertEquals(1.0 / numOutputSSTables, rdr.tokenSpaceCoverage(), 0.05);
+        }
+
+        System.out.println("Total on disk length: " + FBUtilities.prettyPrintMemory(totalOnDiskLength));
+        System.out.println("Total BF size: " + FBUtilities.prettyPrintMemory(totalBFSize));
+        System.out.println("Total key count: " + FBUtilities.prettyPrintDecimal(totalKeyCount, "", ""));
+        try (var filter = FilterFactory.getFilter(totalKeyCount, 0.01))
+        {
+            System.out.println("Optimal total BF size: " + FBUtilities.prettyPrintMemory(filter.serializedSize(false)));
+        }
+        try (var filter = FilterFactory.getFilter(totalKeyCount / numShards, 0.01))
+        {
+            System.out.println("Sharded optimal total BF size: " + FBUtilities.prettyPrintMemory(filter.serializedSize(false) * numShards));
+        }
+
+        cfs.getLiveSSTables().forEach(s -> System.out.println("SSTable: " + s.toString() + " covers " + s.getFirst() + " to " + s.getLast()));
+
+        validateData(cfs, rowCount);
+    }
+
+    static long getFilterSize(SSTableReader rdr)
+    {
+        if (!(rdr instanceof SSTableReaderWithFilter))
+            return 0;
+        return ((SSTableReaderWithFilter) rdr).getFilterSerializedSize();
+    }
+
+    int compact(int numShards, ColumnFamilyStore cfs, ShardManager shardManager, Collection<SSTableReader> selection)
+    {
+        int rows;
+        LifecycleTransaction txn = cfs.getTracker().tryModify(selection, OperationType.COMPACTION);
+        ShardedCompactionWriter writer = new ShardedCompactionWriter(cfs,
+                                                                     cfs.getDirectories(),
+                                                                     txn,
+                                                                     txn.originals(),
+                                                                     false,
+                                                                     true,
+                                                                     shardManager.boundaries(numShards));
+
+        rows = compact(cfs, txn, writer);
+        return rows;
+    }
+
+    static void verifyNoSpannedBoundaries(List<Token> diskBoundaries, SSTableReader rdr)
+    {
+        for (int i = 0; i < diskBoundaries.size(); ++i)
+        {
+            Token boundary = diskBoundaries.get(i);
+            // rdr cannot span a boundary. I.e. it must be either fully before (last <= boundary) or fully after
+            // (first > boundary).
+            assertTrue(rdr.getFirst().getToken().compareTo(boundary) > 0 ||
+                       rdr.getLast().getToken().compareTo(boundary) <= 0);
+        }
+    }
+
+    int compact(ColumnFamilyStore cfs, LifecycleTransaction txn, CompactionAwareWriter writer)
+    {
+        //assert txn.originals().size() == 1;
+        int rowsWritten = 0;
+        long nowInSec = FBUtilities.nowInSeconds();
+        try (AbstractCompactionStrategy.ScannerList scanners = cfs.getCompactionStrategyManager().getScanners(txn.originals());
+             CompactionController controller = new CompactionController(cfs, txn.originals(), cfs.gcBefore(nowInSec));
+             CompactionIterator ci = new CompactionIterator(OperationType.COMPACTION, scanners.scanners, controller, nowInSec, TimeUUID.minAtUnixMillis(System.currentTimeMillis())))
+        {
+            while (ci.hasNext())
+            {
+                if (writer.append(ci.next()))
+                    rowsWritten++;
+            }
+        }
+        writer.finish();
+        return rowsWritten;
+    }
+
+    void populate(int count, boolean compact) throws Throwable
+    {
+        byte [] payload = new byte[5000];
+        new Random(42).nextBytes(payload);
+        ByteBuffer b = ByteBuffer.wrap(payload);
+
+        ColumnFamilyStore cfs = getColumnFamilyStore();
+        for (int i = 0; i < count; i++)
+        {
+            for (int j = 0; j < ROW_PER_PARTITION; j++)
+                execute(String.format("INSERT INTO %s.%s(k, t, v) VALUES (?, ?, ?)", KEYSPACE, TABLE), i, j, b);
+
+            if (i % (count / 4) == 0)
+                cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        }
+
+        cfs.forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
+        if (compact && cfs.getLiveSSTables().size() > 1)
+        {
+            // we want no overlapping sstables to avoid doing actual compaction in compact() above
+            try
+            {
+                cfs.forceMajorCompaction();
+            }
+            catch (Throwable t)
+            {
+                throw new RuntimeException(t);
+            }
+        }
+    }
+
+    void validateData(ColumnFamilyStore cfs, int rowCount) throws Throwable
+    {
+        for (int i = 0; i < rowCount; i++)
+        {
+            Object[][] expected = new Object[ROW_PER_PARTITION][];
+            for (int j = 0; j < ROW_PER_PARTITION; j++)
+                expected[j] = row(i, j);
+
+            assertRows(execute(String.format("SELECT k, t FROM %s.%s WHERE k = :i", KEYSPACE, TABLE), i), expected);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamWriterTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraEntireSSTableStreamWriterTest.java
@@ -104,7 +104,7 @@ public class CassandraEntireSSTableStreamWriterTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         sstable = store.getLiveSSTables().iterator().next();
         descriptor = sstable.descriptor;

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraOutgoingFileTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraOutgoingFileTest.java
@@ -81,7 +81,7 @@ public class CassandraOutgoingFileTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         sstable = store.getLiveSSTables().iterator().next();
     }

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraStreamHeaderTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraStreamHeaderTest.java
@@ -82,7 +82,7 @@ public class CassandraStreamHeaderTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         sstable = store.getLiveSSTables().iterator().next();
     }

--- a/test/unit/org/apache/cassandra/db/streaming/EntireSSTableStreamConcurrentComponentMutationTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/EntireSSTableStreamConcurrentComponentMutationTest.java
@@ -130,7 +130,7 @@ public class EntireSSTableStreamConcurrentComponentMutationTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         Token start = ByteOrderedPartitioner.instance.getTokenFactory().fromString(Long.toHexString(0));
         Token end = ByteOrderedPartitioner.instance.getTokenFactory().fromString(Long.toHexString(100));

--- a/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/LegacySSTableTest.java
@@ -44,7 +44,6 @@ import org.apache.cassandra.cql3.UntypedResultSet;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SinglePartitionSliceCommandTest;
-import org.apache.cassandra.db.compaction.AbstractCompactionTask;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.repair.PendingAntiCompaction;
 import org.apache.cassandra.db.rows.RangeTombstoneMarker;
@@ -398,9 +397,9 @@ public class LegacySSTableTest
             truncateLegacyTables(legacyVersion);
             loadLegacyTables(legacyVersion);
             ColumnFamilyStore cfs = Keyspace.open(LEGACY_TABLES_KEYSPACE).getColumnFamilyStore(String.format("legacy_%s_simple", legacyVersion));
-            AbstractCompactionTask act = cfs.getCompactionStrategyManager().getNextBackgroundTask(0);
+            var act = cfs.getCompactionStrategyManager().getNextBackgroundTasks(0);
             // there should be no compactions to run with auto upgrades disabled:
-            assertEquals(null, act);
+            assertEquals(0, act.size());
         }
 
         DatabaseDescriptor.setAutomaticSSTableUpgradeEnabled(true);

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -159,7 +159,7 @@ public class SSTableReaderTest
                 .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         List<Range<Token>> ranges = new ArrayList<>();
         // 1 key
@@ -397,7 +397,7 @@ public class SSTableReaderTest
                 .applyUnsafe();
             }
             Util.flush(store);
-            CompactionManager.instance.performMaximal(store, false);
+            CompactionManager.instance.performMaximal(store);
 
             // check that all our keys are found correctly
             SSTableReader sstable = store.getLiveSSTables().iterator().next();
@@ -522,7 +522,7 @@ public class SSTableReaderTest
 
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         SSTableReader sstable = store.getLiveSSTables().iterator().next();
         long p2 = sstable.getPosition(dk(2), SSTableReader.Operator.EQ);
@@ -576,7 +576,7 @@ public class SSTableReaderTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         SSTableReader sstable = store.getLiveSSTables().iterator().next();
         KeyCache keyCache = ((KeyCacheSupport<?>) sstable).getKeyCache();
@@ -773,7 +773,7 @@ public class SSTableReaderTest
             }
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         SSTableReaderWithFilter sstable = (SSTableReaderWithFilter) store.getLiveSSTables().iterator().next();
         sstable = (SSTableReaderWithFilter) sstable.cloneWithNewStart(dk(3));
@@ -1114,7 +1114,7 @@ public class SSTableReaderTest
 
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         // construct a range which is present in the sstable, but whose
         // keys are not found in the first segment of the index.
@@ -1151,7 +1151,7 @@ public class SSTableReaderTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         Collection<SSTableReader> sstables = store.getLiveSSTables();
         assert sstables.size() == 1;
@@ -1228,7 +1228,7 @@ public class SSTableReaderTest
             .applyUnsafe();
         }
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         Collection<R> sstables = ServerTestUtils.<R>getLiveIndexSummarySupportingReaders(store);
         assert sstables.size() == 1;

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTestBase.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableWriterTestBase.java
@@ -152,7 +152,7 @@ public class SSTableWriterTestBase extends SchemaLoader
         assertTrue(cfs.getTracker().getCompacting().isEmpty());
 
         if(cfs.getLiveSSTables().size() > 0)
-            assertFalse(CompactionManager.instance.submitMaximal(cfs, cfs.gcBefore((int) (System.currentTimeMillis() / 1000)), false).isEmpty());
+            assertFalse(CompactionManager.instance.submitMaximal(cfs, cfs.gcBefore((int) (System.currentTimeMillis() / 1000)), false, 0).isEmpty());
     }
 
     public static SSTableWriter getWriter(ColumnFamilyStore cfs, File directory, LifecycleTransaction txn, long repairedAt, TimeUUID pendingRepair, boolean isTransient)

--- a/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/VerifyTest.java
@@ -108,6 +108,7 @@ public class VerifyTest
     public static final String COUNTER_CF4 = "Counter4";
     public static final String CORRUPT_CF = "Corrupt1";
     public static final String CORRUPT_CF2 = "Corrupt2";
+    public static final String CORRUPT_CF3 = "Corrupt3";
     public static final String CORRUPTCOUNTER_CF = "CounterCorrupt1";
     public static final String CORRUPTCOUNTER_CF2 = "CounterCorrupt2";
 
@@ -130,6 +131,7 @@ public class VerifyTest
                        standardCFMD(KEYSPACE, CF4),
                        standardCFMD(KEYSPACE, CORRUPT_CF),
                        standardCFMD(KEYSPACE, CORRUPT_CF2),
+                       standardCFMD(KEYSPACE, CORRUPT_CF3),
                        counterCFMD(KEYSPACE, COUNTER_CF).compression(compressionParameters),
                        counterCFMD(KEYSPACE, COUNTER_CF2).compression(compressionParameters),
                        counterCFMD(KEYSPACE, COUNTER_CF3),
@@ -516,7 +518,7 @@ public class VerifyTest
     {
         CompactionManager.instance.disableAutoCompaction();
         Keyspace keyspace = Keyspace.open(KEYSPACE);
-        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CORRUPT_CF2);
+        ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CORRUPT_CF3);
 
         fillCF(cfs, 2);
 

--- a/test/unit/org/apache/cassandra/streaming/EntireSSTableStreamingCorrectFilesCountTest.java
+++ b/test/unit/org/apache/cassandra/streaming/EntireSSTableStreamingCorrectFilesCountTest.java
@@ -104,7 +104,7 @@ public class EntireSSTableStreamingCorrectFilesCountTest
         }
 
         Util.flush(store);
-        CompactionManager.instance.performMaximal(store, false);
+        CompactionManager.instance.performMaximal(store);
 
         sstable = store.getLiveSSTables().iterator().next();
 

--- a/tools/stress/src/org/apache/cassandra/stress/CompactionStress.java
+++ b/tools/stress/src/org/apache/cassandra/stress/CompactionStress.java
@@ -239,7 +239,7 @@ public abstract class CompactionStress implements Runnable
             List<Future<?>> futures = new ArrayList<>(threads);
             if (maximal)
             {
-                futures = CompactionManager.instance.submitMaximal(cfs, FBUtilities.nowInSeconds(), false);
+                futures = CompactionManager.instance.submitMaximal(cfs, FBUtilities.nowInSeconds(), false, Integer.MAX_VALUE);
             }
             else
             {


### PR DESCRIPTION
[CASSANDRA-18802](https://issues.apache.org/jira/browse/CASSANDRA-18802)

Implements parallelization of UCS compactions that would split the output into multiple sstables starting at known in advance boundaries. To do this, introduces a `CompositeLifecycleTransaction` that consists of multiple `PartialLifecycleTransaction` parts and only commits after all individual parts have completed, and creates multiple compaction tasks under the same composite transaction. Each individual task has a separate operation UUID, but to make it possible to recognize composite tasks their UUIDs have a part index as their sequence component (visible as "800n" as the second-to-last component of the UUID string), while non-parallelized ones have 0.

Major compaction is also changed to take advantage of parallelization. To make sure that it can be carried out on an active node, the number of threads used by a major compaction can be limited, to half the compaction threads by default. This is implemented by creating `CompositeCompactionTasks` that execute multiple tasks serially and grouping the major compaction tasks into a limited number of composites.

Because we do not currently support arbitrary filtering of the ranges of an sstable, parallelized compactions cannot use early open. Despite this, they are able to achieve comparable or better performance.

The first two commits bring in CASSANDRA-20092, which is needed for correct calculation of total compaction sizes. The next commit introduces some utilities that are helpful but not ultimately necessary for this patch (it can be easily adjusted to not use them; it is likely that SAI changes will bring these in independently). The final commit simplifies the method of creating the compaction-strategy-specific scanner list variation and is also optional.