### PR TITLE
Update CQL version to 3.4.7 in docker run scripts

### DIFF
--- a/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-load-data.sh
+++ b/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-load-data.sh
@@ -1,4 +1,4 @@
 docker run --rm --network cassandra \
 -v "$(pwd)/data.cql:/scripts/data.cql" \
 -e CQLSH_HOST=cassandra -e CQLSH_PORT=9042 \
--e CQLVERSION=3.4.6 nuvo/docker-cqlsh
+-e CQLVERSION=3.4.7 nuvo/docker-cqlsh

--- a/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
+++ b/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
@@ -1,3 +1,3 @@
 docker run --rm -it --network \
 cassandra nuvo/docker-cqlsh cqlsh cassandra \
-9042 --cqlversion='3.4.5' 
+9042 --cqlversion='3.4.7'


### PR DESCRIPTION
While running the Quickstart Guide for using Cassandra with Docker, I encountered an issue where both scripts required CQL version 3.4.7. Updating the version in the script resolved the issue, so I’ve made corresponding changes to the documentation.