### PR TITLE
CASSANDRA-20088: correct bloom_filter_fp_chance exception message when exceeding threshold

### DIFF
--- a/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
+++ b/src/java/org/apache/cassandra/utils/obs/OffHeapBitSet.java
@@ -41,7 +41,7 @@ public class OffHeapBitSet implements IBitSet
         /** returns the number of 64 bit words it would take to hold numBits */
         long wordCount = (((numBits - 1) >>> 6) + 1);
         if (wordCount > Integer.MAX_VALUE)
-            throw new UnsupportedOperationException("Bloom filter size is > 16GB, reduce the bloom_filter_fp_chance");
+            throw new UnsupportedOperationException("Bloom filter size is > 16GB, increase the bloom_filter_fp_chance");
         try
         {
             long byteCount = wordCount * 8L;


### PR DESCRIPTION
- more details in the [CASSANDRA-20088](https://issues.apache.org/jira/browse/CASSANDRA-20088)