### PR TITLE
CASSANDRA-20092: Introduce SSTableSimpleScanner for compaction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -80,7 +80,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -111,10 +111,10 @@ jobs:
   j17_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -187,7 +187,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -220,7 +220,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -304,7 +304,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -369,7 +369,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -402,7 +402,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -458,7 +458,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -489,10 +489,10 @@ jobs:
   j11_dtests_latest_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -591,7 +591,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -656,7 +656,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -690,7 +690,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -774,7 +774,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -804,10 +804,10 @@ jobs:
   j17_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -882,7 +882,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -912,10 +912,10 @@ jobs:
   j17_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1036,7 +1036,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1066,10 +1066,10 @@ jobs:
   j11_dtests_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1168,7 +1168,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1199,10 +1199,10 @@ jobs:
   j17_cqlsh_dtests_py311_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1277,7 +1277,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1310,7 +1310,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1394,7 +1394,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1428,7 +1428,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1484,7 +1484,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1518,7 +1518,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1602,7 +1602,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1632,10 +1632,10 @@ jobs:
   j11_cqlsh_dtests_py38_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1710,7 +1710,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1744,7 +1744,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1800,7 +1800,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1830,10 +1830,10 @@ jobs:
   j11_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -1908,7 +1908,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -1939,10 +1939,10 @@ jobs:
   j17_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2041,7 +2041,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2071,10 +2071,10 @@ jobs:
   j17_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2195,7 +2195,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2228,7 +2228,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2312,7 +2312,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2346,7 +2346,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2402,7 +2402,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2432,10 +2432,10 @@ jobs:
   j17_cqlsh_dtests_py311:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2510,7 +2510,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2540,10 +2540,10 @@ jobs:
   j11_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2618,7 +2618,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2652,7 +2652,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2708,7 +2708,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2741,7 +2741,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2797,7 +2797,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2831,7 +2831,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -2915,7 +2915,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -2948,7 +2948,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3110,7 +3110,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3141,7 +3141,7 @@ jobs:
   j11_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3195,7 +3195,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3226,10 +3226,10 @@ jobs:
   j11_dtests_large_vnode_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3328,7 +3328,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3359,7 +3359,7 @@ jobs:
   j11_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -3413,7 +3413,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3447,7 +3447,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3503,7 +3503,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3537,7 +3537,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3621,7 +3621,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3652,10 +3652,10 @@ jobs:
   j11_upgrade_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3754,7 +3754,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3788,7 +3788,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -3872,7 +3872,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -3905,7 +3905,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4067,7 +4067,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4173,7 +4173,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4206,7 +4206,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4290,7 +4290,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4324,7 +4324,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4380,7 +4380,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4413,7 +4413,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4497,7 +4497,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4568,7 +4568,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4602,7 +4602,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4658,7 +4658,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4692,7 +4692,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -4748,7 +4748,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4851,7 +4851,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4923,7 +4923,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -4957,7 +4957,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5013,7 +5013,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5126,7 +5126,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5160,7 +5160,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 4
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5244,7 +5244,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5316,7 +5316,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5350,7 +5350,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5406,7 +5406,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5437,10 +5437,10 @@ jobs:
   j17_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5513,7 +5513,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5543,10 +5543,10 @@ jobs:
   j11_dtests_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5645,7 +5645,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5679,7 +5679,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5763,7 +5763,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5797,7 +5797,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -5881,7 +5881,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -5912,10 +5912,10 @@ jobs:
   j17_dtests_latest_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6014,7 +6014,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6047,7 +6047,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6103,7 +6103,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6134,10 +6134,10 @@ jobs:
   j11_upgrade_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 100
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6188,7 +6188,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6219,10 +6219,10 @@ jobs:
   j11_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6321,7 +6321,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6355,7 +6355,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6411,7 +6411,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6482,7 +6482,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6512,7 +6512,7 @@ jobs:
   j17_dtests_large_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -6566,7 +6566,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6596,10 +6596,10 @@ jobs:
   j11_cqlsh_dtests_py38_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6674,7 +6674,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6708,7 +6708,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6764,7 +6764,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6798,7 +6798,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6854,7 +6854,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -6885,10 +6885,10 @@ jobs:
   j11_cqlsh_dtests_py311_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -6963,7 +6963,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7027,7 +7027,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7057,10 +7057,10 @@ jobs:
   j11_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7135,7 +7135,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7169,7 +7169,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7253,7 +7253,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7283,10 +7283,10 @@ jobs:
   j17_cqlsh_dtests_py38_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7361,7 +7361,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7391,10 +7391,10 @@ jobs:
   j17_cqlsh_dtests_py311_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7469,7 +7469,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7502,7 +7502,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 1
+    parallelism: 10
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7586,7 +7586,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7617,10 +7617,10 @@ jobs:
   j17_dtests_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7693,7 +7693,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7726,7 +7726,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -7810,7 +7810,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7881,7 +7881,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -7987,7 +7987,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8021,7 +8021,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8077,7 +8077,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8108,10 +8108,10 @@ jobs:
   j11_dtests_latest:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8162,7 +8162,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8226,7 +8226,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8257,10 +8257,10 @@ jobs:
   j11_dtests:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8311,7 +8311,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8342,10 +8342,10 @@ jobs:
   j17_cqlsh_dtests_py38:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8420,7 +8420,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8453,7 +8453,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8537,7 +8537,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8570,7 +8570,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8626,7 +8626,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8656,7 +8656,7 @@ jobs:
   j17_dtests_large:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 4
@@ -8710,7 +8710,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8743,7 +8743,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8799,7 +8799,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8871,7 +8871,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8904,7 +8904,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -8960,7 +8960,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -8990,10 +8990,10 @@ jobs:
   j11_dtests_vnode:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 50
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9044,7 +9044,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9078,7 +9078,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9134,7 +9134,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9164,10 +9164,10 @@ jobs:
   j17_dtests_large_repeat:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11:latest
-    resource_class: medium
+    resource_class: large
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9266,7 +9266,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9299,7 +9299,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9355,7 +9355,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9388,7 +9388,7 @@ jobs:
     resource_class: medium
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
-    parallelism: 4
+    parallelism: 25
     steps:
     - attach_workspace:
         at: /home/cassandra
@@ -9444,7 +9444,7 @@ jobs:
     - CCM_MAX_HEAP_SIZE: 1024M
     - CCM_HEAP_NEWSIZE: 256M
     - REPEATED_TESTS_STOP_ON_FAILURE: false
-    - REPEATED_UTESTS: null
+    - REPEATED_UTESTS: org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.io.sstable.SSTableScannerTest,org.apache.cassandra.io.sstable.SSTableReaderTest,org.apache.cassandra.io.sstable.SSTableCorruptionDetectionTest,org.apache.cassandra.db.compaction.SingleSSTableLCSTaskTest
     - REPEATED_UTESTS_COUNT: 500
     - REPEATED_UTESTS_FQLTOOL: null
     - REPEATED_UTESTS_FQLTOOL_COUNT: 500
@@ -9481,302 +9481,697 @@ workflows:
     - j11_build:
         requires:
         - start_j11_build
+        upstream:
+          start_j11_build:
+          - success
     - start_j11_unit_tests:
         type: approval
     - j11_unit_tests:
         requires:
         - start_j11_unit_tests
         - j11_build
+        upstream:
+          start_j11_unit_tests:
+          - success
+          j11_build:
+          - success
+    - start_j11_unit_tests_repeat:
+        type: approval
+    - j11_unit_tests_repeat:
+        requires:
+        - start_j11_unit_tests_repeat
+        - j11_build
+        upstream:
+          start_j11_unit_tests_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests:
         type: approval
     - j11_jvm_dtests:
         requires:
         - start_j11_jvm_dtests
         - j11_build
+        upstream:
+          start_j11_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_jvm_dtests_latest_vnode:
         type: approval
     - j11_jvm_dtests_latest_vnode:
         requires:
         - start_j11_jvm_dtests_latest_vnode
         - j11_build
+        upstream:
+          start_j11_jvm_dtests_latest_vnode:
+          - success
+          j11_build:
+          - success
     - start_j17_jvm_dtests:
         type: approval
     - j17_jvm_dtests:
         requires:
         - start_j17_jvm_dtests
         - j11_build
+        upstream:
+          start_j17_jvm_dtests:
+          - success
+          j11_build:
+          - success
     - start_j17_jvm_dtests_latest_vnode:
         type: approval
     - j17_jvm_dtests_latest_vnode:
         requires:
         - start_j17_jvm_dtests_latest_vnode
         - j11_build
+        upstream:
+          start_j17_jvm_dtests_latest_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_simulator_dtests:
         type: approval
     - j11_simulator_dtests:
         requires:
         - start_j11_simulator_dtests
         - j11_build
+        upstream:
+          start_j11_simulator_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_tests:
         type: approval
     - j11_cqlshlib_tests:
         requires:
         - start_j11_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlshlib_cython_tests:
         type: approval
     - j11_cqlshlib_cython_tests:
         requires:
         - start_j11_cqlshlib_cython_tests
         - j11_build
+        upstream:
+          start_j11_cqlshlib_cython_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlshlib_tests:
         type: approval
     - j17_cqlshlib_tests:
         requires:
         - start_j17_cqlshlib_tests
         - j11_build
+        upstream:
+          start_j17_cqlshlib_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlshlib_cython_tests:
         type: approval
     - j17_cqlshlib_cython_tests:
         requires:
         - start_j17_cqlshlib_cython_tests
         - j11_build
+        upstream:
+          start_j17_cqlshlib_cython_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_unit_tests:
         type: approval
     - j17_unit_tests:
         requires:
         - start_j17_unit_tests
         - j11_build
+        upstream:
+          start_j17_unit_tests:
+          - success
+          j11_build:
+          - success
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j11_build
+        upstream:
+          start_j17_unit_tests_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_oa:
         type: approval
     - j11_utests_oa:
         requires:
         - start_j11_utests_oa
         - j11_build
+        upstream:
+          start_j11_utests_oa:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_oa_repeat:
+        type: approval
+    - j11_utests_oa_repeat:
+        requires:
+        - start_j11_utests_oa_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_oa_repeat:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_oa:
         type: approval
     - j17_utests_oa:
         requires:
         - start_j17_utests_oa
         - j11_build
+        upstream:
+          start_j17_utests_oa:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_oa_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_j11_utests_long
         - j11_build
+        upstream:
+          start_j11_utests_long:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_long:
         type: approval
     - j17_utests_long:
         requires:
         - start_j17_utests_long
         - j11_build
+        upstream:
+          start_j17_utests_long:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_j11_utests_cdc
         - j11_build
+        upstream:
+          start_j11_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_cdc:
         type: approval
     - j17_utests_cdc:
         requires:
         - start_j17_utests_cdc
         - j11_build
+        upstream:
+          start_j17_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_cdc_repeat:
+        type: approval
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_j11_utests_cdc_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_cdc_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_cdc_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_j11_utests_compression
         - j11_build
+        upstream:
+          start_j11_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_j17_utests_compression
         - j11_build
+        upstream:
+          start_j17_utests_compression:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_compression_repeat:
+        type: approval
+    - j11_utests_compression_repeat:
+        requires:
+        - start_j11_utests_compression_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_compression_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_compression_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_latest:
         type: approval
     - j11_utests_latest:
         requires:
         - start_j11_utests_latest
         - j11_build
+        upstream:
+          start_j11_utests_latest:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_latest:
         type: approval
     - j17_utests_latest:
         requires:
         - start_j17_utests_latest
         - j11_build
+        upstream:
+          start_j17_utests_latest:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_latest_repeat:
+        type: approval
+    - j11_utests_latest_repeat:
+        requires:
+        - start_j11_utests_latest_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_latest_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_latest_repeat:
+        type: approval
+    - j17_utests_latest_repeat:
+        requires:
+        - start_j17_utests_latest_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_latest_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_j11_utests_stress
         - j11_build
+        upstream:
+          start_j11_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_stress:
         type: approval
     - j17_utests_stress:
         requires:
         - start_j17_utests_stress
         - j11_build
+        upstream:
+          start_j17_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_j11_utests_fqltool
         - j11_build
+        upstream:
+          start_j11_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_fqltool:
         type: approval
     - j17_utests_fqltool:
         requires:
         - start_j17_utests_fqltool
         - j11_build
+        upstream:
+          start_j17_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_j11_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - start_j11_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
     - start_j17_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
         requires:
         - start_j17_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_j17_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
+    - start_j11_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j11_utests_system_keyspace_directory_repeat
+        - j11_build
+        upstream:
+          start_j11_utests_system_keyspace_directory_repeat:
+          - success
+          j11_build:
+          - success
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
+        - j11_build
+        upstream:
+          start_j17_utests_system_keyspace_directory_repeat:
+          - success
+          j11_build:
+          - success
     - start_j11_dtest_jars_build:
         type: approval
     - j11_dtest_jars_build:
         requires:
         - j11_build
         - start_j11_dtest_jars_build
+        upstream:
+          j11_build:
+          - success
+          start_j11_dtest_jars_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j11_jvm_upgrade_dtests:
         requires:
         - start_jvm_upgrade_dtests
         - j11_dtest_jars_build
+        upstream:
+          start_jvm_upgrade_dtests:
+          - success
+          j11_dtest_jars_build:
+          - success
     - start_j11_dtests:
         type: approval
     - j11_dtests:
         requires:
         - start_j11_dtests
         - j11_build
+        upstream:
+          start_j11_dtests:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_vnode:
         type: approval
     - j11_dtests_vnode:
         requires:
         - start_j11_dtests_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_latest:
         type: approval
     - j11_dtests_latest:
         requires:
         - start_j11_dtests_latest
         - j11_build
+        upstream:
+          start_j11_dtests_latest:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests:
         type: approval
     - j17_dtests:
         requires:
         - start_j17_dtests
         - j11_build
+        upstream:
+          start_j17_dtests:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_vnode:
         type: approval
     - j17_dtests_vnode:
         requires:
         - start_j17_dtests_vnode
         - j11_build
+        upstream:
+          start_j17_dtests_vnode:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_latest:
         type: approval
     - j17_dtests_latest:
         requires:
         - start_j17_dtests_latest
         - j11_build
+        upstream:
+          start_j17_dtests_latest:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j11_dtests_large_vnode:
         type: approval
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j11_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j11_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_large_vnode:
         type: approval
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large_vnode
         - j11_build
+        upstream:
+          start_j17_dtests_large_vnode:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests:
         type: approval
     - j11_cqlsh_dtests_py38:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - start_j11_cqlsh_tests
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j11_cqlsh_tests_latest:
         type: approval
     - j11_cqlsh_dtests_py38_latest:
         requires:
         - start_j11_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_latest:
         requires:
         - start_j11_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlsh_tests:
         type: approval
     - j17_cqlsh_dtests_py38:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j11_build:
+          - success
     - start_j17_cqlsh_tests_latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh_tests_latest
         - j11_build
+        upstream:
+          start_j17_cqlsh_tests_latest:
+          - success
+          j11_build:
+          - success
     - start_j11_upgrade_dtests:
         type: approval
     - j11_upgrade_dtests:
         requires:
         - start_j11_upgrade_dtests
         - j11_build
+        upstream:
+          start_j11_upgrade_dtests:
+          - success
+          j11_build:
+          - success
   java11_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -9784,207 +10179,495 @@ workflows:
     - j11_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j11_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_utests_oa:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_utests_oa_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_utests_oa_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_unit_tests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_utests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j11_utests_latest_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_simulator_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_jvm_dtests_latest_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_jvm_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_jvm_dtests_latest_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlshlib_cython_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlshlib_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlshlib_cython_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_unit_tests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_utests_oa:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_unit_tests_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_utests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_utests_latest_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_utests_long:
         type: approval
     - j11_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - j17_utests_long:
         requires:
         - start_utests_long
         - j11_build
+        upstream:
+          start_utests_long:
+          - success
+          j11_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j11_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - j17_utests_cdc:
         requires:
         - start_utests_cdc
         - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - j11_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j11_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j11_build:
+          - success
     - start_utests_compression:
         type: approval
     - j11_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - j17_utests_compression:
         requires:
         - start_utests_compression
         - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
+    - j11_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j11_build
+        upstream:
+          start_utests_compression:
+          - success
+          j11_build:
+          - success
     - start_utests_stress:
         type: approval
     - j11_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - j17_utests_stress:
         requires:
         - start_utests_stress
         - j11_build
+        upstream:
+          start_utests_stress:
+          - success
+          j11_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j11_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - j17_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j11_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j11_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j11_utests_system_keyspace_directory:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
+    - j11_utests_system_keyspace_directory_repeat:
+        requires:
+        - j11_build
+        upstream:
+          j11_build:
+          - success
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j11_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j11_build:
+          - success
     - start_jvm_upgrade_dtests:
         type: approval
     - j11_dtest_jars_build:
         requires:
         - j11_build
         - start_jvm_upgrade_dtests
+        upstream:
+          j11_build:
+          - success
+          start_jvm_upgrade_dtests:
+          - success
     - j11_jvm_upgrade_dtests:
         requires:
         - j11_dtest_jars_build
+        upstream:
+          j11_dtest_jars_build:
+          - success
     - j11_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_dtests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_dtests:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_dtests_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_dtests_latest:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_dtests_large:
         type: approval
     - j11_dtests_large:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_dtests_large_vnode:
         requires:
         - start_j11_dtests_large
         - j11_build
+        upstream:
+          start_j11_dtests_large:
+          - success
+          j11_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j11_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j11_build:
+          - success
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large
         - j11_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j11_cqlsh_dtests_latest:
         type: approval
     - j11_cqlsh_dtests_py38_latest:
         requires:
         - start_j11_cqlsh_dtests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_dtests_latest:
+          - success
+          j11_build:
+          - success
     - j11_cqlsh_dtests_py311_latest:
         requires:
         - start_j11_cqlsh_dtests_latest
         - j11_build
+        upstream:
+          start_j11_cqlsh_dtests_latest:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py38:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - j11_build
+        upstream:
+          j11_build:
+          - success
     - start_j17_cqlsh-dtests-latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j11_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j11_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j11_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j11_build:
+          - success
     - start_j11_upgrade_dtests:
         type: approval
     - j11_upgrade_dtests:
         requires:
         - j11_build
         - start_j11_upgrade_dtests
+        upstream:
+          j11_build:
+          - success
+          start_j11_upgrade_dtests:
+          - success
   java17_separate_tests:
     jobs:
     - start_j17_build:
@@ -9992,142 +10675,331 @@ workflows:
     - j17_build:
         requires:
         - start_j17_build
+        upstream:
+          start_j17_build:
+          - success
     - start_j17_unit_tests:
         type: approval
     - j17_unit_tests:
         requires:
         - start_j17_unit_tests
         - j17_build
+        upstream:
+          start_j17_unit_tests:
+          - success
+          j17_build:
+          - success
+    - start_j17_unit_tests_repeat:
+        type: approval
+    - j17_unit_tests_repeat:
+        requires:
+        - start_j17_unit_tests_repeat
+        - j17_build
+        upstream:
+          start_j17_unit_tests_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_jvm_dtests:
         type: approval
     - j17_jvm_dtests:
         requires:
         - start_j17_jvm_dtests
         - j17_build
+        upstream:
+          start_j17_jvm_dtests:
+          - success
+          j17_build:
+          - success
     - start_j17_jvm_dtests_latest_vnode:
         type: approval
     - j17_jvm_dtests_latest_vnode:
         requires:
         - start_j17_jvm_dtests_latest_vnode
         - j17_build
+        upstream:
+          start_j17_jvm_dtests_latest_vnode:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlshlib_tests:
         type: approval
     - j17_cqlshlib_tests:
         requires:
         - start_j17_cqlshlib_tests
         - j17_build
+        upstream:
+          start_j17_cqlshlib_tests:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlshlib_cython_tests:
         type: approval
     - j17_cqlshlib_cython_tests:
         requires:
         - start_j17_cqlshlib_cython_tests
         - j17_build
+        upstream:
+          start_j17_cqlshlib_cython_tests:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests:
         type: approval
     - j17_dtests:
         requires:
         - start_j17_dtests
         - j17_build
+        upstream:
+          start_j17_dtests:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_vnode:
         type: approval
     - j17_dtests_vnode:
         requires:
         - start_j17_dtests_vnode
         - j17_build
+        upstream:
+          start_j17_dtests_vnode:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_latest:
         type: approval
     - j17_dtests_latest:
         requires:
         - start_j17_dtests_latest
         - j17_build
+        upstream:
+          start_j17_dtests_latest:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j17_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j17_build:
+          - success
     - start_j17_dtests_large_vnode:
         type: approval
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large_vnode
         - j17_build
+        upstream:
+          start_j17_dtests_large_vnode:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlsh_tests:
         type: approval
     - j17_cqlsh_dtests_py38:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - start_j17_cqlsh_tests
         - j17_build
+        upstream:
+          start_j17_cqlsh_tests:
+          - success
+          j17_build:
+          - success
     - start_j17_cqlsh-dtests-latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_oa:
         type: approval
     - j17_utests_oa:
         requires:
         - start_j17_utests_oa
         - j17_build
+        upstream:
+          start_j17_utests_oa:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_oa_repeat:
+        type: approval
+    - j17_utests_oa_repeat:
+        requires:
+        - start_j17_utests_oa_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_oa_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_long:
         type: approval
     - j17_utests_long:
         requires:
         - start_j17_utests_long
         - j17_build
+        upstream:
+          start_j17_utests_long:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_cdc:
         type: approval
     - j17_utests_cdc:
         requires:
         - start_j17_utests_cdc
         - j17_build
+        upstream:
+          start_j17_utests_cdc:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_cdc_repeat:
+        type: approval
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_j17_utests_cdc_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_cdc_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_j17_utests_compression
         - j17_build
+        upstream:
+          start_j17_utests_compression:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_compression_repeat:
+        type: approval
+    - j17_utests_compression_repeat:
+        requires:
+        - start_j17_utests_compression_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_compression_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_latest:
         type: approval
     - j17_utests_latest:
         requires:
         - start_j17_utests_latest
         - j17_build
+        upstream:
+          start_j17_utests_latest:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_latest_repeat:
+        type: approval
+    - j17_utests_latest_repeat:
+        requires:
+        - start_j17_utests_latest_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_latest_repeat:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_stress:
         type: approval
     - j17_utests_stress:
         requires:
         - start_j17_utests_stress
         - j17_build
+        upstream:
+          start_j17_utests_stress:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_fqltool:
         type: approval
     - j17_utests_fqltool:
         requires:
         - start_j17_utests_fqltool
         - j17_build
+        upstream:
+          start_j17_utests_fqltool:
+          - success
+          j17_build:
+          - success
     - start_j17_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
         requires:
         - start_j17_utests_system_keyspace_directory
         - j17_build
+        upstream:
+          start_j17_utests_system_keyspace_directory:
+          - success
+          j17_build:
+          - success
+    - start_j17_utests_system_keyspace_directory_repeat:
+        type: approval
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_j17_utests_system_keyspace_directory_repeat
+        - j17_build
+        upstream:
+          start_j17_utests_system_keyspace_directory_repeat:
+          - success
+          j17_build:
+          - success
   java17_pre-commit_tests:
     jobs:
     - start_pre-commit_tests:
@@ -10135,101 +11007,241 @@ workflows:
     - j17_build:
         requires:
         - start_pre-commit_tests
+        upstream:
+          start_pre-commit_tests:
+          - success
     - j17_unit_tests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_utests_oa:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_utests_oa_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_unit_tests_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_utests_latest:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
+    - j17_utests_latest_repeat:
+        requires:
+        - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_jvm_dtests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_jvm_dtests_latest_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlshlib_tests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlshlib_cython_tests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_dtests:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_dtests_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_dtests_latest:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - start_j17_dtests_large:
         type: approval
     - j17_dtests_large:
         requires:
         - start_j17_dtests_large
         - j17_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j17_build:
+          - success
     - j17_dtests_large_vnode:
         requires:
         - start_j17_dtests_large
         - j17_build
+        upstream:
+          start_j17_dtests_large:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py38:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py38_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_vnode:
         requires:
         - j17_build
+        upstream:
+          j17_build:
+          - success
     - start_j17_cqlsh-dtests-latest:
         type: approval
     - j17_cqlsh_dtests_py38_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - j17_cqlsh_dtests_py311_latest:
         requires:
         - start_j17_cqlsh-dtests-latest
         - j17_build
+        upstream:
+          start_j17_cqlsh-dtests-latest:
+          - success
+          j17_build:
+          - success
     - start_utests_long:
         type: approval
     - j17_utests_long:
         requires:
         - start_utests_long
         - j17_build
+        upstream:
+          start_utests_long:
+          - success
+          j17_build:
+          - success
     - start_utests_cdc:
         type: approval
     - j17_utests_cdc:
         requires:
         - start_utests_cdc
         - j17_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j17_build:
+          - success
+    - j17_utests_cdc_repeat:
+        requires:
+        - start_utests_cdc
+        - j17_build
+        upstream:
+          start_utests_cdc:
+          - success
+          j17_build:
+          - success
     - start_utests_compression:
         type: approval
     - j17_utests_compression:
         requires:
         - start_utests_compression
         - j17_build
+        upstream:
+          start_utests_compression:
+          - success
+          j17_build:
+          - success
+    - j17_utests_compression_repeat:
+        requires:
+        - start_utests_compression
+        - j17_build
+        upstream:
+          start_utests_compression:
+          - success
+          j17_build:
+          - success
     - start_utests_stress:
         type: approval
     - j17_utests_stress:
         requires:
         - start_utests_stress
         - j17_build
+        upstream:
+          start_utests_stress:
+          - success
+          j17_build:
+          - success
     - start_utests_fqltool:
         type: approval
     - j17_utests_fqltool:
         requires:
         - start_utests_fqltool
         - j17_build
+        upstream:
+          start_utests_fqltool:
+          - success
+          j17_build:
+          - success
     - start_utests_system_keyspace_directory:
         type: approval
     - j17_utests_system_keyspace_directory:
         requires:
         - start_utests_system_keyspace_directory
         - j17_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j17_build:
+          - success
+    - j17_utests_system_keyspace_directory_repeat:
+        requires:
+        - start_utests_system_keyspace_directory
+        - j17_build
+        upstream:
+          start_utests_system_keyspace_directory:
+          - success
+          j17_build:
+          - success

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Introduce SSTableSimpleScanner for compaction (CASSANDRA-20092)
  * Include column drop timestamp in alter table transformation (CASSANDRA-18961)
  * Make JMX SSL configurable in cassandra.yaml (CASSANDRA-18508)
  * Fix cqlsh CAPTURE command to save query results without trace details when TRACING is ON (CASSANDRA-19105)

--- a/src/java/org/apache/cassandra/cache/KeyCacheKey.java
+++ b/src/java/org/apache/cassandra/cache/KeyCacheKey.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
 
-import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -31,9 +30,7 @@ public class KeyCacheKey extends CacheKey
 {
     public final Descriptor desc;
 
-    private static final long EMPTY_SIZE = ObjectSizes.measure(new KeyCacheKey(TableMetadata.builder("ks", "tab")
-                                                                                            .addPartitionKeyColumn("pk", UTF8Type.instance)
-                                                                                            .build(), null, ByteBufferUtil.EMPTY_BYTE_BUFFER));
+    private static final long EMPTY_SIZE = ObjectSizes.measure(new KeyCacheKey());
 
     // keeping an array instead of a ByteBuffer lowers the overhead of the key cache working set,
     // without extra copies on lookup since client-provided key ByteBuffers will be array-backed already
@@ -45,6 +42,13 @@ public class KeyCacheKey extends CacheKey
         this.desc = desc;
         this.key = ByteBufferUtil.getArray(key);
         assert this.key != null;
+    }
+
+    private KeyCacheKey() // Only for EMPTY_SIZE
+    {
+        super(null, null);
+        this.desc = null;
+        this.key = null;
     }
 
     public String toString()

--- a/src/java/org/apache/cassandra/db/compaction/CompactionIterator.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionIterator.java
@@ -290,7 +290,7 @@ public class CompactionIterator extends CompactionInfo.Holder implements Unfilte
     {
         long n = 0;
         for (ISSTableScanner scanner : scanners)
-            n += scanner.getCurrentPosition();
+            n += scanner.getBytesScanned();
         bytesRead = n;
     }
 

--- a/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionMetadata.java
@@ -539,6 +539,14 @@ public class CompressionMetadata extends WrappedSharedCloseable
         {
             return String.format("Chunk<offset: %d, length: %d>", offset, length);
         }
+
+        /**
+         * @return the end of the chunk in the file, including the checksum
+         */
+        public long chunkEnd()
+        {
+            return offset + length + 4;
+        }
     }
 
     static class ChunkSerializer implements IVersionedSerializer<Chunk>

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -719,7 +719,7 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     /**
      * Determine the minimal set of sections that can be extracted from this SSTable to cover the given ranges.
      *
-     * @return A sorted list of (offset,end) pairs that cover the given ranges in the datafile for this SSTable.
+     * @return A sorted list of [offset,end) pairs that cover the given ranges in the datafile for this SSTable.
      */
     public List<PartitionPositionBounds> getPositionsForRanges(Collection<Range<Token>> ranges)
     {
@@ -728,27 +728,110 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
         for (Range<Token> range : Range.normalize(ranges))
         {
             assert !range.isWrapAround() || range.right.isMinimum();
-            // truncate the range so it at most covers the sstable
             AbstractBounds<PartitionPosition> bounds = Range.makeRowRange(range);
-            PartitionPosition leftBound = bounds.left.compareTo(first) > 0 ? bounds.left : first.getToken().minKeyBound();
-            PartitionPosition rightBound = bounds.right.isMinimum() ? last.getToken().maxKeyBound() : bounds.right;
-
-            if (leftBound.compareTo(last) > 0 || rightBound.compareTo(first) < 0)
-                continue;
-
-            long left = getPosition(leftBound, Operator.GT);
-            long right = (rightBound.compareTo(last) > 0)
-                         ? uncompressedLength()
-                         : getPosition(rightBound, Operator.GT);
-
-            if (left == right)
-                // empty range
-                continue;
-
-            assert left < right : String.format("Range=%s openReason=%s first=%s last=%s left=%d right=%d", range, openReason, first, last, left, right);
-            positions.add(new PartitionPositionBounds(left, right));
+            PartitionPositionBounds pb = getPositionsForBounds(bounds);
+            if (pb != null)
+                positions.add(pb);
         }
         return positions;
+    }
+
+    /**
+     * Get a list of data positions in this SSTable that correspond to the given list of bounds. This method will remove
+     * non-covered intervals, but will not correct order or overlap in the supplied list, e.g. if bounds overlap, the
+     * result will be sections of the data file that repeat the same positions.
+     *
+     * @return A sorted list of [offset,end) pairs corresponding to the given boundsList in the datafile for this
+     *         SSTable.
+     */
+    public List<PartitionPositionBounds> getPositionsForBoundsIterator(Iterator<AbstractBounds<PartitionPosition>> boundsList)
+    {
+        // use the index to determine a minimal section for each range
+        List<PartitionPositionBounds> positions = new ArrayList<>();
+        while (boundsList.hasNext())
+        {
+            AbstractBounds<PartitionPosition> bounds = boundsList.next();
+            PartitionPositionBounds pb = getPositionsForBounds(bounds);
+            if (pb != null)
+                positions.add(pb);
+        }
+        return positions;
+    }
+
+    /**
+     * Determine the data positions in this SSTable that cover the given bounds.
+     *
+     * @return An [offset,end) pair that cover the given bounds in the datafile for this SSTable, or null if the range
+     *         is not covered by the sstable or is empty.
+     */
+    public PartitionPositionBounds getPositionsForBounds(AbstractBounds<PartitionPosition> bounds)
+    {
+        long left = getPosition(bounds.left, bounds.inclusiveLeft() ? Operator.GE : Operator.GT);
+        // Note: getPosition will apply a moved start if the sstable is in MOVED_START state.
+        if (left < 0) // empty range
+            return null;
+
+        long right = bounds.right.isMinimum() ? -1
+                                              : getPosition(bounds.right, bounds.inclusiveRight() ? Operator.GT
+                                                                                                  : Operator.GE);
+        if (right < 0) // right is beyond end
+            right = uncompressedLength();   // this should also be correct for EARLY readers
+
+        if (left >= right) // empty range
+            return null;
+
+        return new PartitionPositionBounds(left, right);
+    }
+
+    /**
+     * Return an [offset,end) pair that covers the whole file. This could be null if the sstable's moved start has
+     * made the sstable effectively empty.
+     */
+    public PartitionPositionBounds getPositionsForFullRange()
+    {
+        if (openReason != OpenReason.MOVED_START)
+            return new PartitionPositionBounds(0, uncompressedLength());
+        else
+        {
+            // query a full range, so that the required adjustments can be applied
+            PartitionPosition minToken = getPartitioner().getMinimumToken().minKeyBound();
+            return getPositionsForBounds(new Range<>(minToken, minToken));
+        }
+    }
+
+    /**
+     * Calculate a total on-disk (compressed) size for the given partition positions. For uncompressed files this is
+     * equal to the sum of the size of the covered ranges. For compressed files this is the sum of the size of the
+     * chunks that contain the requested ranges and may be significantly bigger than the size of the requested ranges.
+     *
+     * @param positionBounds a list of [offset,end) pairs that specify the relevant sections of the data file; this must
+     *                       be non-overlapping and in ascending order.
+     */
+    public long onDiskSizeForPartitionPositions(Collection<PartitionPositionBounds> positionBounds)
+    {
+        long total = 0;
+        if (!compression)
+        {
+            for (PartitionPositionBounds position : positionBounds)
+                total += position.upperPosition - position.lowerPosition;
+        }
+        else
+        {
+            final CompressionMetadata compressionMetadata = getCompressionMetadata();
+            long lastEnd = 0;
+            for (PartitionPositionBounds position : positionBounds)
+            {
+                // The end of the chunk that contains the last required byte from the range.
+                long upperChunkEnd = compressionMetadata.chunkFor(position.upperPosition - 1).chunkEnd();
+                // The start of the chunk that contains the first required byte from the range.
+                long lowerChunkStart = compressionMetadata.chunkFor(position.lowerPosition).offset;
+                if (lowerChunkStart < lastEnd)  // if regions include the same chunk, count it only once
+                    lowerChunkStart = lastEnd;
+                total += upperChunkEnd - lowerChunkStart;
+                lastEnd = upperChunkEnd;
+            }
+        }
+        return total;
     }
 
     /**
@@ -940,11 +1023,18 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
     }
 
     /**
-     * Direct I/O SSTableScanner over the entirety of the sstable..
+     * Direct I/O SSTableScanner over the entirety of the sstable.
      *
      * @return A Scanner over the full content of the SSTable.
      */
-    public abstract ISSTableScanner getScanner();
+    public ISSTableScanner getScanner()
+    {
+        PartitionPositionBounds fullRange = getPositionsForFullRange();
+        if (fullRange != null)
+            return new SSTableSimpleScanner(this, Collections.singletonList(fullRange));
+        else
+            return new SSTableSimpleScanner(this, Collections.emptyList());
+    }
 
     /**
      * Direct I/O SSTableScanner over a defined collection of ranges of tokens.
@@ -952,15 +1042,25 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
      * @param ranges the range of keys to cover
      * @return A Scanner for seeking over the rows of the SSTable.
      */
-    public abstract ISSTableScanner getScanner(Collection<Range<Token>> ranges);
+    public ISSTableScanner getScanner(Collection<Range<Token>> ranges)
+    {
+        if (ranges != null)
+            return new SSTableSimpleScanner(this, getPositionsForRanges(ranges));
+        else
+            return getScanner();
+    }
 
     /**
      * Direct I/O SSTableScanner over an iterator of bounds.
      *
-     * @param rangeIterator the keys to cover
+     * @param boundsIterator the keys to cover
      * @return A Scanner for seeking over the rows of the SSTable.
      */
-    public abstract ISSTableScanner getScanner(Iterator<AbstractBounds<PartitionPosition>> rangeIterator);
+    public ISSTableScanner getScanner(Iterator<AbstractBounds<PartitionPosition>> boundsIterator)
+    {
+        return new SSTableSimpleScanner(this, getPositionsForBoundsIterator(boundsIterator));
+    }
+
 
     /**
      * Create a {@link FileDataInput} for the data file of the sstable represented by this reader. This method returns

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableScanner.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.io.sstable.format;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -35,9 +34,7 @@ import org.apache.cassandra.db.rows.LazilyInitializedUnfilteredRowIterator;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.AbstractBounds.Boundary;
-import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.AbstractRowIndexEntry;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
@@ -86,24 +83,11 @@ implements ISSTableScanner
         this.listener = listener;
     }
 
-    protected static List<AbstractBounds<PartitionPosition>> makeBounds(SSTableReader sstable, Collection<Range<Token>> tokenRanges)
-    {
-        List<AbstractBounds<PartitionPosition>> boundsList = new ArrayList<>(tokenRanges.size());
-        for (Range<Token> range : Range.normalize(tokenRanges))
-            addRange(sstable, Range.makeRowRange(range), boundsList);
-        return boundsList;
-    }
-
     protected static List<AbstractBounds<PartitionPosition>> makeBounds(SSTableReader sstable, DataRange dataRange)
     {
         List<AbstractBounds<PartitionPosition>> boundsList = new ArrayList<>(2);
         addRange(sstable, dataRange.keyRange(), boundsList);
         return boundsList;
-    }
-
-    protected static AbstractBounds<PartitionPosition> fullRange(SSTableReader sstable)
-    {
-        return new Bounds<>(sstable.getFirst(), sstable.getLast());
     }
 
     private static void addRange(SSTableReader sstable, AbstractBounds<PartitionPosition> requested, List<AbstractBounds<PartitionPosition>> boundsList)

--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableSimpleScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableSimpleScanner.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.io.sstable.format;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.io.sstable.CorruptSSTableException;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.SSTableIdentityIterator;
+import org.apache.cassandra.io.util.RandomAccessReader;
+import org.apache.cassandra.schema.TableMetadata;
+
+import static org.apache.cassandra.io.sstable.format.SSTableReader.PartitionPositionBounds;
+
+/// Simple SSTable scanner that reads sequentially through an SSTable without using the index.
+///
+/// This is a significant improvement for the performance of compaction over using the full-blown DataRange-capable
+/// [SSTableScanner] and enables correct calculation of data sizes to process.
+public class SSTableSimpleScanner
+implements ISSTableScanner
+{
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final RandomAccessReader dfile;
+    private final SSTableReader sstable;
+
+    private final Iterator<PartitionPositionBounds> rangeIterator;
+
+    private long bytesScannedInPreviousRanges;
+
+    private final long sizeInBytes;
+    private final long compressedSizeInBytes;
+
+    private long currentEndPosition;
+    private long currentStartPosition;
+
+    private SSTableIdentityIterator currentIterator;
+    private DecoratedKey lastKey;
+
+    /// Create a new simple scanner over the given sstables and the given ranges of uncompressed positions.
+    /// Each range must start and end on a partition boundary, and, to satisfy the contract of [ISSTableScanner], the
+    /// ranges must be non-overlapping and in ascending order. This scanner will throw an [IllegalArgumentException] if
+    /// the latter is not true.
+    ///
+    /// The ranges can be constructed by [SSTableReader#getPositionsForRanges] and similar methods as done by the
+    /// various [SSTableReader#getScanner] variations.
+    public SSTableSimpleScanner(SSTableReader sstable,
+                                Collection<PartitionPositionBounds> boundsList)
+    {
+        assert sstable != null;
+
+        this.dfile = sstable.openDataReader();
+        this.sstable = sstable;
+        this.sizeInBytes = boundsList.stream().mapToLong(ppb -> ppb.upperPosition - ppb.lowerPosition).sum();
+        this.compressedSizeInBytes = sstable.compression ? sstable.onDiskSizeForPartitionPositions(boundsList) : sizeInBytes;
+        this.rangeIterator = boundsList.iterator();
+        this.currentEndPosition = 0;
+        this.currentStartPosition = 0;
+        this.bytesScannedInPreviousRanges = 0;
+        this.currentIterator = null;
+        this.lastKey = null;
+    }
+
+    public void close()
+    {
+        if (isClosed.compareAndSet(false, true))
+        {
+            // ensure we report what we have actually processed
+            bytesScannedInPreviousRanges += dfile.getFilePointer() - currentStartPosition;
+            dfile.close();
+            // close() may change the file pointer, update so that the difference is 0 when reported by getBytesScanned()
+            currentStartPosition = dfile.getFilePointer();
+        }
+    }
+
+    @Override
+    public long getLengthInBytes()
+    {
+        return sizeInBytes;
+    }
+
+
+    public long getCompressedLengthInBytes()
+    {
+        return compressedSizeInBytes;
+    }
+
+    @Override
+    public long getCurrentPosition()
+    {
+        return dfile.getFilePointer();
+    }
+
+    public long getBytesScanned()
+    {
+        return bytesScannedInPreviousRanges + dfile.getFilePointer() - currentStartPosition;
+    }
+
+    @Override
+    public Set<SSTableReader> getBackingSSTables()
+    {
+        return ImmutableSet.of(sstable);
+    }
+
+    public TableMetadata metadata()
+    {
+        return sstable.metadata();
+    }
+
+    public boolean hasNext()
+    {
+        if (currentIterator != null)
+        {
+            currentIterator.close(); // Ensure that the iterator cannot be used further. No op if already closed.
+
+            // Row iterator must be exhausted to advance to next partition
+            currentIterator.exhaust();
+            currentIterator = null;
+        }
+
+        if (dfile.getFilePointer() < currentEndPosition)
+            return true;
+
+        return advanceRange();
+    }
+
+    boolean advanceRange()
+    {
+        if (!rangeIterator.hasNext())
+            return false;
+
+        bytesScannedInPreviousRanges += currentEndPosition - currentStartPosition;
+
+        PartitionPositionBounds nextRange = rangeIterator.next();
+        if (currentEndPosition > nextRange.lowerPosition)
+            throw new IllegalArgumentException("Ranges supplied to SSTableSimpleScanner must be non-overlapping and in ascending order.");
+
+        currentEndPosition = nextRange.upperPosition;
+        currentStartPosition = nextRange.lowerPosition;
+        dfile.seek(currentStartPosition);
+        return true;
+    }
+
+    public UnfilteredRowIterator next()
+    {
+        if (!hasNext())
+            throw new NoSuchElementException();
+
+        currentIterator = SSTableIdentityIterator.create(sstable, dfile, false);
+        DecoratedKey currentKey = currentIterator.partitionKey();
+        if (lastKey != null && lastKey.compareTo(currentKey) >= 0)
+        {
+            sstable.markSuspect();
+            throw new CorruptSSTableException(new IllegalStateException(String.format("Invalid key order: current %s <= previous %s",
+                                                                                      currentKey,
+                                                                                      lastKey)),
+                                              sstable.getFilename());
+        }
+        lastKey = currentKey;
+        return currentIterator;
+    }
+
+    public void remove()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s(sstable=%s)", getClass().getSimpleName(), sstable);
+    }
+}

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableReader.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,6 @@ import org.apache.cassandra.db.rows.Rows;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.db.rows.UnfilteredRowIteratorWithLowerBound;
 import org.apache.cassandra.db.rows.UnfilteredRowIterators;
-import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.AbstractRowIndexEntry;
@@ -155,41 +153,6 @@ public class BigTableReader extends SSTableReaderWithFilter implements IndexSumm
     public KeyReader keyReader() throws IOException
     {
         return BigTableKeyReader.create(ifile, rowIndexEntrySerializer);
-    }
-
-    /**
-     * Direct I/O SSTableScanner over an iterator of bounds.
-     *
-     * @param boundsIterator the keys to cover
-     * @return A Scanner for seeking over the rows of the SSTable.
-     */
-    public ISSTableScanner getScanner(Iterator<AbstractBounds<PartitionPosition>> boundsIterator)
-    {
-        return BigTableScanner.getScanner(this, boundsIterator);
-    }
-
-    /**
-     * Direct I/O SSTableScanner over the full sstable.
-     *
-     * @return A Scanner for reading the full SSTable.
-     */
-    public ISSTableScanner getScanner()
-    {
-        return BigTableScanner.getScanner(this);
-    }
-
-    /**
-     * Direct I/O SSTableScanner over a defined collection of ranges of tokens.
-     *
-     * @param ranges the range of keys to cover
-     * @return A Scanner for seeking over the rows of the SSTable.
-     */
-    public ISSTableScanner getScanner(Collection<Range<Token>> ranges)
-    {
-        if (ranges != null)
-            return BigTableScanner.getScanner(this, ranges);
-        else
-            return getScanner();
     }
 
     /**

--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableScanner.java
@@ -18,10 +18,7 @@
 package org.apache.cassandra.io.sstable.format.big;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Iterator;
-
-import com.google.common.collect.Iterators;
 
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
@@ -30,8 +27,6 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.SSTable;
@@ -50,28 +45,12 @@ public class BigTableScanner extends SSTableScanner<BigTableReader, RowIndexEntr
 
     private final RowIndexEntry.IndexSerializer rowIndexEntrySerializer;
 
-    // Full scan of the sstables
-    public static ISSTableScanner getScanner(BigTableReader sstable)
-    {
-        return getScanner(sstable, Iterators.singletonIterator(fullRange(sstable)));
-    }
-
     public static ISSTableScanner getScanner(BigTableReader sstable,
                                              ColumnFilter columns,
                                              DataRange dataRange,
                                              SSTableReadsListener listener)
     {
         return new BigTableScanner(sstable, columns, dataRange, makeBounds(sstable, dataRange).iterator(), listener);
-    }
-
-    public static ISSTableScanner getScanner(BigTableReader sstable, Collection<Range<Token>> tokenRanges)
-    {
-        return getScanner(sstable, makeBounds(sstable, tokenRanges).iterator());
-    }
-
-    public static ISSTableScanner getScanner(BigTableReader sstable, Iterator<AbstractBounds<PartitionPosition>> rangeIterator)
-    {
-        return new BigTableScanner(sstable, ColumnFilter.all(sstable.metadata()), null, rangeIterator, SSTableReadsListener.NOOP_LISTENER);
     }
 
     private BigTableScanner(BigTableReader sstable,

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableReader.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -45,7 +44,6 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.Descriptor;
-import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.IVerifier;
 import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
@@ -380,27 +378,6 @@ public class BtiTableReader extends SSTableReaderWithFilter
             return new SSTableReversedIterator(this, dataFileInput, key, indexEntry, slices, selectedColumns, rowIndexFile);
         else
             return new SSTableIterator(this, dataFileInput, key, indexEntry, slices, selectedColumns, rowIndexFile);
-    }
-
-    @Override
-    public ISSTableScanner getScanner()
-    {
-        return BtiTableScanner.getScanner(this);
-    }
-
-    @Override
-    public ISSTableScanner getScanner(Collection<Range<Token>> ranges)
-    {
-        if (ranges != null)
-            return BtiTableScanner.getScanner(this, ranges);
-        else
-            return getScanner();
-    }
-
-    @Override
-    public ISSTableScanner getScanner(Iterator<AbstractBounds<PartitionPosition>> rangeIterator)
-    {
-        return BtiTableScanner.getScanner(this, rangeIterator);
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/bti/BtiTableScanner.java
@@ -19,10 +19,7 @@ package org.apache.cassandra.io.sstable.format.bti;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Iterator;
-
-import com.google.common.collect.Iterators;
 
 import org.apache.cassandra.db.DataRange;
 import org.apache.cassandra.db.DecoratedKey;
@@ -31,36 +28,18 @@ import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
-import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.SSTableReadsListener;
 import org.apache.cassandra.io.sstable.format.SSTableScanner;
 import org.apache.cassandra.io.util.FileUtils;
 
 public class BtiTableScanner extends SSTableScanner<BtiTableReader, TrieIndexEntry, BtiTableScanner.BtiScanningIterator>
 {
-    // Full scan of the sstables
-    public static BtiTableScanner getScanner(BtiTableReader sstable)
-    {
-        return getScanner(sstable, Iterators.singletonIterator(fullRange(sstable)));
-    }
-
     public static BtiTableScanner getScanner(BtiTableReader sstable,
                                              ColumnFilter columns,
                                              DataRange dataRange,
                                              SSTableReadsListener listener)
     {
         return new BtiTableScanner(sstable, columns, dataRange, makeBounds(sstable, dataRange).iterator(), listener);
-    }
-
-    public static BtiTableScanner getScanner(BtiTableReader sstable, Collection<Range<Token>> tokenRanges)
-    {
-        return getScanner(sstable, makeBounds(sstable, tokenRanges).iterator());
-    }
-
-    public static BtiTableScanner getScanner(BtiTableReader sstable, Iterator<AbstractBounds<PartitionPosition>> rangeIterator)
-    {
-        return new BtiTableScanner(sstable, ColumnFilter.all(sstable.metadata()), null, rangeIterator, SSTableReadsListener.NOOP_LISTENER);
     }
 
     private BtiTableScanner(BtiTableReader sstable,

--- a/src/java/org/apache/cassandra/tools/SSTablePartitions.java
+++ b/src/java/org/apache/cassandra/tools/SSTablePartitions.java
@@ -369,13 +369,15 @@ public class SSTablePartitions
         {
             while (scanner.hasNext())
             {
+                // hasNext() positions us on the next partition, next() has to advance to read its header.
+                long startOfPartition = scanner.getCurrentPosition();
                 try (UnfilteredRowIterator partition = scanner.next())
                 {
                     ByteBuffer key = partition.partitionKey().getKey();
                     boolean isExcluded = excludedKeys.contains(metadata.partitionKeyType.getString(key));
 
                     PartitionStats partitionStats = new PartitionStats(key,
-                                                                       scanner.getCurrentPosition(),
+                                                                       startOfPartition,
                                                                        partition.partitionLevelDeletion().isLive());
 
                     // Consume the partition to populate the stats.


### PR DESCRIPTION
[CASSANDRA-20092](https://issues.apache.org/jira/browse/CASSANDRA-20092)

This patch implements a simple `SSTableScanner` variation that directly reads the data file without accessing the index. This speeds up compaction, and enables correct computation of bytes to process when the scanner is restricted to a subrange or a set of subranges of the file (required by [CASSANDRA-18802](https://issues.apache.org/jira/browse/CASSANDRA-18802)).

The patch should not have any visible effects apart from improved compaction performance.