### PR TITLE
Improve entropy of UUID generators

### DIFF
--- a/test/unit/org/apache/cassandra/utils/Generators.java
+++ b/test/unit/org/apache/cassandra/utils/Generators.java
@@ -98,21 +98,21 @@ public final class Generators
 
     public static final Gen<UUID> UUID_RANDOM_GEN = rnd -> {
         long most = rnd.next(Constraint.none());
-        most &= 0x0f << 8; /* clear version        */
-        most += 0x40 << 8; /* set to version 4     */
         long least = rnd.next(Constraint.none());
-        least &= 0x3fl << 56; /* clear variant        */
-        least |= 0x80l << 56; /* set to IETF variant  */
+        most &= ~(0xFL << 12);  /* clear version       */
+        most |= 0x40L << 8;     /* set to version 4    */
+        least &= ~(0x3L << 62); /* clear variant       */
+        least |= 0x80l << 56;   /* set to IETF variant */
         return new UUID(most, least);
     };
 
     public static final Gen<UUID> UUID_TIME_GEN = rnd -> {
         long most = rnd.next(Constraint.none());
-        most &= 0x0f << 8; /* clear version        */
-        most += 0x10 << 8; /* set to version 1     */
+        most &= ~(0xFL << 12);  /* clear version       */
+        most |= 0x10 << 8;      /* set to version 1    */
         long least = rnd.next(Constraint.none());
-        least &= 0x3fl << 56; /* clear variant        */
-        least |= 0x80l << 56; /* set to IETF variant  */
+        least &= ~(0x3L << 62); /* clear variant       */
+        least |= 0x80l << 56  ; /* set to IETF variant */
         return new UUID(most, least);
     };
 

--- a/test/unit/org/apache/cassandra/utils/GeneratorsTest.java
+++ b/test/unit/org/apache/cassandra/utils/GeneratorsTest.java
@@ -18,10 +18,18 @@
 
 package org.apache.cassandra.utils;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 import com.google.common.net.InternetDomainName;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.assertj.core.api.Assertions;
+import org.quicktheories.core.Gen;
+import org.quicktheories.core.RandomnessSource;
+import org.quicktheories.impl.JavaRandom;
 
 import static org.quicktheories.QuickTheory.qt;
 
@@ -39,6 +47,28 @@ public class GeneratorsTest
                       .isEqualTo(2);
         });
     }
+
+    @Test
+    public void randomUUIDEntropy()
+    {
+        UUIDEntropy(Generators.UUID_RANDOM_GEN);
+    }
+
+    @Test
+    public void timeUUIDEntropy()
+    {
+        UUIDEntropy(Generators.UUID_TIME_GEN);
+    }
+
+    private void UUIDEntropy(Gen<UUID> gen)
+    {
+        RandomnessSource rng = new JavaRandom(100);
+        Set<UUID> uuids = new HashSet<>();
+        for (int i = 0; i < 100_000; i++)
+            uuids.add(gen.generate(rng));
+        Assert.assertEquals(100_000, uuids.size());
+    }
+
 
     @Test
     public void dnsDomainName()


### PR DESCRIPTION
JDK UUID Generator uses the following code:

        randomBytes[6]  &= 0x0f;  /* clear version        */
        randomBytes[6]  |= 0x40;  /* set to version 4     */
        randomBytes[8]  &= 0x3f;  /* clear variant        */
        randomBytes[8]  |= 0x80;  /* set to IETF variant  */

Which means that 6ths and 8ths _bytes_ are cleared with patterns using &, and then flags are set with |.

I _think_ this is right but please double check my logic.