### PR TITLE
[CASSANDRA-20084][4.1] Fix the case when WaitQueue.Signal.awaitUninterruptibly() may stuck forever if the invoking thread is interrupted

### DIFF
--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -344,7 +344,7 @@ public interface WaitQueue
             public boolean awaitUntil(long nanoTimeDeadline) throws InterruptedException
             {
                 long now;
-                while (nanoTimeDeadline > (now = nanoTime()) && !isSignalled())
+                while (nanoTimeDeadline > (now = nanoTime()) && !isSet())
                 {
                     checkInterrupted();
                     long delta = nanoTimeDeadline - now;

--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -309,6 +309,7 @@ public interface WaitQueue
                 }
                 if (interrupted)
                     Thread.currentThread().interrupt();
+                checkAndClear();
                 return this;
             }
 

--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -74,7 +74,7 @@ import static org.apache.cassandra.utils.Shared.Scope.SIMULATION;
  * to be met that we no longer need.
  * <p>5. This scheme is not fair</p>
  * <p>6. Only the thread that calls register() may call await()</p>
- *
+ * <p>6. A signal can be cancelled while it is within await() if the invoking thread is interrupted</p>
  * TODO: this class should not be backed by CLQ (should use an intrusive linked-list with lower overhead)
  */
 @Shared(scope = SIMULATION, inner = INTERFACES)
@@ -109,9 +109,9 @@ public interface WaitQueue
         public boolean isSet();
 
         /**
-         * atomically: cancels the Signal if !isSet(), or returns true if isSignalled()
+         * atomically: cancels the Signal if !isSet(), or returns true if isSet()
          *
-         * @return true if isSignalled()
+         * @return true if isSet()
          */
         public boolean checkAndClear();
 
@@ -120,6 +120,23 @@ public interface WaitQueue
          * and if signalled propagates the signal to another waiting thread
          */
         public abstract void cancel();
+
+        /**
+         * Await indefinitely, throwing any interrupt.
+         * No spurious wakeups.
+         * Important: the signal can be cancelled if the thread executing await() is interrupted
+         * @throws InterruptedException if interrupted
+         */
+        Awaitable await() throws InterruptedException;
+
+        /**
+         * Await until the deadline (in nanoTime), throwing any interrupt.
+         * No spurious wakeups.
+         * @return true if we were signalled, false if the deadline elapsed
+         * Important: the signal can be cancelled if the thread executing await() is interrupted
+         * @throws InterruptedException if interrupted
+         */
+        boolean awaitUntil(long nanoTimeDeadline) throws InterruptedException;
     }
 
     /**
@@ -281,60 +298,34 @@ public interface WaitQueue
          */
         public static abstract class AbstractSignal extends AbstractAwaitable implements Signal
         {
-            public Signal awaitUninterruptibly()
+            public Signal await() throws InterruptedException
             {
-                boolean interrupted = false;
-                while (true)
+                while (!isSet())
                 {
-                    try
-                    {
-                        await(false);
-                        break;
-                    }
-                    catch (InterruptedException e)
-                    {
-                        interrupted = true;
-                    }
-                }
-                if (interrupted)
-                    Thread.currentThread().interrupt();
-                return this;
-            }
-
-            public Signal await(boolean cancelOnInterrupt) throws InterruptedException
-            {
-                while (!isSignalled())
-                {
-                    checkInterrupted(cancelOnInterrupt);
+                    checkInterrupted();
                     LockSupport.park();
                 }
                 checkAndClear();
                 return this;
             }
 
-            public Signal await() throws InterruptedException
-            {
-                return await(true);
-            }
-
             public boolean awaitUntil(long nanoTimeDeadline) throws InterruptedException
             {
                 long now;
-                while (nanoTimeDeadline > (now = nanoTime()) && !isSignalled())
+                while (nanoTimeDeadline > (now = nanoTime()) && !isSet())
                 {
-                    checkInterrupted(true);
+                    checkInterrupted();
                     long delta = nanoTimeDeadline - now;
                     LockSupport.parkNanos(delta);
                 }
                 return checkAndClear();
             }
 
-            private void checkInterrupted(boolean cancelOnInterrupt) throws InterruptedException
+            private void checkInterrupted() throws InterruptedException
             {
                 if (Thread.interrupted())
                 {
-                    if (cancelOnInterrupt)
-                        cancel();
+                    cancel();
                     throw new InterruptedException();
                 }
             }

--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -74,7 +74,7 @@ import static org.apache.cassandra.utils.Shared.Scope.SIMULATION;
  * to be met that we no longer need.
  * <p>5. This scheme is not fair</p>
  * <p>6. Only the thread that calls register() may call await()</p>
- * <p>6. A signal can be cancelled while it is within await() if the invoking thread is interrupted</p>
+ * <p>7. A signal can be cancelled while it is within await() if the invoking thread is interrupted</p>
  * TODO: this class should not be backed by CLQ (should use an intrusive linked-list with lower overhead)
  */
 @Shared(scope = SIMULATION, inner = INTERFACES)

--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -301,17 +301,11 @@ public interface WaitQueue
             public Signal awaitUninterruptibly()
             {
                 boolean interrupted = false;
-                while (true)
+                while (!isSet())
                 {
-                    try
-                    {
-                        await(false);
-                        break;
-                    }
-                    catch (InterruptedException e)
-                    {
+                    if (Thread.interrupted())
                         interrupted = true;
-                    }
+                    LockSupport.park();
                 }
                 if (interrupted)
                     Thread.currentThread().interrupt();
@@ -320,14 +314,9 @@ public interface WaitQueue
 
             public Signal await() throws InterruptedException
             {
-                return await(true);
-            }
-
-            private Signal await(boolean cancelOnInterrupt) throws InterruptedException
-            {
                 while (!isSet())
                 {
-                    checkInterrupted(cancelOnInterrupt);
+                    checkInterrupted();
                     LockSupport.park();
                 }
                 checkAndClear();
@@ -337,47 +326,37 @@ public interface WaitQueue
             public boolean awaitUntilUninterruptibly(long nanoTimeDeadline)
             {
                 boolean interrupted = false;
-                boolean result;
-                while (true)
+                long now;
+                while (nanoTimeDeadline > (now = nanoTime()) && !isSet())
                 {
-                    try
-                    {
-                        result = awaitUntil(nanoTimeDeadline, false);
-                        break;
-                    }
-                    catch (InterruptedException e)
-                    {
+                    if (Thread.interrupted())
                         interrupted = true;
-                    }
+                    long delta = nanoTimeDeadline - now;
+                    LockSupport.parkNanos(delta);
                 }
                 if (interrupted)
                     Thread.currentThread().interrupt();
-                return result;
+
+                return checkAndClear();
             }
 
             public boolean awaitUntil(long nanoTimeDeadline) throws InterruptedException
             {
-                return awaitUntil(nanoTimeDeadline, true);
-            }
-
-            private boolean awaitUntil(long nanoTimeDeadline, boolean cancelOnInterrupt) throws InterruptedException
-            {
                 long now;
-                while (nanoTimeDeadline > (now = nanoTime()) && !isSet())
+                while (nanoTimeDeadline > (now = nanoTime()) && !isSignalled())
                 {
-                    checkInterrupted(cancelOnInterrupt);
+                    checkInterrupted();
                     long delta = nanoTimeDeadline - now;
                     LockSupport.parkNanos(delta);
                 }
                 return checkAndClear();
             }
 
-            private void checkInterrupted(boolean cancelOnInterrupt) throws InterruptedException
+            private void checkInterrupted() throws InterruptedException
             {
                 if (Thread.interrupted())
                 {
-                    if (cancelOnInterrupt)
-                        cancel();
+                    cancel();
                     throw new InterruptedException();
                 }
             }

--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -298,34 +298,86 @@ public interface WaitQueue
          */
         public static abstract class AbstractSignal extends AbstractAwaitable implements Signal
         {
+            public Signal awaitUninterruptibly()
+            {
+                boolean interrupted = false;
+                while (true)
+                {
+                    try
+                    {
+                        await(false);
+                        break;
+                    }
+                    catch (InterruptedException e)
+                    {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted)
+                    Thread.currentThread().interrupt();
+                return this;
+            }
+
             public Signal await() throws InterruptedException
+            {
+                return await(true);
+            }
+
+            private Signal await(boolean cancelOnInterrupt) throws InterruptedException
             {
                 while (!isSet())
                 {
-                    checkInterrupted();
+                    checkInterrupted(cancelOnInterrupt);
                     LockSupport.park();
                 }
                 checkAndClear();
                 return this;
             }
 
+            public boolean awaitUntilUninterruptibly(long nanoTimeDeadline)
+            {
+                boolean interrupted = false;
+                boolean result;
+                while (true)
+                {
+                    try
+                    {
+                        result = awaitUntil(nanoTimeDeadline, false);
+                        break;
+                    }
+                    catch (InterruptedException e)
+                    {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted)
+                    Thread.currentThread().interrupt();
+                return result;
+            }
+
             public boolean awaitUntil(long nanoTimeDeadline) throws InterruptedException
+            {
+                return awaitUntil(nanoTimeDeadline, true);
+            }
+
+            private boolean awaitUntil(long nanoTimeDeadline, boolean cancelOnInterrupt) throws InterruptedException
             {
                 long now;
                 while (nanoTimeDeadline > (now = nanoTime()) && !isSet())
                 {
-                    checkInterrupted();
+                    checkInterrupted(cancelOnInterrupt);
                     long delta = nanoTimeDeadline - now;
                     LockSupport.parkNanos(delta);
                 }
                 return checkAndClear();
             }
 
-            private void checkInterrupted() throws InterruptedException
+            private void checkInterrupted(boolean cancelOnInterrupt) throws InterruptedException
             {
                 if (Thread.interrupted())
                 {
-                    cancel();
+                    if (cancelOnInterrupt)
+                        cancel();
                     throw new InterruptedException();
                 }
             }

--- a/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
+++ b/src/java/org/apache/cassandra/utils/concurrent/WaitQueue.java
@@ -281,15 +281,40 @@ public interface WaitQueue
          */
         public static abstract class AbstractSignal extends AbstractAwaitable implements Signal
         {
-            public Signal await() throws InterruptedException
+            public Signal awaitUninterruptibly()
+            {
+                boolean interrupted = false;
+                while (true)
+                {
+                    try
+                    {
+                        await(false);
+                        break;
+                    }
+                    catch (InterruptedException e)
+                    {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted)
+                    Thread.currentThread().interrupt();
+                return this;
+            }
+
+            public Signal await(boolean cancelOnInterrupt) throws InterruptedException
             {
                 while (!isSignalled())
                 {
-                    checkInterrupted();
+                    checkInterrupted(cancelOnInterrupt);
                     LockSupport.park();
                 }
                 checkAndClear();
                 return this;
+            }
+
+            public Signal await() throws InterruptedException
+            {
+                return await(true);
             }
 
             public boolean awaitUntil(long nanoTimeDeadline) throws InterruptedException
@@ -297,18 +322,19 @@ public interface WaitQueue
                 long now;
                 while (nanoTimeDeadline > (now = nanoTime()) && !isSignalled())
                 {
-                    checkInterrupted();
+                    checkInterrupted(true);
                     long delta = nanoTimeDeadline - now;
                     LockSupport.parkNanos(delta);
                 }
                 return checkAndClear();
             }
 
-            private void checkInterrupted() throws InterruptedException
+            private void checkInterrupted(boolean cancelOnInterrupt) throws InterruptedException
             {
                 if (Thread.interrupted())
                 {
-                    cancel();
+                    if (cancelOnInterrupt)
+                        cancel();
                     throw new InterruptedException();
                 }
             }

--- a/test/unit/org/apache/cassandra/concurrent/WaitQueueTest.java
+++ b/test/unit/org/apache/cassandra/concurrent/WaitQueueTest.java
@@ -26,6 +26,7 @@ import org.apache.cassandra.utils.concurrent.WaitQueue;
 import org.junit.*;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -132,10 +133,10 @@ public class WaitQueueTest
 
         writerAwaitThread.start();
 
-        Thread.sleep(1000); // wait to enter signal.awaitUninterruptibly()
+        Thread.sleep(1_000); // wait to enter signal.awaitUninterruptibly()
         waitQueue.signalAll();
 
-        writerAwaitThread.join(4000);
+        writerAwaitThread.join(4_000);
         if (writerAwaitThread.isAlive())
         {
             printThreadStackTrace(writerAwaitThread);
@@ -143,14 +144,37 @@ public class WaitQueueTest
         }
     }
 
-    public static Thread createThread(Runnable job, String name)
+    @Test
+    public void testInterruptOfSignalAwaitingWithTimeoutThread() throws InterruptedException
     {
-        Thread thread = new Thread(job::run, name);
+        final WaitQueue waitQueue = newWaitQueue();
+        Thread writerAwaitThread = createThread(() -> {
+            Thread.currentThread().interrupt();
+            WaitQueue.Signal signal = waitQueue.register();
+            signal.awaitUninterruptibly(100_000, TimeUnit.MILLISECONDS);
+        }, "writer.await");
+
+        writerAwaitThread.start();
+
+        Thread.sleep(1_000); // wait to enter signal.awaitUninterruptibly()
+        waitQueue.signalAll();
+
+        writerAwaitThread.join(4_000);
+        if (writerAwaitThread.isAlive())
+        {
+            printThreadStackTrace(writerAwaitThread);
+            fail("signal.awaitUninterruptibly() is stuck");
+        }
+    }
+
+    private static Thread createThread(Runnable job, String name)
+    {
+        Thread thread = new Thread(job, name);
         thread.setDaemon(true);
         return thread;
     }
 
-    public static void printThreadStackTrace(Thread thread)
+    private static void printThreadStackTrace(Thread thread)
     {
         System.out.println("Stack trace for thread: " + thread.getName());
         StackTraceElement[] stackTrace = thread.getStackTrace();

--- a/test/unit/org/apache/cassandra/concurrent/WaitQueueTest.java
+++ b/test/unit/org/apache/cassandra/concurrent/WaitQueueTest.java
@@ -119,4 +119,50 @@ public class WaitQueueTest
         assertFalse(fail.get());
     }
 
+    @Test
+    public void testInterruptOfSignalAwaitingThread() throws InterruptedException
+    {
+        final WaitQueue waitQueue = newWaitQueue();
+        Thread writerAwaitThread = createThread(() -> {
+            Thread.currentThread().interrupt();
+            WaitQueue.Signal signal = waitQueue.register();
+            signal.awaitUninterruptibly();
+
+        }, "writer.await");
+
+        writerAwaitThread.start();
+
+        Thread.sleep(1000); // wait to enter signal.awaitUninterruptibly()
+        waitQueue.signalAll();
+
+        writerAwaitThread.join(4000);
+        if (writerAwaitThread.isAlive())
+        {
+            printThreadStackTrace(writerAwaitThread);
+            fail("signal.awaitUninterruptibly() is stuck");
+        }
+    }
+
+    public static Thread createThread(Runnable job, String name)
+    {
+        Thread thread = new Thread(job::run, name);
+        thread.setDaemon(true);
+        return thread;
+    }
+
+    public static void printThreadStackTrace(Thread thread)
+    {
+        System.out.println("Stack trace for thread: " + thread.getName());
+        StackTraceElement[] stackTrace = thread.getStackTrace();
+        if (stackTrace.length == 0)
+        {
+            System.out.println("The thread is not currently running or has no stack trace.");
+        } else
+        {
+            for (StackTraceElement element : stackTrace)
+            {
+                System.out.println("\tat " + element);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix the case when WaitQueue.Signal.awaitUninterruptibly() may stuck forever if the invoking thread is interrupted

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20084