### PR TITLE
 CASSANDRA-20104: Sort output in nodetool status

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -237,15 +237,6 @@ public class Status extends NodeToolCmd {
         }
     }
 
-    private void validateArguments(PrintStream out)
-    {
-        if (sortOrder != null && sortBy == SortBy.none)
-        {
-            out.printf("%nError: %s%n", "Sort order (-o / --order) can only be used while sorting using -s or --sort.");
-            System.exit(1);
-        }
-    }
-
     @Override
     public void execute(NodeProbe probe)
     {
@@ -354,6 +345,15 @@ public class Status extends NodeToolCmd {
         }
 
         out.printf("%n" + errors);
+    }
+
+    private void validateArguments(PrintStream out)
+    {
+        if (sortOrder != null && sortBy == SortBy.none)
+        {
+            out.printf("%nError: %s%n", "Sort order (-o / --order) can only be used while sorting using -s or --sort.");
+            System.exit(1);
+        }
     }
 
     private void addNodesHeader(boolean hasEffectiveOwns, TableBuilder tableBuilder)

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -197,24 +197,24 @@ public class Status extends NodeToolCmd {
 
         public abstract Map<String, List<Object>> sort(Map<String, List<Object>> data);
 
-        boolean descending(SortOrder sortOrder)
+        protected boolean descending(SortOrder sortOrder)
         {
             return sortOrder == null ? descendingByDefault : sortOrder == SortOrder.desc;
         }
 
-        SortBy sortOrder(SortOrder sortOrder)
+        protected SortBy sortOrder(SortOrder sortOrder)
         {
             this.sortOrder = sortOrder;
             return this;
         }
 
-        SortBy tokenPerNode(boolean tokenPerNode)
+        protected SortBy tokenPerNode(boolean tokenPerNode)
         {
             this.tokenPerNode = tokenPerNode;
             return this;
         }
 
-        int evaluateComparision(int comparisionResult)
+        protected int evaluateComparision(int comparisionResult)
         {
             if (comparisionResult < 0)
                 return descending(sortOrder) ? 1 : -1;

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -220,20 +220,13 @@ public class Status extends NodeToolCmd
     {
         String endpoint = addressAndPort.getHostAddressAndPort();
         String status, state, load, strOwns, hostID, rack;
-        if (liveNodes.contains(endpoint))
-            status = "U";
-        else if (unreachableNodes.contains(endpoint))
-            status = "D";
-        else
-            status = "?";
-        if (joiningNodes.contains(endpoint))
-            state = "J";
-        else if (leavingNodes.contains(endpoint))
-            state = "L";
-        else if (movingNodes.contains(endpoint))
-            state = "M";
-        else
-            state = "N";
+        if (liveNodes.contains(endpoint)) status = "U";
+        else if (unreachableNodes.contains(endpoint)) status = "D";
+        else status = "?";
+        if (joiningNodes.contains(endpoint)) state = "J";
+        else if (leavingNodes.contains(endpoint)) state = "L";
+        else if (movingNodes.contains(endpoint)) state = "M";
+        else state = "N";
 
         String statusAndState = status.concat(state);
         load = loadMap.getOrDefault(endpoint, "?");

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -224,7 +224,7 @@ public class Status extends NodeToolCmd {
             return 0;
         }
 
-        LinkedHashMap<String, List<Object>> compareStrings(Map<String, List<Object>> data, int index)
+        protected LinkedHashMap<String, List<Object>> compareStrings(Map<String, List<Object>> data, int index)
         {
             return data.entrySet()
                     .stream()

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -29,6 +29,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.TreeMap;
+import java.util.Collections;
 
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.tools.NodeProbe;
@@ -48,11 +52,18 @@ public class Status extends NodeToolCmd
     @Option(title = "resolve_ip", name = {"-r", "--resolve-ip"}, description = "Show node domain names instead of IPs")
     private boolean resolveIp = false;
 
+    @Option(title = "sort", name = {"-s", "--sort"}, description = "Sort by [IP, Load, Owns, ID, Rack, Status]")
+    private String sortBy = null;
+
+
+    @Option(title = "sort_order", name = {"-o","--order"}, description = "Sort order: a or ascending for ascending, d or descending for descending")
+    private String sortOrder = null;
+
     private boolean isTokenPerNode = true;
     private Collection<String> joiningNodes, leavingNodes, movingNodes, liveNodes, unreachableNodes;
     private Map<String, String> loadMap, hostIDMap;
     private EndpointSnitchInfoMBean epSnitchInfo;
-
+    SortedMap<String, List<Object>> data;
     @Override
     public void execute(NodeProbe probe)
     {
@@ -95,6 +106,21 @@ public class Status extends NodeToolCmd
             out.printf("%nError: %s%n", ex.getMessage());
             System.exit(1);
         }
+        try
+        {
+            if (sortOrder != null && sortBy == null) {
+                throw new IllegalArgumentException("Sort order (a or ascending or d or descending) can only be used with -s or --sort.");
+            }
+            if(getSortOrder()==3)
+            {
+                throw new IllegalArgumentException("Given Wrong Value for Sort order (a or ascending or d or descending)");
+            }
+        }
+        catch (IllegalArgumentException ex)
+        {
+            out.printf("%nError: %s%n", ex.getMessage());
+            System.exit(1);
+        }
 
         SortedMap<String, SetHostStatWithPort> dcs = NodeTool.getOwnershipByDcWithPort(probe, resolveIp, tokensToEndpoints, ownerships);
 
@@ -105,6 +131,7 @@ public class Status extends NodeToolCmd
         // Datacenters
         for (Map.Entry<String, SetHostStatWithPort> dc : dcs.entrySet())
         {
+            data = new TreeMap<>();
             TableBuilder tableBuilder = sharedTable.next();
             addNodesHeader(hasEffectiveOwns, tableBuilder);
 
@@ -117,6 +144,10 @@ public class Status extends NodeToolCmd
                 Float owns = ownerships.get(endpoint);
                 List<HostStatWithPort> tokens = hostToTokens.get(endpoint);
                 addNode(endpoint, owns, tokens.get(0), tokens.size(), hasEffectiveOwns, tableBuilder);
+            }
+            if(sortBy!=null)
+            {
+                sortData(tableBuilder,probe);
             }
         }
 
@@ -154,7 +185,7 @@ public class Status extends NodeToolCmd
     }
 
     private void addNode(String endpoint, Float owns, HostStatWithPort hostStat, int size, boolean hasEffectiveOwns,
-                           TableBuilder tableBuilder)
+                         TableBuilder tableBuilder)
     {
         String status, state, load, strOwns, hostID, rack, epDns;
         if (liveNodes.contains(endpoint)) status = "U";
@@ -180,14 +211,225 @@ public class Status extends NodeToolCmd
         }
 
         epDns = hostStat.ipOrDns(printPort);
-        if (isTokenPerNode)
+        if (sortBy != null)
         {
-            tableBuilder.add(statusAndState, epDns, load, strOwns, hostID, hostStat.token, rack);
+            if (isTokenPerNode)
+            {
+                data.put(epDns,new ArrayList<>(Arrays.asList(statusAndState, load, strOwns, hostID, hostStat.token, rack)));
+            }
+            else
+            {
+                data.put(epDns,new ArrayList<>(Arrays.asList(statusAndState, load, String.valueOf(size), strOwns, hostID, rack)));
+            }
         }
         else
         {
-            tableBuilder.add(statusAndState, epDns, load, String.valueOf(size), strOwns, hostID, rack);
+            if (isTokenPerNode)
+            {
+                tableBuilder.add(statusAndState, epDns, load, strOwns, hostID, hostStat.token, rack);
+            }
+            else
+            {
+                tableBuilder.add(statusAndState, epDns, load, String.valueOf(size), strOwns, hostID, rack);
+            }
         }
     }
 
+
+    // Method to sort data based on specified criteria and print it in the sorted order
+    private void sortData(TableBuilder tableBuilder, NodeProbe probe) {
+        PrintStream out = probe.output().out;
+
+        // Convert the map entries to a list for sorting
+        List<Map.Entry<String, List<Object>>> entryList = new ArrayList<>(data.entrySet());
+
+        // Sort data based on the specified sorting criteria
+        switch (sortBy) {
+            case "ip":
+                sortByIp(entryList, false); // Sort by IP address
+                break;
+            case "load":
+                sortByNumericIndex(entryList, 1, true); // Sort by load, treated as numeric
+                break;
+            case "id":
+                // Sort by ID, with logic varying based on whether tokens per node is used
+                sortByIndex(entryList, isTokenPerNode ? 3 : 4, false);
+                break;
+            case "rack":
+                sortByIndex(entryList, 5, false); // Sort by rack information
+                break;
+            case "owns":
+                // Sort by ownership percentage, with different indices based on token settings
+                sortByIndex(entryList, isTokenPerNode ? 2 : 3, true);
+                break;
+            case "status":
+                sortByIndex(entryList, 0, true); // Sort by status
+                break;
+            default:
+                // Handle invalid sorting criteria with an error message and exit
+                out.printf("%nError: Given Wrong Value for -s or --sort(ip,load,id,rack,owns,status)%n");
+                System.exit(1);
+        }
+
+        // Print the sorted data
+        sortPrinter(entryList, tableBuilder);
+    }
+
+    // Method to sort entries by IP address, optionally descending
+    private void sortByIp(List<Map.Entry<String, List<Object>>> entryList, boolean descending) {
+        entryList.sort((entry1, entry2) -> {
+            String key1 = entry1.getKey();
+            String key2 = entry2.getKey();
+
+            // Check if the keys are valid IP addresses
+            boolean isIp1 = key1.matches("\\d+\\.\\d+\\.\\d+\\.\\d+(:\\d+)?");
+            boolean isIp2 = key2.matches("\\d+\\.\\d+\\.\\d+\\.\\d+(:\\d+)?");
+
+            // Resolve non-IP addresses to sort lexicographically if needed
+            if (resolveIp) {
+                if (!isIp1 && isIp2) return -1;
+                if (isIp1 && !isIp2) return 1;
+                if (!isIp1 && !isIp2) return key1.compareTo(key2);
+            }
+
+            // Split IPs and compare individual parts numerically
+            String[] ipPort1 = key1.split(":");
+            String[] ipPort2 = key2.split(":");
+            String[] parts1 = ipPort1[0].split("\\.");
+            String[] parts2 = ipPort2[0].split("\\.");
+            for (int i = 0; i < 4; i++) {
+                int num1 = Integer.parseInt(parts1[i]);
+                int num2 = Integer.parseInt(parts2[i]);
+                if (num1 != num2) return Integer.compare(num1, num2);
+            }
+
+            // Compare port numbers if present
+            if (ipPort1.length > 1 && ipPort2.length > 1) {
+                int port1 = Integer.parseInt(ipPort1[1]);
+                int port2 = Integer.parseInt(ipPort2[1]);
+                return Integer.compare(port1, port2);
+            }
+
+            // Handle cases where only one key has a port
+            if (ipPort1.length > 1) return 1;
+            if (ipPort2.length > 1) return -1;
+
+            return 0;
+        });
+
+        // Apply the specified sort order
+        applySortOrder(entryList, descending);
+    }
+
+    // Generic method to sort entries by a specific index, treating values as strings or percentages
+    private void sortByIndex(List<Map.Entry<String, List<Object>>> entryList, int index, boolean descending) {
+        entryList.sort((entry1, entry2) -> {
+            String str1 = (String) entry1.getValue().get(index);
+            String str2 = (String) entry2.getValue().get(index);
+
+            // Handle sorting for percentage values
+            if (str1.endsWith("%") && str2.endsWith("%")) {
+                double value1 = Double.parseDouble(str1.replace("%", ""));
+                double value2 = Double.parseDouble(str2.replace("%", ""));
+                return Double.compare(value1, value2);
+            }
+
+            // Lexicographical comparison as fallback
+            return str1.compareTo(str2);
+        });
+
+        // Apply the specified sort order
+        applySortOrder(entryList, descending);
+    }
+
+    // Method to sort entries by numeric index values
+    private void sortByNumericIndex(List<Map.Entry<String, List<Object>>> entryList, int index, boolean descending) {
+        entryList.sort((entry1, entry2) -> {
+            double value1 = parseSize((String) entry1.getValue().get(index));
+            double value2 = parseSize((String) entry2.getValue().get(index));
+            return Double.compare(value1, value2);
+        });
+
+        // Apply the specified sort order
+        applySortOrder(entryList, descending);
+    }
+
+    // Reverse the list if descending order is specified
+    private void applySortOrder(List<Map.Entry<String, List<Object>>> entryList, boolean descending) {
+        if (getSortOrder() == 1) return; // Ascending, no change needed
+        if (getSortOrder() == -1 || descending) Collections.reverse(entryList);
+    }
+
+    // Print the sorted entries using the provided table builder
+    private void sortPrinter(List<Map.Entry<String, List<Object>>> entryList, TableBuilder tableBuilder) {
+        for (Map.Entry<String, List<Object>> entry : entryList) {
+            String epDns = entry.getKey();
+            List<Object> values = entry.getValue();
+            String statusAndState = (String) values.get(0);
+            String load = (String) values.get(1);
+            String rack = (String) values.get(5);
+
+            // Different logic for token per node configurations
+            String strOwns, hostID, tokens;
+            if (isTokenPerNode) {
+                strOwns = (String) values.get(2);
+                hostID = (String) values.get(3);
+                tokens = (String) values.get(4);
+            } else {
+                tokens = (String) values.get(2);
+                strOwns = (String) values.get(3);
+                hostID = (String) values.get(4);
+            }
+
+            // Add the row to the table
+            if (isTokenPerNode) {
+                tableBuilder.add(statusAndState, epDns, load, strOwns, hostID, tokens, rack);
+            } else {
+                tableBuilder.add(statusAndState, epDns, load, tokens, strOwns, hostID, rack);
+            }
+        }
+    }
+
+    // Determine the sort order based on the user-specified value
+    private int getSortOrder() {
+        if (sortOrder == null) return 0; // Default: no specific order
+        switch (sortOrder) {
+            case "a":
+            case "ascending":
+                return 1; // Ascending order
+            case "d":
+            case "descending":
+                return -1; // Descending order
+            default:
+                return 3; // Invalid order, treated as no sorting
+        }
+    }
+
+    // Parse a size string into its numeric value in bytes
+    private double parseSize(String sizeStr) {
+        if (sizeStr == null || sizeStr.isEmpty()) return 0;
+
+        String[] parts = sizeStr.split(" ");
+        if (parts.length != 2) return 0;
+
+        try {
+            double value = Double.parseDouble(parts[0]);
+            switch (parts[1]) {
+                case "KiB":
+                    return value * 1024;
+                case "MiB":
+                    return value * 1024 * 1024;
+                case "GiB":
+                    return value * 1024 * 1024 * 1024;
+                case "TiB":
+                    return value * 1024L * 1024 * 1024 * 1024;
+                case "PiB":
+                    return value * 1024L * 1024 * 1024 * 1024 * 1024;
+                default:
+                    return value;
+            }
+        } catch (NumberFormatException e) {
+            return 0; // Return zero for invalid numbers
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -24,23 +25,26 @@ import io.airlift.airline.Option;
 import java.io.PrintStream;
 import java.net.UnknownHostException;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.TreeMap;
-import java.util.Collections;
 
+import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 import org.apache.cassandra.tools.nodetool.formatter.TableBuilder;
 
 import com.google.common.collect.ArrayListMultimap;
+
+import static java.util.stream.Collectors.toMap;
 
 @SuppressWarnings("UseOfSystemOutOrSystemErr")
 @Command(name = "status", description = "Print cluster information (state, load, IDs, ...)")
@@ -52,21 +56,54 @@ public class Status extends NodeToolCmd
     @Option(title = "resolve_ip", name = {"-r", "--resolve-ip"}, description = "Show node domain names instead of IPs")
     private boolean resolveIp = false;
 
-    @Option(title = "sort", name = {"-s", "--sort"}, description = "Sort by [IP, Load, Owns, ID, Rack, Status]")
-    private String sortBy = null;
+    @Option(title = "sort",
+            name = {"-s", "--sort"},
+            description = "Sort by one of 'ip', 'load', 'owns', 'id', 'rack' or 'status', Defaults to 'none', Default Ordering is 'asc' for 'ip', 'id', 'rack' and 'desc' for 'load', 'owns', 'status' ",
+            allowedValues = { "ip", "load", "owns", "id", "rack", "status", "none" })
+    private SortBy sortBy = SortBy.none;
 
-
-    @Option(title = "sort_order", name = {"-o","--order"}, description = "Sort order: a or ascending for ascending, d or descending for descending")
-    private String sortOrder = null;
+    @Option(title = "sort_order",
+            name = {"-o","--order"},
+            description = "Sort order: 'asc' for ascending, 'desc' for descending",
+            allowedValues = {"asc", "desc"})
+    private SortOrder sortOrder = null;
 
     private boolean isTokenPerNode = true;
     private Collection<String> joiningNodes, leavingNodes, movingNodes, liveNodes, unreachableNodes;
     private Map<String, String> loadMap, hostIDMap;
     private EndpointSnitchInfoMBean epSnitchInfo;
-    SortedMap<String, List<Object>> data;
+
+    public enum SortOrder
+    {
+        asc,
+        desc
+    }
+
+    public enum SortBy
+    {
+        none,
+        ip,
+        load,
+        owns,
+        id,
+        rack,
+        status
+    }
+
+    private void validateArguments(PrintStream out)
+    {
+        if (sortOrder != null && sortBy == SortBy.none)
+        {
+            out.printf("%nError: %s%n", "Sort order (-o / --order) can only be used while sorting using -s or --sort.");
+            System.exit(1);
+        }
+    }
+
     @Override
     public void execute(NodeProbe probe)
     {
+        validateArguments(probe.output().out);
+
         PrintStream out = probe.output().out;
         joiningNodes = probe.getJoiningNodes(true);
         leavingNodes = probe.getLeavingNodes(true);
@@ -106,21 +143,6 @@ public class Status extends NodeToolCmd
             out.printf("%nError: %s%n", ex.getMessage());
             System.exit(1);
         }
-        try
-        {
-            if (sortOrder != null && sortBy == null) {
-                throw new IllegalArgumentException("Sort order (a or ascending or d or descending) can only be used with -s or --sort.");
-            }
-            if(getSortOrder()==3)
-            {
-                throw new IllegalArgumentException("Given Wrong Value for Sort order (a or ascending or d or descending)");
-            }
-        }
-        catch (IllegalArgumentException ex)
-        {
-            out.printf("%nError: %s%n", ex.getMessage());
-            System.exit(1);
-        }
 
         SortedMap<String, SetHostStatWithPort> dcs = NodeTool.getOwnershipByDcWithPort(probe, resolveIp, tokensToEndpoints, ownerships);
 
@@ -131,23 +153,35 @@ public class Status extends NodeToolCmd
         // Datacenters
         for (Map.Entry<String, SetHostStatWithPort> dc : dcs.entrySet())
         {
-            data = new TreeMap<>();
             TableBuilder tableBuilder = sharedTable.next();
             addNodesHeader(hasEffectiveOwns, tableBuilder);
 
-            ArrayListMultimap<String, HostStatWithPort> hostToTokens = ArrayListMultimap.create();
+            ArrayListMultimap<InetAddressAndPort, HostStatWithPort> hostToTokens = ArrayListMultimap.create();
             for (HostStatWithPort stat : dc.getValue())
-                hostToTokens.put(stat.endpointWithPort.getHostAddressAndPort(), stat);
+                hostToTokens.put(stat.endpointWithPort, stat);
 
-            for (String endpoint : hostToTokens.keySet())
+            Map<String, List<Object>> data = new HashMap<>();
+            for (InetAddressAndPort endpoint : hostToTokens.keySet())
             {
-                Float owns = ownerships.get(endpoint);
+                Float owns = ownerships.get(endpoint.getHostAddressAndPort());
                 List<HostStatWithPort> tokens = hostToTokens.get(endpoint);
-                addNode(endpoint, owns, tokens.get(0), tokens.size(), hasEffectiveOwns, tableBuilder);
+
+                HostStatWithPort hostStatWithPort = tokens.get(0);
+                String epDns = hostStatWithPort.ipOrDns(printPort);
+                List<Object> nodeData = addNode(epDns, endpoint, owns, hostStatWithPort, tokens.size(), hasEffectiveOwns);
+                data.put(epDns, nodeData);
             }
-            if(sortBy!=null)
+
+            data = sort(data);
+
+            for (Map.Entry<String, List<Object>> entry : data.entrySet())
             {
-                sortData(tableBuilder,probe);
+                List<Object> values = entry.getValue();
+                List<String> row = new ArrayList<>();
+                for (int i = 1; i < values.size(); i++)
+                    row.add((String) values.get(i));
+
+                tableBuilder.add(row);
             }
         }
 
@@ -184,10 +218,10 @@ public class Status extends NodeToolCmd
             tableBuilder.add("--", "Address", "Load", "Tokens", owns, "Host ID", "Rack");
     }
 
-    private void addNode(String endpoint, Float owns, HostStatWithPort hostStat, int size, boolean hasEffectiveOwns,
-                         TableBuilder tableBuilder)
+    private List<Object> addNode(String epDns, InetAddressAndPort addressAndPort, Float owns, HostStatWithPort hostStat, int size, boolean hasEffectiveOwns)
     {
-        String status, state, load, strOwns, hostID, rack, epDns;
+        String endpoint = addressAndPort.getHostAddressAndPort();
+        String status, state, load, strOwns, hostID, rack;
         if (liveNodes.contains(endpoint)) status = "U";
         else if (unreachableNodes.contains(endpoint)) status = "D";
         else status = "?";
@@ -210,226 +244,112 @@ public class Status extends NodeToolCmd
             throw new RuntimeException(e);
         }
 
-        epDns = hostStat.ipOrDns(printPort);
-        if (sortBy != null)
+        if (isTokenPerNode)
+            return List.of(addressAndPort, statusAndState, epDns, load, strOwns, hostID, hostStat.token, rack);
+        else
+            return List.of(addressAndPort, statusAndState, epDns, load, String.valueOf(size), strOwns, hostID, rack);
+    }
+
+    private Boolean desc()
+    {
+        if(sortOrder==sortOrder.desc)
         {
-            if (isTokenPerNode)
-            {
-                data.put(epDns,new ArrayList<>(Arrays.asList(statusAndState, load, strOwns, hostID, hostStat.token, rack)));
-            }
-            else
-            {
-                data.put(epDns,new ArrayList<>(Arrays.asList(statusAndState, load, String.valueOf(size), strOwns, hostID, rack)));
-            }
+            return true;
+        }
+        else if(sortOrder==sortOrder.asc)
+        {
+            return false;
         }
         else
         {
-            if (isTokenPerNode)
-            {
-                tableBuilder.add(statusAndState, epDns, load, strOwns, hostID, hostStat.token, rack);
-            }
-            else
-            {
-                tableBuilder.add(statusAndState, epDns, load, String.valueOf(size), strOwns, hostID, rack);
-            }
+            return null;
         }
     }
 
-
-    // Method to sort data based on specified criteria and print it in the sorted order
-    private void sortData(TableBuilder tableBuilder, NodeProbe probe) {
-        PrintStream out = probe.output().out;
-
-        // Convert the map entries to a list for sorting
-        List<Map.Entry<String, List<Object>>> entryList = new ArrayList<>(data.entrySet());
-
-        // Sort data based on the specified sorting criteria
-        switch (sortBy) {
-            case "ip":
-                sortByIp(entryList, false); // Sort by IP address
-                break;
-            case "load":
-                sortByNumericIndex(entryList, 1, true); // Sort by load, treated as numeric
-                break;
-            case "id":
-                // Sort by ID, with logic varying based on whether tokens per node is used
-                sortByIndex(entryList, isTokenPerNode ? 3 : 4, false);
-                break;
-            case "rack":
-                sortByIndex(entryList, 5, false); // Sort by rack information
-                break;
-            case "owns":
-                // Sort by ownership percentage, with different indices based on token settings
-                sortByIndex(entryList, isTokenPerNode ? 2 : 3, true);
-                break;
-            case "status":
-                sortByIndex(entryList, 0, true); // Sort by status
-                break;
+    private Map<String, List<Object>> sort(Map<String, List<Object>> map)
+    {
+        switch (sortBy)
+        {
+            case none:
+                return map;
+            case ip:
+                return sortInternal(map, SortBy.ip, 0, desc() != null ? desc() : false); // default order is ascending
+            case load:
+                return sortInternal(map, SortBy.load, 3, desc() != null ? desc() : true); // default order is descending
+            case id:
+                return sortInternal(map, SortBy.id, isTokenPerNode ? 5 : 6, desc() != null ? desc() : false); // default order is ascending
+            case rack:
+                return sortInternal(map, SortBy.rack, 7, desc() != null ? desc() : false); // default order is ascending
+            case owns:
+                return sortInternal(map, SortBy.owns, isTokenPerNode ? 4 : 5, desc() != null ? desc() : true); // default order is descending
+            case status:
+                return  sortInternal(map, SortBy.status, 1, desc() != null ? desc() : true); // default order is descending
             default:
-                // Handle invalid sorting criteria with an error message and exit
-                out.printf("%nError: Given Wrong Value for -s or --sort(ip,load,id,rack,owns,status)%n");
-                System.exit(1);
-        }
-
-        // Print the sorted data
-        sortPrinter(entryList, tableBuilder);
-    }
-
-    // Method to sort entries by IP address, optionally descending
-    private void sortByIp(List<Map.Entry<String, List<Object>>> entryList, boolean descending) {
-        entryList.sort((entry1, entry2) -> {
-            String key1 = entry1.getKey();
-            String key2 = entry2.getKey();
-
-            // Check if the keys are valid IP addresses
-            boolean isIp1 = key1.matches("\\d+\\.\\d+\\.\\d+\\.\\d+(:\\d+)?");
-            boolean isIp2 = key2.matches("\\d+\\.\\d+\\.\\d+\\.\\d+(:\\d+)?");
-
-            // Resolve non-IP addresses to sort lexicographically if needed
-            if (resolveIp) {
-                if (!isIp1 && isIp2) return -1;
-                if (isIp1 && !isIp2) return 1;
-                if (!isIp1 && !isIp2) return key1.compareTo(key2);
-            }
-
-            // Split IPs and compare individual parts numerically
-            String[] ipPort1 = key1.split(":");
-            String[] ipPort2 = key2.split(":");
-            String[] parts1 = ipPort1[0].split("\\.");
-            String[] parts2 = ipPort2[0].split("\\.");
-            for (int i = 0; i < 4; i++) {
-                int num1 = Integer.parseInt(parts1[i]);
-                int num2 = Integer.parseInt(parts2[i]);
-                if (num1 != num2) return Integer.compare(num1, num2);
-            }
-
-            // Compare port numbers if present
-            if (ipPort1.length > 1 && ipPort2.length > 1) {
-                int port1 = Integer.parseInt(ipPort1[1]);
-                int port2 = Integer.parseInt(ipPort2[1]);
-                return Integer.compare(port1, port2);
-            }
-
-            // Handle cases where only one key has a port
-            if (ipPort1.length > 1) return 1;
-            if (ipPort2.length > 1) return -1;
-
-            return 0;
-        });
-
-        // Apply the specified sort order
-        applySortOrder(entryList, descending);
-    }
-
-    // Generic method to sort entries by a specific index, treating values as strings or percentages
-    private void sortByIndex(List<Map.Entry<String, List<Object>>> entryList, int index, boolean descending) {
-        entryList.sort((entry1, entry2) -> {
-            String str1 = (String) entry1.getValue().get(index);
-            String str2 = (String) entry2.getValue().get(index);
-
-            // Handle sorting for percentage values
-            if (str1.endsWith("%") && str2.endsWith("%")) {
-                double value1 = Double.parseDouble(str1.replace("%", ""));
-                double value2 = Double.parseDouble(str2.replace("%", ""));
-                return Double.compare(value1, value2);
-            }
-
-            // Lexicographical comparison as fallback
-            return str1.compareTo(str2);
-        });
-
-        // Apply the specified sort order
-        applySortOrder(entryList, descending);
-    }
-
-    // Method to sort entries by numeric index values
-    private void sortByNumericIndex(List<Map.Entry<String, List<Object>>> entryList, int index, boolean descending) {
-        entryList.sort((entry1, entry2) -> {
-            double value1 = parseSize((String) entry1.getValue().get(index));
-            double value2 = parseSize((String) entry2.getValue().get(index));
-            return Double.compare(value1, value2);
-        });
-
-        // Apply the specified sort order
-        applySortOrder(entryList, descending);
-    }
-
-    // Reverse the list if descending order is specified
-    private void applySortOrder(List<Map.Entry<String, List<Object>>> entryList, boolean descending) {
-        if (getSortOrder() == 1) return; // Ascending, no change needed
-        if (getSortOrder() == -1 || descending) Collections.reverse(entryList);
-    }
-
-    // Print the sorted entries using the provided table builder
-    private void sortPrinter(List<Map.Entry<String, List<Object>>> entryList, TableBuilder tableBuilder) {
-        for (Map.Entry<String, List<Object>> entry : entryList) {
-            String epDns = entry.getKey();
-            List<Object> values = entry.getValue();
-            String statusAndState = (String) values.get(0);
-            String load = (String) values.get(1);
-            String rack = (String) values.get(5);
-
-            // Different logic for token per node configurations
-            String strOwns, hostID, tokens;
-            if (isTokenPerNode) {
-                strOwns = (String) values.get(2);
-                hostID = (String) values.get(3);
-                tokens = (String) values.get(4);
-            } else {
-                tokens = (String) values.get(2);
-                strOwns = (String) values.get(3);
-                hostID = (String) values.get(4);
-            }
-
-            // Add the row to the table
-            if (isTokenPerNode) {
-                tableBuilder.add(statusAndState, epDns, load, strOwns, hostID, tokens, rack);
-            } else {
-                tableBuilder.add(statusAndState, epDns, load, tokens, strOwns, hostID, rack);
-            }
+                throw new IllegalArgumentException("Sorting by " + sortBy + " is not supported.");
         }
     }
 
-    // Determine the sort order based on the user-specified value
-    private int getSortOrder() {
-        if (sortOrder == null) return 0; // Default: no specific order
-        switch (sortOrder) {
-            case "a":
-            case "ascending":
-                return 1; // Ascending order
-            case "d":
-            case "descending":
-                return -1; // Descending order
-            default:
-                return 3; // Invalid order, treated as no sorting
-        }
-    }
+    private LinkedHashMap<String, List<Object>> sortInternal(Map<String, List<Object>> data, SortBy sortBy, int index, boolean descending)
+    {
+        return data.entrySet()
+                .stream()
+                .sorted((e1, e2) -> {
+                    if (sortBy == SortBy.ip)
+                    {
+                        InetAddressAndPort addr1 = (InetAddressAndPort) e1.getValue().get(index);
+                        InetAddressAndPort addr2 = (InetAddressAndPort) e2.getValue().get(index);
+                        // if ip's are resolved, strings will be DNS names
+                        if (resolveIp)
+                        {
+                            String str1 = addr1.getHostAddressAndPort();
+                            String str2 = addr2.getHostAddressAndPort();
 
-    // Parse a size string into its numeric value in bytes
-    private double parseSize(String sizeStr) {
-        if (sizeStr == null || sizeStr.isEmpty()) return 0;
+                            if (descending)
+                                return str2.compareTo(str1);
+                            else
+                                return str1.compareTo(str2);
+                        }
+                        else
+                        {
+                            if (descending)
+                                return addr2.compareTo(addr1);
+                            else
+                                return addr1.compareTo(addr2);
+                        }
+                    }
 
-        String[] parts = sizeStr.split(" ");
-        if (parts.length != 2) return 0;
+                    String str1 = (String) e1.getValue().get(index);
+                    String str2 = (String) e2.getValue().get(index);
 
-        try {
-            double value = Double.parseDouble(parts[0]);
-            switch (parts[1]) {
-                case "KiB":
-                    return value * 1024;
-                case "MiB":
-                    return value * 1024 * 1024;
-                case "GiB":
-                    return value * 1024 * 1024 * 1024;
-                case "TiB":
-                    return value * 1024L * 1024 * 1024 * 1024;
-                case "PiB":
-                    return value * 1024L * 1024 * 1024 * 1024 * 1024;
-                default:
-                    return value;
-            }
-        } catch (NumberFormatException e) {
-            return 0; // Return zero for invalid numbers
-        }
+                    if (sortBy == SortBy.owns)
+                    {
+                        double value1 = Double.parseDouble(str1.replace("%", ""));
+                        double value2 = Double.parseDouble(str2.replace("%", ""));
+
+                        if (descending)
+                            return Double.compare(value2, value1);
+                        else
+                            return Double.compare(value1, value2);
+                    }
+                    else if (sortBy == SortBy.load)
+                    {
+                        long value1 = FileUtils.parseFileSize(str1);
+                        long value2 = FileUtils.parseFileSize(str2);
+
+                        if (descending)
+                            return Long.compare(value2, value1);
+                        else
+                            return Long.compare(value1, value2);
+                    }
+                    // Lexicographical comparison as fallback
+                    else if (descending)
+                    {
+                        return str2.compareTo(str1);
+                    }
+                    else
+                    {
+                        return str1.compareTo(str2);
+                    }
+                }).collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -1,4 +1,3 @@
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -48,7 +47,8 @@ import static java.util.stream.Collectors.toMap;
 
 @SuppressWarnings("UseOfSystemOutOrSystemErr")
 @Command(name = "status", description = "Print cluster information (state, load, IDs, ...)")
-public class Status extends NodeToolCmd {
+public class Status extends NodeToolCmd
+{
     @Arguments(usage = "[<keyspace>]", description = "The keyspace name")
     private String keyspace = null;
 
@@ -72,12 +72,14 @@ public class Status extends NodeToolCmd {
     private Map<String, String> loadMap, hostIDMap;
     private EndpointSnitchInfoMBean epSnitchInfo;
 
-    public enum SortOrder {
+    public enum SortOrder
+    {
         asc,
         desc
     }
 
-    public enum SortBy {
+    public enum SortBy
+    {
         none,
         ip,
         load,
@@ -87,15 +89,18 @@ public class Status extends NodeToolCmd {
         state
     }
 
-    private void validateArguments(PrintStream out) {
-        if (sortOrder != null && sortBy == SortBy.none) {
+    private void validateArguments(PrintStream out)
+    {
+        if (sortOrder != null && sortBy == SortBy.none)
+        {
             out.printf("%nError: %s%n", "Sort order (-o / --order) can only be used while sorting using -s or --sort.");
             System.exit(1);
         }
     }
 
     @Override
-    public void execute(NodeProbe probe) {
+    public void execute(NodeProbe probe)
+    {
         validateArguments(probe.output().out);
 
         PrintStream out = probe.output().out;
@@ -114,18 +119,26 @@ public class Status extends NodeToolCmd {
 
         Map<String, Float> ownerships = null;
         boolean hasEffectiveOwns = false;
-        try {
+        try
+        {
             ownerships = probe.effectiveOwnershipWithPort(keyspace);
             hasEffectiveOwns = true;
-        } catch (IllegalStateException e) {
-            try {
+        }
+        catch (IllegalStateException e)
+        {
+            try
+            {
                 ownerships = probe.getOwnershipWithPort();
                 errors.append("Note: ").append(e.getMessage()).append("%n");
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 out.printf("%nError: %s%n", ex.getMessage());
                 System.exit(1);
             }
-        } catch (IllegalArgumentException ex) {
+        }
+        catch (IllegalArgumentException ex)
+        {
             out.printf("%nError: %s%n", ex.getMessage());
             System.exit(1);
         }
@@ -137,7 +150,8 @@ public class Status extends NodeToolCmd {
             isTokenPerNode = false;
 
         // Datacenters
-        for (Map.Entry<String, SetHostStatWithPort> dc : dcs.entrySet()) {
+        for (Map.Entry<String, SetHostStatWithPort> dc : dcs.entrySet())
+        {
             TableBuilder tableBuilder = sharedTable.next();
             addNodesHeader(hasEffectiveOwns, tableBuilder);
 
@@ -146,7 +160,8 @@ public class Status extends NodeToolCmd {
                 hostToTokens.put(stat.endpointWithPort, stat);
 
             Map<String, List<Object>> data = new HashMap<>();
-            for (InetAddressAndPort endpoint : hostToTokens.keySet()) {
+            for (InetAddressAndPort endpoint : hostToTokens.keySet())
+            {
                 Float owns = ownerships.get(endpoint.getHostAddressAndPort());
                 List<HostStatWithPort> tokens = hostToTokens.get(endpoint);
 
@@ -158,7 +173,8 @@ public class Status extends NodeToolCmd {
 
             data = sort(data);
 
-            for (Map.Entry<String, List<Object>> entry : data.entrySet()) {
+            for (Map.Entry<String, List<Object>> entry : data.entrySet())
+            {
                 List<Object> values = entry.getValue();
                 List<String> row = new ArrayList<>();
                 for (int i = 1; i < values.size(); i++)
@@ -170,10 +186,10 @@ public class Status extends NodeToolCmd {
 
         Iterator<TableBuilder> results = sharedTable.complete().iterator();
         boolean first = true;
-        for (Map.Entry<String, SetHostStatWithPort> dc : dcs.entrySet()) {
-            if (!first) {
+        for (Map.Entry<String, SetHostStatWithPort> dc : dcs.entrySet())
+        {
+            if (!first)
                 out.println();
-            }
             first = false;
             String dcHeader = String.format("Datacenter: %s%n", dc.getKey());
             out.print(dcHeader);
@@ -190,7 +206,8 @@ public class Status extends NodeToolCmd {
         out.printf("%n" + errors);
     }
 
-    private void addNodesHeader(boolean hasEffectiveOwns, TableBuilder tableBuilder) {
+    private void addNodesHeader(boolean hasEffectiveOwns, TableBuilder tableBuilder)
+    {
         String owns = hasEffectiveOwns ? "Owns (effective)" : "Owns";
 
         if (isTokenPerNode)
@@ -199,25 +216,36 @@ public class Status extends NodeToolCmd {
             tableBuilder.add("--", "Address", "Load", "Tokens", owns, "Host ID", "Rack");
     }
 
-    private List<Object> addNode(String epDns, InetAddressAndPort addressAndPort, Float owns, HostStatWithPort hostStat, int size, boolean hasEffectiveOwns) {
+    private List<Object> addNode(String epDns, InetAddressAndPort addressAndPort, Float owns, HostStatWithPort hostStat, int size, boolean hasEffectiveOwns)
+    {
         String endpoint = addressAndPort.getHostAddressAndPort();
         String status, state, load, strOwns, hostID, rack;
-        if (liveNodes.contains(endpoint)) status = "U";
-        else if (unreachableNodes.contains(endpoint)) status = "D";
-        else status = "?";
-        if (joiningNodes.contains(endpoint)) state = "J";
-        else if (leavingNodes.contains(endpoint)) state = "L";
-        else if (movingNodes.contains(endpoint)) state = "M";
-        else state = "N";
+        if (liveNodes.contains(endpoint))
+            status = "U";
+        else if (unreachableNodes.contains(endpoint))
+            status = "D";
+        else
+            status = "?";
+        if (joiningNodes.contains(endpoint))
+            state = "J";
+        else if (leavingNodes.contains(endpoint))
+            state = "L";
+        else if (movingNodes.contains(endpoint))
+            state = "M";
+        else
+            state = "N";
 
         String statusAndState = status.concat(state);
         load = loadMap.getOrDefault(endpoint, "?");
         strOwns = owns != null && hasEffectiveOwns ? new DecimalFormat("##0.0%").format(owns) : "?";
         hostID = hostIDMap.get(endpoint);
 
-        try {
+        try
+        {
             rack = epSnitchInfo.getRack(endpoint);
-        } catch (UnknownHostException e) {
+        }
+        catch (UnknownHostException e)
+        {
             throw new RuntimeException(e);
         }
 
@@ -228,46 +256,55 @@ public class Status extends NodeToolCmd {
     }
 
     // To check for descending order
-    private Boolean desc() {
+    private Boolean desc()
+    {
         return sortOrder == null ? null : sortOrder == SortOrder.desc;
     }
 
     // Sort function to sort the data
-    private Map<String, List<Object>> sort(Map<String, List<Object>> map) {
-        switch (sortBy) {
+    private Map<String, List<Object>> sort(Map<String, List<Object>> map)
+    {
+        switch (sortBy)
+        {
             case none:
                 return map;
             case ip:
-                return sortByIp(map, 0, desc() != null ? desc() : false);
+                return sortByIp(map);
             case load:
-                return sortByLoad(map, 3, desc() != null ? desc() : true);
+                return sortByLoad(map);
             case id:
-                return sortById(map, isTokenPerNode ? 5 : 6, desc() != null ? desc() : false);
+                return sortById(map);
             case rack:
-                return sortByRack(map, 7, desc() != null ? desc() : false);
+                return sortByRack(map);
             case owns:
-                return sortByOwns(map, isTokenPerNode ? 4 : 5, desc() != null ? desc() : true);
+                return sortByOwns(map);
             case state:
-                return sortByState(map, 1, desc() != null ? desc() : true);
+                return sortByState(map);
             default:
                 throw new IllegalArgumentException("Sorting by " + sortBy + " is not supported.");
         }
     }
 
     // Helper Function to Sort by Ip
-    private LinkedHashMap<String, List<Object>> sortByIp(Map<String, List<Object>> data, int index, boolean descending) {
+    private LinkedHashMap<String, List<Object>> sortByIp(Map<String, List<Object>> data)
+    {
+        int index = 0;
+        boolean desc = desc() != null ? desc() : false; // default is ascending
         return data.entrySet()
                 .stream()
                 .sorted((e1, e2) -> {
                     InetAddressAndPort addr1 = (InetAddressAndPort) e1.getValue().get(index);
                     InetAddressAndPort addr2 = (InetAddressAndPort) e2.getValue().get(index);
-                    return descending ? addr2.compareTo(addr1) : addr1.compareTo(addr2);
+                    return desc ? addr2.compareTo(addr1) : addr1.compareTo(addr2);
                 })
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 
     // Helper Function to Sort by Load
-    private LinkedHashMap<String, List<Object>> sortByLoad(Map<String, List<Object>> data, int index, boolean descending) {
+    private LinkedHashMap<String, List<Object>> sortByLoad(Map<String, List<Object>> data)
+    {
+        int index = 3;
+        boolean desc = desc() != null ? desc() : true; // defalut is descending
         return data.entrySet()
                 .stream()
                 .sorted((e1, e2) -> {
@@ -276,71 +313,80 @@ public class Status extends NodeToolCmd {
                     // Check if str1 or str2 contains a '?' and set a value for it.
                     boolean containsQuestionMark1 = str1.contains("?");
                     boolean containsQuestionMark2 = str2.contains("?");
-                    if (containsQuestionMark1 && containsQuestionMark2) {
-                        // If both contain '?', return 0 (they are considered equal).
+
+                    if (containsQuestionMark1 && containsQuestionMark2) // If both contain '?', return 0 (they are considered equal).
                         return 0;
-                    }
 
-                    if (containsQuestionMark1) {
-                        // If str1 contains '?', ensure it's last (or first depending on descending).
-                        return descending ? 1 : -1;
-                    }
+                    if (containsQuestionMark1) // If str1 contains '?', ensure it's last (or first depending on descending).
+                        return desc ? 1 : -1;
 
-                    if (containsQuestionMark2) {
-                        // If str2 contains '?', ensure it's last (or first depending on descending).
-                        return descending ? -1 : 1;
-                    }
+                    if (containsQuestionMark2) // If str2 contains '?', ensure it's last (or first depending on descending).
+                        return desc ? -1 : 1;
+
                     // If neither contain '?', parse the file sizes and compare.
                     long value1 = FileUtils.parseFileSize((String) e1.getValue().get(index));
                     long value2 = FileUtils.parseFileSize((String) e2.getValue().get(index));
-                    return descending ? Long.compare(value2, value1) : Long.compare(value1, value2);
+                    return desc ? Long.compare(value2, value1) : Long.compare(value1, value2);
                 })
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 
     // Helper Function to Sort by Host ID
-    private LinkedHashMap<String, List<Object>> sortById(Map<String, List<Object>> data, int index, boolean descending) {
+    private LinkedHashMap<String, List<Object>> sortById(Map<String, List<Object>> data)
+    {
+        int index = isTokenPerNode ? 5 : 6;
+        boolean desc = desc() != null ? desc() : false; // default is ascending
         return data.entrySet()
                 .stream()
                 .sorted((e1, e2) -> {
                     String str1 = (String) e1.getValue().get(index);
                     String str2 = (String) e2.getValue().get(index);
-                    return descending ? str2.compareTo(str1) : str1.compareTo(str2);
+                    return desc ? str2.compareTo(str1) : str1.compareTo(str2);
                 })
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 
     // Helper Function to Sort by Rack
-    private LinkedHashMap<String, List<Object>> sortByRack(Map<String, List<Object>> data, int index, boolean descending) {
+    private LinkedHashMap<String, List<Object>> sortByRack(Map<String, List<Object>> data)
+    {
+        int index = 7;
+        boolean desc = desc() != null ? desc() : false; // default is ascending
         return data.entrySet()
                 .stream()
                 .sorted((e1, e2) -> {
                     String str1 = (String) e1.getValue().get(index);
                     String str2 = (String) e2.getValue().get(index);
-                    return descending ? str2.compareTo(str1) : str1.compareTo(str2);
+                    return desc ? str2.compareTo(str1) : str1.compareTo(str2);
                 })
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
+
     // Helper Function to Sort by Owns
-    private LinkedHashMap<String, List<Object>> sortByOwns(Map<String, List<Object>> data, int index, boolean descending) {
+    private LinkedHashMap<String, List<Object>> sortByOwns(Map<String, List<Object>> data)
+    {
+        int index = isTokenPerNode ? 4 : 5;
+        boolean desc = desc() != null ? desc() : true; // default is descending
         return data.entrySet()
                 .stream()
                 .sorted((e1, e2) -> {
                     double value1 = Double.parseDouble(((String) e1.getValue().get(index)).replace("%", ""));
                     double value2 = Double.parseDouble(((String) e2.getValue().get(index)).replace("%", ""));
-                    return descending ? Double.compare(value2, value1) : Double.compare(value1, value2);
+                    return desc ? Double.compare(value2, value1) : Double.compare(value1, value2);
                 })
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
 
     // Helper Function to Sort by State
-    private LinkedHashMap<String, List<Object>> sortByState(Map<String, List<Object>> data, int index, boolean descending) {
+    private LinkedHashMap<String, List<Object>> sortByState(Map<String, List<Object>> data)
+    {
+        int index = 1;
+        boolean desc = desc() != null ? desc() : true; // default is descending
         return data.entrySet()
                 .stream()
                 .sorted((e1, e2) -> {
                     String str1 = (String) e1.getValue().get(index);
                     String str2 = (String) e2.getValue().get(index);
-                    return descending ? str2.compareTo(str1) : str1.compareTo(str2);
+                    return desc ? str2.compareTo(str1) : str1.compareTo(str2);
                 })
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/NodeToolStatusTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NodeToolStatusTest.java
@@ -1,0 +1,411 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.io.IOException;
+
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+import org.apache.cassandra.distributed.api.NodeToolResult;
+
+
+import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.locator.InetAddressAndPort;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.net.UnknownHostException;
+import java.util.stream.Collectors;
+
+
+public class NodeToolStatusTest extends TestBaseImpl {
+    private static Cluster CLUSTER;
+    private static IInvokableInstance NODE_1;
+    private static IInvokableInstance NODE_2;
+    private static IInvokableInstance NODE_3;
+
+    @BeforeClass
+    public static void before() throws IOException {
+        CLUSTER = init(Cluster.build().withNodes(3).start());
+        NODE_1 = CLUSTER.get(1);
+        NODE_2 = CLUSTER.get(2);
+        NODE_3 = CLUSTER.get(3);
+    }
+
+    @AfterClass
+    public static void after() {
+        if (CLUSTER != null)
+            CLUSTER.close();
+    }
+
+    // Test Commands to validate the commands are working as expected.
+    @Test
+    public void testCommands() {
+        assertEquals(0, NODE_1.nodetool("status"));
+        assertEquals(0, NODE_1.nodetool("status", "-s", "ip"));
+        assertEquals(0, NODE_1.nodetool("status", "-s", "ip", "-o", "asc"));
+        assertEquals(0, NODE_1.nodetool("status", "-s", "ip", "-o", "desc"));
+        assertEquals(0, NODE_1.nodetool("status", "--sort", "ip", "--order", "desc"));
+        assertEquals(1, NODE_1.nodetool("status", "--sort", "not_an_option"));
+        assertEquals(1, NODE_1.nodetool("status", "--sort", "ip", "-o", "not_an_order"));
+    }
+
+    // Test Cases for Ip
+    @Test
+    public void testSortByIpDefault() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "ip");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract IP addresses and ensure they are sorted in ascending order (default order)
+        List<String> ipAddresses = extractColumn(output, 1);
+        List<InetAddressAndPort> ipList = ipAddresses.stream()
+                .map(this::parseInetAddress)
+                .collect(Collectors.toList());
+        List<InetAddressAndPort> sortedIpList = new ArrayList<>(ipList);
+        Collections.sort(sortedIpList);
+        assertEquals("IP addresses are not sorted in ascending order", sortedIpList, ipList);
+    }
+
+    @Test
+    public void testSortByIpAsc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "ip", "-o", "asc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract IP addresses and ensure they are sorted in ascending order
+        List<String> ipAddresses = extractColumn(output, 1);
+        List<InetAddressAndPort> ipList = ipAddresses.stream()
+                .map(this::parseInetAddress)
+                .collect(Collectors.toList());
+        List<InetAddressAndPort> sortedIpList = new ArrayList<>(ipList);
+        Collections.sort(sortedIpList);
+        assertEquals("IP addresses are not sorted in ascending order", sortedIpList, ipList);
+    }
+
+    @Test
+    public void testSortByIpDesc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "ip", "-o", "desc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract IP addresses and ensure they are sorted in descending order
+        List<String> ipAddresses = extractColumn(output, 1);
+        List<InetAddressAndPort> ipList = ipAddresses.stream()
+                .map(this::parseInetAddress)
+                .collect(Collectors.toList());
+        List<InetAddressAndPort> sortedIpList = new ArrayList<>(ipList);
+        Collections.sort(sortedIpList, Collections.reverseOrder());
+        assertEquals("IP addresses are not sorted in descending order", sortedIpList, ipList);
+    }
+
+    // Test Cases for Load
+    @Test
+    public void testSortByLoadDefault() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "load");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract the load values and handle '?' placement
+        List<String> loads = extractColumn(output, 2);
+        List<Long> loadList = loads.stream()
+                .map(load -> {
+                    // If load contains '?', assign it a value that will be placed last
+                    if (load.contains("?")) {
+                        return Long.MIN_VALUE;
+                    }
+                    return FileUtils.parseFileSize(load);
+                })
+                .collect(Collectors.toList());
+
+        // Sort the load list in descending order (default order)
+        List<Long> sortedLoadList = new ArrayList<>(loadList);
+        Collections.sort(sortedLoadList, Collections.reverseOrder());
+
+        // Assert that the load values are sorted in descending order, considering '?' as last
+        assertEquals("Load values are not sorted in descending order", sortedLoadList, loadList);
+    }
+
+    @Test
+    public void testSortByLoadAsc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "load", "-o", "asc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract the load values and handle '?' placement
+        List<String> loads = extractColumn(output, 2);
+        List<Long> loadList = loads.stream()
+                .map(load -> {
+                    // If load contains '?', assign it a value that will be placed first
+                    if (load.contains("?")) {
+                        return Long.MIN_VALUE;
+                    }
+                    return FileUtils.parseFileSize(load);
+                })
+                .collect(Collectors.toList());
+
+        // Sort the load list in ascending order
+        List<Long> sortedLoadList = new ArrayList<>(loadList);
+        Collections.sort(sortedLoadList);
+
+        // Assert that the load values are sorted in ascending order, considering '?' as first
+        assertEquals("Load values are not sorted in ascending order", sortedLoadList, loadList);
+    }
+
+    @Test
+    public void testSortByLoadDesc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "load", "-o", "desc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract the load values and handle '?' placement
+        List<String> loads = extractColumn(output, 2);
+        List<Long> loadList = loads.stream()
+                .map(load -> {
+                    // If load contains '?', assign it a value that will be placed last
+                    if (load.contains("?")) {
+                        return Long.MIN_VALUE;
+                    }
+                    return FileUtils.parseFileSize(load);
+                })
+                .collect(Collectors.toList());
+
+        // Sort the load list in descending order
+        List<Long> sortedLoadList = new ArrayList<>(loadList);
+        Collections.sort(sortedLoadList, Collections.reverseOrder());
+
+        // Assert that the load values are sorted in descending order, considering '?' as last
+        assertEquals("Load values are not sorted in descending order", sortedLoadList, loadList);
+    }
+
+    // Test cases for owns
+    @Test
+    public void testSortByOwnsDefault() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "owns");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract the ownership percentage and ensure they are sorted in descending order (default order)
+        List<String> owns = extractColumn(output, 3);
+        List<Double> ownsList = owns.stream()
+                .map(s -> Double.parseDouble(s.replace("%", "")))
+                .collect(Collectors.toList());
+        List<Double> sortedOwnsList = new ArrayList<>(ownsList);
+        Collections.sort(sortedOwnsList, Collections.reverseOrder());
+        assertEquals("Ownership percentages are not sorted in descending order", sortedOwnsList, ownsList);
+    }
+
+    @Test
+    public void testSortByOwnsAsc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "owns", "-o", "asc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract the ownership percentage and ensure they are sorted in ascending order
+        List<String> owns = extractColumn(output, 3);
+        List<Double> ownsList = owns.stream()
+                .map(s -> Double.parseDouble(s.replace("%", "")))
+                .collect(Collectors.toList());
+        List<Double> sortedOwnsList = new ArrayList<>(ownsList);
+        Collections.sort(sortedOwnsList);
+        assertEquals("Ownership percentages are not sorted in ascending order", sortedOwnsList, ownsList);
+    }
+
+    @Test
+    public void testSortByOwnsDesc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "owns", "-o", "desc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract the ownership percentage and ensure they are sorted in descending order
+        List<String> owns = extractColumn(output, 3);
+        List<Double> ownsList = owns.stream()
+                .map(s -> Double.parseDouble(s.replace("%", "")))
+                .collect(Collectors.toList());
+        List<Double> sortedOwnsList = new ArrayList<>(ownsList);
+        Collections.sort(sortedOwnsList, Collections.reverseOrder());
+        assertEquals("Ownership percentages are not sorted in descending order", sortedOwnsList, ownsList);
+    }
+
+    // Test cases for State
+    @Test
+    public void testSortByStateDefault() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "state");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract state values and ensure they are sorted in descending order (default order)
+        List<String> states = extractColumn(output, 0);
+        List<String> sortedStates = new ArrayList<>(states);
+        Collections.sort(sortedStates, Collections.reverseOrder());
+        assertEquals("States are not sorted in descending order", sortedStates, states);
+    }
+
+    @Test
+    public void testSortByStateAsc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "state", "-o", "asc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract state values and ensure they are sorted in ascending order
+        List<String> states = extractColumn(output, 0);
+        List<String> sortedStates = new ArrayList<>(states);
+        Collections.sort(sortedStates);
+        assertEquals("States are not sorted in ascending order", sortedStates, states);
+    }
+
+    @Test
+    public void testSortByStateDesc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "state", "-o", "desc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract state values and ensure they are sorted in descending order
+        List<String> states = extractColumn(output, 0);
+        List<String> sortedStates = new ArrayList<>(states);
+        Collections.sort(sortedStates, Collections.reverseOrder());
+        assertEquals("States are not sorted in descending order", sortedStates, states);
+    }
+
+    // Test cases for Host
+    @Test
+    public void testSortByHostDefault() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "id");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract rack values and ensure they are sorted in ascending order (default order)
+        List<String> racks = extractColumn(output, 5);
+        List<String> sortedRacks = new ArrayList<>(racks);
+        Collections.sort(sortedRacks);
+        assertEquals("Rack values are not sorted in ascending order", sortedRacks, racks);
+    }
+
+    @Test
+    public void testSortByHostAsc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "id", "-o", "asc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract rack values and ensure they are sorted in ascending order
+        List<String> racks = extractColumn(output, 5);
+        List<String> sortedRacks = new ArrayList<>(racks);
+        Collections.sort(sortedRacks);
+        assertEquals("Rack values are not sorted in ascending order", sortedRacks, racks);
+    }
+
+    @Test
+    public void testSortByHostDesc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "id", "-o", "desc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract rack values and ensure they are sorted in descending order
+        List<String> racks = extractColumn(output, 5);
+        List<String> sortedRacks = new ArrayList<>(racks);
+        Collections.sort(sortedRacks, Collections.reverseOrder());
+        assertEquals("Rack values are not sorted in descending order", sortedRacks, racks);
+    }
+
+    // Test cases for Rack
+    @Test
+    public void testSortByRackDefault() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "rack");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract rack values and ensure they are sorted in ascending order (default order)
+        List<String> racks = extractColumn(output, 6);
+        List<String> sortedRacks = new ArrayList<>(racks);
+        Collections.sort(sortedRacks);
+        assertEquals("Rack values are not sorted in ascending order", sortedRacks, racks);
+    }
+
+    @Test
+    public void testSortByRackAsc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "rack", "-o", "asc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract rack values and ensure they are sorted in ascending order
+        List<String> racks = extractColumn(output, 6);
+        List<String> sortedRacks = new ArrayList<>(racks);
+        Collections.sort(sortedRacks);
+        assertEquals("Rack values are not sorted in ascending order", sortedRacks, racks);
+    }
+
+    @Test
+    public void testSortByRackDesc() {
+        NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "rack", "-o", "desc");
+        result.asserts().success();
+        String output = result.getStdout();
+
+        // Extract rack values and ensure they are sorted in descending order
+        List<String> racks = extractColumn(output, 6);
+        List<String> sortedRacks = new ArrayList<>(racks);
+        Collections.sort(sortedRacks, Collections.reverseOrder());
+        assertEquals("Rack values are not sorted in descending order", sortedRacks, racks);
+    }
+
+    // Helper Methods
+    private InetAddressAndPort parseInetAddress(String ip) {
+        try {
+            return InetAddressAndPort.getByName(ip);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP address", e);
+        }
+    }
+
+    private List<String> extractColumn(String output, int columnIndex) {
+        List<String> columnValues = new ArrayList<>();
+        String[] lines = output.split("\n");
+
+        // Skip the first five lines as headers
+        int skippedLines = 0;
+        for (String line : lines) {
+            if (line.trim().isEmpty()) {
+                continue; // Skip separator lines and empty lines
+            }
+
+            // Skip the first five lines as they are headers
+            if (skippedLines < 5) {
+                skippedLines++;
+                continue;
+            }
+
+            // Use regular expression to extract columns
+            // Pattern will match any column with possible varying whitespace
+            String[] columns = line.trim().split("\\s{2,}");  // Split on 2 or more spaces
+
+            // Check if the line has enough columns (avoid index out of bounds errors)
+            if (columns.length > columnIndex) {
+                columnValues.add(columns[columnIndex].trim());
+            }
+        }
+
+        return columnValues;
+    }

--- a/test/distributed/org/apache/cassandra/distributed/test/NodeToolStatusTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NodeToolStatusTest.java
@@ -42,14 +42,16 @@ import java.net.UnknownHostException;
 import java.util.stream.Collectors;
 
 
-public class NodeToolStatusTest extends TestBaseImpl {
+public class NodeToolStatusTest extends TestBaseImpl
+{
     private static Cluster CLUSTER;
     private static IInvokableInstance NODE_1;
     private static IInvokableInstance NODE_2;
     private static IInvokableInstance NODE_3;
 
     @BeforeClass
-    public static void before() throws IOException {
+    public static void before() throws IOException
+    {
         CLUSTER = init(Cluster.build().withNodes(3).start());
         NODE_1 = CLUSTER.get(1);
         NODE_2 = CLUSTER.get(2);
@@ -57,14 +59,16 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @AfterClass
-    public static void after() {
+    public static void after()
+    {
         if (CLUSTER != null)
             CLUSTER.close();
     }
 
     // Test Commands to validate the commands are working as expected.
     @Test
-    public void testCommands() {
+    public void testCommands()
+    {
         assertEquals(0, NODE_1.nodetool("status"));
         assertEquals(0, NODE_1.nodetool("status", "-s", "ip"));
         assertEquals(0, NODE_1.nodetool("status", "-s", "ip", "-o", "asc"));
@@ -76,7 +80,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
 
     // Test Cases for Ip
     @Test
-    public void testSortByIpDefault() {
+    public void testSortByIpDefault()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "ip");
         result.asserts().success();
         String output = result.getStdout();
@@ -92,7 +97,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByIpAsc() {
+    public void testSortByIpAsc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "ip", "-o", "asc");
         result.asserts().success();
         String output = result.getStdout();
@@ -108,7 +114,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByIpDesc() {
+    public void testSortByIpDesc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "ip", "-o", "desc");
         result.asserts().success();
         String output = result.getStdout();
@@ -125,7 +132,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
 
     // Test Cases for Load
     @Test
-    public void testSortByLoadDefault() {
+    public void testSortByLoadDefault()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "load");
         result.asserts().success();
         String output = result.getStdout();
@@ -135,9 +143,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
         List<Long> loadList = loads.stream()
                 .map(load -> {
                     // If load contains '?', assign it a value that will be placed last
-                    if (load.contains("?")) {
+                    if (load.contains("?"))
                         return Long.MIN_VALUE;
-                    }
                     return FileUtils.parseFileSize(load);
                 })
                 .collect(Collectors.toList());
@@ -151,7 +158,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByLoadAsc() {
+    public void testSortByLoadAsc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "load", "-o", "asc");
         result.asserts().success();
         String output = result.getStdout();
@@ -161,9 +169,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
         List<Long> loadList = loads.stream()
                 .map(load -> {
                     // If load contains '?', assign it a value that will be placed first
-                    if (load.contains("?")) {
+                    if (load.contains("?"))
                         return Long.MIN_VALUE;
-                    }
                     return FileUtils.parseFileSize(load);
                 })
                 .collect(Collectors.toList());
@@ -177,7 +184,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByLoadDesc() {
+    public void testSortByLoadDesc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "load", "-o", "desc");
         result.asserts().success();
         String output = result.getStdout();
@@ -187,9 +195,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
         List<Long> loadList = loads.stream()
                 .map(load -> {
                     // If load contains '?', assign it a value that will be placed last
-                    if (load.contains("?")) {
+                    if (load.contains("?"))
                         return Long.MIN_VALUE;
-                    }
                     return FileUtils.parseFileSize(load);
                 })
                 .collect(Collectors.toList());
@@ -204,7 +211,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
 
     // Test cases for owns
     @Test
-    public void testSortByOwnsDefault() {
+    public void testSortByOwnsDefault()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "owns");
         result.asserts().success();
         String output = result.getStdout();
@@ -220,7 +228,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByOwnsAsc() {
+    public void testSortByOwnsAsc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "owns", "-o", "asc");
         result.asserts().success();
         String output = result.getStdout();
@@ -236,7 +245,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByOwnsDesc() {
+    public void testSortByOwnsDesc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "owns", "-o", "desc");
         result.asserts().success();
         String output = result.getStdout();
@@ -253,7 +263,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
 
     // Test cases for State
     @Test
-    public void testSortByStateDefault() {
+    public void testSortByStateDefault()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "state");
         result.asserts().success();
         String output = result.getStdout();
@@ -266,7 +277,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByStateAsc() {
+    public void testSortByStateAsc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "state", "-o", "asc");
         result.asserts().success();
         String output = result.getStdout();
@@ -279,7 +291,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByStateDesc() {
+    public void testSortByStateDesc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "state", "-o", "desc");
         result.asserts().success();
         String output = result.getStdout();
@@ -293,7 +306,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
 
     // Test cases for Host
     @Test
-    public void testSortByHostDefault() {
+    public void testSortByHostDefault()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "id");
         result.asserts().success();
         String output = result.getStdout();
@@ -306,7 +320,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByHostAsc() {
+    public void testSortByHostAsc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "id", "-o", "asc");
         result.asserts().success();
         String output = result.getStdout();
@@ -319,7 +334,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByHostDesc() {
+    public void testSortByHostDesc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "id", "-o", "desc");
         result.asserts().success();
         String output = result.getStdout();
@@ -333,7 +349,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
 
     // Test cases for Rack
     @Test
-    public void testSortByRackDefault() {
+    public void testSortByRackDefault()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "rack");
         result.asserts().success();
         String output = result.getStdout();
@@ -346,7 +363,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByRackAsc() {
+    public void testSortByRackAsc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "rack", "-o", "asc");
         result.asserts().success();
         String output = result.getStdout();
@@ -359,7 +377,8 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     @Test
-    public void testSortByRackDesc() {
+    public void testSortByRackDesc()
+    {
         NodeToolResult result = NODE_1.nodetoolResult("status", "-s", "rack", "-o", "desc");
         result.asserts().success();
         String output = result.getStdout();
@@ -372,27 +391,33 @@ public class NodeToolStatusTest extends TestBaseImpl {
     }
 
     // Helper Methods
-    private InetAddressAndPort parseInetAddress(String ip) {
-        try {
+    private InetAddressAndPort parseInetAddress(String ip)
+    {
+        try
+        {
             return InetAddressAndPort.getByName(ip);
-        } catch (UnknownHostException e) {
+        }
+        catch (UnknownHostException e)
+        {
             throw new IllegalArgumentException("Invalid IP address", e);
         }
     }
 
-    private List<String> extractColumn(String output, int columnIndex) {
+    private List<String> extractColumn(String output, int columnIndex)
+    {
         List<String> columnValues = new ArrayList<>();
         String[] lines = output.split("\n");
 
         // Skip the first five lines as headers
         int skippedLines = 0;
-        for (String line : lines) {
-            if (line.trim().isEmpty()) {
+        for (String line : lines)
+        {
+            if (line.trim().isEmpty())
                 continue; // Skip separator lines and empty lines
-            }
 
             // Skip the first five lines as they are headers
-            if (skippedLines < 5) {
+            if (skippedLines < 5)
+            {
                 skippedLines++;
                 continue;
             }
@@ -402,10 +427,10 @@ public class NodeToolStatusTest extends TestBaseImpl {
             String[] columns = line.trim().split("\\s{2,}");  // Split on 2 or more spaces
 
             // Check if the line has enough columns (avoid index out of bounds errors)
-            if (columns.length > columnIndex) {
+            if (columns.length > columnIndex)
                 columnValues.add(columns[columnIndex].trim());
-            }
         }
 
         return columnValues;
     }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -117,4 +117,52 @@ public class StatusTest extends CQLTester
         assertThat(hostStatus).endsWith(SimpleSnitch.RACK_NAME);
         assertThat(hostStatus).doesNotContain("?");
     }
+
+    @Test
+    public void testSortByIp() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "ip");
+    }
+    @Test
+    public void testSortByLoad() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "load");
+    }
+    @Test
+    public void testSortByOwnership() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "owns");
+    }
+    @Test
+    public void testSortById() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "id");
+    }
+    @Test
+    public void testSortByRack() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "rack");
+    }
+    @Test
+    public void testSortByStatus() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "status");
+    }
+    @Test
+    public void testInvalidSortOption() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "invalid");
+    }
+    @Test
+    public void testSortOrderAscending() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "ip", "-o", "a");
+    }
+
+    @Test
+    public void testSortOrderDescending() {
+        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
+        validateStatusOutput(host.ipOrDns(false), "-s", "ip", "-o", "d");
+    }
+
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -150,7 +150,7 @@ public class StatusTest extends CQLTester
     @Test
     public void testSortByStatus() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "status", "-s", "status");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "state");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -55,14 +55,14 @@ public class StatusTest extends CQLTester
     {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false),
-                            "status");
+                "status");
         validateStatusOutput(host.ipOrDns(true),
-                            "-pp", "status");
+                "-pp", "status");
         host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), true, null);
         validateStatusOutput(host.ipOrDns(false),
-                            "status", "-r");
+                "status", "-r");
         validateStatusOutput(host.ipOrDns(true),
-                            "-pp", "status", "-r");
+                "-pp", "status", "-r");
     }
 
     /**
@@ -121,48 +121,47 @@ public class StatusTest extends CQLTester
     @Test
     public void testSortByIp() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "ip");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "ip");
     }
+
     @Test
     public void testSortByLoad() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "load");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "load");
     }
+
     @Test
     public void testSortByOwnership() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "owns");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "owns");
     }
+
     @Test
     public void testSortById() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "id");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "id");
     }
     @Test
     public void testSortByRack() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "rack");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "rack");
     }
+
     @Test
     public void testSortByStatus() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "status");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "status");
     }
-    @Test
-    public void testInvalidSortOption() {
-        HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "invalid");
-    }
+
     @Test
     public void testSortOrderAscending() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "ip", "-o", "a");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "ip", "-o", "asc");
     }
 
     @Test
     public void testSortOrderDescending() {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
-        validateStatusOutput(host.ipOrDns(false), "-s", "ip", "-o", "d");
+        validateStatusOutput(host.ipOrDns(false), "status", "-s", "ip", "-o", "desc");
     }
-
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -80,7 +80,7 @@ public class StatusTest extends CQLTester
         tool.assertOnCleanExit();
         String[] lines = PATTERN.split(tool.getStdout());
 
-        String hostStatus = lines[lines.length-3].trim();
+        String hostStatus = lines[lines.length - 3].trim();
         assertThat(hostStatus).startsWith("UN");
         assertThat(hostStatus).contains(FBUtilities.getJustLocalAddress().getHostAddress());
         assertThat(hostStatus).containsPattern("\\d+\\.?\\d+ KiB");
@@ -88,7 +88,7 @@ public class StatusTest extends CQLTester
         assertThat(hostStatus).contains(token);
         assertThat(hostStatus).endsWith(SimpleSnitch.RACK_NAME);
 
-        String bootstrappingWarn = lines[lines.length-1].trim();
+        String bootstrappingWarn = lines[lines.length - 1].trim();
         assertThat(bootstrappingWarn)
                 .contains("probably still bootstrapping. Effective ownership information is meaningless.");
     }
@@ -107,7 +107,7 @@ public class StatusTest extends CQLTester
          */
         String[] lines = PATTERN.split(tool.getStdout());
         assertThat(lines[0].trim()).endsWith(SimpleSnitch.DATA_CENTER_NAME);
-        String hostStatus = lines[lines.length-1].trim();
+        String hostStatus = lines[lines.length - 1].trim();
         assertThat(hostStatus).startsWith("UN");
         assertThat(hostStatus).contains(hostForm);
         assertThat(hostStatus).containsPattern("\\d+\\.?\\d+ KiB");
@@ -119,48 +119,57 @@ public class StatusTest extends CQLTester
     }
 
     @Test
-    public void testSortByIp() {
+    public void testSortByIp()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "ip");
     }
 
     @Test
-    public void testSortByLoad() {
+    public void testSortByLoad()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "load");
     }
 
     @Test
-    public void testSortByOwnership() {
+    public void testSortByOwnership()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "owns");
     }
 
     @Test
-    public void testSortById() {
+    public void testSortById()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "id");
     }
+
     @Test
-    public void testSortByRack() {
+    public void testSortByRack()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "rack");
     }
 
     @Test
-    public void testSortByStatus() {
+    public void testSortByStatus()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "state");
     }
 
     @Test
-    public void testSortOrderAscending() {
+    public void testSortOrderAscending()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "ip", "-o", "asc");
     }
 
     @Test
-    public void testSortOrderDescending() {
+    public void testSortOrderDescending()
+    {
         HostStatWithPort host = new HostStatWithPort(null, FBUtilities.getBroadcastAddressAndPort(), false, null);
         validateStatusOutput(host.ipOrDns(false), "status", "-s", "ip", "-o", "desc");
     }


### PR DESCRIPTION
 CASSANDRA-20104: Sort output in nodetool status
```
Sort output in nodetool status for improved readability

This patch sorts the output of the `nodetool status` command to provide a more organized and readable display, making it easier for users to interpret node status information.

Use -s or --sort option with any of the following : [ip, load, owns, id, rack, state]
It also includes an -o or --order option to specifically sort it in ascending or descending order : [asc for ascending and desc or descending]

if order is not specified it takes the default order as : asc for  'ip', 'id', 'rack' and desc for 'load', 'owns', 'state'
```
![image](https://github.com/user-attachments/assets/393aea94-d91b-458f-9354-2b9f4e6653f8)


https://issues.apache.org/jira/browse/CASSANDRA-20104


