### PR TITLE
NPE when Clean.apply called with null as first argument

### DIFF
--- a/src/java/org/apache/cassandra/utils/memory/MemtableCleanerThread.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemtableCleanerThread.java
@@ -94,7 +94,7 @@ public class MemtableCleanerThread<P extends MemtablePool> implements Interrupti
             final int tasks = numPendingTasks.decrementAndGet();
 
             // if the cleaning job was scheduled (res == true) or had an error, trigger again after decrementing the tasks
-            if ((res || err != null) && pool.needsCleaning())
+            if (((res != null && res) || err != null) && pool.needsCleaning())
                 wait.signal();
 
             if (err != null)

--- a/test/unit/org/apache/cassandra/utils/memory/MemtableCleanerThreadTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/MemtableCleanerThreadTest.java
@@ -35,6 +35,7 @@ import org.mockito.MockitoAnnotations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 public class MemtableCleanerThreadTest
@@ -109,6 +110,22 @@ public class MemtableCleanerThreadTest
         waitForPendingTasks();
 
         stopThread();
+    }
+
+    @Test
+    public void testCleanerError() throws Exception
+    {
+        when(pool.needsCleaning()).thenReturn(false);
+        AsyncPromise<Boolean > fut = new AsyncPromise<>();
+        cleaner = () -> {
+            return fut;
+        };
+
+        Clean<> clean = new Clean<>(pool, cleaner);
+
+        Boolean res = clean.apply(null, null);
+
+        assertNull(res);
     }
 
     @Test


### PR DESCRIPTION
Our Cassandra 5.0.2 cluster is struggling when consuming large amounts of embeddings (>200M) and at some point (a node dies with the following stack trace:
```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "res" is null
	at org.apache.cassandra.utils.memory.MemtableCleanerThread$Clean.apply(MemtableCleanerThread.java:97)
	at org.apache.cassandra.utils.concurrent.ListenerList$CallbackBiConsumerListener.run(ListenerList.java:244)
	at org.apache.cassandra.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:140)
	at org.apache.cassandra.utils.concurrent.ListenerList.safeExecute(ListenerList.java:166)
	at org.apache.cassandra.utils.concurrent.ListenerList.notifyListener(ListenerList.java:157)
	at org.apache.cassandra.utils.concurrent.ListenerList$CallbackBiConsumerListener.notifySelf(ListenerList.java:250)
	at org.apache.cassandra.utils.concurrent.ListenerList.lambda$notifyExclusive$0(ListenerList.java:124)
	at org.apache.cassandra.utils.concurrent.IntrusiveStack.forEach(IntrusiveStack.java:195)
	at org.apache.cassandra.utils.concurrent.ListenerList.notifyExclusive(ListenerList.java:124)
	at org.apache.cassandra.utils.concurrent.ListenerList.notify(ListenerList.java:96)
	at org.apache.cassandra.utils.concurrent.AsyncFuture.trySet(AsyncFuture.java:104)
	at org.apache.cassandra.utils.concurrent.AbstractFuture.tryFailure(AbstractFuture.java:148)
	at org.apache.cassandra.utils.concurrent.AsyncPromise.tryFailure(AsyncPromise.java:139)
	at org.apache.cassandra.db.memtable.AbstractAllocatorMemtable.lambda$flushLargestMemtable$0(AbstractAllocatorMemtable.java:306)
	at org.apache.cassandra.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:140)
	at org.apache.cassandra.utils.concurrent.ListenerList.safeExecute(ListenerList.java:166)
	at org.apache.cassandra.utils.concurrent.ListenerList.notifyListener(ListenerList.java:157)
	at org.apache.cassandra.utils.concurrent.ListenerList$RunnableWithExecutor.notifySelf(ListenerList.java:345)
	at org.apache.cassandra.utils.concurrent.ListenerList.lambda$notifyExclusive$0(ListenerList.java:124)
	at org.apache.cassandra.utils.concurrent.IntrusiveStack.forEach(IntrusiveStack.java:195)
	at org.apache.cassandra.utils.concurrent.ListenerList.notifyExclusive(ListenerList.java:124)
	at org.apache.cassandra.utils.concurrent.ListenerList.notify(ListenerList.java:96)
	at org.apache.cassandra.utils.concurrent.AsyncFuture.trySet(AsyncFuture.java:104)
	at org.apache.cassandra.utils.concurrent.AbstractFuture.tryFailure(AbstractFuture.java:148)
	at org.apache.cassandra.concurrent.FutureTask.tryFailure(FutureTask.java:87)
	at org.apache.cassandra.concurrent.FutureTask.run(FutureTask.java:75)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

Which results from the Clean.apply method being called with null for the first argument, which seems to be intentional given the code in ListenerList.java:244, and since the apply function in MemtableCleanerThread.java:97 accepts a Boolean and not a bool primitive, we should handle it being NULL, otherwise the parameter should be of a primitive type to disallow NULL.

When the res parameter is NULL, i treat it as if it is false which seems correct from the context but this needs to be reviewed.

Addresses the immediate issue in: [CASSANDRA-20141](https://issues.apache.org/jira/browse/CASSANDRA-20141)