### PR TITLE
Handle partitioned nodes in DiscoverySimulationTest

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/tcm/CMSPlacementAfterMoveTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/tcm/CMSPlacementAfterMoveTest.java
@@ -39,6 +39,7 @@ public class CMSPlacementAfterMoveTest extends TestBaseImpl
     {
         try (Cluster cluster = init(Cluster.build(4)
                                            .withConfig(c -> c.with(Feature.GOSSIP, Feature.NETWORK))
+                                           .withoutVNodes()
                                            .start()))
         {
             cluster.get(1).nodetoolResult("cms", "reconfigure", "3").asserts().success();


### PR DESCRIPTION
CASSANDRA-19505 & also includes a fix for CASSANDRA-19881, which is simply to not run the `move` test with vnodes