### PR TITLE
Update storage-engine.adoc - minor spelling fix in documentation

### DIFF
--- a/doc/modules/cassandra/pages/architecture/storage-engine.adoc
+++ b/doc/modules/cassandra/pages/architecture/storage-engine.adoc
@@ -244,7 +244,7 @@ For implementation docs see (https://github.com/apache/cassandra/blob/cassandra-
 
 === Version 5
 
-* da (5.0): initial version of the BIT format
+* da (5.0): initial version of the BTI format
 
 === Example Code
 


### PR DESCRIPTION
architecture/storage-engine.adoc
line 247 has spelling mistake "BIT" in-place of "BTI".
