### PR TITLE
[CASSANDRA-20162][5.0] Avoid memory allocation in NativeCell.valueSize() and NativeClustering.dataSize()

### DIFF
--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -93,6 +93,12 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return MemoryUtil.getShort(peer);
     }
 
+    public int dataSize()
+    {
+        int dataSizeOffset = (size() * 2) + 2; // metadataSize - 2
+        return MemoryUtil.getShort(peer + dataSizeOffset);
+    }
+
     public ByteBuffer get(int i)
     {
         // offset at which we store the dataOffset

--- a/src/java/org/apache/cassandra/db/rows/NativeCell.java
+++ b/src/java/org/apache/cassandra/db/rows/NativeCell.java
@@ -145,6 +145,11 @@ public class NativeCell extends AbstractCell<ByteBuffer>
         return ByteBufferAccessor.instance;  // FIXME: add native accessor
     }
 
+    public int valueSize()
+    {
+        return MemoryUtil.getInt(peer + LENGTH);
+    }
+
     public CellPath path()
     {
         if (!hasPath())

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.db;
 
 import java.nio.ByteBuffer;
+import java.util.Iterator;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -163,9 +164,29 @@ public class NativeCellTest extends CQLTester
         Assert.assertEquals(row.clustering(), brow.clustering());
         Assert.assertEquals(nrow.clustering(), brow.clustering());
 
+        Assert.assertEquals(row.clustering().dataSize(), nrow.clustering().dataSize());
+        Assert.assertEquals(row.clustering().dataSize(), brow.clustering().dataSize());
+
         ClusteringComparator comparator = new ClusteringComparator(UTF8Type.instance);
         Assert.assertEquals(0, comparator.compare(row.clustering(), nrow.clustering()));
         Assert.assertEquals(0, comparator.compare(row.clustering(), brow.clustering()));
         Assert.assertEquals(0, comparator.compare(nrow.clustering(), brow.clustering()));
+
+        assertCellsDataSize(row, nrow);
+        assertCellsDataSize(row, brow);
+
     }
+
+    private static void assertCellsDataSize(Row row1, Row row2)
+    {
+        Iterator<Cell<?>> row1Iterator = row1.cells().iterator();
+        Iterator<Cell<?>> row2Iterator = row2.cells().iterator();
+        while (row1Iterator.hasNext())
+        {
+            Cell cell1 = row1Iterator.next();
+            Cell cell2 = row2Iterator.next();
+            Assert.assertEquals(cell1.dataSize(), cell2.dataSize());
+        }
+    }
+
 }


### PR DESCRIPTION
Avoid memory allocation in NativeCell.valueSize() and NativeClustering.dataSize()

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20162