### PR TITLE
[CASSANDRA-20166][5.0] Avoid ByteBuffer allocation during decoding bind values of prepared CQL modification and batch statements

### DIFF
--- a/src/java/org/apache/cassandra/audit/AuditLogManager.java
+++ b/src/java/org/apache/cassandra/audit/AuditLogManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.audit;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -293,7 +292,7 @@ public class AuditLogManager implements QueryEvents.Listener, AuthEvents.Listene
             log(entry, cause, query == null ? null : ImmutableList.of(query));
     }
 
-    public void batchSuccess(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<List<ByteBuffer>> values, QueryOptions options, QueryState state, long queryTime, Message.Response response)
+    public void batchSuccess(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<byte[][]> values, QueryOptions options, QueryState state, long queryTime, Message.Response response)
     {
         List<AuditLogEntry> entries = buildEntriesForBatch(statements, queries, state, options, queryTime);
         for (AuditLogEntry auditLogEntry : entries)
@@ -302,7 +301,7 @@ public class AuditLogManager implements QueryEvents.Listener, AuthEvents.Listene
         }
     }
 
-    public void batchFailure(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<List<ByteBuffer>> values, QueryOptions options, QueryState state, Exception cause)
+    public void batchFailure(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<byte[][]> values, QueryOptions options, QueryState state, Exception cause)
     {
         String auditMessage = String.format("BATCH of %d statements at consistency %s", statements.size(), options.getConsistency());
         AuditLogEntry entry = new AuditLogEntry.Builder(state).setOperation(auditMessage)

--- a/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
@@ -29,6 +29,8 @@ import org.apache.cassandra.service.QueryState;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import static org.apache.cassandra.utils.ByteArrayUtil.convertToByteBufferValue;
+
 public abstract class BatchQueryOptions
 {
     public static BatchQueryOptions DEFAULT = withoutPerStatementVariables(QueryOptions.DEFAULT);
@@ -47,7 +49,7 @@ public abstract class BatchQueryOptions
         return new WithoutPerStatementVariables(options, Collections.<Object>emptyList());
     }
 
-    public static BatchQueryOptions withPerStatementVariables(QueryOptions options, List<List<ByteBuffer>> variables, List<Object> queryOrIdList)
+    public static BatchQueryOptions withPerStatementVariables(QueryOptions options, List<byte[][]> variables, List<Object> queryOrIdList)
     {
         return new WithPerStatementVariables(options, variables, queryOrIdList);
     }
@@ -89,6 +91,79 @@ public abstract class BatchQueryOptions
         return wrapped.getNowInSeconds(state);
     }
 
+    private static class BatchQueryOptionsWrapper extends QueryOptions.QueryOptionsWrapper {
+        private static final ByteBuffer NOT_INITIALIZED = ByteBuffer.wrap(new byte[]{});
+
+        private final byte[][] valuesAsByteArray;
+        private List<ByteBuffer> values;
+
+        private boolean fullyFilled;
+
+        BatchQueryOptionsWrapper(QueryOptions wrapped, byte[][] vars)
+        {
+            super(wrapped);
+            this.valuesAsByteArray = vars;
+        }
+        public List<ByteBuffer> getValues()
+        {
+            if (values == null)
+            {
+                fullyFilled = true;
+                values = new ArrayList<>(valuesAsByteArray.length);
+                for (byte[] byteArrayValue : valuesAsByteArray)
+                    values.add(convertToByteBufferValue(byteArrayValue));
+            }
+            if (!fullyFilled)
+            {
+                fullyFilled = true;
+                for (int i = 0; i < valuesAsByteArray.length; i++)
+                {
+                    ByteBuffer value = values.get(i);
+                    if (value == NOT_INITIALIZED)
+                    {
+                        value = convertToByteBufferValue(valuesAsByteArray[i]);
+                        values.set(i, value);
+                    }
+                }
+            }
+            return values;
+        }
+
+        public int getValuesSize()
+        {
+            return valuesAsByteArray.length;
+        }
+
+        public ByteBuffer getValue(int index)
+        {
+            if (values == null) // we convert values to ByteBuffer in a lazy way, on demand
+            {
+                values = new ArrayList<>(valuesAsByteArray.length);
+                for (int i = 0; i < valuesAsByteArray.length; i++)
+                    values.add(NOT_INITIALIZED);
+            }
+
+            ByteBuffer value = values.get(index);
+            if (value == NOT_INITIALIZED)
+            {
+                value = convertToByteBufferValue(valuesAsByteArray[index]);
+                values.set(index, value);
+            }
+            return value;
+        }
+
+        public boolean isByteArrayValuesGetSupported()
+        {
+            return true;
+        }
+
+        public byte[][] getByteArrayValues()
+        {
+            return valuesAsByteArray;
+        }
+    }
+
+
     private static class WithoutPerStatementVariables extends BatchQueryOptions
     {
         private WithoutPerStatementVariables(QueryOptions wrapped, List<Object> queryOrIdList)
@@ -106,19 +181,13 @@ public abstract class BatchQueryOptions
     {
         private final List<QueryOptions> perStatementOptions;
 
-        private WithPerStatementVariables(QueryOptions wrapped, List<List<ByteBuffer>> variables, List<Object> queryOrIdList)
+        private WithPerStatementVariables(QueryOptions wrapped, List<byte[][]> variables, List<Object> queryOrIdList)
         {
             super(wrapped, queryOrIdList);
             this.perStatementOptions = new ArrayList<>(variables.size());
-            for (final List<ByteBuffer> vars : variables)
+            for (final byte[][] vars : variables)
             {
-                perStatementOptions.add(new QueryOptions.QueryOptionsWrapper(wrapped)
-                {
-                    public List<ByteBuffer> getValues()
-                    {
-                        return vars;
-                    }
-                });
+                perStatementOptions.add(new BatchQueryOptionsWrapper(wrapped, vars));
             }
         }
 

--- a/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
@@ -92,12 +92,8 @@ public abstract class BatchQueryOptions
     }
 
     private static class BatchQueryOptionsWrapper extends QueryOptions.QueryOptionsWrapper {
-        private static final ByteBuffer NOT_INITIALIZED = ByteBuffer.wrap(new byte[]{});
-
         private final byte[][] valuesAsByteArray;
         private List<ByteBuffer> values;
-
-        private boolean fullyFilled;
 
         BatchQueryOptionsWrapper(QueryOptions wrapped, byte[][] vars)
         {
@@ -108,23 +104,9 @@ public abstract class BatchQueryOptions
         {
             if (values == null)
             {
-                fullyFilled = true;
                 values = new ArrayList<>(valuesAsByteArray.length);
                 for (byte[] byteArrayValue : valuesAsByteArray)
                     values.add(convertToByteBufferValue(byteArrayValue));
-            }
-            if (!fullyFilled)
-            {
-                fullyFilled = true;
-                for (int i = 0; i < valuesAsByteArray.length; i++)
-                {
-                    ByteBuffer value = values.get(i);
-                    if (value == NOT_INITIALIZED)
-                    {
-                        value = convertToByteBufferValue(valuesAsByteArray[i]);
-                        values.set(i, value);
-                    }
-                }
             }
             return values;
         }
@@ -138,18 +120,11 @@ public abstract class BatchQueryOptions
         {
             if (values == null) // we convert values to ByteBuffer in a lazy way, on demand
             {
-                values = new ArrayList<>(valuesAsByteArray.length);
-                for (int i = 0; i < valuesAsByteArray.length; i++)
-                    values.add(NOT_INITIALIZED);
-            }
-
-            ByteBuffer value = values.get(index);
-            if (value == NOT_INITIALIZED)
+                return convertToByteBufferValue(valuesAsByteArray[index]);
+            } else
             {
-                value = convertToByteBufferValue(valuesAsByteArray[index]);
-                values.set(index, value);
+                return values.get(index);
             }
-            return value;
         }
 
         public boolean isByteArrayValuesGetSupported()

--- a/src/java/org/apache/cassandra/cql3/Constants.java
+++ b/src/java/org/apache/cassandra/cql3/Constants.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FastByteOperations;
 
@@ -451,9 +452,30 @@ public abstract class Constants
         {
             try
             {
-                ByteBuffer value = options.getValues().get(bindIndex);
+                ByteBuffer value = options.getValue(bindIndex);
                 if (value != null && value != ByteBufferUtil.UNSET_BYTE_BUFFER)
                     receiver.type.validate(value);
+                return value;
+            }
+            catch (MarshalException e)
+            {
+                throw new InvalidRequestException(e.getMessage());
+            }
+        }
+
+        public boolean isByteArrayGetSupported(QueryOptions options)
+        {
+            return options.isByteArrayValuesGetSupported();
+        }
+
+        @Override
+        public byte[] bindAndGetByteArray(QueryOptions options) throws InvalidRequestException
+        {
+            try
+            {
+                byte[] value = options.getByteArrayValues()[bindIndex];
+                if (value != null && value != ByteArrayUtil.UNSET_BYTE_ARRAY)
+                    receiver.type.validate(value, ByteArrayAccessor.instance);
                 return value;
             }
             catch (MarshalException e)
@@ -482,11 +504,22 @@ public abstract class Constants
 
         public void execute(DecoratedKey partitionKey, UpdateParameters params) throws InvalidRequestException
         {
-            ByteBuffer value = t.bindAndGet(params.options);
-            if (value == null)
-                params.addTombstone(column);
-            else if (value != ByteBufferUtil.UNSET_BYTE_BUFFER) // use reference equality and not object equality
-                params.addCell(column, value);
+            if (t.isByteArrayGetSupported(params.options))
+            {
+                byte[] value = t.bindAndGetByteArray(params.options);
+                if (value == null)
+                    params.addTombstone(column);
+                else if (value != ByteArrayUtil.UNSET_BYTE_ARRAY) // use reference equality and not object equality
+                    params.addCell(column, value);
+            }
+            else
+            {
+                ByteBuffer value = t.bindAndGet(params.options);
+                if (value == null)
+                    params.addTombstone(column);
+                else if (value != ByteBufferUtil.UNSET_BYTE_BUFFER) // use reference equality and not object equality
+                    params.addCell(column, value);
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/QueryEvents.java
+++ b/src/java/org/apache/cassandra/cql3/QueryEvents.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.cql3;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -146,7 +145,7 @@ public class QueryEvents
     public void notifyBatchSuccess(BatchStatement.Type batchType,
                                    List<? extends CQLStatement> statements,
                                    List<String> queries,
-                                   List<List<ByteBuffer>> values,
+                                   List<byte[][]> values,
                                    QueryOptions options,
                                    QueryState state,
                                    long queryTime,
@@ -167,7 +166,7 @@ public class QueryEvents
     public void notifyBatchFailure(List<QueryHandler.Prepared> prepared,
                                    BatchStatement.Type batchType,
                                    List<Object> queryOrIdList,
-                                   List<List<ByteBuffer>> values,
+                                   List<byte[][]> values,
                                    QueryOptions options,
                                    QueryState state,
                                    Exception cause)
@@ -288,7 +287,7 @@ public class QueryEvents
         default void batchSuccess(BatchStatement.Type batchType,
                                   List<? extends CQLStatement> statements,
                                   List<String> queries,
-                                  List<List<ByteBuffer>> values,
+                                  List<byte[][]> values,
                                   QueryOptions options,
                                   QueryState state,
                                   long queryTime,
@@ -296,7 +295,7 @@ public class QueryEvents
         default void batchFailure(BatchStatement.Type batchType,
                                   List<? extends CQLStatement> statements,
                                   List<String> queries,
-                                  List<List<ByteBuffer>> values,
+                                  List<byte[][]> values,
                                   QueryOptions options,
                                   QueryState state,
                                   Exception cause) {}

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -365,11 +365,9 @@ public abstract class QueryOptions
 
     static class DefaultQueryOptions extends QueryOptions
     {
-        private static final ByteBuffer NOT_INITIALIZED = ByteBuffer.wrap(new byte[]{});
         private final ConsistencyLevel consistency;
         private List<ByteBuffer> values;
         private final byte[][] valuesAsByteArray;
-        private boolean valuesFullyFilled;
         private final boolean isByteArrayGetSupported;
 
         private final boolean skipMetadata;
@@ -379,17 +377,13 @@ public abstract class QueryOptions
         private final transient ProtocolVersion protocolVersion;
         private final transient ReadThresholds readThresholds = ReadThresholds.create();
 
-        DefaultQueryOptions(ConsistencyLevel consistency, List<ByteBuffer> values, byte[][] valuesAsByteArray, boolean skipMetadata, SpecificOptions options, ProtocolVersion protocolVersion)
+        DefaultQueryOptions(ConsistencyLevel consistency, List<ByteBuffer> values,
+                            byte[][] valuesAsByteArray, boolean skipMetadata,
+                            SpecificOptions options, ProtocolVersion protocolVersion)
         {
             this.consistency = consistency;
             this.values = values;
-            if (values != null)
-            {
-                valuesFullyFilled = true;
-                isByteArrayGetSupported = false;
-            }
-            else
-                this.isByteArrayGetSupported = true;
+            isByteArrayGetSupported = (values == null);
             this.valuesAsByteArray = valuesAsByteArray;
             this.skipMetadata = skipMetadata;
             this.options = options;
@@ -405,23 +399,9 @@ public abstract class QueryOptions
         {
             if (values == null)
             {
-                valuesFullyFilled = true;
                 values = new ArrayList<>(valuesAsByteArray.length);
                 for (byte[] byteArrayValue : valuesAsByteArray)
                     values.add(convertToByteBufferValue(byteArrayValue));
-            }
-            if (!valuesFullyFilled)
-            {
-                valuesFullyFilled = true;
-                for (int i = 0; i < valuesAsByteArray.length; i++)
-                {
-                    ByteBuffer value = values.get(i);
-                    if (value == NOT_INITIALIZED)
-                    {
-                        value = convertToByteBufferValue(valuesAsByteArray[i]);
-                        values.set(i, value);
-                    }
-                }
             }
             return values;
         }
@@ -433,20 +413,10 @@ public abstract class QueryOptions
 
         public ByteBuffer getValue(int index)
         {
-            if (values == null) // we convert values to ByteBuffer in a lazy way, on demand
-            {
-                values = new ArrayList<>(valuesAsByteArray.length);
-                for (int i = 0; i < valuesAsByteArray.length; i++)
-                    values.add(NOT_INITIALIZED);
-            }
+            if (values != null)
+                return values.get(index);
 
-            ByteBuffer value = values.get(index);
-            if (value == NOT_INITIALIZED)
-            {
-                value = convertToByteBufferValue(valuesAsByteArray[index]);
-                values.set(index, value);
-            }
-            return value;
+            return convertToByteBufferValue(valuesAsByteArray[index]);
         }
 
         public boolean isByteArrayValuesGetSupported()

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -36,10 +36,13 @@ import org.apache.cassandra.transport.CBCodec;
 import org.apache.cassandra.transport.CBUtil;
 import org.apache.cassandra.transport.ProtocolException;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.CassandraUInt;
 import org.apache.cassandra.utils.Pair;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
+import static org.apache.cassandra.utils.ByteArrayUtil.convertToByteBufferValue;
 
 /**
  * Options for a query.
@@ -48,6 +51,7 @@ public abstract class QueryOptions
 {
     public static final QueryOptions DEFAULT = new DefaultQueryOptions(ConsistencyLevel.ONE,
                                                                        Collections.emptyList(),
+                                                                       ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS,
                                                                        false,
                                                                        SpecificOptions.DEFAULT,
                                                                        ProtocolVersion.CURRENT);
@@ -61,22 +65,22 @@ public abstract class QueryOptions
 
     public static QueryOptions forInternalCalls(ConsistencyLevel consistency, List<ByteBuffer> values)
     {
-        return new DefaultQueryOptions(consistency, values, false, SpecificOptions.DEFAULT, ProtocolVersion.V3);
+        return new DefaultQueryOptions(consistency, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, SpecificOptions.DEFAULT, ProtocolVersion.V3);
     }
 
     public static QueryOptions forInternalCallsWithNowInSec(long nowInSec, ConsistencyLevel consistency, List<ByteBuffer> values)
     {
-        return new DefaultQueryOptions(consistency, values, false, SpecificOptions.DEFAULT.withNowInSec(nowInSec), ProtocolVersion.CURRENT);
+        return new DefaultQueryOptions(consistency, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, SpecificOptions.DEFAULT.withNowInSec(nowInSec), ProtocolVersion.CURRENT);
     }
 
     public static QueryOptions forInternalCalls(List<ByteBuffer> values)
     {
-        return new DefaultQueryOptions(ConsistencyLevel.ONE, values, false, SpecificOptions.DEFAULT, ProtocolVersion.V3);
+        return new DefaultQueryOptions(ConsistencyLevel.ONE, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, SpecificOptions.DEFAULT, ProtocolVersion.V3);
     }
 
     public static QueryOptions forProtocolVersion(ProtocolVersion protocolVersion)
     {
-        return new DefaultQueryOptions(null, null, true, null, protocolVersion);
+        return new DefaultQueryOptions(null, null, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, true, null, protocolVersion);
     }
 
     public static QueryOptions create(ConsistencyLevel consistency,
@@ -104,6 +108,7 @@ public abstract class QueryOptions
     {
         return new DefaultQueryOptions(consistency,
                                        values,
+                                       ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS,
                                        skipMetadata,
                                        new SpecificOptions(pageSize, pagingState, serialConsistency, timestamp, keyspace, nowInSeconds),
                                        version);
@@ -126,6 +131,30 @@ public abstract class QueryOptions
 
     public abstract ConsistencyLevel getConsistency();
     public abstract List<ByteBuffer> getValues();
+
+    public abstract int getValuesSize();
+
+    public ByteBuffer getValue(int index)
+    {
+        return getValues().get(index);
+    }
+
+    /**
+     * to check if it is possible to get values as byte[] instead of ByteBuffer
+     * the logic is added as a memory allocation optimization
+     * to avoid creating of HeapByteBuffer wrappers for some typical requests
+     * getValues method is still in use and must be supported even if true is returned
+     */
+    public boolean isByteArrayValuesGetSupported()
+    {
+        return false;
+    }
+
+    public byte[][] getByteArrayValues()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     public abstract boolean skipMetadata();
 
     /**
@@ -336,8 +365,13 @@ public abstract class QueryOptions
 
     static class DefaultQueryOptions extends QueryOptions
     {
+        private static final ByteBuffer NOT_INITIALIZED = ByteBuffer.wrap(new byte[]{});
         private final ConsistencyLevel consistency;
-        private final List<ByteBuffer> values;
+        private List<ByteBuffer> values;
+        private final byte[][] valuesAsByteArray;
+        private boolean valuesFullyFilled;
+        private final boolean isByteArrayGetSupported;
+
         private final boolean skipMetadata;
 
         private final SpecificOptions options;
@@ -345,10 +379,18 @@ public abstract class QueryOptions
         private final transient ProtocolVersion protocolVersion;
         private final transient ReadThresholds readThresholds = ReadThresholds.create();
 
-        DefaultQueryOptions(ConsistencyLevel consistency, List<ByteBuffer> values, boolean skipMetadata, SpecificOptions options, ProtocolVersion protocolVersion)
+        DefaultQueryOptions(ConsistencyLevel consistency, List<ByteBuffer> values, byte[][] valuesAsByteArray, boolean skipMetadata, SpecificOptions options, ProtocolVersion protocolVersion)
         {
             this.consistency = consistency;
             this.values = values;
+            if (values != null)
+            {
+                valuesFullyFilled = true;
+                isByteArrayGetSupported = false;
+            }
+            else
+                this.isByteArrayGetSupported = true;
+            this.valuesAsByteArray = valuesAsByteArray;
             this.skipMetadata = skipMetadata;
             this.options = options;
             this.protocolVersion = protocolVersion;
@@ -361,7 +403,60 @@ public abstract class QueryOptions
 
         public List<ByteBuffer> getValues()
         {
+            if (values == null)
+            {
+                valuesFullyFilled = true;
+                values = new ArrayList<>(valuesAsByteArray.length);
+                for (byte[] byteArrayValue : valuesAsByteArray)
+                    values.add(convertToByteBufferValue(byteArrayValue));
+            }
+            if (!valuesFullyFilled)
+            {
+                valuesFullyFilled = true;
+                for (int i = 0; i < valuesAsByteArray.length; i++)
+                {
+                    ByteBuffer value = values.get(i);
+                    if (value == NOT_INITIALIZED)
+                    {
+                        value = convertToByteBufferValue(valuesAsByteArray[i]);
+                        values.set(i, value);
+                    }
+                }
+            }
             return values;
+        }
+
+        public int getValuesSize()
+        {
+            return isByteArrayValuesGetSupported() ? valuesAsByteArray.length : values.size();
+        }
+
+        public ByteBuffer getValue(int index)
+        {
+            if (values == null) // we convert values to ByteBuffer in a lazy way, on demand
+            {
+                values = new ArrayList<>(valuesAsByteArray.length);
+                for (int i = 0; i < valuesAsByteArray.length; i++)
+                    values.add(NOT_INITIALIZED);
+            }
+
+            ByteBuffer value = values.get(index);
+            if (value == NOT_INITIALIZED)
+            {
+                value = convertToByteBufferValue(valuesAsByteArray[index]);
+                values.set(index, value);
+            }
+            return value;
+        }
+
+        public boolean isByteArrayValuesGetSupported()
+        {
+            return isByteArrayGetSupported;
+        }
+
+        public byte[][] getByteArrayValues()
+        {
+            return valuesAsByteArray;
         }
 
         public boolean skipMetadata()
@@ -398,6 +493,26 @@ public abstract class QueryOptions
         public List<ByteBuffer> getValues()
         {
             return this.wrapped.getValues();
+        }
+
+        public int getValuesSize()
+        {
+            return wrapped.getValuesSize();
+        }
+
+        public ByteBuffer getValue(int index)
+        {
+            return this.wrapped.getValue(index);
+        }
+
+        public boolean isByteArrayValuesGetSupported()
+        {
+            return wrapped.isByteArrayValuesGetSupported();
+        }
+
+        public byte[][] getByteArrayValues()
+        {
+            return wrapped.getByteArrayValues();
         }
 
         public ConsistencyLevel getConsistency()
@@ -611,19 +726,19 @@ public abstract class QueryOptions
                                                    ? (int)body.readUnsignedInt()
                                                    : (int)body.readUnsignedByte());
 
-            List<ByteBuffer> values = Collections.<ByteBuffer>emptyList();
+            byte[][] values = ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS;
             List<String> names = null;
             if (flags.contains(Flag.VALUES))
             {
                 if (flags.contains(Flag.NAMES_FOR_VALUES))
                 {
-                    Pair<List<String>, List<ByteBuffer>> namesAndValues = CBUtil.readNameAndValueList(body, version);
+                    Pair<List<String>, byte[][]> namesAndValues = CBUtil.readNameAndValueListAsByteArrays(body, version);
                     names = namesAndValues.left;
                     values = namesAndValues.right;
                 }
                 else
                 {
-                    values = CBUtil.readValueList(body, version);
+                    values = CBUtil.readValueListAsByteArrays(body, version);
                 }
             }
 
@@ -651,7 +766,7 @@ public abstract class QueryOptions
                 options = new SpecificOptions(pageSize, pagingState, serialConsistency, timestamp, keyspace, nowInSeconds);
             }
 
-            DefaultQueryOptions opts = new DefaultQueryOptions(consistency, values, skipMetadata, options, version);
+            DefaultQueryOptions opts = new DefaultQueryOptions(consistency, null, values, skipMetadata, options, version);
             return names == null ? opts : new OptionsWithNames(opts, names);
         }
 

--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -812,19 +812,19 @@ public class QueryProcessor implements QueryHandler
     public ResultMessage processPrepared(CQLStatement statement, QueryState queryState, QueryOptions options, Dispatcher.RequestTime requestTime)
     throws RequestExecutionException, RequestValidationException
     {
-        List<ByteBuffer> variables = options.getValues();
+        int variablesSize = options.getValuesSize();
         // Check to see if there are any bound variables to verify
-        if (!(variables.isEmpty() && statement.getBindVariables().isEmpty()))
+        if (!(variablesSize == 0 && statement.getBindVariables().isEmpty()))
         {
-            if (variables.size() != statement.getBindVariables().size())
+            if (variablesSize != statement.getBindVariables().size())
                 throw new InvalidRequestException(String.format("there were %d markers(?) in CQL but %d bound variables",
                                                                 statement.getBindVariables().size(),
-                                                                variables.size()));
+                                                                variablesSize));
 
             // at this point there is a match in count between markers and variables that is non-zero
             if (logger.isTraceEnabled())
-                for (int i = 0; i < variables.size(); i++)
-                    logger.trace("[{}] '{}'", i+1, variables.get(i));
+                for (int i = 0; i < variablesSize; i++)
+                    logger.trace("[{}] '{}'", i+1, options.getValues().get(i));
         }
 
         metrics.preparedStatementsExecuted.inc();

--- a/src/java/org/apache/cassandra/cql3/Term.java
+++ b/src/java/org/apache/cassandra/cql3/Term.java
@@ -61,6 +61,16 @@ public interface Term
      */
     public ByteBuffer bindAndGet(QueryOptions options) throws InvalidRequestException;
 
+    public default boolean isByteArrayGetSupported(QueryOptions options)
+    {
+        return false;
+    }
+
+    public default byte[] bindAndGetByteArray(QueryOptions options) throws InvalidRequestException
+    {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Whether or not that term contains at least one bind marker.
      *

--- a/src/java/org/apache/cassandra/cql3/UpdateParameters.java
+++ b/src/java/org/apache/cassandra/cql3/UpdateParameters.java
@@ -161,6 +161,11 @@ public class UpdateParameters
         return addCell(column, null, value);
     }
 
+    public Cell<?> addCell(ColumnMetadata column, byte[] value) throws InvalidRequestException
+    {
+        return addCell(column, null, value);
+    }
+
     public Cell<?> addCell(ColumnMetadata column, CellPath path, ByteBuffer value) throws InvalidRequestException
     {
         Guardrails.columnValueSize.guard(value.remaining(), column.name.toString(), false, clientState);
@@ -171,6 +176,21 @@ public class UpdateParameters
         Cell<?> cell = ttl == LivenessInfo.NO_TTL
                        ? BufferCell.live(column, timestamp, value, path)
                        : BufferCell.expiring(column, timestamp, ttl, nowInSec, value, path);
+        builder.addCell(cell);
+        return cell;
+    }
+
+
+    public Cell<?> addCell(ColumnMetadata column, CellPath path, byte[] value) throws InvalidRequestException
+    {
+        Guardrails.columnValueSize.guard(value.length, column.name.toString(), false, clientState);
+
+        if (path != null && column.type.isMultiCell())
+            Guardrails.columnValueSize.guard(path.dataSize(), column.name.toString(), false, clientState);
+
+        Cell<?> cell = ttl == LivenessInfo.NO_TTL
+                       ? ArrayCell.live(column, timestamp, value, path)
+                       : ArrayCell.expiring(column, timestamp, ttl, nowInSec, value, path);
         builder.addCell(cell);
         return cell;
     }

--- a/src/java/org/apache/cassandra/db/rows/ArrayCell.java
+++ b/src/java/org/apache/cassandra/db/rows/ArrayCell.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.rows;
 
 import java.nio.ByteBuffer;
 
+import org.apache.cassandra.db.ExpirationDateOverflowHandling;
 import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.ByteType;
 import org.apache.cassandra.db.marshal.ValueAccessor;
@@ -57,6 +58,17 @@ public class ArrayCell extends AbstractCell<byte[]>
         this.localDeletionTimeUnsignedInteger = localDeletionTimeUnsignedInteger;
         this.value = value;
         this.path = path;
+    }
+
+    public static ArrayCell live(ColumnMetadata column, long timestamp, byte[] value, CellPath path)
+    {
+        return new ArrayCell(column, timestamp, NO_TTL, NO_DELETION_TIME, value, path);
+    }
+
+    public static ArrayCell expiring(ColumnMetadata column, long timestamp, int ttl, long nowInSec, byte[] value, CellPath path)
+    {
+        assert ttl != NO_TTL;
+        return new ArrayCell(column, timestamp, ttl, ExpirationDateOverflowHandling.computeLocalExpirationTime(nowInSec, ttl), value, path);
     }
 
     public long timestamp()

--- a/src/java/org/apache/cassandra/db/rows/Cell.java
+++ b/src/java/org/apache/cassandra/db/rows/Cell.java
@@ -120,6 +120,11 @@ public abstract class Cell<V> extends ColumnData
         return accessor().toBuffer(value());
     }
 
+    public byte[] valueAsArray()
+    {
+        return accessor().toArray(value());
+    }
+
     /**
      * The cell timestamp.
      * <p>

--- a/src/java/org/apache/cassandra/db/rows/NativeCell.java
+++ b/src/java/org/apache/cassandra/db/rows/NativeCell.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.rows;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.schema.ColumnMetadata;
@@ -48,6 +49,39 @@ public class NativeCell extends AbstractCell<ByteBuffer>
         this.peer = 0;
     }
 
+    public static NativeCell build(NativeAllocator allocator,
+                                   OpOrder.Group writeOp,
+                                   Cell<?> cell)
+    {
+        if (cell.accessor() == ByteArrayAccessor.instance) // to avoid ByteBuffer allocation via cell.value()
+        {
+            byte[] value = cell.valueAsArray();
+            return new NativeCell(allocator,
+                                  writeOp,
+                                  cell.column(),
+                                  cell.timestamp(),
+                                  cell.ttl(),
+                                  cell.localDeletionTimeAsUnsignedInt(),
+                                  value,
+                                  value.length,
+                                  cell.path());
+        }
+        else
+        {
+            ByteBuffer byteBuffer = cell.buffer();
+            assert byteBuffer.order() == ByteOrder.BIG_ENDIAN;
+            return new NativeCell(allocator,
+                                  writeOp,
+                                  cell.column(),
+                                  cell.timestamp(),
+                                  cell.ttl(),
+                                  cell.localDeletionTimeAsUnsignedInt(),
+                                  byteBuffer,
+                                  byteBuffer.remaining(),
+                                  cell.path());
+        }
+    }
+
     public NativeCell(NativeAllocator allocator,
                       OpOrder.Group writeOp,
                       Cell<?> cell)
@@ -73,22 +107,22 @@ public class NativeCell extends AbstractCell<ByteBuffer>
                       ByteBuffer value,
                       CellPath path)
     {
-        this(allocator, writeOp, column, timestamp, ttl, deletionTimeLongToUnsignedInteger(localDeletionTime), value, path);
+        this(allocator, writeOp, column, timestamp, ttl, deletionTimeLongToUnsignedInteger(localDeletionTime), value, value.remaining(), path);
     }
 
-    public NativeCell(NativeAllocator allocator,
-                      OpOrder.Group writeOp,
-                      ColumnMetadata column,
-                      long timestamp,
-                      int ttl,
-                      int localDeletionTimeUnsignedInteger,
-                      ByteBuffer value,
-                      CellPath path)
+    private NativeCell(NativeAllocator allocator,
+                       OpOrder.Group writeOp,
+                       ColumnMetadata column,
+                       long timestamp,
+                       int ttl,
+                       int localDeletionTimeUnsignedInteger,
+                       Object value,
+                       int valueLength,
+                       CellPath path)
     {
         super(column);
-        long size = offHeapSizeWithoutPath(value.remaining());
+        long size = offHeapSizeWithoutPath(valueLength);
 
-        assert value.order() == ByteOrder.BIG_ENDIAN;
         assert column.isComplex() == (path != null);
         if (path != null)
         {
@@ -105,15 +139,22 @@ public class NativeCell extends AbstractCell<ByteBuffer>
         MemoryUtil.setLong(peer + TIMESTAMP, timestamp);
         MemoryUtil.setInt(peer + TTL, ttl);
         MemoryUtil.setInt(peer + DELETION, localDeletionTimeUnsignedInteger);
-        MemoryUtil.setInt(peer + LENGTH, value.remaining());
-        MemoryUtil.setBytes(peer + VALUE, value);
+        MemoryUtil.setInt(peer + LENGTH, valueLength);
+        if (value instanceof byte[])
+        {
+            MemoryUtil.setBytes(peer + VALUE, (byte[]) value, 0, valueLength);
+        } else if (value instanceof ByteBuffer)
+        {
+            MemoryUtil.setBytes(peer + VALUE, (ByteBuffer) value);
+        } else
+            throw new IllegalArgumentException();
 
         if (path != null)
         {
             ByteBuffer pathbuffer = path.get(0);
             assert pathbuffer.order() == ByteOrder.BIG_ENDIAN;
 
-            long offset = peer + VALUE + value.remaining();
+            long offset = peer + VALUE + valueLength;
             MemoryUtil.setInt(offset, pathbuffer.remaining());
             MemoryUtil.setBytes(offset + 4, pathbuffer);
         }

--- a/src/java/org/apache/cassandra/fql/FullQueryLogger.java
+++ b/src/java/org/apache/cassandra/fql/FullQueryLogger.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.fql;
 
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -268,7 +267,7 @@ public class FullQueryLogger implements QueryEvents.Listener
     public void batchSuccess(BatchStatement.Type type,
                              List<? extends CQLStatement> statements,
                              List<String> queries,
-                             List<List<ByteBuffer>> values,
+                             List<byte[][]> values,
                              QueryOptions queryOptions,
                              QueryState queryState,
                              long batchTimeMillis,
@@ -383,11 +382,11 @@ public class FullQueryLogger implements QueryEvents.Listener
         private final int weight;
         private final BatchStatement.Type batchType;
         private final List<String> queries;
-        private final List<List<ByteBuffer>> values;
+        private final List<byte[][]> values;
 
         public Batch(BatchStatement.Type batchType,
                      List<String> queries,
-                     List<List<ByteBuffer>> values,
+                     List<byte[][]> values,
                      QueryOptions queryOptions,
                      QueryState queryState,
                      long batchTimeMillis)
@@ -406,11 +405,11 @@ public class FullQueryLogger implements QueryEvents.Listener
                 queriesSize += ObjectSizes.sizeOf(checkNotNull(query));
 
             long valuesSize = EMPTY_LIST_SIZE + ObjectSizes.sizeOfReferenceArray(values.size());
-            for (List<ByteBuffer> subValues : values)
+            for (byte[][] subValues : values)
             {
-                valuesSize += EMPTY_LIST_SIZE + ObjectSizes.sizeOfReferenceArray(subValues.size());
-                for (ByteBuffer subValue : subValues)
-                    valuesSize += ObjectSizes.sizeOnHeapOf(subValue);
+                valuesSize += EMPTY_LIST_SIZE + ObjectSizes.sizeOfReferenceArray(subValues.length);
+                for (byte[] subValue : subValues)
+                    valuesSize += ObjectSizes.sizeOfArray(subValue);
             }
 
             // No need to add the batch type which is an enum.
@@ -450,10 +449,10 @@ public class FullQueryLogger implements QueryEvents.Listener
             }
             valueOut = wire.write(VALUES);
             valueOut.int32(values.size());
-            for (List<ByteBuffer> subValues : values)
+            for (byte[][] subValues : values)
             {
-                valueOut.int32(subValues.size());
-                for (ByteBuffer value : subValues)
+                valueOut.int32(subValues.length);
+                for (byte[] value : subValues)
                 {
                     valueOut.bytes(BytesStore.wrap(value));
                 }

--- a/src/java/org/apache/cassandra/transport/CBUtil.java
+++ b/src/java/org/apache/cassandra/transport/CBUtil.java
@@ -40,6 +40,7 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.Pair;
 import org.apache.cassandra.utils.TimeUUID;
@@ -548,6 +549,36 @@ public abstract class CBUtil
         return l;
     }
 
+    public static byte[][] readValueListAsByteArrays(ByteBuf cb, ProtocolVersion protocolVersion)
+    {
+        int size = cb.readUnsignedShort();
+        if (size == 0)
+            return ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS;
+
+        byte[][] l = new byte[size][];
+        for (int i = 0; i < size; i++)
+            l[i] = readBoundValueAsByteArray(cb, protocolVersion);
+        return l;
+    }
+
+    public static byte[] readBoundValueAsByteArray(ByteBuf cb, ProtocolVersion protocolVersion)
+    {
+        int length = cb.readInt();
+        if (length < 0)
+        {
+            if (protocolVersion.isSmallerThan(ProtocolVersion.V4)) // backward compatibility for pre-version 4
+                return null;
+            if (length == -1)
+                return null;
+            else if (length == -2)
+                return ByteArrayUtil.UNSET_BYTE_ARRAY;
+            else
+                throw new ProtocolException("Invalid ByteBuf length " + length);
+        }
+        return readRawBytes(cb, length);
+    }
+
+
     public static void writeValueList(List<ByteBuffer> values, ByteBuf cb)
     {
         cb.writeShort(values.size());
@@ -555,10 +586,25 @@ public abstract class CBUtil
             CBUtil.writeValue(value, cb);
     }
 
+    public static void writeValueListOfByteArrays(byte[][] values, ByteBuf cb)
+    {
+        cb.writeShort(values.length);
+        for (byte[] value : values)
+            CBUtil.writeValue(value, cb);
+    }
+
     public static int sizeOfValueList(List<ByteBuffer> values)
     {
         int size = 2;
         for (ByteBuffer value : values)
+            size += CBUtil.sizeOfValue(value);
+        return size;
+    }
+
+    public static int sizeOfValueListOfByteArrays(byte[][] values)
+    {
+        int size = 2;
+        for (byte[] value : values)
             size += CBUtil.sizeOfValue(value);
         return size;
     }
@@ -575,6 +621,22 @@ public abstract class CBUtil
         {
             s.add(readString(cb));
             l.add(readBoundValue(cb, protocolVersion));
+        }
+        return Pair.create(s, l);
+    }
+
+    public static Pair<List<String>, byte[][]> readNameAndValueListAsByteArrays(ByteBuf cb, ProtocolVersion protocolVersion)
+    {
+        int size = cb.readUnsignedShort();
+        if (size == 0)
+            return Pair.create(Collections.<String>emptyList(), ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS);
+
+        List<String> s = new ArrayList<>(size);
+        byte[][] l = new byte[size][];
+        for (int i = 0; i < size; i++)
+        {
+            s.add(readString(cb));
+            l[i] = readBoundValueAsByteArray(cb, protocolVersion);
         }
         return Pair.create(s, l);
     }

--- a/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/BatchMessage.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.transport.messages;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,7 +57,7 @@ public class BatchMessage extends Message.Request
             byte type = body.readByte();
             int n = body.readUnsignedShort();
             List<Object> queryOrIds = new ArrayList<>(n);
-            List<List<ByteBuffer>> variables = new ArrayList<>(n);
+            List<byte[][]> variables = new ArrayList<>(n);
             for (int i = 0; i < n; i++)
             {
                 byte kind = body.readByte();
@@ -68,7 +67,7 @@ public class BatchMessage extends Message.Request
                     queryOrIds.add(MD5Digest.wrap(CBUtil.readBytes(body)));
                 else
                     throw new ProtocolException("Invalid query kind in BATCH messages. Must be 0 or 1 but got " + kind);
-                variables.add(CBUtil.readValueList(body, version));
+                variables.add(CBUtil.readValueListAsByteArrays(body, version));
             }
             QueryOptions options = QueryOptions.codec.decode(body, version);
 
@@ -91,7 +90,7 @@ public class BatchMessage extends Message.Request
                 else
                     CBUtil.writeBytes(((MD5Digest)q).bytes, dest);
 
-                CBUtil.writeValueList(msg.values.get(i), dest);
+                CBUtil.writeValueListOfByteArrays(msg.values.get(i), dest);
             }
 
             if (version.isSmallerThan(ProtocolVersion.V3))
@@ -110,7 +109,7 @@ public class BatchMessage extends Message.Request
                              ? CBUtil.sizeOfLongString((String)q)
                              : CBUtil.sizeOfBytes(((MD5Digest)q).bytes));
 
-                size += CBUtil.sizeOfValueList(msg.values.get(i));
+                size += CBUtil.sizeOfValueListOfByteArrays(msg.values.get(i));
             }
             size += version.isSmallerThan(ProtocolVersion.V3)
                   ? CBUtil.sizeOfConsistencyLevel(msg.options.getConsistency())
@@ -145,10 +144,10 @@ public class BatchMessage extends Message.Request
 
     public final BatchStatement.Type batchType;
     public final List<Object> queryOrIdList;
-    public final List<List<ByteBuffer>> values;
+    public final List<byte[][]> values;
     public final QueryOptions options;
 
-    public BatchMessage(BatchStatement.Type type, List<Object> queryOrIdList, List<List<ByteBuffer>> values, QueryOptions options)
+    public BatchMessage(BatchStatement.Type type, List<Object> queryOrIdList, List<byte[][]> values, QueryOptions options)
     {
         super(Message.Type.BATCH);
         this.batchType = type;
@@ -197,11 +196,11 @@ public class BatchMessage extends Message.Request
                         throw new PreparedQueryNotFoundException((MD5Digest)query);
                 }
 
-                List<ByteBuffer> queryValues = values.get(i);
-                if (queryValues.size() != p.statement.getBindVariables().size())
+                byte[][] queryValues = values.get(i);
+                if (queryValues.length != p.statement.getBindVariables().size())
                     throw new InvalidRequestException(String.format("There were %d markers(?) in CQL but %d bound variables",
                                                                     p.statement.getBindVariables().size(),
-                                                                    queryValues.size()));
+                                                                    queryValues.length));
 
                 prepared.add(p);
             }
@@ -260,7 +259,7 @@ public class BatchMessage extends Message.Request
         for (int i = 0; i < queryOrIdList.size(); i++)
         {
             if (i > 0) sb.append(", ");
-            sb.append(queryOrIdList.get(i)).append(" with ").append(values.get(i).size()).append(" values");
+            sb.append(queryOrIdList.get(i)).append(" with ").append(values.get(i).length).append(" values");
         }
         sb.append("] at consistency ").append(options.getConsistency());
         return sb.toString();

--- a/src/java/org/apache/cassandra/utils/ByteArrayUtil.java
+++ b/src/java/org/apache/cassandra/utils/ByteArrayUtil.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 public class ByteArrayUtil
 {
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+    public static final byte[][] EMPTY_ARRAY_OF_BYTE_ARRAYS = new byte[0][];
+    public static final byte[] UNSET_BYTE_ARRAY = new byte[0];
 
     public static int compareUnsigned(byte[] o1, byte[] o2)
     {
@@ -276,5 +278,16 @@ public class ByteArrayUtil
     public static void copyBytes(byte[] src, int srcPos, ByteBuffer dst, int dstPos, int length)
     {
         FastByteOperations.copy(src, srcPos, dst, dstPos, length);
+    }
+
+    public static ByteBuffer convertToByteBufferValue(byte[] arrayValue)
+    {
+        if (arrayValue == null)
+            return null;
+        if (arrayValue == ByteArrayUtil.UNSET_BYTE_ARRAY)
+            return ByteBufferUtil.UNSET_BYTE_BUFFER; // it is important for correctness to preserve unset value
+        if (arrayValue == ByteArrayUtil.EMPTY_BYTE_ARRAY)
+            return ByteBufferUtil.EMPTY_BYTE_BUFFER;
+        return ByteBuffer.wrap(arrayValue);
     }
 }

--- a/src/java/org/apache/cassandra/utils/memory/NativeAllocator.java
+++ b/src/java/org/apache/cassandra/utils/memory/NativeAllocator.java
@@ -87,7 +87,7 @@ public class NativeAllocator extends MemtableAllocator
         @Override
         public void addCell(Cell<?> cell)
         {
-            super.addCell(new NativeCell(allocator, writeOp, cell));
+            super.addCell(NativeCell.build(allocator, writeOp, cell));
         }
     }
 
@@ -125,7 +125,7 @@ public class NativeAllocator extends MemtableAllocator
                     @Override
                     public Cell<?> clone(Cell<?> cell)
                     {
-                        return new NativeCell(NativeAllocator.this, opGroup, cell);
+                        return NativeCell.build(NativeAllocator.this, opGroup, cell);
                     }
                 };
     }

--- a/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
+++ b/test/microbench/org/apache/cassandra/test/microbench/BatchStatementBench.java
@@ -18,13 +18,10 @@
 
 package org.apache.cassandra.test.microbench;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import com.google.common.collect.Lists;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Attributes;
@@ -44,6 +41,7 @@ import org.apache.cassandra.schema.SchemaTestUtil;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -63,8 +61,6 @@ import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-
-import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -108,14 +104,14 @@ public class BatchStatementBench
         SchemaTestUtil.addOrUpdateKeyspace(ksm.withSwapped(ksm.tables.with(metadata)), false);
 
         List<ModificationStatement> modifications = new ArrayList<>(batchSize);
-        List<List<ByteBuffer>> parameters = new ArrayList<>(batchSize);
+        List<byte[][]> parameters = new ArrayList<>(batchSize);
         List<Object> queryOrIdList = new ArrayList<>(batchSize);
         QueryHandler.Prepared prepared = QueryProcessor.prepareInternal(String.format("INSERT INTO %s.%s (id, ck, v) VALUES (?,?,?)", keyspace, table));
 
         for (int i = 0; i < batchSize; i++)
         {
             modifications.add((ModificationStatement) prepared.statement);
-            parameters.add(Lists.newArrayList(bytes(uniquePartition ? i : 1), bytes(i), bytes(i)));
+            parameters.add(new byte[][] {ByteArrayUtil.bytes(uniquePartition ? i : 1), ByteArrayUtil.bytes(i), ByteArrayUtil.bytes(i)});
             queryOrIdList.add(prepared.rawCQLStatement);
         }
         bs = new BatchStatement(BatchStatement.Type.UNLOGGED, VariableSpecifications.empty(), modifications, Attributes.none());

--- a/test/unit/org/apache/cassandra/cql3/QueryEventsTest.java
+++ b/test/unit/org/apache/cassandra/cql3/QueryEventsTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.cql3;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,8 +38,9 @@ import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.Message;
 import org.apache.cassandra.transport.messages.ResultMessage;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.ByteArrayUtil;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -144,9 +144,9 @@ public class QueryEventsTest extends CQLTester
         assertEquals(3, listener.queries.size());
         assertEquals(BatchStatement.Type.UNLOGGED, listener.batchType);
         assertEquals(newArrayList(q1, q1, q2), listener.queries);
-        assertEquals(newArrayList(newArrayList(ByteBufferUtil.bytes(1), ByteBufferUtil.bytes(1)),
-                                  newArrayList(ByteBufferUtil.bytes(2), ByteBufferUtil.bytes(2)),
-                                  newArrayList(newArrayList())), listener.values);
+        assertListOfArraysEquals(newArrayList(new byte[][] {ByteArrayUtil.bytes(1), ByteArrayUtil.bytes(1)},
+                                              new byte[][] {ByteArrayUtil.bytes(2), ByteArrayUtil.bytes(2)},
+                                              new byte[][] {}), listener.values);
 
         batch.add(new SimpleStatement("insert into abc.def (id, v) values (1,1)"));
         try
@@ -162,10 +162,17 @@ public class QueryEventsTest extends CQLTester
         assertEquals(3, listener.queries.size());
         assertEquals(BatchStatement.Type.UNLOGGED, listener.batchType);
         assertEquals(newArrayList(q1, q1, q2), listener.queries);
-        assertEquals(newArrayList(newArrayList(ByteBufferUtil.bytes(1), ByteBufferUtil.bytes(1)),
-                                  newArrayList(ByteBufferUtil.bytes(2), ByteBufferUtil.bytes(2)),
-                                  newArrayList(newArrayList()),
-                                  newArrayList(newArrayList())), listener.values);
+        assertListOfArraysEquals(newArrayList(new byte[][] {ByteArrayUtil.bytes(1), ByteArrayUtil.bytes(1)},
+                                              new byte[][] {ByteArrayUtil.bytes(2), ByteArrayUtil.bytes(2)},
+                                              new byte[][] {},
+                                              new byte[][] {}), listener.values);
+    }
+
+    private static void assertListOfArraysEquals(List<byte[][]> expected, List<byte[][]> actual)
+    {
+        assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++)
+            assertArrayEquals(expected.get(i), actual.get(i));
     }
 
     @Test
@@ -323,7 +330,7 @@ public class QueryEventsTest extends CQLTester
     private static class BatchMockListener extends MockListener
     {
         private List<String> queries;
-        private List<List<ByteBuffer>> values;
+        private List<byte[][]> values;
         private BatchStatement.Type batchType;
 
         BatchMockListener(ColumnFamilyStore currentColumnFamilyStore)
@@ -331,7 +338,7 @@ public class QueryEventsTest extends CQLTester
             super(currentColumnFamilyStore);
         }
 
-        public void batchSuccess(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<List<ByteBuffer>> values, QueryOptions options, QueryState state, long queryTime, Message.Response response)
+        public void batchSuccess(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<byte[][]> values, QueryOptions options, QueryState state, long queryTime, Message.Response response)
         {
             inc("batchSuccess");
             this.queries = queries;
@@ -340,7 +347,7 @@ public class QueryEventsTest extends CQLTester
             this.queryTime = queryTime;
         }
 
-        public void batchFailure(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<List<ByteBuffer>> values, QueryOptions options, QueryState state, Exception cause)
+        public void batchFailure(BatchStatement.Type batchType, List<? extends CQLStatement> statements, List<String> queries, List<byte[][]> values, QueryOptions options, QueryState state, Exception cause)
         {
             inc("batchFailure");
             this.queries = queries;

--- a/test/unit/org/apache/cassandra/fql/FullQueryLoggerTest.java
+++ b/test/unit/org/apache/cassandra/fql/FullQueryLoggerTest.java
@@ -58,6 +58,7 @@ import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.binlog.BinLogTest;
 
@@ -462,9 +463,9 @@ public class FullQueryLoggerTest extends CQLTester
         configureFQL();
         logBatch(Type.UNLOGGED,
                  Arrays.asList("foo1", "foo2"),
-                 Arrays.asList(Arrays.asList(ByteBuffer.allocate(1),
-                                             ByteBuffer.allocateDirect(2)),
-                               Collections.emptyList()),
+                 Arrays.asList(new byte[][] {new byte[1],
+                                             new byte[2]},
+                               ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS),
                  QueryOptions.DEFAULT,
                  queryState("abcdefgh"),
                  1);
@@ -486,9 +487,9 @@ public class FullQueryLoggerTest extends CQLTester
         configureFQL();
         logBatch(Type.UNLOGGED,
                  Arrays.asList("foo1", "foo2"),
-                 Arrays.asList(Arrays.asList(ByteBuffer.allocate(1),
-                                             ByteBuffer.allocateDirect(2)),
-                               Collections.emptyList()),
+                 Arrays.asList(new byte[][] {new byte[1],
+                                             new byte[2]},
+                               ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS),
                  QueryOptions.DEFAULT,
                  queryState(),
                  1);
@@ -599,12 +600,10 @@ public class FullQueryLoggerTest extends CQLTester
 
         bigList = null;
         //The size of the list of values should be reflected
-        List<List<ByteBuffer>> bigValues = new ArrayList<>(100000);
+        List<byte[][]> bigValues = new ArrayList<>(100000);
         for (int ii = 0; ii < 100000; ii++)
-        {
-            bigValues.add(new ArrayList<>(0));
-        }
-        bigValues.get(0).add(ByteBuffer.allocate(1024 * 1024 * 5));
+            bigValues.add(ii == 0 ? new byte[][] {new byte[1024 * 1024 * 5]} : new byte[][]{});
+
         batch = new Batch(Type.UNLOGGED, new ArrayList<>(), bigValues, QueryOptions.DEFAULT, queryState(), 1);
         assertTrue(batch.weight() > ObjectSizes.measureDeep(bigValues));
 
@@ -642,7 +641,7 @@ public class FullQueryLoggerTest extends CQLTester
     @Test(expected = NullPointerException.class)
     public void testLogBatchNullValuesValue() throws Exception
     {
-        logBatch(Type.UNLOGGED, new ArrayList<>(), Arrays.asList((List<ByteBuffer>)null), null, queryState(), 1);
+        logBatch(Type.UNLOGGED, new ArrayList<>(), Arrays.asList(null), null, queryState(), 1);
     }
 
     @Test(expected = NullPointerException.class)
@@ -737,7 +736,7 @@ public class FullQueryLoggerTest extends CQLTester
 
     private void logBatch(BatchStatement.Type type,
                           List<String> queries,
-                          List<List<ByteBuffer>> values,
+                          List<byte[][]> values,
                           QueryOptions options,
                           QueryState queryState,
                           long time)

--- a/test/unit/org/apache/cassandra/metrics/ClientRequestRowAndColumnMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ClientRequestRowAndColumnMetricsTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.metrics;
 
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,6 +36,7 @@ import org.apache.cassandra.service.paxos.Paxos;
 import org.apache.cassandra.transport.SimpleClient;
 import org.apache.cassandra.transport.messages.BatchMessage;
 import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.utils.ByteArrayUtil;
 
 import static org.junit.Assert.assertEquals;
 
@@ -257,7 +257,7 @@ public class ClientRequestRowAndColumnMetricsTest extends CQLTester
             String first = String.format("INSERT INTO %s.%s (pk, v1, v2) VALUES (1, 10, 100)", KEYSPACE, currentTable());
             String second = String.format("INSERT INTO %s.%s (pk, v1, v2) VALUES (2, 20, 200)", KEYSPACE, currentTable());
 
-            List<List<ByteBuffer>> values = ImmutableList.of(Collections.emptyList(), Collections.emptyList());
+            List<byte[][]> values = ImmutableList.of(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS);
             BatchMessage batch = new BatchMessage(BatchStatement.Type.LOGGED, ImmutableList.of(first, second), values, QueryOptions.DEFAULT);
             client.execute(batch);
 
@@ -312,7 +312,7 @@ public class ClientRequestRowAndColumnMetricsTest extends CQLTester
             String first = String.format("INSERT INTO %s.%s (pk, ck, v0, v1, v2) VALUES (0, 1, 2, 3, 4)", KEYSPACE, currentTable());
             String second = String.format("INSERT INTO %s.%s (pk, ck, v0, v1, v2) VALUES (0, 2, 3, 5, 6)", KEYSPACE, currentTable());
 
-            List<List<ByteBuffer>> values = ImmutableList.of(Collections.emptyList(), Collections.emptyList());
+            List<byte[][]> values = ImmutableList.of(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS);
             BatchMessage batch = new BatchMessage(BatchStatement.Type.LOGGED, ImmutableList.of(first, second), values, QueryOptions.DEFAULT);
             client.execute(batch);
 
@@ -373,7 +373,7 @@ public class ClientRequestRowAndColumnMetricsTest extends CQLTester
             String first = String.format("INSERT INTO %s.%s (pk, ck, v1, v2) VALUES (1, 2, 3, 4)", KEYSPACE, currentTable());
             String second = String.format("DELETE FROM %s.%s WHERE pk = 1 AND ck > 1", KEYSPACE, currentTable());
 
-            List<List<ByteBuffer>> values = ImmutableList.of(Collections.emptyList(), Collections.emptyList());
+            List<byte[][]> values = ImmutableList.of(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS);
             BatchMessage batch = new BatchMessage(BatchStatement.Type.LOGGED, ImmutableList.of(first, second), values, QueryOptions.DEFAULT);
             client.execute(batch);
 

--- a/test/unit/org/apache/cassandra/transport/MessagePayloadTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessagePayloadTest.java
@@ -46,6 +46,7 @@ import org.apache.cassandra.transport.messages.ExecuteMessage;
 import org.apache.cassandra.transport.messages.PrepareMessage;
 import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.transport.messages.ResultMessage;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.MD5Digest;
 import org.apache.cassandra.utils.ReflectionUtils;
 
@@ -172,7 +173,7 @@ public class MessagePayloadTest extends CQLTester
 
                 BatchMessage batchMessage = new BatchMessage(BatchStatement.Type.UNLOGGED,
                                                              Collections.<Object>singletonList("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')"),
-                                                             Collections.singletonList(Collections.<ByteBuffer>emptyList()),
+                                                             Collections.singletonList(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS),
                                                              queryOptions);
                 reqMap = Collections.singletonMap("foo", bytes(45));
                 responsePayload = respMap = Collections.singletonMap("bar", bytes(45));
@@ -241,7 +242,7 @@ public class MessagePayloadTest extends CQLTester
 
                 BatchMessage batchMessage = new BatchMessage(BatchStatement.Type.UNLOGGED,
                                                              Collections.<Object>singletonList("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')"),
-                                                             Collections.singletonList(Collections.<ByteBuffer>emptyList()),
+                                                             Collections.singletonList(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS),
                                                              QueryOptions.DEFAULT);
                 reqMap = Collections.singletonMap("foo", bytes(45));
                 responsePayload = respMap = Collections.singletonMap("bar", bytes(45));
@@ -342,7 +343,7 @@ public class MessagePayloadTest extends CQLTester
 
                 BatchMessage batchMessage = new BatchMessage(BatchStatement.Type.UNLOGGED,
                                                              Collections.<Object>singletonList("INSERT INTO " + KEYSPACE + ".atable (pk,v) VALUES (1, 'foo')"),
-                                                             Collections.singletonList(Collections.<ByteBuffer>emptyList()),
+                                                             Collections.singletonList(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS),
                                                              QueryOptions.DEFAULT);
                 reqMap = Collections.singletonMap("foo", bytes(45));
                 responsePayload = Collections.singletonMap("bar", bytes(45));

--- a/tools/fqltool/src/org/apache/cassandra/fqltool/FQLQuery.java
+++ b/tools/fqltool/src/org/apache/cassandra/fqltool/FQLQuery.java
@@ -244,11 +244,17 @@ public abstract class FQLQuery implements Comparable<FQLQuery>
         public BinLog.ReleaseableWriteMarshallable toMarshallable()
         {
             List<String> queryStrings = new ArrayList<>();
-            List<List<ByteBuffer>> values = new ArrayList<>();
+            List<byte[][]> values = new ArrayList<>();
             for (Single q : queries)
             {
                 queryStrings.add(q.query);
-                values.add(q.values);
+                byte[][] valuesAsArray = new byte[q.values.size()][];
+                int i = 0;
+                for (ByteBuffer value : q.values)
+                {
+                    valuesAsArray[i++] = value.array();
+                }
+                values.add(valuesAsArray);
             }
             return new FullQueryLogger.Batch(org.apache.cassandra.cql3.statements.BatchStatement.Type.valueOf(batchType.name()), queryStrings, values, queryOptions, queryState, queryStartTime);
         }

--- a/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
+++ b/tools/fqltool/test/unit/org/apache/cassandra/fqltool/FQLReplayTest.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.fqltool.commands.Replay;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.tools.Util;
+import org.apache.cassandra.utils.ByteArrayUtil;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.MergeIterator;
 import org.apache.cassandra.utils.Pair;
@@ -705,11 +706,11 @@ public class FQLReplayTest
                 {
                     int batchSize = random ? r.nextInt(99) + 1 : i + 1;
                     List<String> queries = new ArrayList<>(batchSize);
-                    List<List<ByteBuffer>> values = new ArrayList<>(batchSize);
+                    List<byte[][]> values = new ArrayList<>(batchSize);
                     for (int jj = 0; jj < (random ? r.nextInt(batchSize) : 10); jj++)
                     {
                         queries.add("aaaaaa batch "+i+":"+jj);
-                        values.add(Collections.emptyList());
+                        values.add(ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS);
                     }
                     FullQueryLogger.Batch batch = new FullQueryLogger.Batch(BatchStatement.Type.UNLOGGED,
                                                                             queries,


### PR DESCRIPTION
Use byte[] directly and convert them to ArrayCell instead of BufferCell. Additionally replace List with array for bind values (we know the size in advance during a decoding), so in total: List<List<ByteBuffer>> is replaced with byte[][] QueryOptions classes support both ways to get values now: using an old API with ByteBuffer and a new API with byte[].

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20166

