### PR TITLE
[CASSANDRA-20173][5.0] Introduce NativeAccessor to avoid new ByteBuffer allocation on flush for each NativeCell

### DIFF
--- a/src/java/org/apache/cassandra/db/ClusteringPrefix.java
+++ b/src/java/org/apache/cassandra/db/ClusteringPrefix.java
@@ -257,6 +257,25 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
      */
     public V get(int i);
 
+    /**
+     * The method is introduced to allow to avoid a value object retrieval/allocation for simple checks
+     */
+    public default boolean isNull(int i)
+    {
+        return get(i) == null;
+    }
+
+    /**
+     * The method is introduced to allow to avoid a value object retrieval/allocation for simple checks
+     */
+    public default boolean isEmpty(int i)
+    {
+        V v = get(i);
+        if (v == null)
+            return true;
+        return accessor().isEmpty(v);
+    }
+
     public ValueAccessor<V> accessor();
 
     default ByteBuffer bufferAt(int i)
@@ -401,7 +420,7 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
      * memory (i.e. in memtables) to minimized on-heap versions.
      * If the object is already in minimal form, no action will be taken.
      */
-    public ClusteringPrefix<V> retainable();
+    public ClusteringPrefix<?> retainable();
 
     public static class Serializer
     {
@@ -548,14 +567,12 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
         private static <V> long makeHeader(ClusteringPrefix<V> clustering, int offset, int limit)
         {
             long header = 0;
-            ValueAccessor<V> accessor = clustering.accessor();
             for (int i = offset ; i < limit ; i++)
             {
-                V v = clustering.get(i);
                 // no need to do modulo arithmetic for i, since the left-shift execute on the modulus of RH operand by definition
-                if (v == null)
+                if (clustering.isNull(i))
                     header |= (1L << (i * 2) + 1);
-                else if (accessor.isEmpty(v))
+                else if (clustering.isEmpty(i))
                     header |= (1L << (i * 2));
             }
             return header;

--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -3,7 +3,7 @@
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
 * regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (thec
+ * to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
 *
@@ -18,19 +18,16 @@
 */
 package org.apache.cassandra.db;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import io.netty.util.concurrent.FastThreadLocal;
+import org.apache.cassandra.db.marshal.AddressBasedNativeData;
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
-import org.apache.cassandra.db.marshal.ByteBufferSliceNativeData;
 import org.apache.cassandra.db.marshal.NativeAccessor;
 import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
-import org.apache.cassandra.io.util.DataOutputPlus;
-import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.FastByteOperations;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.HeapCloner;
@@ -131,48 +128,38 @@ public class NativeClustering implements Clustering<NativeData>
         }
 
         @Override
-        public NativeData slice(int offset, int length)
+        public NativeData slice(int offset, int sliceLength)
         {
-            ByteBuffer byteBuffer = asByteBuffer(); // we get a new buffer here each time, so duplicate() is not needed
-            byteBuffer.position(byteBuffer.position() + offset);
-            byteBuffer.limit(byteBuffer.position() + length);
-            return new ByteBufferSliceNativeData(byteBuffer);
+            int clusteringSize = parentSize();
+            if (i >= clusteringSize)
+                throw new IndexOutOfBoundsException();
+
+            int metadataSize = (clusteringSize * 2) + 4;
+            int bitmapSize = ((clusteringSize + 7) >>> 3);
+            long bitmapStart = peer + metadataSize;
+            int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
+            if ((b & (1 << (i & 7))) != 0)
+                return AddressBasedNativeData.EMPTY;
+
+            int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
+            int endOffset = MemoryUtil.getShort(peer + 4 + i * 2);
+            long address = bitmapStart + bitmapSize + startOffset;
+            int length =  endOffset - startOffset;
+
+            if (offset < 0 || offset > length)
+                throw new IllegalArgumentException("offset must but be >= 0 and < parent length");
+            if (sliceLength < 0 || offset + sliceLength > length) {
+                throw new IllegalArgumentException("length must but be >= 0 and offset + length > parent length");
+            }
+
+            if (length == 0) {
+                return AddressBasedNativeData.EMPTY;
+            }
+            return new AddressBasedNativeData(address + offset, sliceLength);
         }
 
         private int parentSize() {
             return MemoryUtil.getShort(peer);
-        }
-
-        private static final FastThreadLocal<ByteBuffer> REUSABLE_WRITE_BUFFER_1 = new FastThreadLocal<ByteBuffer>()
-        {
-            @Override
-            protected ByteBuffer initialValue()
-            {
-                return MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
-            }
-        };
-
-        /**
-         * we need two re-usable buffers to be able to do compare operation without memory allocations
-         */
-        private static final FastThreadLocal<ByteBuffer> REUSABLE_WRITE_BUFFER_2 = new FastThreadLocal<ByteBuffer>()
-        {
-            @Override
-            protected ByteBuffer initialValue()
-            {
-                return MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
-            }
-        };
-
-        @Override
-        public void writeTo(DataOutputPlus out) throws IOException
-        {
-            ByteBuffer byteBuffer = getByteBuffer((address, length) -> {
-                ByteBuffer result = REUSABLE_WRITE_BUFFER_1.get();
-                MemoryUtil.setDirectByteBuffer(result, address, length);
-                return result;
-            });
-            out.write(byteBuffer);
         }
 
         private ByteBuffer getByteBuffer(ByteBufferProvider provider)
@@ -192,33 +179,35 @@ public class NativeClustering implements Clustering<NativeData>
         @Override
         public int compareTo(NativeData right)
         {
-            ByteBuffer leftByteBuffer = getByteBuffer((address, length) -> {
-                ByteBuffer result = REUSABLE_WRITE_BUFFER_1.get();
-                MemoryUtil.setDirectByteBuffer(result, address, length);
-                return result;
-            });
-            if (right instanceof NativeClusteringValue) {
-                NativeClusteringValue rightNativeClusteringValue = (NativeClusteringValue) right;
-                ByteBuffer rightByteBuffer = rightNativeClusteringValue.getByteBuffer((address, length) -> {
-                    ByteBuffer result = REUSABLE_WRITE_BUFFER_2.get();
-                    MemoryUtil.setDirectByteBuffer(result, address, length);
-                    return result;
-                });
-                return ByteBufferUtil.compareUnsigned(leftByteBuffer, rightByteBuffer);
-            } else {
-                return ByteBufferUtil.compareUnsigned(leftByteBuffer, right.asByteBuffer());
-            }
+            int leftSize = this.nativeDataSize();
+            int rightSize = right.nativeDataSize();
+            return FastByteOperations.compareUnsigned(this.getAddress(), leftSize, right.getAddress(), rightSize);
+        }
+
+        @Override
+        public long getAddress()
+        {
+            int parentSize = parentSize();
+            if (i >= parentSize)
+                throw new IndexOutOfBoundsException();
+
+            int metadataSize = (parentSize * 2) + 4;
+            int bitmapSize = ((parentSize + 7) >>> 3);
+            long bitmapStart = peer + metadataSize;
+            int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
+            if ((b & (1 << (i & 7))) != 0)
+                return -1;
+
+            int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
+            long address = bitmapStart + bitmapSize + startOffset;
+            return  address;
         }
 
         @Override
         public int compareTo(ByteBuffer right)
         {
-            ByteBuffer leftByteBuffer = getByteBuffer((address, length) -> {
-                ByteBuffer result = REUSABLE_WRITE_BUFFER_1.get();
-                MemoryUtil.setDirectByteBuffer(result, address, length);
-                return result;
-            });
-            return ByteBufferUtil.compareUnsigned(leftByteBuffer, right);
+            int leftSize = this.nativeDataSize();
+            return -FastByteOperations.compareUnsigned(right, this.getAddress(), leftSize);
         }
     }
 
@@ -236,12 +225,12 @@ public class NativeClustering implements Clustering<NativeData>
         return isNull(peer, size, i);
     }
 
-    static boolean isNull(long peer, int size, int i)
+    static boolean isNull(long peer, int parentSize, int i)
     {
-        if (i >= size)
+        if (i >= parentSize)
             throw new IndexOutOfBoundsException();
 
-        int metadataSize = (size * 2) + 4;
+        int metadataSize = (parentSize * 2) + 4;
         long bitmapStart = peer + metadataSize;
         int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
         return ((b & (1 << (i & 7))) != 0);
@@ -252,9 +241,9 @@ public class NativeClustering implements Clustering<NativeData>
         return nativeDataSize(peer, size(), i) == 0;
     }
 
-    static int nativeDataSize(long peer, int size, int i)
+    static int nativeDataSize(long peer, int parentSize, int i)
     {
-        if (isNull(peer, size, i))
+        if (isNull(peer, parentSize, i))
             return 0;
 
         int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);

--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -27,7 +27,6 @@ import org.apache.cassandra.db.marshal.NativeAccessor;
 import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.utils.FBUtilities;
-import org.apache.cassandra.utils.FastByteOperations;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.HeapCloner;
@@ -103,134 +102,22 @@ public class NativeClustering implements Clustering<NativeData>
         return MemoryUtil.getShort(peer + dataSizeOffset);
     }
 
-
-    private static class NativeClusteringValue implements NativeData {
-        private final long peer;
-        private final int i;
-
-        private NativeClusteringValue(long peer, int i)
-        {
-            this.peer = peer;
-            this.i = i;
-        }
-
-        @Override
-        public int nativeDataSize()
-        {
-            int size = parentSize();
-            return NativeClustering.nativeDataSize(peer, size, i);
-        }
-
-        @Override
-        public ByteBuffer asByteBuffer()
-        {
-            return getByteBuffer((address, length) -> MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN));
-        }
-
-        @Override
-        public NativeData slice(int offset, int sliceLength)
-        {
-            int clusteringSize = parentSize();
-            if (i >= clusteringSize)
-                throw new IndexOutOfBoundsException();
-
-            int metadataSize = (clusteringSize * 2) + 4;
-            int bitmapSize = ((clusteringSize + 7) >>> 3);
-            long bitmapStart = peer + metadataSize;
-            int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
-            if ((b & (1 << (i & 7))) != 0)
-                return AddressBasedNativeData.EMPTY;
-
-            int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
-            int endOffset = MemoryUtil.getShort(peer + 4 + i * 2);
-            long address = bitmapStart + bitmapSize + startOffset;
-            int length =  endOffset - startOffset;
-
-            if (offset < 0 || offset > length)
-                throw new IllegalArgumentException("offset must but be >= 0 and < parent length");
-            if (sliceLength < 0 || offset + sliceLength > length) {
-                throw new IllegalArgumentException("length must but be >= 0 and offset + length > parent length");
-            }
-
-            if (length == 0) {
-                return AddressBasedNativeData.EMPTY;
-            }
-            return new AddressBasedNativeData(address + offset, sliceLength);
-        }
-
-        private int parentSize() {
-            return MemoryUtil.getShort(peer);
-        }
-
-        private ByteBuffer getByteBuffer(ByteBufferProvider provider)
-        {
-            int size = parentSize();
-            if (i >= size)
-                throw new IndexOutOfBoundsException();
-
-            return NativeClustering.getByteBuffer(peer, i, size, provider);
-        }
-
-        private interface ByteBufferProvider
-        {
-            ByteBuffer get(long address, int length);
-        }
-
-        @Override
-        public int compareTo(NativeData right)
-        {
-            int leftSize = this.nativeDataSize();
-            int rightSize = right.nativeDataSize();
-            return FastByteOperations.compareUnsigned(this.getAddress(), leftSize, right.getAddress(), rightSize);
-        }
-
-        @Override
-        public long getAddress()
-        {
-            int parentSize = parentSize();
-            if (i >= parentSize)
-                throw new IndexOutOfBoundsException();
-
-            int metadataSize = (parentSize * 2) + 4;
-            int bitmapSize = ((parentSize + 7) >>> 3);
-            long bitmapStart = peer + metadataSize;
-            int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
-            if ((b & (1 << (i & 7))) != 0)
-                return -1;
-
-            int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
-            long address = bitmapStart + bitmapSize + startOffset;
-            return  address;
-        }
-
-        @Override
-        public int compareTo(ByteBuffer right)
-        {
-            int leftSize = this.nativeDataSize();
-            return -FastByteOperations.compareUnsigned(right, this.getAddress(), leftSize);
-        }
-    }
-
     public NativeData get(int i)
     {
-        if (isNull(i))
-            return null;
-
-        return new NativeClusteringValue(peer, i);
+        return buildDataObject(i, AddressBasedNativeData::new);
     }
 
     public boolean isNull(int i)
     {
-        int size = size();
-        return isNull(peer, size, i);
+        return isNull(peer, size(), i);
     }
 
-    static boolean isNull(long peer, int parentSize, int i)
+    private static boolean isNull(long peer, int size, int i)
     {
-        if (i >= parentSize)
+        if (i >= size)
             throw new IndexOutOfBoundsException();
 
-        int metadataSize = (parentSize * 2) + 4;
+        int metadataSize = (size * 2) + 4;
         long bitmapStart = peer + metadataSize;
         int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
         return ((b & (1 << (i & 7))) != 0);
@@ -238,30 +125,28 @@ public class NativeClustering implements Clustering<NativeData>
 
     public boolean isEmpty(int i)
     {
-        return nativeDataSize(peer, size(), i) == 0;
-    }
-
-    static int nativeDataSize(long peer, int parentSize, int i)
-    {
-        if (isNull(peer, parentSize, i))
-            return 0;
+        int size = size();
+        if (isNull(peer, size, i))
+            return true;
 
         int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
         int endOffset = MemoryUtil.getShort(peer + 4 + i * 2);
-        return (endOffset - startOffset);
+        return (endOffset - startOffset) == 0;
     }
+
 
     private ByteBuffer getByteBuffer(int i)
     {
-        int size = size();
-        if (i >= size)
-            throw new IndexOutOfBoundsException();
-
-        return getByteBuffer(peer, i, size, (address, length) -> MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN));
+        return buildDataObject(i, (long address, int length) -> MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN));
     }
 
-    static ByteBuffer getByteBuffer(long peer, int i, int size, NativeClusteringValue.ByteBufferProvider provider)
+    private interface DataObjectBuilder<D> {
+        D build(long address, int length);
+    }
+
+    private <D> D buildDataObject(int i, DataObjectBuilder<D> builder)
     {
+        int size = size();
         if (i >= size)
             throw new IndexOutOfBoundsException();
 
@@ -274,8 +159,10 @@ public class NativeClustering implements Clustering<NativeData>
 
         int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
         int endOffset = MemoryUtil.getShort(peer + 4 + i * 2);
-        return provider.get(bitmapStart + bitmapSize + startOffset,
-                            endOffset - startOffset);
+
+        long address = bitmapStart + bitmapSize + startOffset;
+        int length = endOffset - startOffset;
+        return builder.build(address, length);
     }
 
     public NativeData[] getRawValues()

--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -3,7 +3,7 @@
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
 * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
+* to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
 *

--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -3,7 +3,7 @@
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information
 * regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
+* to you under the Apache License, Version 2.0 (thec
 * "License"); you may not use this file except in compliance
 * with the License.  You may obtain a copy of the License at
 *
@@ -18,11 +18,18 @@
 */
 package org.apache.cassandra.db;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import io.netty.util.concurrent.FastThreadLocal;
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
+import org.apache.cassandra.db.marshal.ByteBufferSliceNativeData;
+import org.apache.cassandra.db.marshal.NativeAccessor;
+import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.concurrent.OpOrder;
@@ -30,7 +37,7 @@ import org.apache.cassandra.utils.memory.HeapCloner;
 import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.apache.cassandra.utils.memory.NativeAllocator;
 
-public class NativeClustering implements Clustering<ByteBuffer>
+public class NativeClustering implements Clustering<NativeData>
 {
     private static final long EMPTY_SIZE = ObjectSizes.measure(new NativeClustering());
 
@@ -83,7 +90,7 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return Kind.CLUSTERING;
     }
 
-    public ClusteringPrefix<ByteBuffer> clustering()
+    public ClusteringPrefix<NativeData> clustering()
     {
         return this;
     }
@@ -99,10 +106,173 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return MemoryUtil.getShort(peer + dataSizeOffset);
     }
 
-    public ByteBuffer get(int i)
+
+    private static class NativeClusteringValue implements NativeData {
+        private final long peer;
+        private final int i;
+
+        private NativeClusteringValue(long peer, int i)
+        {
+            this.peer = peer;
+            this.i = i;
+        }
+
+        @Override
+        public int nativeDataSize()
+        {
+            int size = parentSize();
+            return NativeClustering.nativeDataSize(peer, size, i);
+        }
+
+        @Override
+        public ByteBuffer asByteBuffer()
+        {
+            return getByteBuffer((address, length) -> MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN));
+        }
+
+        @Override
+        public NativeData slice(int offset, int length)
+        {
+            ByteBuffer byteBuffer = asByteBuffer(); // we get a new buffer here each time, so duplicate() is not needed
+            byteBuffer.position(byteBuffer.position() + offset);
+            byteBuffer.limit(byteBuffer.position() + length);
+            return new ByteBufferSliceNativeData(byteBuffer);
+        }
+
+        private int parentSize() {
+            return MemoryUtil.getShort(peer);
+        }
+
+        private static final FastThreadLocal<ByteBuffer> REUSABLE_WRITE_BUFFER_1 = new FastThreadLocal<ByteBuffer>()
+        {
+            @Override
+            protected ByteBuffer initialValue()
+            {
+                return MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
+            }
+        };
+
+        /**
+         * we need two re-usable buffers to be able to do compare operation without memory allocations
+         */
+        private static final FastThreadLocal<ByteBuffer> REUSABLE_WRITE_BUFFER_2 = new FastThreadLocal<ByteBuffer>()
+        {
+            @Override
+            protected ByteBuffer initialValue()
+            {
+                return MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
+            }
+        };
+
+        @Override
+        public void writeTo(DataOutputPlus out) throws IOException
+        {
+            ByteBuffer byteBuffer = getByteBuffer((address, length) -> {
+                ByteBuffer result = REUSABLE_WRITE_BUFFER_1.get();
+                MemoryUtil.setDirectByteBuffer(result, address, length);
+                return result;
+            });
+            out.write(byteBuffer);
+        }
+
+        private ByteBuffer getByteBuffer(ByteBufferProvider provider)
+        {
+            int size = parentSize();
+            if (i >= size)
+                throw new IndexOutOfBoundsException();
+
+            return NativeClustering.getByteBuffer(peer, i, size, provider);
+        }
+
+        private interface ByteBufferProvider
+        {
+            ByteBuffer get(long address, int length);
+        }
+
+        @Override
+        public int compareTo(NativeData right)
+        {
+            ByteBuffer leftByteBuffer = getByteBuffer((address, length) -> {
+                ByteBuffer result = REUSABLE_WRITE_BUFFER_1.get();
+                MemoryUtil.setDirectByteBuffer(result, address, length);
+                return result;
+            });
+            if (right instanceof NativeClusteringValue) {
+                NativeClusteringValue rightNativeClusteringValue = (NativeClusteringValue) right;
+                ByteBuffer rightByteBuffer = rightNativeClusteringValue.getByteBuffer((address, length) -> {
+                    ByteBuffer result = REUSABLE_WRITE_BUFFER_2.get();
+                    MemoryUtil.setDirectByteBuffer(result, address, length);
+                    return result;
+                });
+                return ByteBufferUtil.compareUnsigned(leftByteBuffer, rightByteBuffer);
+            } else {
+                return ByteBufferUtil.compareUnsigned(leftByteBuffer, right.asByteBuffer());
+            }
+        }
+
+        @Override
+        public int compareTo(ByteBuffer right)
+        {
+            ByteBuffer leftByteBuffer = getByteBuffer((address, length) -> {
+                ByteBuffer result = REUSABLE_WRITE_BUFFER_1.get();
+                MemoryUtil.setDirectByteBuffer(result, address, length);
+                return result;
+            });
+            return ByteBufferUtil.compareUnsigned(leftByteBuffer, right);
+        }
+    }
+
+    public NativeData get(int i)
     {
-        // offset at which we store the dataOffset
+        if (isNull(i))
+            return null;
+
+        return new NativeClusteringValue(peer, i);
+    }
+
+    public boolean isNull(int i)
+    {
         int size = size();
+        return isNull(peer, size, i);
+    }
+
+    static boolean isNull(long peer, int size, int i)
+    {
+        if (i >= size)
+            throw new IndexOutOfBoundsException();
+
+        int metadataSize = (size * 2) + 4;
+        long bitmapStart = peer + metadataSize;
+        int b = MemoryUtil.getByte(bitmapStart + (i >>> 3));
+        return ((b & (1 << (i & 7))) != 0);
+    }
+
+    public boolean isEmpty(int i)
+    {
+        return nativeDataSize(peer, size(), i) == 0;
+    }
+
+    static int nativeDataSize(long peer, int size, int i)
+    {
+        if (isNull(peer, size, i))
+            return 0;
+
+        int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
+        int endOffset = MemoryUtil.getShort(peer + 4 + i * 2);
+        return (endOffset - startOffset);
+    }
+
+    private ByteBuffer getByteBuffer(int i)
+    {
+        int size = size();
+        if (i >= size)
+            throw new IndexOutOfBoundsException();
+
+        return getByteBuffer(peer, i, size, (address, length) -> MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN));
+    }
+
+    static ByteBuffer getByteBuffer(long peer, int i, int size, NativeClusteringValue.ByteBufferProvider provider)
+    {
         if (i >= size)
             throw new IndexOutOfBoundsException();
 
@@ -115,14 +285,13 @@ public class NativeClustering implements Clustering<ByteBuffer>
 
         int startOffset = MemoryUtil.getShort(peer + 2 + i * 2);
         int endOffset = MemoryUtil.getShort(peer + 4 + i * 2);
-        return MemoryUtil.getByteBuffer(bitmapStart + bitmapSize + startOffset,
-                                        endOffset - startOffset,
-                                        ByteOrder.BIG_ENDIAN);
+        return provider.get(bitmapStart + bitmapSize + startOffset,
+                            endOffset - startOffset);
     }
 
-    public ByteBuffer[] getRawValues()
+    public NativeData[] getRawValues()
     {
-        ByteBuffer[] values = new ByteBuffer[size()];
+        NativeData[] values = new NativeData[size()];
         for (int i = 0 ; i < values.length ; i++)
             values[i] = get(i);
         return values;
@@ -130,13 +299,15 @@ public class NativeClustering implements Clustering<ByteBuffer>
 
     public ByteBuffer[] getBufferArray()
     {
-        return getRawValues();
+        ByteBuffer[] values = new ByteBuffer[size()];
+        for (int i = 0 ; i < values.length ; i++)
+            values[i] = getByteBuffer(i);
+        return values;
     }
 
-    public ValueAccessor<ByteBuffer> accessor()
+    public ValueAccessor<NativeData> accessor()
     {
-        // TODO: add a native accessor
-        return ByteBufferAccessor.instance;
+        return NativeAccessor.instance;
     }
 
     public long unsharedHeapSize()
@@ -161,8 +332,9 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return ClusteringPrefix.equals(this, o);
     }
 
+    // data are copied to heap byte buffers to detach from a NativeAllocator lifecycle
     @Override
-    public ClusteringPrefix<ByteBuffer> retainable()
+    public ClusteringPrefix<?> retainable()
     {
         assert kind() == Kind.CLUSTERING; // tombstones are never stored natively
 
@@ -170,10 +342,10 @@ public class NativeClustering implements Clustering<ByteBuffer>
         ByteBuffer[] values = new ByteBuffer[size()];
         for (int i = 0; i < values.length; ++i)
         {
-            ByteBuffer value = get(i);
+            ByteBuffer value = getByteBuffer(i);
             values[i] = value != null ? HeapCloner.instance.clone(value) : null;
         }
 
-        return accessor().factory().clustering(values);
+        return ByteBufferAccessor.instance.factory().clustering(values);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
@@ -18,47 +18,58 @@
 
 package org.apache.cassandra.db.marshal;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
-import org.apache.cassandra.io.util.DataOutputPlus;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 /**
  * Temporary created object as a part of slicing (usually to parse collection parts)
  */
-public class ByteBufferSliceNativeData implements NativeData
+public class AddressBasedNativeData implements NativeData
 {
-    public static final ByteBufferSliceNativeData EMPTY = new ByteBufferSliceNativeData(ByteBufferUtil.EMPTY_BYTE_BUFFER);
+    public static final AddressBasedNativeData EMPTY = new AddressBasedNativeData(-1, 0);
 
-    private final ByteBuffer byteBuffer;
+    private final long address;
+    private final int length;
 
-    public ByteBufferSliceNativeData(ByteBuffer byteBuffer)
+    public AddressBasedNativeData(long address, int length)
     {
-        this.byteBuffer = byteBuffer;
+        this.address = address;
+        this.length = length;
     }
+
 
     @Override
     public int nativeDataSize()
     {
-        return byteBuffer.remaining();
+        return length;
     }
 
     @Override
     public ByteBuffer asByteBuffer()
     {
-        return byteBuffer;
+        return MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN);
     }
 
     @Override
     public NativeData slice(int offset, int length)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.slice(byteBuffer, offset, length));
+        if (offset < 0 || offset > this.length)
+            throw new IllegalArgumentException("offset must but be >= 0 and < parent length");
+        if (length < 0 || offset + length > this.length) {
+            throw new IllegalArgumentException("length must but be >= 0 and offset + length > parent length");
+        }
+
+        if (length == 0) {
+            return EMPTY;
+        }
+        return new AddressBasedNativeData(address + offset, length);
     }
 
     @Override
-    public void writeTo(DataOutputPlus out) throws IOException
+    public long getAddress()
     {
-        out.write(byteBuffer);
+        return address;
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
@@ -23,12 +23,12 @@ import java.nio.ByteOrder;
 
 import org.apache.cassandra.utils.memory.MemoryUtil;
 
-/**
- * Temporary created object as a part of slicing (usually to parse collection parts)
- */
 public class AddressBasedNativeData implements NativeData
 {
-    public static final AddressBasedNativeData EMPTY = new AddressBasedNativeData(-1, 0);
+    // use a real address, just in case
+    private static final ByteBuffer EMPTY_NATIVE_BUFFER = ByteBuffer.allocateDirect(1);
+    private static final long EMPTY_VALUE_ADDRESS = MemoryUtil.getAddress(EMPTY_NATIVE_BUFFER);
+    public static final AddressBasedNativeData EMPTY = new AddressBasedNativeData(EMPTY_VALUE_ADDRESS, 0);
 
     private final long address;
     private final int length;

--- a/src/java/org/apache/cassandra/db/marshal/ByteBufferSliceNativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/ByteBufferSliceNativeData.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+/**
+ * Temporary created object as a part of slicing (usually to parse collection parts)
+ */
+public class ByteBufferSliceNativeData implements NativeData
+{
+    public static final ByteBufferSliceNativeData EMPTY = new ByteBufferSliceNativeData(ByteBufferUtil.EMPTY_BYTE_BUFFER);
+
+    private final ByteBuffer byteBuffer;
+
+    public ByteBufferSliceNativeData(ByteBuffer byteBuffer)
+    {
+        this.byteBuffer = byteBuffer;
+    }
+
+    @Override
+    public int nativeDataSize()
+    {
+        return byteBuffer.remaining();
+    }
+
+    @Override
+    public ByteBuffer asByteBuffer()
+    {
+        return byteBuffer;
+    }
+
+    @Override
+    public NativeData slice(int offset, int length)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.slice(byteBuffer, offset, length));
+    }
+
+    @Override
+    public void writeTo(DataOutputPlus out) throws IOException
+    {
+        out.write(byteBuffer);
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -20,10 +20,11 @@ package org.apache.cassandra.db.marshal;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.util.UUID;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.cassandra.db.Digest;
 import org.apache.cassandra.db.TypeSizes;
@@ -34,6 +35,7 @@ import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.FastByteOperations;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.UUIDGen;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 /**
  * ValueAccessor has a lot of different methods are grouped together in a single interface.
@@ -64,7 +66,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public void write(NativeData sourceValue, DataOutputPlus out) throws IOException
     {
-        sourceValue.writeTo(out);
+        out.writeMemory(sourceValue.getAddress(), sourceValue.nativeDataSize());
     }
 
     @Override
@@ -78,35 +80,50 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public void write(NativeData value, ByteBuffer out)
     {
-        out.put(value.asByteBuffer().duplicate()); // ByteBufferSliceNativeDataasByteBuffer() returns a re-usable byte buffer
+        int size = value.nativeDataSize();
+        MemoryUtil.getBytes(value.getAddress(), out, size);
+        out.position(out.position() + size);
+
     }
 
     @Override
     public <V2> int copyTo(NativeData src, int srcOffset, V2 dst, ValueAccessor<V2> dstAccessor, int dstOffset, int size)
     {
-        dstAccessor.copyByteBufferTo(src.asByteBuffer(), srcOffset, dst, dstOffset, size);
+        if (dstAccessor == ByteArrayAccessor.instance)
+            MemoryUtil.getBytes(src.getAddress() + srcOffset, dstAccessor.toArray(dst), dstOffset, size);
+        else if (dstAccessor == ByteBufferAccessor.instance)
+        {
+            ByteBuffer dstBuffer = dstAccessor.toBuffer(dst);
+            MemoryUtil.getBytes(src.getAddress() + srcOffset, dstBuffer, dstOffset, size);
+            dstBuffer.position(dstBuffer.position() + size);
+        }
+        else if (dstAccessor == NativeAccessor.instance)
+            MemoryUtil.setBytes(src.getAddress() + srcOffset, ((NativeData) dst).getAddress() + dstOffset, size);
+        else
+            dstAccessor.copyByteBufferTo(src.asByteBuffer(), srcOffset, dst, dstOffset, size);
+
         return size;
     }
 
     @Override
     public int copyByteArrayTo(byte[] src, int srcOffset, NativeData dstNative, int dstOffset, int size)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        FastByteOperations.copy(src, srcOffset, dst, dst.position() + dstOffset, size);
+        MemoryUtil.setBytes(src, srcOffset, dstNative.getAddress() + dstOffset, size);
         return size;
     }
 
     @Override
     public int copyByteBufferTo(ByteBuffer src, int srcOffset, NativeData dstNative, int dstOffset, int size)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        FastByteOperations.copy(src, src.position() + srcOffset, dst, dst.position() + dstOffset, size);
+        MemoryUtil.setBytes(dstNative.getAddress() + dstOffset, src, srcOffset, size);
         return size;
     }
 
     @Override
     public void digest(NativeData value, int offset, int size, Digest digest)
     {
+        // not used for NativeData (we copy data to heap during a select)
+        // so, there is no much reason to optimize to avoid a ByteBuffer object allocation
         ByteBuffer byteBuffer = value.asByteBuffer();
         digest.update(byteBuffer, byteBuffer.position() + offset, size);
     }
@@ -120,23 +137,31 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public <VR> int compare(NativeData left, VR right, ValueAccessor<VR> accessorR)
     {
-        if (right instanceof NativeData)
+
+        if (accessorR == ByteArrayAccessor.instance)
+            return -compareByteArrayTo(accessorR.toArray(right), left);
+        else if (accessorR == ByteBufferAccessor.instance)
+            return -compareByteBufferTo(accessorR.toBuffer(right), left);
+        if (accessorR == NativeAccessor.instance)
         {
-            return left.compareTo((NativeData) right);
-        }
-        return left.compareTo(accessorR.toBuffer(right));
+            NativeData rightNative = (NativeData) right;
+            int leftSize = left.nativeDataSize();
+            int rightSize = rightNative.nativeDataSize();
+            return FastByteOperations.compareUnsigned(left.getAddress(), leftSize, rightNative.getAddress(), rightSize);
+        } else
+            return left.compareTo(accessorR.toBuffer(right));
     }
 
     @Override
     public int compareByteArrayTo(byte[] left, NativeData right)
     {
-        return ByteBufferUtil.compare(left, right.asByteBuffer());
+        return FastByteOperations.compareUnsigned(left, 0, left.length, right.getAddress(), right.nativeDataSize());
     }
 
     @Override
     public int compareByteBufferTo(ByteBuffer left, NativeData right)
     {
-        return -right.compareTo(left); // we want to avoid ByteBuffer retrieval from NativeData
+        return FastByteOperations.compareUnsigned(left, right.getAddress(), right.nativeDataSize());
     }
 
      // -----------------------------------------------------------------------------
@@ -147,7 +172,10 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     {
         if (value == null)
             return null;
-        return ByteBufferUtil.getArray(value.asByteBuffer());
+        int size = value.nativeDataSize();
+        byte[] result = new byte[size];
+        MemoryUtil.getBytes(value.getAddress(), result, 0, size);
+        return result;
     }
 
     @Override
@@ -155,8 +183,10 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     {
         if (value == null)
             return null;
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return ByteBufferUtil.getArray(byteBuffer, byteBuffer.position() + offset, length);
+        int size = value.nativeDataSize();
+        byte[] result = new byte[size];
+        MemoryUtil.getBytes(value.getAddress() + offset, result, 0, size);
+        return result;
     }
 
     @Override
@@ -174,117 +204,118 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public byte toByte(NativeData value)
     {
-        return ByteBufferUtil.toByte(value.asByteBuffer());
+        return getByte(value, 0);
     }
 
     @Override
     public byte getByte(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return byteBuffer.get(byteBuffer.position() + offset);
+        return MemoryUtil.getByte(value.getAddress() + offset);
     }
 
     @Override
     public short toShort(NativeData value)
     {
-        return ByteBufferUtil.toShort(value.asByteBuffer());
+        return getShort(value, 0);
     }
 
     @Override
     public short getShort(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return byteBuffer.getShort(byteBuffer.position() + offset);
+        return (short) MemoryUtil.getShort(value.getAddress() + offset, true);
     }
 
     @Override
     public int getUnsignedShort(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return ByteBufferUtil.getUnsignedShort(byteBuffer, byteBuffer.position() + offset);
+        return ((short) MemoryUtil.getShort(value.getAddress() + offset, true)) & 0xFFFF;
     }
 
     @Override
     public int toInt(NativeData value)
     {
-        return ByteBufferUtil.toInt(value.asByteBuffer());
+        return getInt(value, 0);
     }
 
     @Override
     public int getInt(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return byteBuffer.getInt(byteBuffer.position() + offset);
+        return MemoryUtil.getInt(value.getAddress() + offset, true);
     }
 
     @Override
     public long toLong(NativeData value)
     {
-        return ByteBufferUtil.toLong(value.asByteBuffer());
+        return getLong(value, 0);
     }
 
     @Override
     public long getLong(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return byteBuffer.getLong(byteBuffer.position() + offset);
+        return MemoryUtil.getLong(value.getAddress() + offset, true);
     }
 
     @Override
     public float getFloat(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return byteBuffer.getFloat(byteBuffer.position() + offset);
+        return Float.intBitsToFloat(MemoryUtil.getInt(value.getAddress() + offset, true));
     }
 
     @Override
     public double getDouble(NativeData value, int offset)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return byteBuffer.getDouble(byteBuffer.position() + offset);
+        return Double.longBitsToDouble(MemoryUtil.getLong(value.getAddress() + offset, true));
     }
 
     @Override
     public float toFloat(NativeData value)
     {
-        return ByteBufferUtil.toFloat(value.asByteBuffer());
+        return getFloat(value, 0);
     }
 
     @Override
     public double toDouble(NativeData value)
     {
-        return ByteBufferUtil.toDouble(value.asByteBuffer());
+        return getDouble(value, 0);
     }
 
     @Override
     public UUID toUUID(NativeData value)
     {
-        return UUIDGen.getUUID(value.asByteBuffer());
+        long mostSigBits = getLong(value, 0);
+        long leastSigBits = getLong(value, 8);
+
+        return UUIDGen.getUUID(mostSigBits, leastSigBits);
     }
 
     @Override
     public TimeUUID toTimeUUID(NativeData value)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        return TimeUUID.fromBytes(byteBuffer.getLong(byteBuffer.position()), byteBuffer.getLong(byteBuffer.position() + 8));
+        long mostSigBits = getLong(value, 0);
+        long leastSigBits = getLong(value, 8);
+        return TimeUUID.fromBytes(mostSigBits, leastSigBits);
     }
 
     @Override
     public Ballot toBallot(NativeData value)
     {
-        return Ballot.deserialize(value.asByteBuffer());
+        long mostSigBits = getLong(value, 0);
+        long leastSigBits = getLong(value, 8);
+        return Ballot.fromBytes(mostSigBits, leastSigBits);
     }
 
     @Override
     public float[] toFloatArray(NativeData value, int dimension)
     {
-        ByteBuffer byteBuffer = value.asByteBuffer();
-        FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-        if (floatBuffer.remaining() != dimension)
+        int arraySize = value.nativeDataSize() / Float.BYTES;
+        if (arraySize != dimension)
             throw new IllegalArgumentException(String.format("Could not convert to a float[] with different dimension. " +
-                                                             "Was expecting %d but got %d", dimension, floatBuffer.remaining()));
-        float[] floatArray = new float[floatBuffer.remaining()];
-        floatBuffer.get(floatArray);
+                                                             "Was expecting %d but got %d", dimension, arraySize));
+        float[] floatArray = new float[arraySize];
+        for (int i = 0; i < arraySize; i++)
+        {
+            floatArray[i] = Float.intBitsToFloat(getInt(value, i * Float.BYTES));
+        }
         return floatArray;
     }
 
@@ -294,40 +325,35 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public int putByte(NativeData dstNative, int offset, byte value)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        dst.put(dst.position() + offset, value);
+        MemoryUtil.setByte(dstNative.getAddress() + offset, value);
         return TypeSizes.BYTE_SIZE;
     }
 
     @Override
     public int putShort(NativeData dstNative, int offset, short value)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        dst.putShort(dst.position() + offset, value);
+        MemoryUtil.setShort(dstNative.getAddress() + offset, value, true);
         return TypeSizes.SHORT_SIZE;
     }
 
     @Override
     public int putInt(NativeData dstNative, int offset, int value)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        dst.putInt(dst.position() + offset, value);
+        MemoryUtil.setInt(dstNative.getAddress() + offset, value, true);
         return TypeSizes.INT_SIZE;
     }
 
     @Override
     public int putLong(NativeData dstNative, int offset, long value)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        dst.putLong(dst.position() + offset, value);
+        MemoryUtil.setLong(dstNative.getAddress() + offset, value, true);
         return TypeSizes.LONG_SIZE;
     }
 
     @Override
     public int putFloat(NativeData dstNative, int offset, float value)
     {
-        ByteBuffer dst = dstNative.asByteBuffer();
-        dst.putFloat(dst.position() + offset, value);
+        putLong(dstNative, offset, Float.floatToIntBits(value));
         return TypeSizes.FLOAT_SIZE;
     }
 
@@ -341,98 +367,106 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     // Value object creation methods
     // We do not expect the methods are used in real logic for NativeData,
     // but they are needed to reuse existing unit tests written for other implementation of ValueAccessor.
-    // The objects created by the methods don't actually represent a real native memory
-    // but just heap ByteBuffer wrappers which provide NativeData
+    
+    private static NativeDataAllocator allocator = NativeDataAllocator.UNSUPPORTED;
+
+    @VisibleForTesting
+    public static void setNativeMemoryAllocator(NativeDataAllocator allocatorToSet)
+    {
+        allocator = allocatorToSet;
+    }
 
     @Override
     public NativeData read(DataInputPlus in, int length) throws IOException
     {
         ByteBuffer data = ByteBufferUtil.read(in, length);
-        return new ByteBufferSliceNativeData(data);
+        return allocator.allocateBasedOnBuffer(data);
     }
 
     @Override
     public NativeData empty()
     {
-        return ByteBufferSliceNativeData.EMPTY;
+        return AddressBasedNativeData.EMPTY;
     }
 
     @Override
     public NativeData valueOf(byte[] bytes)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(bytes));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(bytes));
     }
 
     @Override
     public NativeData valueOf(ByteBuffer bytes)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(bytes));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(bytes));
     }
 
     @Override
     public NativeData valueOf(String s, Charset charset)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(s, charset));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(s, charset));
     }
 
     @Override
     public NativeData valueOf(UUID v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(boolean v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(byte v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(short v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(int v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(long v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(float v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public NativeData valueOf(double v)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
     }
 
     @Override
     public <V2> NativeData convert(V2 src, ValueAccessor<V2> accessor)
     {
-        return new ByteBufferSliceNativeData(accessor.toBuffer(src));
+        if (accessor == NativeAccessor.instance)
+            return (NativeData) src;
+        return allocator.allocateBasedOnBuffer(accessor.toBuffer(src));
     }
 
     @Override
     public NativeData allocate(int size)
     {
-        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.allocate(size));
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.allocate(size));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -147,7 +147,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
             NativeData rightNative = (NativeData) right;
             int leftSize = left.nativeDataSize();
             int rightSize = rightNative.nativeDataSize();
-            return FastByteOperations.compareUnsigned(left.getAddress(), leftSize, rightNative.getAddress(), rightSize);
+            return FastByteOperations.compareMemoryUnsigned(left.getAddress(), leftSize, rightNative.getAddress(), rightSize);
         } else // just in case of new implementations of ValueAccessor appear
             return ByteBufferUtil.compareUnsigned(left.asByteBuffer(), accessorR.toBuffer(right));
     }
@@ -155,13 +155,13 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public int compareByteArrayTo(byte[] left, NativeData right)
     {
-        return FastByteOperations.compareUnsigned(left, 0, left.length, right.getAddress(), right.nativeDataSize());
+        return FastByteOperations.compareWithMemoryUnsigned(left, 0, left.length, right.getAddress(), right.nativeDataSize());
     }
 
     @Override
     public int compareByteBufferTo(ByteBuffer left, NativeData right)
     {
-        return FastByteOperations.compareUnsigned(left, right.getAddress(), right.nativeDataSize());
+        return FastByteOperations.compareWithMemoryUnsigned(left, right.getAddress(), right.nativeDataSize());
     }
 
      // -----------------------------------------------------------------------------

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -1,0 +1,447 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.util.UUID;
+
+import org.apache.cassandra.db.Digest;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.service.paxos.Ballot;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FastByteOperations;
+import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.UUIDGen;
+
+/**
+ * ValueAccessor has a lot of different methods are grouped together in a single interface.
+ * Technically the methods can be classfied to 4 categories:
+ * 1) basic methods to deal with the existing data as an abstract read-only container of bytes
+ * 2) deserialization methods to decode the data into different data types
+ * 3) serialization methods to encode and write different data types into the value entity
+ * 4) Value object creation methods
+ *
+ *  NativeAccessor provides a support for real NativeData objects (on top of off-heap memory) for 1-3 categories
+ *  with a focus on 1) category and only emulates 4th category using ByteBufferSliceNativeData on top of heap ByteBuffers.
+ *  We expect NativeData is used only to store data in Memtables with an explicit allocator and memory regions lifecycle
+ *  and not used to create short-living Mutation requests and transfer them between nodes.
+ */
+public class NativeAccessor implements ValueAccessor<NativeData>
+{
+    public static final ValueAccessor<NativeData> instance = new NativeAccessor();
+
+    // -----------------------------------------------------------------------------
+    // basic methods to deal with data as a read-only container of bytes
+
+    @Override
+    public int size(NativeData value)
+    {
+        return value.nativeDataSize();
+    }
+
+    @Override
+    public void write(NativeData sourceValue, DataOutputPlus out) throws IOException
+    {
+        sourceValue.writeTo(out);
+    }
+
+    @Override
+    public ByteBuffer toBuffer(NativeData value)
+    {
+        if (value == null)
+            return null;
+        return value.asByteBuffer();
+    }
+
+    @Override
+    public void write(NativeData value, ByteBuffer out)
+    {
+        out.put(value.asByteBuffer().duplicate()); // ByteBufferSliceNativeDataasByteBuffer() returns a re-usable byte buffer
+    }
+
+    @Override
+    public <V2> int copyTo(NativeData src, int srcOffset, V2 dst, ValueAccessor<V2> dstAccessor, int dstOffset, int size)
+    {
+        dstAccessor.copyByteBufferTo(src.asByteBuffer(), srcOffset, dst, dstOffset, size);
+        return size;
+    }
+
+    @Override
+    public int copyByteArrayTo(byte[] src, int srcOffset, NativeData dstNative, int dstOffset, int size)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        FastByteOperations.copy(src, srcOffset, dst, dst.position() + dstOffset, size);
+        return size;
+    }
+
+    @Override
+    public int copyByteBufferTo(ByteBuffer src, int srcOffset, NativeData dstNative, int dstOffset, int size)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        FastByteOperations.copy(src, src.position() + srcOffset, dst, dst.position() + dstOffset, size);
+        return size;
+    }
+
+    @Override
+    public void digest(NativeData value, int offset, int size, Digest digest)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        digest.update(byteBuffer, byteBuffer.position() + offset, size);
+    }
+
+    @Override
+    public NativeData slice(NativeData input, int offset, int length)
+    {
+        return input.slice(offset, length);
+    }
+
+    @Override
+    public <VR> int compare(NativeData left, VR right, ValueAccessor<VR> accessorR)
+    {
+        if (right instanceof NativeData)
+        {
+            return left.compareTo((NativeData) right);
+        }
+        return accessorR.compareByteBufferTo(left.asByteBuffer(), right);
+    }
+
+    @Override
+    public int compareByteArrayTo(byte[] left, NativeData right)
+    {
+        return ByteBufferUtil.compare(left, right.asByteBuffer());
+    }
+
+    @Override
+    public int compareByteBufferTo(ByteBuffer left, NativeData right)
+    {
+        return ByteBufferUtil.compareUnsigned(left, right.asByteBuffer());
+    }
+
+     // -----------------------------------------------------------------------------
+     // Data deserialization methods
+
+    @Override
+    public byte[] toArray(NativeData value)
+    {
+        if (value == null)
+            return null;
+        return ByteBufferUtil.getArray(value.asByteBuffer());
+    }
+
+    @Override
+    public byte[] toArray(NativeData value, int offset, int length)
+    {
+        if (value == null)
+            return null;
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return ByteBufferUtil.getArray(byteBuffer, byteBuffer.position() + offset, length);
+    }
+
+    @Override
+    public String toString(NativeData value, Charset charset) throws CharacterCodingException
+    {
+        return ByteBufferUtil.string(value.asByteBuffer(), charset);
+    }
+
+    @Override
+    public String toHex(NativeData value)
+    {
+        return ByteBufferUtil.bytesToHex(value.asByteBuffer());
+    }
+
+    @Override
+    public byte toByte(NativeData value)
+    {
+        return ByteBufferUtil.toByte(value.asByteBuffer());
+    }
+
+    @Override
+    public byte getByte(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return byteBuffer.get(byteBuffer.position() + offset);
+    }
+
+    @Override
+    public short toShort(NativeData value)
+    {
+        return ByteBufferUtil.toShort(value.asByteBuffer());
+    }
+
+    @Override
+    public short getShort(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return byteBuffer.getShort(byteBuffer.position() + offset);
+    }
+
+    @Override
+    public int getUnsignedShort(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return ByteBufferUtil.getUnsignedShort(byteBuffer, byteBuffer.position() + offset);
+    }
+
+    @Override
+    public int toInt(NativeData value)
+    {
+        return ByteBufferUtil.toInt(value.asByteBuffer());
+    }
+
+    @Override
+    public int getInt(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return byteBuffer.getInt(byteBuffer.position() + offset);
+    }
+
+    @Override
+    public long toLong(NativeData value)
+    {
+        return ByteBufferUtil.toLong(value.asByteBuffer());
+    }
+
+    @Override
+    public long getLong(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return byteBuffer.getLong(byteBuffer.position() + offset);
+    }
+
+    @Override
+    public float getFloat(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return byteBuffer.getFloat(byteBuffer.position() + offset);
+    }
+
+    @Override
+    public double getDouble(NativeData value, int offset)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return byteBuffer.getDouble(byteBuffer.position() + offset);
+    }
+
+    @Override
+    public float toFloat(NativeData value)
+    {
+        return ByteBufferUtil.toFloat(value.asByteBuffer());
+    }
+
+    @Override
+    public double toDouble(NativeData value)
+    {
+        return ByteBufferUtil.toDouble(value.asByteBuffer());
+    }
+
+    @Override
+    public UUID toUUID(NativeData value)
+    {
+        return UUIDGen.getUUID(value.asByteBuffer());
+    }
+
+    @Override
+    public TimeUUID toTimeUUID(NativeData value)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        return TimeUUID.fromBytes(byteBuffer.getLong(byteBuffer.position()), byteBuffer.getLong(byteBuffer.position() + 8));
+    }
+
+    @Override
+    public Ballot toBallot(NativeData value)
+    {
+        return Ballot.deserialize(value.asByteBuffer());
+    }
+
+    @Override
+    public float[] toFloatArray(NativeData value, int dimension)
+    {
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
+        if (floatBuffer.remaining() != dimension)
+            throw new IllegalArgumentException(String.format("Could not convert to a float[] with different dimension. " +
+                                                             "Was expecting %d but got %d", dimension, floatBuffer.remaining()));
+        float[] floatArray = new float[floatBuffer.remaining()];
+        floatBuffer.get(floatArray);
+        return floatArray;
+    }
+
+
+    // -----------------------------------------------------------------------------
+    // Data serialization methods
+    @Override
+    public int putByte(NativeData dstNative, int offset, byte value)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        dst.put(dst.position() + offset, value);
+        return TypeSizes.BYTE_SIZE;
+    }
+
+    @Override
+    public int putShort(NativeData dstNative, int offset, short value)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        dst.putShort(dst.position() + offset, value);
+        return TypeSizes.SHORT_SIZE;
+    }
+
+    @Override
+    public int putInt(NativeData dstNative, int offset, int value)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        dst.putInt(dst.position() + offset, value);
+        return TypeSizes.INT_SIZE;
+    }
+
+    @Override
+    public int putLong(NativeData dstNative, int offset, long value)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        dst.putLong(dst.position() + offset, value);
+        return TypeSizes.LONG_SIZE;
+    }
+
+    @Override
+    public int putFloat(NativeData dstNative, int offset, float value)
+    {
+        ByteBuffer dst = dstNative.asByteBuffer();
+        dst.putFloat(dst.position() + offset, value);
+        return TypeSizes.FLOAT_SIZE;
+    }
+
+    @Override
+    public NativeData[] createArray(int length)
+    {
+        return new NativeData[length];
+    }
+
+    // -----------------------------------------------------------------------------
+    // Value object creation methods
+    // We do not expect the methods are used in real logic for NativeData,
+    // but they are needed to reuse existing unit tests written for other implementation of ValueAccessor.
+    // The objects created by the methods don't actually represent a real native memory
+    // but just heap ByteBuffer wrappers which provide NativeData
+
+    @Override
+    public NativeData read(DataInputPlus in, int length) throws IOException
+    {
+        ByteBuffer data = ByteBufferUtil.read(in, length);
+        return new ByteBufferSliceNativeData(data);
+    }
+
+    @Override
+    public NativeData empty()
+    {
+        return ByteBufferSliceNativeData.EMPTY;
+    }
+
+    @Override
+    public NativeData valueOf(byte[] bytes)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(bytes));
+    }
+
+    @Override
+    public NativeData valueOf(ByteBuffer bytes)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(bytes));
+    }
+
+    @Override
+    public NativeData valueOf(String s, Charset charset)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(s, charset));
+    }
+
+    @Override
+    public NativeData valueOf(UUID v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(boolean v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(byte v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(short v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(int v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(long v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(float v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(double v)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public <V2> NativeData convert(V2 src, ValueAccessor<V2> accessor)
+    {
+        return new ByteBufferSliceNativeData(accessor.toBuffer(src));
+    }
+
+    @Override
+    public NativeData allocate(int size)
+    {
+        return new ByteBufferSliceNativeData(ByteBufferAccessor.instance.allocate(size));
+    }
+
+    @Override
+    public ObjectFactory<NativeData> factory()
+    {
+        // The method is used to de-serialize and create different parts of a Mutation object
+        // to transfer it between Cassandra nodes.
+        // The current implementation of NativeData does not support creating of such objects in-flight
+        // because it requires to have a native memory pool/allocator and manage its lifecycle.
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -356,7 +356,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public int putFloat(NativeData dstNative, int offset, float value)
     {
-        putLong(dstNative, offset, Float.floatToIntBits(value));
+        putInt(dstNative, offset, Float.floatToIntBits(value));
         return TypeSizes.FLOAT_SIZE;
     }
 

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -99,7 +99,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
         }
         else if (dstAccessor == NativeAccessor.instance)
             MemoryUtil.setBytes(src.getAddress() + srcOffset, ((NativeData) dst).getAddress() + dstOffset, size);
-        else
+        else // just in case of new implementations of ValueAccessor appear
             dstAccessor.copyByteBufferTo(src.asByteBuffer(), srcOffset, dst, dstOffset, size);
 
         return size;
@@ -148,8 +148,8 @@ public class NativeAccessor implements ValueAccessor<NativeData>
             int leftSize = left.nativeDataSize();
             int rightSize = rightNative.nativeDataSize();
             return FastByteOperations.compareUnsigned(left.getAddress(), leftSize, rightNative.getAddress(), rightSize);
-        } else
-            return left.compareTo(accessorR.toBuffer(right));
+        } else // just in case of new implementations of ValueAccessor appear
+            return ByteBufferUtil.compareUnsigned(left.asByteBuffer(), accessorR.toBuffer(right));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -95,7 +95,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
         {
             ByteBuffer dstBuffer = dstAccessor.toBuffer(dst);
             MemoryUtil.getBytes(src.getAddress() + srcOffset, dstBuffer, dstOffset, size);
-            dstBuffer.position(dstBuffer.position() + size);
+            // note: position of dstBuffer expected to stay the same
         }
         else if (dstAccessor == NativeAccessor.instance)
             MemoryUtil.setBytes(src.getAddress() + srcOffset, ((NativeData) dst).getAddress() + dstOffset, size);
@@ -184,8 +184,11 @@ public class NativeAccessor implements ValueAccessor<NativeData>
         if (value == null)
             return null;
         int size = value.nativeDataSize();
-        byte[] result = new byte[size];
-        MemoryUtil.getBytes(value.getAddress() + offset, result, 0, size);
+        if (length > size)
+            throw new IllegalArgumentException("length (" + length + ") cannot be more than the value size (" + size + ")");
+
+        byte[] result = new byte[length];
+        MemoryUtil.getBytes(value.getAddress() + offset, result, 0, length);
         return result;
     }
 
@@ -228,7 +231,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public int getUnsignedShort(NativeData value, int offset)
     {
-        return ((short) MemoryUtil.getShort(value.getAddress() + offset, true)) & 0xFFFF;
+        return MemoryUtil.getShort(value.getAddress() + offset, true);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -124,7 +124,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
         {
             return left.compareTo((NativeData) right);
         }
-        return accessorR.compareByteBufferTo(left.asByteBuffer(), right);
+        return left.compareTo(accessorR.toBuffer(right));
     }
 
     @Override
@@ -136,7 +136,7 @@ public class NativeAccessor implements ValueAccessor<NativeData>
     @Override
     public int compareByteBufferTo(ByteBuffer left, NativeData right)
     {
-        return ByteBufferUtil.compareUnsigned(left, right.asByteBuffer());
+        return -right.compareTo(left); // we want to avoid ByteBuffer retrieval from NativeData
     }
 
      // -----------------------------------------------------------------------------

--- a/src/java/org/apache/cassandra/db/marshal/NativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeData.java
@@ -38,4 +38,9 @@ public interface NativeData
     {
         return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right.asByteBuffer());
     }
+
+    default int compareTo(ByteBuffer right)
+    {
+        return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right);
+    }
 }

--- a/src/java/org/apache/cassandra/db/marshal/NativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeData.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+public interface NativeData
+{
+    int nativeDataSize();
+
+    ByteBuffer asByteBuffer();
+
+    NativeData slice(int offset, int length);
+
+    void writeTo(DataOutputPlus out) throws IOException;
+
+    default int compareTo(NativeData right)
+    {
+        return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right.asByteBuffer());
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/NativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeData.java
@@ -20,8 +20,6 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 
-import org.apache.cassandra.utils.ByteBufferUtil;
-
 public interface NativeData
 {
     int nativeDataSize();
@@ -30,15 +28,5 @@ public interface NativeData
 
     NativeData slice(int offset, int length);
 
-    default int compareTo(NativeData right)
-    {
-        return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right.asByteBuffer());
-    }
-
     public long getAddress();
-
-    default int compareTo(ByteBuffer right)
-    {
-        return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right);
-    }
 }

--- a/src/java/org/apache/cassandra/db/marshal/NativeDataAllocator.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeDataAllocator.java
@@ -20,25 +20,15 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 
-import org.apache.cassandra.utils.ByteBufferUtil;
-
-public interface NativeData
+public interface NativeDataAllocator extends AutoCloseable
 {
-    int nativeDataSize();
+    NativeDataAllocator UNSUPPORTED = data -> {
+        throw new UnsupportedOperationException("The method is not expected to be used by NativeAccessor outside of tests. " +
+                                                "NativeData can be allocated only by a memtable NativeAllocator");
+    };
 
-    ByteBuffer asByteBuffer();
+    NativeData allocateBasedOnBuffer(ByteBuffer data);
 
-    NativeData slice(int offset, int length);
-
-    default int compareTo(NativeData right)
-    {
-        return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right.asByteBuffer());
-    }
-
-    public long getAddress();
-
-    default int compareTo(ByteBuffer right)
-    {
-        return ByteBufferUtil.compareUnsigned(this.asByteBuffer(), right);
-    }
+    @Override
+    default void close() {};
 }

--- a/src/java/org/apache/cassandra/db/rows/NativeCell.java
+++ b/src/java/org/apache/cassandra/db/rows/NativeCell.java
@@ -17,11 +17,16 @@
  */
 package org.apache.cassandra.db.rows;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import org.apache.cassandra.db.marshal.ByteBufferAccessor;
+import io.netty.util.concurrent.FastThreadLocal;
+import org.apache.cassandra.db.marshal.ByteBufferSliceNativeData;
+import org.apache.cassandra.db.marshal.NativeAccessor;
+import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
+import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -29,7 +34,7 @@ import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.apache.cassandra.utils.memory.NativeAllocator;
 
-public class NativeCell extends AbstractCell<ByteBuffer>
+public class NativeCell extends AbstractCell<NativeData> implements NativeData
 {
     private static final long EMPTY_SIZE = ObjectSizes.measure(new NativeCell());
 
@@ -134,15 +139,20 @@ public class NativeCell extends AbstractCell<ByteBuffer>
         return MemoryUtil.getInt(peer + TTL);
     }
 
-    public ByteBuffer value()// FIXME: add native accessor
+    public NativeData value()
+    {
+        return this;
+    }
+
+    public ByteBuffer byteBufferValue()
     {
         int length = MemoryUtil.getInt(peer + LENGTH);
         return MemoryUtil.getByteBuffer(peer + VALUE, length, ByteOrder.BIG_ENDIAN);
     }
 
-    public ValueAccessor<ByteBuffer> accessor()
+    public ValueAccessor<NativeData> accessor()
     {
-        return ByteBufferAccessor.instance;  // FIXME: add native accessor
+        return NativeAccessor.instance;
     }
 
     public int valueSize()
@@ -167,12 +177,12 @@ public class NativeCell extends AbstractCell<ByteBuffer>
 
     public Cell<?> withUpdatedTimestampAndLocalDeletionTime(long newTimestamp, long newLocalDeletionTime)
     {
-        return new BufferCell(column, newTimestamp, ttl(), newLocalDeletionTime, value(), path());
+        return new BufferCell(column, newTimestamp, ttl(), newLocalDeletionTime, byteBufferValue(), path());
     }
 
     public Cell<?> withUpdatedColumn(ColumnMetadata column)
     {
-        return new BufferCell(column, timestamp(), ttl(), localDeletionTimeAsUnsignedInt(), value(), path());
+        return new BufferCell(column, timestamp(), ttl(), localDeletionTimeAsUnsignedInt(), byteBufferValue(), path());
     }
 
     public Cell withSkippedValue()
@@ -209,5 +219,44 @@ public class NativeCell extends AbstractCell<ByteBuffer>
     protected int localDeletionTimeAsUnsignedInt()
     {
         return MemoryUtil.getInt(peer + DELETION);
+    }
+
+
+    @Override
+    public int nativeDataSize()
+    {
+        return valueSize();
+    }
+
+    @Override
+    public ByteBuffer asByteBuffer()
+    {
+        return byteBufferValue();
+    }
+    @Override
+    public NativeData slice(int offset, int length)
+    {
+        ByteBuffer byteBuffer = asByteBuffer(); // we get a new buffer here each time, so duplicate() is not needed
+        byteBuffer.position(byteBuffer.position() + offset);
+        byteBuffer.limit(byteBuffer.position() + length);
+        return new ByteBufferSliceNativeData(byteBuffer);
+    }
+
+    private static final FastThreadLocal<ByteBuffer> REUSABLE_WRITE_BUFFER = new FastThreadLocal<>()
+    {
+        @Override
+        protected ByteBuffer initialValue()
+        {
+            return MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
+        }
+    };
+
+    @Override
+    public void writeTo(DataOutputPlus out) throws IOException
+    {
+        int length = MemoryUtil.getInt(peer + LENGTH);
+        ByteBuffer byteBuffer = REUSABLE_WRITE_BUFFER.get();
+        MemoryUtil.setDirectByteBuffer(byteBuffer, peer + VALUE, length);
+        out.write(byteBuffer);
     }
 }

--- a/src/java/org/apache/cassandra/db/rows/NativeCell.java
+++ b/src/java/org/apache/cassandra/db/rows/NativeCell.java
@@ -17,16 +17,13 @@
  */
 package org.apache.cassandra.db.rows;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import io.netty.util.concurrent.FastThreadLocal;
-import org.apache.cassandra.db.marshal.ByteBufferSliceNativeData;
+import org.apache.cassandra.db.marshal.AddressBasedNativeData;
 import org.apache.cassandra.db.marshal.NativeAccessor;
 import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
-import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -146,8 +143,8 @@ public class NativeCell extends AbstractCell<NativeData> implements NativeData
 
     public ByteBuffer byteBufferValue()
     {
-        int length = MemoryUtil.getInt(peer + LENGTH);
-        return MemoryUtil.getByteBuffer(peer + VALUE, length, ByteOrder.BIG_ENDIAN);
+        int length = valueSize();
+        return MemoryUtil.getByteBuffer(getAddress(), length, ByteOrder.BIG_ENDIAN);
     }
 
     public ValueAccessor<NativeData> accessor()
@@ -165,7 +162,7 @@ public class NativeCell extends AbstractCell<NativeData> implements NativeData
         if (!hasPath())
             return null;
 
-        long offset = peer + VALUE + MemoryUtil.getInt(peer + LENGTH);
+        long offset = getAddress() + valueSize();
         int size = MemoryUtil.getInt(offset);
         return CellPath.create(MemoryUtil.getByteBuffer(offset + 4, size, ByteOrder.BIG_ENDIAN));
     }
@@ -236,27 +233,12 @@ public class NativeCell extends AbstractCell<NativeData> implements NativeData
     @Override
     public NativeData slice(int offset, int length)
     {
-        ByteBuffer byteBuffer = asByteBuffer(); // we get a new buffer here each time, so duplicate() is not needed
-        byteBuffer.position(byteBuffer.position() + offset);
-        byteBuffer.limit(byteBuffer.position() + length);
-        return new ByteBufferSliceNativeData(byteBuffer);
+        return new AddressBasedNativeData(getAddress() + offset, length);
     }
 
-    private static final FastThreadLocal<ByteBuffer> REUSABLE_WRITE_BUFFER = new FastThreadLocal<>()
-    {
-        @Override
-        protected ByteBuffer initialValue()
-        {
-            return MemoryUtil.getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
-        }
-    };
-
     @Override
-    public void writeTo(DataOutputPlus out) throws IOException
+    public long getAddress()
     {
-        int length = MemoryUtil.getInt(peer + LENGTH);
-        ByteBuffer byteBuffer = REUSABLE_WRITE_BUFFER.get();
-        MemoryUtil.setDirectByteBuffer(byteBuffer, peer + VALUE, length);
-        out.write(byteBuffer);
+        return peer + VALUE;
     }
 }

--- a/src/java/org/apache/cassandra/io/util/BufferedDataOutputStreamPlus.java
+++ b/src/java/org/apache/cassandra/io/util/BufferedDataOutputStreamPlus.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 
 import net.nicoulaj.compilecommand.annotations.DontInline;
 import org.apache.cassandra.utils.FastByteOperations;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.NIO_DATA_OUTPUT_STREAM_PLUS_BUFFER_SIZE;
 
@@ -135,6 +136,25 @@ public class BufferedDataOutputStreamPlus extends DataOutputStreamPlus
             doFlush(src.limit() - srcPos);
         }
         FastByteOperations.copy(src, srcPos, buffer, buffer.position(), srcCount);
+        buffer.position(buffer.position() + srcCount);
+    }
+
+    @Override
+    public void writeMemory(long address, int length) throws IOException
+    {
+        assert buffer != null : "Attempt to use a closed data output";
+        long srcPos = address;
+        int srcCount = length;
+        int trgAvailable;
+        while (srcCount > (trgAvailable = buffer.remaining()))
+        {
+            MemoryUtil.getBytes(srcPos, buffer, trgAvailable);
+            buffer.position(buffer.position() + trgAvailable);
+            srcPos += trgAvailable;
+            srcCount -= trgAvailable;
+            doFlush(srcCount);
+        }
+        MemoryUtil.getBytes(srcPos, buffer, srcCount);
         buffer.position(buffer.position() + srcCount);
     }
 

--- a/src/java/org/apache/cassandra/io/util/DataOutputPlus.java
+++ b/src/java/org/apache/cassandra/io/util/DataOutputPlus.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.io.util;
 
 import org.apache.cassandra.utils.Shared;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.apache.cassandra.utils.vint.VIntCoding;
 
 import java.io.DataOutput;
@@ -42,6 +43,11 @@ public interface DataOutputPlus extends DataOutput
     {
         for (ByteBuffer buffer : memory.asByteBuffers(offset, length))
             write(buffer);
+    }
+
+    default void writeMemory(long address, int length) throws IOException
+    {
+        write(MemoryUtil.getByteBuffer(address, length));
     }
 
     default void writeVInt(long i) throws IOException

--- a/src/java/org/apache/cassandra/utils/FastByteOperations.java
+++ b/src/java/org/apache/cassandra/utils/FastByteOperations.java
@@ -70,17 +70,17 @@ public class FastByteOperations
         return BestHolder.BEST.compare(b1, b2);
     }
 
-    public static int compareUnsigned(ByteBuffer b1, long address2, int length2)
+    public static int compareWithMemoryUnsigned(ByteBuffer b1, long address2, int length2)
     {
         return BestHolder.BEST.compare(b1, address2, length2);
     }
 
-    public static int compareUnsigned(byte[] b1, int s1, int l1, long address2, int length2)
+    public static int compareWithMemoryUnsigned(byte[] b1, int s1, int l1, long address2, int length2)
     {
         return BestHolder.BEST.compare(b1, s1,l1, address2, length2);
     }
 
-    public static int compareUnsigned(long address1, int length1, long address2, int length2)
+    public static int compareMemoryUnsigned(long address1, int length1, long address2, int length2)
     {
         return BestHolder.BEST.compare(address1, length1, address2, length2);
     }

--- a/src/java/org/apache/cassandra/utils/FastByteOperations.java
+++ b/src/java/org/apache/cassandra/utils/FastByteOperations.java
@@ -70,6 +70,21 @@ public class FastByteOperations
         return BestHolder.BEST.compare(b1, b2);
     }
 
+    public static int compareUnsigned(ByteBuffer b1, long address2, int length2)
+    {
+        return BestHolder.BEST.compare(b1, address2, length2);
+    }
+
+    public static int compareUnsigned(byte[] b1, int s1, int l1, long address2, int length2)
+    {
+        return BestHolder.BEST.compare(b1, s1,l1, address2, length2);
+    }
+
+    public static int compareUnsigned(long address1, int length1, long address2, int length2)
+    {
+        return BestHolder.BEST.compare(address1, length1, address2, length2);
+    }
+
     public static int compareUnsigned(byte[] b1, byte[] b2)
     {
         return compareUnsigned(b1, 0, b1.length, b2, 0, b2.length);
@@ -101,6 +116,12 @@ public class FastByteOperations
                                     byte[] buffer2, int offset2, int length2);
 
         abstract public int compare(ByteBuffer buffer1, byte[] buffer2, int offset2, int length2);
+
+        abstract public int compare(ByteBuffer buffer1, long address2, int length2);
+
+        abstract public int compare(long address1, int length1, long address2, int length2);
+
+        abstract public int compare(byte[] buffer1, int offset1, int length1, long address2, int length2);
 
         abstract public int compare(ByteBuffer buffer1, int offset1, int length1, byte[] buffer2, int offset2, int length2);
 
@@ -221,6 +242,44 @@ public class FastByteOperations
             return compare(buffer1, buffer1.position(), buffer1.remaining(), buffer2, offset2, length2);
         }
 
+        @Override
+        public int compare(ByteBuffer buffer1, long address2, int length2)
+        {
+            return compare(buffer1, buffer1.position(), buffer1.remaining(), address2, length2);
+        }
+
+        public int compare(ByteBuffer buffer1, int position1, int length1, long address2, int length2)
+        {
+            {
+                Object obj1;
+                long offset1;
+                if (buffer1.hasArray())
+                {
+                    obj1 = buffer1.array();
+                    offset1 = BYTE_ARRAY_BASE_OFFSET + buffer1.arrayOffset() + position1;
+                }
+                else
+                {
+                    obj1 = null;
+                    offset1 = theUnsafe.getLong(buffer1, DIRECT_BUFFER_ADDRESS_OFFSET) + position1;
+                }
+
+                return compareTo(obj1, offset1, length1, null, address2, length2);
+            }
+        }
+        @Override
+        public int compare(long address1, int length1, long address2, int length2)
+        {
+            return compareTo(null, address1, length1, null, address2, length2);
+        }
+
+        @Override
+        public int compare(byte[] buffer1, int offset1, int length1, long address2, int length2)
+        {
+            return compareTo(buffer1, BYTE_ARRAY_BASE_OFFSET + offset1, length1,
+                             null, address2, length2);
+        }
+
         public int compare(ByteBuffer buffer1, int position1, int length1, byte[] buffer2, int offset2, int length2)
         {
             Object obj1;
@@ -262,7 +321,7 @@ public class FastByteOperations
             if (trg.hasArray())
                 System.arraycopy(src, srcPosition, trg.array(), trg.arrayOffset() + trgPosition, length);
             else
-                copy(null, srcPosition + theUnsafe.getLong(src, Unsafe.ARRAY_BYTE_BASE_OFFSET), trg, trgPosition, length);
+                copy(src, (long) srcPosition + Unsafe.ARRAY_BYTE_BASE_OFFSET, trg, trgPosition, length);
         }
 
         public void copy(ByteBuffer srcBuf, int srcPosition, ByteBuffer trgBuf, int trgPosition, int length)
@@ -463,6 +522,24 @@ public class FastByteOperations
             }
 
             return compare(buffer1, ByteBuffer.wrap(buffer2, offset2, length2));
+        }
+
+        @Override
+        public int compare(ByteBuffer b1, long address2, int length2)
+        {
+            throw new UnsupportedOperationException("native memory address is an argument, we cannot do it using a pure Java");
+        }
+
+        @Override
+        public int compare(long address1, int length1, long address2, int length2)
+        {
+            throw new UnsupportedOperationException("native memory address is an argument, we cannot do it using a pure Java");
+        }
+
+        @Override
+        public int compare(byte[] b1, int s1, int l1, long address2, int length2)
+        {
+            throw new UnsupportedOperationException("native memory address is an argument, we cannot do it using a pure Java");
         }
 
         public int compare(ByteBuffer buffer1, ByteBuffer buffer2)

--- a/src/java/org/apache/cassandra/utils/UUIDGen.java
+++ b/src/java/org/apache/cassandra/utils/UUIDGen.java
@@ -30,7 +30,12 @@ public class UUIDGen
     /** creates a type 1 uuid from raw bytes. */
     public static UUID getUUID(ByteBuffer raw)
     {
-        return new UUID(raw.getLong(raw.position()), raw.getLong(raw.position() + 8));
+        return getUUID(raw.getLong(raw.position()), raw.getLong(raw.position() + 8));
+    }
+
+    public static UUID getUUID(long mostSigBits, long leastSigBits)
+    {
+        return new UUID(mostSigBits, leastSigBits);
     }
 
     public static ByteBuffer toByteBuffer(UUID uuid)

--- a/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
@@ -146,6 +146,9 @@ public abstract class MemoryUtil
     }
 
 
+    /**
+     * @return unsigned short
+     */
     public static int getShort(long address, boolean isBigEndian)
     {
         if (Architecture.IS_UNALIGNED)

--- a/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
@@ -104,25 +104,40 @@ public abstract class MemoryUtil
         unsafe.setMemory(address, count, b);
     }
 
+    public static void setShort(long address, short s, boolean isBigEndian)
+    {
+        unsafe.putShort(address, isBigEndian ? Short.reverseBytes(s) : s);
+    }
+
     public static void setShort(long address, short s)
     {
         unsafe.putShort(address, Architecture.BIG_ENDIAN ? Short.reverseBytes(s) : s);
     }
 
-    public static void setInt(long address, int l)
+    public static void setInt(long address, int l, boolean isBigEndian)
     {
         if (Architecture.IS_UNALIGNED)
-            unsafe.putInt(address, Architecture.BIG_ENDIAN ? Integer.reverseBytes(l) : l);
+            unsafe.putInt(address, isBigEndian ? Integer.reverseBytes(l) : l);
         else
-            putIntByByte(address, l);
+            putIntByByte(address, l, isBigEndian);
+    }
+
+    public static void setInt(long address, int l)
+    {
+        setInt(address, l, Architecture.BIG_ENDIAN);
+    }
+
+    public static void setLong(long address, long l, boolean isBigEndian)
+    {
+        if (Architecture.IS_UNALIGNED)
+            unsafe.putLong(address, isBigEndian ? Long.reverseBytes(l) : l);
+        else
+            putLongByByte(address, l, isBigEndian);
     }
 
     public static void setLong(long address, long l)
     {
-        if (Architecture.IS_UNALIGNED)
-            unsafe.putLong(address, Architecture.BIG_ENDIAN ? Long.reverseBytes(l) : l);
-        else
-            putLongByByte(address, l);
+        setLong(address, l, Architecture.BIG_ENDIAN);
     }
 
     public static byte getByte(long address)
@@ -130,28 +145,43 @@ public abstract class MemoryUtil
         return unsafe.getByte(address);
     }
 
-    public static int getShort(long address)
+
+    public static int getShort(long address, boolean isBigEndian)
     {
         if (Architecture.IS_UNALIGNED)
-            return (Architecture.BIG_ENDIAN ? Short.reverseBytes(unsafe.getShort(address)) : unsafe.getShort(address)) & 0xffff;
+            return (isBigEndian ? Short.reverseBytes(unsafe.getShort(address)) : unsafe.getShort(address)) & 0xffff;
         else
-            return getShortByByte(address) & 0xffff;
+            return getShortByByte(address, isBigEndian) & 0xffff;
+    }
+    public static int getShort(long address)
+    {
+        return getShort(address, Architecture.BIG_ENDIAN);
 	}
+
+    public static int getInt(long address, boolean isBigEndian)
+    {
+        if (Architecture.IS_UNALIGNED)
+            return isBigEndian ? Integer.reverseBytes(unsafe.getInt(address)) : unsafe.getInt(address);
+        else
+            return getIntByByte(address, isBigEndian);
+    }
 
     public static int getInt(long address)
     {
-        if (Architecture.IS_UNALIGNED)
-            return Architecture.BIG_ENDIAN ? Integer.reverseBytes(unsafe.getInt(address)) : unsafe.getInt(address);
-        else
-            return getIntByByte(address);
+        return getInt(address, Architecture.BIG_ENDIAN);
 	}
+
+    public static long getLong(long address, boolean isBigEndian)
+    {
+        if (Architecture.IS_UNALIGNED)
+            return isBigEndian ? Long.reverseBytes(unsafe.getLong(address)) : unsafe.getLong(address);
+        else
+            return getLongByByte(address, isBigEndian);
+    }
 
     public static long getLong(long address)
     {
-        if (Architecture.IS_UNALIGNED)
-            return Architecture.BIG_ENDIAN ? Long.reverseBytes(unsafe.getLong(address)) : unsafe.getLong(address);
-        else
-            return getLongByByte(address);
+        return getLong(address, Architecture.BIG_ENDIAN);
 	}
 
     public static ByteBuffer getByteBuffer(long address, int length)
@@ -250,9 +280,9 @@ public abstract class MemoryUtil
         unsafe.putInt(instance, DIRECT_BYTE_BUFFER_CAPACITY_OFFSET, capacity);
     }
 
-    public static long getLongByByte(long address)
+    public static long getLongByByte(long address, boolean isBigEndian)
     {
-        if (Architecture.BIG_ENDIAN)
+        if (isBigEndian)
         {
             return  (((long) unsafe.getByte(address    )       ) << 56) |
                     (((long) unsafe.getByte(address + 1) & 0xff) << 48) |
@@ -276,9 +306,9 @@ public abstract class MemoryUtil
         }
     }
 
-    public static int getIntByByte(long address)
+    public static int getIntByByte(long address, boolean isBigEndian)
     {
-        if (Architecture.BIG_ENDIAN)
+        if (isBigEndian)
         {
             return  (((int) unsafe.getByte(address    )       ) << 24) |
                     (((int) unsafe.getByte(address + 1) & 0xff) << 16) |
@@ -294,10 +324,9 @@ public abstract class MemoryUtil
         }
     }
 
-
-    public static int getShortByByte(long address)
+    public static int getShortByByte(long address, boolean isBigEndian)
     {
-        if (Architecture.BIG_ENDIAN)
+        if (isBigEndian)
         {
             return  (((int) unsafe.getByte(address    )       ) << 8) |
                     (((int) unsafe.getByte(address + 1) & 0xff)     );
@@ -309,9 +338,9 @@ public abstract class MemoryUtil
         }
     }
 
-    public static void putLongByByte(long address, long value)
+    public static void putLongByByte(long address, long value, boolean isBigEndian)
     {
-        if (Architecture.BIG_ENDIAN)
+        if (isBigEndian)
         {
             unsafe.putByte(address, (byte) (value >> 56));
             unsafe.putByte(address + 1, (byte) (value >> 48));
@@ -335,9 +364,9 @@ public abstract class MemoryUtil
         }
     }
 
-    public static void putIntByByte(long address, int value)
+    public static void putIntByByte(long address, int value, boolean isBigEndian)
     {
-        if (Architecture.BIG_ENDIAN)
+        if (isBigEndian)
         {
             unsafe.putByte(address, (byte) (value >> 24));
             unsafe.putByte(address + 1, (byte) (value >> 16));
@@ -359,6 +388,26 @@ public abstract class MemoryUtil
         int count = buffer.limit() - start;
         if (count == 0)
             return;
+
+        if (buffer.isDirect())
+            setBytes(getAddress(buffer) + start, address, count);
+        else
+            setBytes(address, buffer.array(), buffer.arrayOffset() + start, count);
+    }
+
+    /**
+     * Transfers count bytes to Memory starting at memoryOffset from ByteBuffer starting at bufferOffset
+     *
+     * @param address target start offset in the memory
+     * @param buffer the source data buffer
+     * @param bufferOffset start offset of the buffer
+     * @param count number of bytes to transfer
+     */
+    public static void setBytes(long address, ByteBuffer buffer, int bufferOffset, int count)
+    {
+        if (count == 0)
+            return;
+        int start = buffer.position() + bufferOffset;
 
         if (buffer.isDirect())
             setBytes(getAddress(buffer) + start, address, count);
@@ -406,7 +455,7 @@ public abstract class MemoryUtil
     }
 
     /**
-     * Transfers count bytes from Memory starting at memoryOffset to buffer starting at bufferOffset
+     * Transfers count bytes from Memory starting at address to buffer starting at bufferOffset
      *
      * @param address start offset in the memory
      * @param buffer the data buffer
@@ -423,5 +472,53 @@ public abstract class MemoryUtil
             return;
 
         unsafe.copyMemory(null, address, buffer, BYTE_ARRAY_BASE_OFFSET + bufferOffset, count);
+    }
+
+
+    /**
+     * Transfers count bytes from Memory starting at address to ByteBuffer starting at bufferOffset
+     *
+     * @param address start offset in the memory
+     * @param buffer the target data buffer
+     * @param bufferOffset start offset of the buffer
+     * @param length number of bytes to transfer
+     */
+    public static void getBytes(long address, ByteBuffer buffer, int bufferOffset, int length)
+    {
+        if (buffer == null)
+            throw new NullPointerException();
+        else if (length < 0 || length > buffer.remaining())
+            throw new IndexOutOfBoundsException();
+        else if (length == 0)
+            return;
+
+        Object obj;
+        long offset;
+        if (buffer.hasArray())
+        {
+            obj = buffer.array();
+            offset = BYTE_ARRAY_BASE_OFFSET + buffer.arrayOffset();
+        }
+        else
+        {
+            obj = null;
+            offset = unsafe.getLong(buffer, DIRECT_BYTE_BUFFER_ADDRESS_OFFSET);
+        }
+        offset += buffer.position();
+        offset += bufferOffset;
+
+        unsafe.copyMemory(null, address, obj, offset, length);
+    }
+
+    /**
+     * Transfers count bytes from Memory starting at address to ByteBuffer
+     *
+     * @param address start offset in the memory
+     * @param buffer the target data buffer
+     * @param length number of bytes to transfer
+     */
+    public static void getBytes(long address, ByteBuffer buffer, int length)
+    {
+        getBytes(address, buffer, 0, length);
     }
 }

--- a/test/unit/org/apache/cassandra/db/ClusteringPrefixTest.java
+++ b/test/unit/org/apache/cassandra/db/ClusteringPrefixTest.java
@@ -180,7 +180,7 @@ public class ClusteringPrefixTest
 
     public <V> void testRetainable(ValueAccessor.ObjectFactory<V> factory,
                                    Function<String, V[]> allocator,
-                                   Function<ClusteringPrefix<V>, ClusteringPrefix<V>> mapper)
+                                   Function<ClusteringPrefix<?>, ClusteringPrefix<?>> mapper)
     {
         ClusteringPrefix<V>[] clusterings = new ClusteringPrefix[]
         {

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.db;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Random;
@@ -30,6 +31,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -63,7 +65,7 @@ public class NativeCellTest extends CQLTester
     }
 
     @Test
-    public void testCells()
+    public void testCells() throws IOException
     {
         for (int run = 0 ; run < 1000 ; run++)
         {
@@ -152,7 +154,7 @@ public class NativeCellTest extends CQLTester
         return Math.min(Math.max(1, randomsize), 1 << 26);
     }
 
-    private static void test(Row row)
+    private static void test(Row row)  throws IOException
     {
         Row nrow = row.clone(nativeAllocator.cloner(group));
         Row brow = row.clone(HeapCloner.instance);
@@ -175,6 +177,44 @@ public class NativeCellTest extends CQLTester
         assertCellsDataSize(row, nrow);
         assertCellsDataSize(row, brow);
 
+        assertCellsWrittenToOutput(row, nrow);
+        assertCellsWrittenToOutput(row, brow);
+
+        assertCellsSlicing(row, nrow);
+        assertCellsSlicing(row, brow);
+    }
+
+    private static void assertCellsWrittenToOutput(Row row1, Row row2) throws IOException
+    {
+        Iterator<Cell<?>> row1Iterator = row1.cells().iterator();
+        Iterator<Cell<?>> row2Iterator = row2.cells().iterator();
+        while (row1Iterator.hasNext())
+        {
+            Cell cell1 = row1Iterator.next();
+            Cell cell2 = row2Iterator.next();
+            DataOutputBuffer output1 = new DataOutputBuffer(cell1.dataSize());
+            DataOutputBuffer output2 = new DataOutputBuffer(cell2.dataSize());
+            cell1.accessor().write(cell1.value(), output1);
+            cell2.accessor().write(cell2.value(), output2);
+            Assert.assertArrayEquals(output1.toByteArray(), output2.toByteArray());
+        }
+    }
+
+    private static void assertCellsSlicing(Row row1, Row row2)
+    {
+        Iterator<Cell<?>> row1Iterator = row1.cells().iterator();
+        Iterator<Cell<?>> row2Iterator = row2.cells().iterator();
+        while (row1Iterator.hasNext())
+        {
+            Cell cell1 = row1Iterator.next();
+            Cell cell2 = row2Iterator.next();
+            int offset = cell1.accessor().size(cell1.value()) / 3;
+            int length = cell1.accessor().size(cell1.value()) / 2;
+            Object slice1 = cell1.accessor().slice(cell1.value(), offset, length);
+            Object slice2 = cell2.accessor().slice(cell2.value(), offset, length);
+            Assert.assertEquals(0, cell1.accessor().compare(slice1, slice2, cell2.accessor()));
+            Assert.assertEquals(0, cell2.accessor().compare(slice2, slice1, cell1.accessor()));
+        }
     }
 
     private static void assertCellsDataSize(Row row1, Row row2)

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.rows.*;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.concurrent.ImmediateFuture;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.HeapCloner;
@@ -65,7 +66,7 @@ public class NativeCellTest extends CQLTester
     }
 
     @Test
-    public void testCells() throws IOException
+    public void testCells() throws Exception
     {
         for (int run = 0 ; run < 1000 ; run++)
         {
@@ -154,7 +155,7 @@ public class NativeCellTest extends CQLTester
         return Math.min(Math.max(1, randomsize), 1 << 26);
     }
 
-    private static void test(Row row)  throws IOException
+    private static void test(Row row)  throws Exception
     {
         Row nrow = row.clone(nativeAllocator.cloner(group));
         Row brow = row.clone(HeapCloner.instance);
@@ -162,17 +163,20 @@ public class NativeCellTest extends CQLTester
         Assert.assertEquals(row, brow);
         Assert.assertEquals(nrow, brow);
 
-        Assert.assertEquals(row.clustering(), nrow.clustering());
-        Assert.assertEquals(row.clustering(), brow.clustering());
-        Assert.assertEquals(nrow.clustering(), brow.clustering());
+        Digest rowDigest = Digest.forReadResponse();
+        Digest nativeRowDigest = Digest.forReadResponse();
+        Digest byteBufferRowDigest = Digest.forReadResponse();
+        row.digest(rowDigest);
+        nrow.digest(nativeRowDigest);
+        brow.digest(byteBufferRowDigest);
+        byte[] rowDigestValue = rowDigest.digest();
+        Assert.assertArrayEquals(rowDigestValue, nativeRowDigest.digest());
+        Assert.assertArrayEquals(rowDigestValue, byteBufferRowDigest.digest());
 
-        Assert.assertEquals(row.clustering().dataSize(), nrow.clustering().dataSize());
-        Assert.assertEquals(row.clustering().dataSize(), brow.clustering().dataSize());
+        Assert.assertEquals(row.dataSize(), nrow.dataSize());
+        Assert.assertEquals(row.dataSize(), brow.dataSize());
 
-        ClusteringComparator comparator = new ClusteringComparator(UTF8Type.instance);
-        Assert.assertEquals(0, comparator.compare(row.clustering(), nrow.clustering()));
-        Assert.assertEquals(0, comparator.compare(row.clustering(), brow.clustering()));
-        Assert.assertEquals(0, comparator.compare(nrow.clustering(), brow.clustering()));
+        assertClustering(row, brow, nrow);
 
         assertCellsDataSize(row, nrow);
         assertCellsDataSize(row, brow);
@@ -182,6 +186,114 @@ public class NativeCellTest extends CQLTester
 
         assertCellsSlicing(row, nrow);
         assertCellsSlicing(row, brow);
+    }
+
+    private static void assertClustering(Row row, Row byteBufferRow, Row nativeRow) throws Exception
+    {
+        Assert.assertEquals(row.clustering(), nativeRow.clustering());
+        Assert.assertEquals(row.clustering(), byteBufferRow.clustering());
+        Assert.assertEquals(nativeRow.clustering(), byteBufferRow.clustering());
+
+        ClusteringComparator comparator = new ClusteringComparator(UTF8Type.instance);
+        Assert.assertEquals(0, comparator.compare(row.clustering(), nativeRow.clustering()));
+        Assert.assertEquals(0, comparator.compare(row.clustering(), byteBufferRow.clustering()));
+        Assert.assertEquals(0, comparator.compare(nativeRow.clustering(), byteBufferRow.clustering()));
+        Assert.assertEquals(0, comparator.compare(nativeRow.clustering(), row.clustering()));
+        Assert.assertEquals(0, comparator.compare(nativeRow.clustering(), nativeRow.clustering()));
+
+
+        Assert.assertEquals(row.clustering().size(), nativeRow.clustering().size());
+        Assert.assertEquals(row.clustering().size(), byteBufferRow.clustering().size());
+
+        assertByteBufferArrayEquals(row.clustering().getBufferArray(), nativeRow.clustering().getBufferArray());
+        assertByteBufferArrayEquals(row.clustering().getBufferArray(), byteBufferRow.clustering().getBufferArray());
+
+        assertRawValuesEquals(row.clustering(), nativeRow.clustering());
+        assertRawValuesEquals(row.clustering(), byteBufferRow.clustering());
+
+
+        for (int i = 0; i < row.clustering().size(); i++)
+        {
+            Assert.assertEquals(row.clustering().isEmpty(i), byteBufferRow.clustering().isEmpty(i));
+            Assert.assertEquals(row.clustering().isEmpty(i), nativeRow.clustering().isEmpty(i));
+
+            Assert.assertEquals(row.clustering().isNull(i), byteBufferRow.clustering().isNull(i));
+            Assert.assertEquals(row.clustering().isNull(i), nativeRow.clustering().isNull(i));
+        }
+
+        assertClusteringElementSizes(row.clustering(), byteBufferRow.clustering());
+        assertClusteringElementSizes(row.clustering(), nativeRow.clustering());
+
+        assertClusteringElementWrittenToOutput(row.clustering(), byteBufferRow.clustering());
+        assertClusteringElementWrittenToOutput(row.clustering(), nativeRow.clustering());
+
+        assertClusteringSlicing(row.clustering(), byteBufferRow.clustering());
+        assertClusteringSlicing(row.clustering(), nativeRow.clustering());
+
+    }
+
+    private static <V1, V2> void assertRawValuesEquals(Clustering<V1> c1, Clustering<V2> c2)
+    {
+        V1[] rawValues1 = c1.getRawValues();
+        V2[] rawValues2 = c2.getRawValues();
+        Assert.assertEquals(rawValues1.length, rawValues2.length);
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (rawValues1[i] != null)
+                Assert.assertEquals(0, c1.accessor().compare(rawValues1[i], rawValues2[i], c2.accessor()));
+        }
+    }
+
+    private static <V1, V2> void assertClusteringElementSizes(Clustering<V1> c1, Clustering<V2> c2)
+    {
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (c1.get(i) != null)
+            {
+                int sizeC1 = c1.accessor().size(c1.get(i));
+                int sizeC2 = c2.accessor().size(c2.get(i));
+                Assert.assertEquals(sizeC1, sizeC2);
+            }
+        }
+    }
+
+    private static <V1, V2> void assertClusteringElementWrittenToOutput(Clustering<V1> c1, Clustering<V2> c2) throws IOException
+    {
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (c1.get(i) != null)
+            {
+                DataOutputBuffer outputC1 = new DataOutputBuffer(c1.dataSize());
+                DataOutputBuffer outputC2 = new DataOutputBuffer(c2.dataSize());
+                c1.accessor().write(c1.get(i), outputC1);
+                c2.accessor().write(c2.get(i), outputC2);
+                Assert.assertArrayEquals(outputC1.toByteArray(), outputC2.toByteArray());
+            }
+        }
+    }
+
+    private static <V1, V2> void assertClusteringSlicing(Clustering<V1> c1, Clustering<V2> c2) throws IOException
+    {
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (c1.get(i) != null)
+            {
+                int offset = c1.accessor().size(c1.get(i)) / 3;
+                int length = c1.accessor().size(c1.get(i)) / 2;
+                V1 slice1 = c1.accessor().slice(c1.get(i), offset, length);
+                V2 slice2 = c2.accessor().slice(c2.get(i), offset, length);
+                Assert.assertEquals(0, c1.accessor().compare(slice1, slice2, c2.accessor()));
+                Assert.assertEquals(0, c2.accessor().compare(slice2, slice1, c1.accessor()));
+            }
+        }
+    }
+
+    private static void assertByteBufferArrayEquals(ByteBuffer[] array1, ByteBuffer[] array2) {
+        Assert.assertEquals(array1.length, array2.length);
+        for (int i = 0; i < array1.length; i++) {
+            if (array1[i] != null)
+                Assert.assertEquals(0, ByteBufferUtil.compareUnsigned(array1[i], array2[i]));
+        }
     }
 
     private static void assertCellsWrittenToOutput(Row row1, Row row2) throws IOException

--- a/test/unit/org/apache/cassandra/db/marshal/ByteBufferAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ByteBufferAccessorTest.java
@@ -20,7 +20,9 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -29,6 +31,21 @@ import static org.quicktheories.QuickTheory.qt;
 
 public class ByteBufferAccessorTest extends ValueAccessorTester
 {
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
+
     private static byte[] array(int start, int size)
     {
         byte[] a = new byte[size];

--- a/test/unit/org/apache/cassandra/db/marshal/CollectionTypesTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CollectionTypesTest.java
@@ -27,7 +27,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQL3Type;
@@ -36,6 +38,20 @@ import static org.apache.cassandra.db.marshal.ValueAccessors.ACCESSORS;
 
 public class CollectionTypesTest
 {
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
     interface TypeFactory<T extends CollectionType> { T createType(AbstractType<?> keyType, AbstractType<?> valType); }
     interface ValueFactory<T> { T createValue(ValueGenerator keyGen, ValueGenerator valGen, int size, Random random); }
 
@@ -68,6 +84,7 @@ public class CollectionTypesTest
                         Assert.assertEquals(srcString, dstString);
                     }
                 }
+                allocator.releaseMemory();
             }
         }
     }

--- a/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.FieldIdentifier;
@@ -33,6 +35,20 @@ import static org.apache.cassandra.db.marshal.ValueAccessors.ACCESSORS;
 
 public class CompositeAndTupleTypesTest
 {
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
     interface TypeFactory<T extends AbstractType> { T createType(List<AbstractType<?>> types); }
     interface ValueCombiner<V> { V combine(ValueAccessor<V> accessor, V[] values); }
 
@@ -106,6 +122,7 @@ public class CompositeAndTupleTypesTest
                         Assert.assertEquals(srcString, dstString);
                     }
                 }
+                allocator.releaseMemory();
             }
         }
     }

--- a/test/unit/org/apache/cassandra/db/marshal/CompositeTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CompositeTypeTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.CharacterCodingException;
 import java.util.*;
 
 import com.google.common.collect.Lists;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -68,6 +69,20 @@ public class CompositeTypeTest
     {
         for (int i = 0; i < UUID_COUNT; ++i)
             uuids[i] = nextTimeUUID();
+    }
+
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
     }
 
     @BeforeClass

--- a/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import com.google.common.primitives.UnsignedBytes;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.integers;
+
+public class NativeAccessorTest extends ValueAccessorTester
+{
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
+    @Test
+    public void testCompare()
+    {
+        qt().forAll(accessors(),
+                    byteArrays(integers().between(0, 200)),
+                    byteArrays(integers().between(0, 200))
+            ).checkAssert(this::testCompare);
+    }
+
+    private <V> void testCompare(ValueAccessor<V> rightAccessor, byte[] leftArray, byte[] rightArray)
+    {
+        NativeData left = NativeAccessor.instance.valueOf(leftArray);
+        V right = rightAccessor.valueOf(rightArray);
+        int expectedResult = Integer.signum(UnsignedBytes.lexicographicalComparator().compare(leftArray, rightArray));
+        int actualResult = Integer.signum(NativeAccessor.instance.compare(left, right, rightAccessor));
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testCopy()
+    {
+        qt().forAll(accessors(),
+                    byteArrays(integers().between(10, 100)),
+                    integers().between(0, 9),
+                    integers().between(0, 9)
+        ).checkAssert(this::testCopy);
+    }
+
+    private <V> void testCopy(ValueAccessor<V> dstAccessor, byte[] dataToCopy, int srcOffset, int dstOffset)
+    {
+        ValueAccessor<NativeData> srcAcccessor = NativeAccessor.instance;
+        NativeData src = srcAcccessor.valueOf(dataToCopy);
+        V dst = dstAccessor.valueOf(new byte[dataToCopy.length + dstOffset - srcOffset]);
+        NativeAccessor.instance.copyTo(src, srcOffset, dst, dstAccessor, dstOffset,  dataToCopy.length - srcOffset);
+        V dstSlice = dstAccessor.slice(dst, dstOffset, dataToCopy.length - srcOffset);
+        NativeData expectedData = srcAcccessor.slice(src, srcOffset, dataToCopy.length - srcOffset);
+
+        Assert.assertArrayEquals(srcAcccessor.toArray(src, srcOffset, dataToCopy.length - srcOffset), dstAccessor.toArray(dstSlice));
+        Assert.assertArrayEquals(srcAcccessor.toArray(expectedData), dstAccessor.toArray(dstSlice));
+
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.service.paxos.Ballot;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.UUIDGen;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.quicktheories.QuickTheory.qt;
@@ -258,6 +259,15 @@ public class NativeAccessorTest extends ValueAccessorTester
         NativeData nativeData = nativeAccessor.valueOf(originalData);
         String nativeHex = nativeAccessor.toHex(nativeData);
         Assert.assertEquals(bufferHex, nativeHex);
+    }
+
+    @Test
+    public void test() {
+        NativeData nativeData = nativeAccessor.allocate(4);
+        MemoryUtil.setInt(nativeData.getAddress(), 0x00FF);
+
+        String nativeHex = nativeAccessor.toHex(nativeData);
+        System.out.println(nativeHex);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
@@ -18,12 +18,29 @@
 
 package org.apache.cassandra.db.marshal;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import com.google.common.primitives.UnsignedBytes;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.db.Digest;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.service.paxos.Ballot;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.UUIDGen;
+
+import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.integers;
 
@@ -41,6 +58,9 @@ public class NativeAccessorTest extends ValueAccessorTester
     {
         allocator.close();
     }
+
+    private final ValueAccessor<NativeData> nativeAccessor = NativeAccessor.instance;
+    private final ValueAccessor<ByteBuffer> bufferAccessor = ByteBufferAccessor.instance;
 
     @Test
     public void testCompare()
@@ -81,6 +101,257 @@ public class NativeAccessorTest extends ValueAccessorTester
 
         Assert.assertArrayEquals(srcAcccessor.toArray(src, srcOffset, dataToCopy.length - srcOffset), dstAccessor.toArray(dstSlice));
         Assert.assertArrayEquals(srcAcccessor.toArray(expectedData), dstAccessor.toArray(dstSlice));
+    }
 
+    @Test
+    public void testPutMethods()
+    {
+        testNativePut((byte) 42, nativeAccessor::putByte, bufferAccessor::getByte);
+
+        testNativePut((short )(Short.MAX_VALUE - 3), nativeAccessor::putShort, bufferAccessor::getShort);
+
+        testNativePut(Integer.MAX_VALUE - 5, nativeAccessor::putInt, bufferAccessor::getInt);
+
+        testNativePut((float) Math.PI, nativeAccessor::putFloat, bufferAccessor::getFloat);
+
+        testNativePut(Long.MAX_VALUE - 2, nativeAccessor::putLong, bufferAccessor::getLong);
+
+        testNativePut(0L, nativeAccessor::putVInt, bufferAccessor::getVInt);
+        testNativePut(42L, nativeAccessor::putVInt, bufferAccessor::getVInt);
+        testNativePut(0xFFFFFFL, nativeAccessor::putVInt, bufferAccessor::getVInt);
+        testNativePut(Long.MAX_VALUE - 1, nativeAccessor::putVInt, bufferAccessor::getVInt);
+
+        testNativePut(42, nativeAccessor::putVInt32, bufferAccessor::getVInt32);
+        testNativePut(0xFFFFF, nativeAccessor::putVInt32, bufferAccessor::getVInt32);
+        testNativePut(Integer.MAX_VALUE - 1, nativeAccessor::putVInt32, bufferAccessor::getVInt32);
+
+        testNativePut(42L, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+        testNativePut(0xFFFFFL, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+        testNativePut(0xFFFFFFFL, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+        testNativePut(Long.MAX_VALUE - 1, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+    }
+
+    @Test
+    public void testPutDouble() // there is no putDouble method to test it like others
+    {
+        Double originalValue = Math.PI; // Double conversion is used to compare values as bit values
+        NativeData nativeData = nativeAccessor.allocate(25);
+        ByteBuffer bufferData = bufferAccessor.allocate(25);
+        int offset = 7;
+        bufferData.putDouble(offset, originalValue);
+        nativeAccessor.copyByteBufferTo(bufferData, 0, nativeData, 0, bufferAccessor.size(bufferData));
+        Double getValue = nativeAccessor.getDouble(nativeData, offset);
+        Assert.assertEquals(originalValue, getValue);
+
+        NativeData nativeDataSlice = nativeAccessor.slice(nativeData, offset, nativeData.nativeDataSize() - offset);
+        Double toValue = nativeAccessor.toDouble(nativeDataSlice);
+        Assert.assertEquals(originalValue, toValue);
+
+    }
+
+    private <V> void testNativePut(V originalValue, TriFunction<NativeData, Integer, V, Integer> putMethod,
+                                   BiFunction<ByteBuffer, Integer, V> getMethod)
+    {
+        NativeData nativeData = nativeAccessor.allocate(25);
+        int offset = 2;
+        putMethod.apply(nativeData, offset, originalValue);
+        ByteBuffer buffer = nativeAccessor.toBuffer(nativeData);
+        V getValue = getMethod.apply(buffer, offset);
+        Assert.assertEquals(originalValue, getValue);
+    }
+
+    @Test
+    public void testGetMethods()
+    {
+        testNativeGet((byte) 42, bufferAccessor::putByte, nativeAccessor::getByte, nativeAccessor::toByte);
+
+        testNativeGet((short )(Short.MAX_VALUE - 3), bufferAccessor::putShort, nativeAccessor::getShort, nativeAccessor::toShort);
+
+        // nativeAccessor::getUnsignedShort is already tested by org.apache.cassandra.db.marshal.ValueAccessorTest.testUnsignedShort()
+
+        testNativeGet(Integer.MAX_VALUE - 5, bufferAccessor::putInt, nativeAccessor::getInt, nativeAccessor::toInt);
+
+        testNativeGet((float) Math.PI, bufferAccessor::putFloat, nativeAccessor::getFloat, nativeAccessor::toFloat);
+
+        testNativeGet(Long.MAX_VALUE - 2, bufferAccessor::putLong, nativeAccessor::getLong, nativeAccessor::toLong);
+
+        testNativeGet(0L, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+        testNativeGet(42L, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+        testNativeGet(0xFFFFFFL, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+        testNativeGet(Long.MAX_VALUE - 1, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+
+        testNativeGet(42, bufferAccessor::putVInt32, nativeAccessor::getVInt32, null);
+        testNativeGet(0xFFFFF, bufferAccessor::putVInt32, nativeAccessor::getVInt32, null);
+        testNativeGet(Integer.MAX_VALUE - 1, bufferAccessor::putVInt32, nativeAccessor::getVInt32, null);
+
+        testNativeGet(42L, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+        testNativeGet(0xFFFFFL, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+        testNativeGet(0xFFFFFFFL, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+        testNativeGet(Long.MAX_VALUE - 1, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+    }
+
+    private <V> void testNativeGet(V originalValue, TriFunction<ByteBuffer, Integer, V, Integer> putMethod,
+                                   BiFunction<NativeData, Integer, V> getMethod, Function<NativeData, V> toMethod)
+    {
+        ByteBuffer bufferData = bufferAccessor.allocate(25);
+        NativeData nativeData = nativeAccessor.allocate(25);
+        int offset = 2;
+        putMethod.apply(bufferData, offset, originalValue);
+        nativeAccessor.copyByteBufferTo(bufferData, 0, nativeData, 0, bufferAccessor.size(bufferData));
+        V getValue = getMethod.apply(nativeData, offset);
+        Assert.assertEquals(originalValue, getValue);
+
+        if (toMethod != null)
+        {
+            NativeData nativeDataSlice = nativeAccessor.slice(nativeData, offset, nativeData.nativeDataSize() - offset);
+            V toValue = toMethod.apply(nativeDataSlice);
+            Assert.assertEquals(originalValue, toValue);
+        }
+    }
+
+    @Test
+    public void testToUUID() {
+        UUID originalValue = UUID.randomUUID();
+        ByteBuffer encodedOriginalValue = UUIDGen.toByteBuffer(originalValue);
+        int size = encodedOriginalValue.remaining();
+        NativeData nativeData = nativeAccessor.allocate(size);
+        nativeAccessor.copyByteBufferTo(encodedOriginalValue, 0, nativeData, 0, size);
+
+        UUID nativeUUID = nativeAccessor.toUUID(nativeData);
+        Assert.assertEquals(originalValue, nativeUUID);
+    }
+
+    @Test
+    public void testToTimeUUID() {
+        TimeUUID originalValue = nextTimeUUID();
+        ByteBuffer encodedOriginalValue = originalValue.toBytes();
+        int size = encodedOriginalValue.remaining();
+        NativeData nativeData = nativeAccessor.allocate(size);
+        nativeAccessor.copyByteBufferTo(encodedOriginalValue, 0, nativeData, 0, size);
+
+        TimeUUID nativeUUID = nativeAccessor.toTimeUUID(nativeData);
+        Assert.assertEquals(originalValue, nativeUUID);
+    }
+
+    @Test
+    public void testToBullot() {
+        Ballot originalValue = Ballot.fromUuid(nextTimeUUID().asUUID());
+        ByteBuffer encodedOriginalValue = originalValue.toBytes();
+        int size = encodedOriginalValue.remaining();
+        NativeData nativeData = nativeAccessor.allocate(size);
+        nativeAccessor.copyByteBufferTo(encodedOriginalValue, 0, nativeData, 0, size);
+
+        Ballot nativeBallot = nativeAccessor.toBallot(nativeData);
+        Assert.assertEquals(originalValue, nativeBallot);
+    }
+
+    @Test
+    public void testToHex() {
+        int valueSize = 42;
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+
+        ByteBuffer bufferData = bufferAccessor.valueOf(originalData);
+        String bufferHex = bufferAccessor.toHex(bufferData);
+
+        NativeData nativeData = nativeAccessor.valueOf(originalData);
+        String nativeHex = nativeAccessor.toHex(nativeData);
+        Assert.assertEquals(bufferHex, nativeHex);
+    }
+
+    @Test
+    public void testToString() throws CharacterCodingException
+    {
+        String originalData = "test string value";
+        NativeData nativeData = nativeAccessor.valueOf(originalData, StandardCharsets.UTF_8);
+        String nativeToString = nativeAccessor.toString(nativeData, StandardCharsets.UTF_8);
+        Assert.assertEquals(originalData, nativeToString);
+    }
+
+    @Test
+    public void testToFloatArray() {
+        int valueSize = 42;
+        ByteBuffer buffer = ByteBuffer.allocate(valueSize * Float.BYTES);
+        FloatBuffer floatBuffer = buffer.asFloatBuffer();
+        for (int i = 0; i < valueSize; i++)
+            floatBuffer.put((float) i);
+
+        NativeData nativeData = nativeAccessor.valueOf(buffer);
+        float[] decodedFloatArray = nativeAccessor.toFloatArray(nativeData, valueSize);
+
+        for (int i = 0; i < valueSize; i++)
+            Assert.assertEquals((Float) floatBuffer.get(i), (Float) decodedFloatArray[i]);
+        // Float conversion is used to compare values as bit values
+    }
+
+    @Test
+    public void testDataOutputPlusWrite() throws IOException
+    {
+        int valueSize = 25;
+        NativeData nativeData = nativeAccessor.allocate(valueSize);
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+        nativeAccessor.putBytes(nativeData, 0, originalData);
+
+        try(DataOutputBuffer dataOutput = new DataOutputBuffer())
+        {
+            nativeAccessor.write(nativeData, dataOutput);
+            byte[] writenData = dataOutput.toByteArray();
+            Assert.assertArrayEquals(originalData, writenData);
+        }
+    }
+
+    @Test
+    public void testHeapByteBufferWrite()
+    {
+        testHeapByteBufferWrite(ByteBuffer.allocate(25), 23);
+    }
+
+    @Test
+    public void testDirectByteBufferWrite()
+    {
+        testHeapByteBufferWrite(ByteBuffer.allocateDirect(25), 23);
+    }
+
+    private void testHeapByteBufferWrite(ByteBuffer buffer, int valueSize)
+    {
+        NativeData nativeData = nativeAccessor.allocate(valueSize);
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+        nativeAccessor.putBytes(nativeData, 0, originalData);
+
+        int initialPosition = buffer.position();
+        nativeAccessor.write(nativeData, buffer);
+        Assert.assertEquals(valueSize, buffer.position() - initialPosition);
+        buffer.flip();
+        Assert.assertArrayEquals(originalData, ByteBufferUtil.getArray(buffer));
+    }
+
+    @Test
+    public void testDigest()
+    {
+        int valueSize = 25;
+        NativeData nativeData = nativeAccessor.allocate(valueSize);
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+        nativeAccessor.putBytes(nativeData, 0, originalData);
+
+        Digest byteArrayDigest = Digest.forReadResponse();
+        byteArrayDigest.update(originalData, 0, originalData.length);
+
+        Digest nativeDigest = Digest.forReadResponse();
+        nativeAccessor.digest(nativeData, nativeDigest);
+
+        Assert.assertArrayEquals(byteArrayDigest.digest(), nativeDigest.digest());
+    }
+
+    @FunctionalInterface
+    interface TriFunction<A,B,C,R>
+    {
+        R apply(A a, B b, C c);
     }
 }

--- a/test/unit/org/apache/cassandra/db/marshal/TestNativeDataAllocator.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TestNativeDataAllocator.java
@@ -37,14 +37,17 @@ public class TestNativeDataAllocator implements NativeDataAllocator, Closeable
     private final NativePool nativePool = new NativePool(0, 10 * 1024 * 1024, 1.0f,
                                                          () -> ImmediateFuture.success(true));
     private NativeAllocator nativeAllocator = nativePool.newAllocator("test");
+    private final OpOrder order = new OpOrder();
+
     @Override
     public NativeData allocateBasedOnBuffer(ByteBuffer data)
     {
-        OpOrder order = new OpOrder();
-        OpOrder.Group group = order.start();
-        long address = nativeAllocator.allocate(data.remaining(), group);
-        MemoryUtil.setBytes(address, data);
-        return new AddressBasedNativeData(address, data.remaining());
+        try(OpOrder.Group group = order.start())
+        {
+            long address = nativeAllocator.allocate(data.remaining(), group);
+            MemoryUtil.setBytes(address, data);
+            return new AddressBasedNativeData(address, data.remaining());
+        }
     }
 
     public void releaseMemory() {

--- a/test/unit/org/apache/cassandra/db/marshal/TestNativeDataAllocator.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TestNativeDataAllocator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.apache.cassandra.utils.memory.MemoryUtil;
+import org.apache.cassandra.utils.memory.NativeAllocator;
+import org.apache.cassandra.utils.memory.NativePool;
+
+/**
+ * A primitive NativeData allocator is used for test purposes only
+ * It releases memory only when releaseMemory() or close() are called
+ */
+public class TestNativeDataAllocator implements NativeDataAllocator, Closeable
+{
+    private final NativePool nativePool = new NativePool(0, 10 * 1024 * 1024, 1.0f,
+                                                         () -> ImmediateFuture.success(true));
+    private NativeAllocator nativeAllocator = nativePool.newAllocator("test");
+    @Override
+    public NativeData allocateBasedOnBuffer(ByteBuffer data)
+    {
+        OpOrder order = new OpOrder();
+        OpOrder.Group group = order.start();
+        long address = nativeAllocator.allocate(data.remaining(), group);
+        MemoryUtil.setBytes(address, data);
+        return new AddressBasedNativeData(address, data.remaining());
+    }
+
+    public void releaseMemory() {
+        nativeAllocator.setDiscarding();
+        nativeAllocator.setDiscarded();
+        nativeAllocator = nativePool.newAllocator("test");
+    }
+
+    public void close() {
+        nativeAllocator.setDiscarding();
+        nativeAllocator.setDiscarded();
+        try
+        {
+            nativePool.shutdownAndWait(5, TimeUnit.SECONDS);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/test/unit/org/apache/cassandra/db/marshal/ValueAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ValueAccessorTest.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -67,6 +69,19 @@ public class ValueAccessorTest extends ValueAccessorTester
         ByteBuffer buffer2 = accessor2.toBuffer(value2);
         Assert.assertEquals(String.format("Inconsistent byte buffers (%s != %s)", bytesToHex(buffer1), bytesToHex(buffer1)),
                             buffer1, buffer2);
+    }
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/marshal/ValueAccessors.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ValueAccessors.java
@@ -22,7 +22,8 @@ import java.nio.ByteBuffer;
 
 public class ValueAccessors
 {
-    public static final ValueAccessor[] ACCESSORS = new ValueAccessor[]{ ByteBufferAccessor.instance, ByteArrayAccessor.instance };
+    public static final ValueAccessor[] ACCESSORS = new ValueAccessor[]{ ByteBufferAccessor.instance, ByteArrayAccessor.instance, NativeAccessor.instance };
+    public static final ValueAccessor[] FACTORY_SUPPORTED_ACCESSORS = new ValueAccessor[]{ ByteBufferAccessor.instance, ByteArrayAccessor.instance };
 
     public static <V1, V2> void assertDataEquals(V1 expected, ValueAccessor<V1> expectedAccessor, V2 actual, ValueAccessor<V2> actualAccessor)
     {

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceConversionTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceConversionTest.java
@@ -341,7 +341,7 @@ public class ByteSourceConversionTest extends ByteSourceTestBase
 
     void assertClusteringPairConvertsSame(AbstractType t1, AbstractType t2, Object o1, Object o2)
     {
-        for (ValueAccessor<?> accessor : ValueAccessors.ACCESSORS)
+        for (ValueAccessor<?> accessor : ValueAccessors.FACTORY_SUPPORTED_ACCESSORS)
             assertClusteringPairConvertsSame(accessor, t1, t2, o1, o2, AbstractType::decompose);
     }
 


### PR DESCRIPTION
Introduce NativeAccessor to avoid new ByteBuffer allocation on flush for each NativeCell

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20173