### PR TITLE
Cassandra 19631: autocompletion of in-built functions in CQLSH

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Add autocompletion in CQLSH for built-in functions (CASSANDRA-19631)
  * Introduce metadata serialization version V4 (CASSANDRA-19970)
  * Allow CMS reconfiguration to work around DOWN nodes (CASSANDRA-19943)
  * Make TableParams.Serializer set allowAutoSnapshots and incrementalBackups (CASSANDRA-19954)

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -780,6 +780,17 @@ syntax_rules += r'''
              | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
              | "MAX_TIMEUUID" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
+             | "COLLECTION_AVG" "(" [colname]=<cident> ")"
+             | "COLLECTION_COUNT" "(" [colname]=<cident> ")"
+             | "COLLECTION_MIN" "(" [colname]=<cident> ")"
+             | "COLLECTION_MAX" "(" [colname]=<cident> ")"
+             | "COLLECTION_SUM" "(" [colname]=<cident> ")"
+             | "MASK_NULL" "(" [colname]=<cident> ")"
+             | "MASK_DEFAULT" "(" [colname]=<cident> ")"
+             | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
+             | "MASK_HASH" "(" [colname]=<cident> ")"
+             | "MASK_INNER" "(" [colname]=<cident> ")"
+             | "MASK_OUTER" "(" [colname]=<cident> ")"
              | <functionName> <selectionFunctionArguments>
              | <term>
              ;

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -747,8 +747,8 @@ syntax_rules += r'''
                              ")" ("=" | "<" | ">" | "<=" | ">=") <tokenDefinition>
              | [rel_lhs]=<cident> (( "NOT" )? "IN" ) "(" <term> ( "," <term> )* ")"
              | [rel_lhs]=<cident> "BETWEEN" <term> "AND" <term>
-             | "maxTimeuuid()" "(" [colname]=<cident> ")"
-             | "minTimeuuid()" "(" [colname]=<cident> ")"
+             | "MAX_TIMEUUID()" "(" [colname]=<cident> ")"
+             | "MIN_TIMEUUID()" "(" [colname]=<cident> ")"
              ;
 <selectClause> ::= "DISTINCT"? <selector> ("AS" <cident>)? ("," <selector> ("AS" <cident>)?)*
                  | "*"
@@ -758,7 +758,8 @@ syntax_rules += r'''
 <selector> ::= [colname]=<cident> ( "[" ( <term> ( ".." <term> "]" )? | <term> ".." ) )?
              | <udtSubfieldSelection>
              | "WRITETIME" "(" [colname]=<cident> ")"
-             | "MAXWRITETIME" "(" [colname]=<cident> ")"
+             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
+             | "MIN_WRITETIME" "(" [colname]=<cident> ")"
              | "TTL" "(" [colname]=<cident> ")"
              | "COUNT" "(" star=( "*" | "1" ) ")"
              | "AVG" "(" star=( "*" | "1" ) ")"
@@ -770,15 +771,14 @@ syntax_rules += r'''
              | "LOG" "(" star=( "*" | "1" ) ")"
              | "LOG10" "(" star=( "*" | "1" ) ")"
              | "ROUND" "(" [colname]=<cident> ")"
-             | "TODATE" "(" [colname]=<cident> ")"
-             | "TOTIMESTAMP" "(" [colname]=<cident> ")"
-             | "TOUNIXTIMESTAMP" "(" [colname]=<cident> ")"
+             | "TO_DATE" "(" [colname]=<cident> ")"
+             | "TO_TIMESTAMP" "(" [colname]=<cident> ")"
+             | "TO_UNIX_TIMESTAMP" "(" [colname]=<cident> ")"
              | "TOKEN" "(" [colname]=<cident> ")"
-             | "TODATE" "(" [colname]=<cident> ")"
              | "MAP_KEYS" "(" [colname]=<cident> ")"
              | "MAP_VALUES" "(" [colname]=<cident> ")"
-             | "MINTIMEUUID" "(" [colname]=<cident> ")"
-             | "MAXTIMEUUID" "(" [colname]=<cident> ")"
+             | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
+             | "MAX_TIMEUUID" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
              | <functionName> <selectionFunctionArguments>
              | <term>

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -747,6 +747,9 @@ syntax_rules += r'''
                              ")" ("=" | "<" | ">" | "<=" | ">=") <tokenDefinition>
              | [rel_lhs]=<cident> (( "NOT" )? "IN" ) "(" <term> ( "," <term> )* ")"
              | [rel_lhs]=<cident> "BETWEEN" <term> "AND" <term>
+             | "maxTimeuuid()" "(" [colname]=<cident> ")"
+             | "minTimeuuid()" "(" [colname]=<cident> ")"
+             | "token()" "(" [colname]=<cident> ")"
              ;
 <selectClause> ::= "DISTINCT"? <selector> ("AS" <cident>)? ("," <selector> ("AS" <cident>)?)*
                  | "*"
@@ -759,10 +762,29 @@ syntax_rules += r'''
              | "MAXWRITETIME" "(" [colname]=<cident> ")"
              | "TTL" "(" [colname]=<cident> ")"
              | "COUNT" "(" star=( "*" | "1" ) ")"
+             | "AVG" "(" star=( "*" | "1" ) ")"
+             | "MIN" "(" star=( "*" | "1" ) ")"
+             | "MAX" "(" star=( "*" | "1" ) ")"
+             | "SUM" "(" star=( "*" | "1" ) ")"
+             | "ABS" "(" star=( "*" | "1" ) ")"
+             | "EXP" "(" star=( "*" | "1" ) ")"
+             | "LOG" "(" star=( "*" | "1" ) ")"
+             | "LOG10" "(" star=( "*" | "1" ) ")"
+             | "ROUND" "(" [colname]=<cident> ")"
+             | "TODATE" "(" [colname]=<cident> ")"
+             | "TOTIMESTAMP" "(" [colname]=<cident> ")"
+             | "TOUNIXTIMESTAMP" "(" [colname]=<cident> ")"
+             | "TOKEN" "(" [colname]=<cident> ")"
+             | "TODATE" "(" [colname]=<cident> ")"
+             | "MAP_KEYS" "(" [colname]=<cident> ")"
+             | "MAP_VALUES" "(" [colname]=<cident> ")"
+             | "MINTIMEUUID" "(" [colname]=<cident> ")"
+             | "MAXTIMEUUID" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
              | <functionName> <selectionFunctionArguments>
              | <term>
              ;
+
 <selectionFunctionArguments> ::= "(" ( <selector> ( "," <selector> )* )? ")"
                           ;
 <orderByClause> ::= [ordercol]=<cident> ( "ASC" | "DESC" )?

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -749,7 +749,6 @@ syntax_rules += r'''
              | [rel_lhs]=<cident> "BETWEEN" <term> "AND" <term>
              | "maxTimeuuid()" "(" [colname]=<cident> ")"
              | "minTimeuuid()" "(" [colname]=<cident> ")"
-             | "token()" "(" [colname]=<cident> ")"
              ;
 <selectClause> ::= "DISTINCT"? <selector> ("AS" <cident>)? ("," <selector> ("AS" <cident>)?)*
                  | "*"

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -163,7 +163,7 @@ dequote_value = CqlRuleSet.dequote_value
 dequote_name = CqlRuleSet.dequote_name
 escape_value = CqlRuleSet.escape_value
 
-# BEGIN BNF SYNTAX/COMPLETION RULE DEFINITIONS
+# BEGIN SYNTAX/COMPLETION RULE DEFINITIONS
 
 syntax_rules = r'''
 <Start> ::= <CQL_Statement>*
@@ -602,7 +602,7 @@ def cf_prop_val_mapender_completer(ctxt, cass):
 
 @completer_for('tokenDefinition', 'token')
 def token_word_completer(ctxt, cass):
-    return ['token']
+    return ['TOKEN']
 
 
 @completer_for('simpleStorageType', 'typename')
@@ -741,9 +741,7 @@ syntax_rules += r'''
                     ;
 <whereClause> ::= <relation> ( "AND" <relation> )*
                 ;
-<termOrScalar> ::= <term> | <scalarMathFunction>
-                ;
-<relation> ::= [rel_lhs]=<cident> ( "[" <term> "]" )? ( "=" | "<" | ">" | "<=" | ">=" | "!=" | ( "NOT" )? "CONTAINS" ( "KEY" )? ) <termOrScalar>
+<relation> ::= [rel_lhs]=<cident> ( "[" <term> "]" )? ( "=" | "<" | ">" | "<=" | ">=" | "!=" | ( "NOT" )? "CONTAINS" ( "KEY" )? ) <term>
              | token="TOKEN" "(" [rel_tokname]=<cident>
                                  ( "," [rel_tokname]=<cident> )*
                              ")" ("=" | "<" | ">" | "<=" | ">=") <tokenDefinition>
@@ -800,19 +798,22 @@ syntax_rules += r'''
                              ;
 <groupByFunctionArgument> ::= [groupcol]=<cident>
                             | <term>
-                ;
+                            ;
+
 <aggregateMathFunction> ::= "COUNT" "(" star=( "*" | "1" ) ")"
              | "AVG" "(" star=( "*" | "1" ) ")"
              | "MIN" "(" star=( "*" | "1" ) ")"
              | "MAX" "(" star=( "*" | "1" ) ")"
              | "SUM" "(" star=( "*" | "1" ) ")"
-                ;
+             ;
+
 <scalarMathFunction> ::= "ABS" "(" [colname]=<cident> ")"
              | "EXP" "(" [colname]=<cident> ")"
              | "LOG" "(" [colname]=<cident> ")"
              | "LOG10" "(" [colname]=<cident> ")"
              | "ROUND" "(" [colname]=<cident> ")"
-                ;
+             ;
+
 '''
 
 

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -602,7 +602,7 @@ def cf_prop_val_mapender_completer(ctxt, cass):
 
 @completer_for('tokenDefinition', 'token')
 def token_word_completer(ctxt, cass):
-    return ['token(']
+    return ['token']
 
 
 @completer_for('simpleStorageType', 'typename')

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -383,7 +383,7 @@ class Shell(cmd.Cmd):
             baseversion = baseversion[0:extra]
         if baseversion != build_version:
             print("WARNING: cqlsh was built against {}, but this server is {}.  All features may not work!"
-                  .format(build_version, baseversion))  # ToDo: use file=sys.stderr)
+                  .format(build_version, baseversion), file=sys.stderr)
 
     @property
     def batch_mode(self):

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -405,7 +405,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs'",
                             choices=[',', 'WHERE'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE ",
-                            choices=['TOKEN(', 'MIN_TIMEUUID()', 'MAX_TIMEUUID()', 'lonelykey'])
+                            choices=['TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonel",
                             immediate='ykey ')
@@ -414,7 +414,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 ",
                             choices=['AND', 'IF', ';'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 AND ",
-                            choices=['TOKEN(', 'MIN_TIMEUUID()', 'MAX_TIMEUUID()', 'lonelykey'])
+                            choices=['TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey ",
                             choices=[',', ')'])
@@ -490,13 +490,13 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 ',
                             immediate='WHERE ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE ',
-                            choices=['a', 'b', 'MAX_TIMEUUID()', 'MIN_TIMEUUID()', 'TOKEN('])
+                            choices=['a', 'b', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
                             choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT' , '[', '=', '<', '>', '!='])
 
-        self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(',
-                            immediate='a ')
+        self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN',
+                            immediate=' (a ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a',
                             immediate=' ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a ',
@@ -505,7 +505,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['>=', '<=', '=', '<', '>'])
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a) >= ',
                             choices=['false', 'true', '<pgStringLiteral>',
-                                     'token(', '-', '<float>', 'TOKEN',
+                                     'token', '-', '<float>', 'TOKEN',
                                      '<identifier>', '<uuid>', '{', '[', 'NULL',
                                      '<quotedStringLiteral>', '<blobLiteral>',
                                      '<wholenumber>'])

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -376,7 +376,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs'",
                             choices=[',', 'WHERE'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE ",
-                            choices=['TOKEN(', 'lonelykey'])
+                            choices=['TOKEN(', 'minTimeuuid()', 'maxTimeuuid()', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonel",
                             immediate='ykey ')
@@ -385,7 +385,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 ",
                             choices=['AND', 'IF', ';'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 AND ",
-                            choices=['TOKEN(', 'lonelykey'])
+                            choices=['TOKEN(', 'minTimeuuid()', 'maxTimeuuid()', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey ",
                             choices=[',', ')'])
@@ -461,7 +461,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 ',
                             immediate='WHERE ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE ',
-                            choices=['a', 'b', 'TOKEN('])
+                            choices=['a', 'b', 'maxTimeuuid()', 'minTimeuuid()', 'TOKEN('])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
                             choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT' , '[', '=', '<', '>', '!='])

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -180,7 +180,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_uuid(self):
         pass
 
-    def test_complete__in_select(self):
+    # for pytest ordering, use zero in test name to precede create keyspace and functions
+    def test_complete_0_in_select(self):
         self.trycompletions('SELECT ',
                             choices=('*', '-',
                                      '<blobLiteral>', '<colname>', '<float>',
@@ -196,12 +197,14 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      'NULL', 'ROUND', 'SUM', 'TOKEN',
                                      'TO_DATE', 'TO_TIMESTAMP', 'TO_UNIX_TIMESTAMP',
                                      'TTL', 'WRITETIME',
+                                     'COLLECTION_AVG', 'COLLECTION_COUNT', 'COLLECTION_MAX',
+                                     'COLLECTION_MIN', 'COLLECTION_SUM',
+                                     'MASK_DEFAULT', 'MASK_INNER', 'MASK_NULL',
+                                     'MASK_OUTER', 'MASK_REPLACE',
                                      '[', 'false', 'true', '{'
                                      ),
                             ignore_system_keyspaces=True
                             )
-
-
 
     def test_complete_in_insert(self):
         self.trycompletions('INSERT INTO  ',

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -180,7 +180,6 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_uuid(self):
         pass
 
-    # for pytest ordering, use zero in test name to precede create keyspace and functions
     def test_complete_in_select(self):
         self.trycompletions('SELECT ',
                             choices=('*', '-',

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -427,7 +427,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['EXISTS', '<quotedName>', '<identifier>'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey) <= TOKEN(13) IF EXISTS ",
-                            choices=['>=', '!=', '<=', 'IN','[', ';', '=', '<', '>', '.', 'CONTAINS'])
+                            choices=['>=', '!=', '<=', 'IN', '[', ';', '=', '<', '>', '.', 'CONTAINS'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey) <= TOKEN(13) IF lonelykey ",
                             choices=['>=', '!=', '<=', 'IN', '=', '<', '>', 'CONTAINS'])
@@ -494,7 +494,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['a', 'b', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
-                            choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT' , '[', '=', '<', '>', '!='])
+                            choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT', '[', '=', '<', '>', '!='])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN',
                             immediate=' (a ')

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -143,7 +143,7 @@ class CqlshCompletionCase(BaseTestCase):
 
     def trycompletions(self, inputstring, immediate='', choices=(),
                        other_choices_ok=False, split_completed_lines=True,
-                        ignore_system_keyspaces=False):
+                       ignore_system_keyspaces=False):
         try:
             self._trycompletions_inner(inputstring, immediate, choices,
                                        other_choices_ok=other_choices_ok,
@@ -199,7 +199,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      'TTL', 'WRITETIME',
                                      'COLLECTION_AVG', 'COLLECTION_COUNT', 'COLLECTION_MAX',
                                      'COLLECTION_MIN', 'COLLECTION_SUM',
-                                     'MASK_DEFAULT', 'MASK_INNER', 'MASK_NULL',
+                                     'MASK_DEFAULT', 'MASK_HASH', 'MASK_INNER', 'MASK_NULL',
                                      'MASK_OUTER', 'MASK_REPLACE',
                                      '[', 'false', 'true', '{'
                                      ),

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -181,7 +181,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         pass
 
     # for pytest ordering, use zero in test name to precede create keyspace and functions
-    def test_complete_0_in_select(self):
+    def test_complete_in_select(self):
         self.trycompletions('SELECT ',
                             choices=('*', '-',
                                      '<blobLiteral>', '<colname>', '<float>',
@@ -201,9 +201,10 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      'COLLECTION_MIN', 'COLLECTION_SUM',
                                      'MASK_DEFAULT', 'MASK_HASH', 'MASK_INNER', 'MASK_NULL',
                                      'MASK_OUTER', 'MASK_REPLACE',
-                                     '[', 'false', 'true', '{'
+                                     '[', 'false', 'true', '{',
+                                     self.cqlsh.keyspace + '.'
                                      ),
-                            ignore_system_keyspaces=True
+                            other_choices_ok=True
                             )
 
     def test_complete_in_insert(self):

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -182,28 +182,39 @@ class TestCqlshCompletion(CqlshCompletionCase):
 
     def test_complete_in_select(self):
         self.trycompletions('SELECT ',
-                            choices=('*', '-',
-                                     '<blobLiteral>', '<colname>', '<float>',
-                                     '<identifier>', '<pgStringLiteral>',
-                                     '<quotedStringLiteral>', '<uuid>',
-                                     '<wholenumber>',
+                            choices=('*', '<colname>',
+                                     '-', '<blobLiteral>', '<float>', '<wholenumber>', '<uuid>',
+                                     '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
                                      'ABS', 'AVG', 'CAST', 'COUNT', 'DISTINCT',
                                      'EXP', 'JSON', 'LOG', 'LOG10',
                                      'MAP_KEYS', 'MAP_VALUES',
                                      'MAX', 'MAX_TIMEUUID', 'MIN_TIMEUUID',
                                      'MIN', 'MIN_TIMEUUID', 'MIN_TIMEUUID',
                                      'MAX_WRITETIME', 'MIN_WRITETIME',
-                                     'NULL', 'ROUND', 'SUM', 'TOKEN',
+                                     'ROUND', 'SUM', 'TOKEN',
                                      'TO_DATE', 'TO_TIMESTAMP', 'TO_UNIX_TIMESTAMP',
                                      'TTL', 'WRITETIME',
                                      'COLLECTION_AVG', 'COLLECTION_COUNT', 'COLLECTION_MAX',
                                      'COLLECTION_MIN', 'COLLECTION_SUM',
                                      'MASK_DEFAULT', 'MASK_HASH', 'MASK_INNER', 'MASK_NULL',
                                      'MASK_OUTER', 'MASK_REPLACE',
-                                     '[', 'false', 'true', '{',
-                                     self.cqlsh.keyspace + '.'
+                                     '[', '{', 'false', 'true', 'NULL'
                                      ),
                             other_choices_ok=True
+                            )
+
+    def test_complete_in_select_where(self):
+        self.trycompletions('SELECT * FROM system.peers WHERE ',
+                            choices=('<identifier>', '<quotedName>', 'peer', 'TOKEN', 'MAX_TIMEUUID', 'MIN_TIMEUUID')
+                            )
+
+    def test_complete_in_select_where_equal(self):
+        self.trycompletions('SELECT * FROM system.peers WHERE rack = ',
+                            choices=('-', '<blobLiteral>', '<float>', '<wholenumber>', '<uuid>',
+                                     '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
+                                     '[', '{', 'false', 'true', 'NULL',
+                                     'TOKEN'
+                                     )
                             )
 
     def test_complete_in_insert(self):
@@ -495,8 +506,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
                             choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT', '[', '=', '<', '>', '!='])
 
-        self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN',
-                            immediate=' (a ')
+        self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(',
+                            immediate='a ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a',
                             immediate=' ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a ',
@@ -505,7 +516,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['>=', '<=', '=', '<', '>'])
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a) >= ',
                             choices=['false', 'true', '<pgStringLiteral>',
-                                     'token', '-', '<float>', 'TOKEN',
+                                     '-', '<float>', 'TOKEN',
                                      '<identifier>', '<uuid>', '{', '[', 'NULL',
                                      '<quotedStringLiteral>', '<blobLiteral>',
                                      '<wholenumber>'])


### PR DESCRIPTION
This PR adds CQL grammar to support the autocompletion of over two dozen built-in function. These include:

- abs, exp, log, log10, round (scalar math functions)
- avg, min, max, sum (aggregate math functions)
- collection_{avg, min, max, sum} (collection aggregates)
- to_data, to_timestamp, to_unix_timestamp
- map_keys, map_values
- min_timeuuid, max_timeuuid
- min_writetime, max_writetime
- mask_ {default, hash, inner, null, outer}

Unit tests have been updated to add:

- test_complete_in_select
- test_complete_in_select_where
- test_complete_in_select_where_equal

Authors: Dhanush Ananthkar and Brad Schoening

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

