### PR TITLE
Cassandra 19631: autocompletion of in-built functions in CQLSH

### DIFF
--- a/doc/modules/cassandra/examples/CQL/to_date.cql
+++ b/doc/modules/cassandra/examples/CQL/to_date.cql
@@ -1,0 +1,1 @@
+SELECT id, to_date(create_ts) FROM myTable

--- a/doc/modules/cassandra/pages/developing/cql/functions.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/functions.adoc
@@ -184,11 +184,11 @@ time where the function is invoked:
 |===
 |Function name |Output type
 
-| `current_timestamp` | `timestamp`
-
 | `current_date` | `date`
 
 | `current_time` | `time`
+
+| `current_timestamp` | `timestamp`
 
 | `current_timeuuid` | `timeUUID`
 |===
@@ -222,6 +222,13 @@ A number of functions are provided to convert a `timeuuid`, a `timestamp` or a `
 
 | `to_unix_timestamp` | `date` | Converts the `date` argument into a `bigInt` raw value
 |===
+
+For example, a timestamp can be converted to a date with the following:
+
+[source,cql]
+----
+include::cassandra:example$CQL/to_date.cql[]
+----
 
 ==== Blob conversion functions
 

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -741,14 +741,13 @@ syntax_rules += r'''
                     ;
 <whereClause> ::= <relation> ( "AND" <relation> )*
                 ;
-<relation> ::= [rel_lhs]=<cident> ( "[" <term> "]" )? ( "=" | "<" | ">" | "<=" | ">=" | "!=" | ( "NOT" )? "CONTAINS" ( "KEY" )? ) <term>
+<relation> ::= [rel_lhs]=<cident> ( "[" <term> "]" )? ( "=" | "<" | ">" | "<=" | ">=" | "!=" | ( "NOT" )? "CONTAINS" ( "KEY" )? ) (<term> |  <rhsFunctions>)
              | token="TOKEN" "(" [rel_tokname]=<cident>
                                  ( "," [rel_tokname]=<cident> )*
                              ")" ("=" | "<" | ">" | "<=" | ">=") <tokenDefinition>
              | [rel_lhs]=<cident> (( "NOT" )? "IN" ) "(" <term> ( "," <term> )* ")"
              | [rel_lhs]=<cident> "BETWEEN" <term> "AND" <term>
-             | "MAX_TIMEUUID" "(" [colname]=<cident> ")"
-             | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
+             | <timeuuidFunctions>
              ;
 <selectClause> ::= "DISTINCT"? <selector> ("AS" <cident>)? ("," <selector> ("AS" <cident>)?)*
                  | "*"
@@ -758,25 +757,20 @@ syntax_rules += r'''
 <selector> ::= [colname]=<cident> ( "[" ( <term> ( ".." <term> "]" )? | <term> ".." ) )?
              | <udtSubfieldSelection>
              | "WRITETIME" "(" [colname]=<cident> ")"
-             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
              | "MIN_WRITETIME" "(" [colname]=<cident> ")"
+             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
              | "TTL" "(" [colname]=<cident> ")"
-             | <aggregateMathFunction>
-             | <scalarMathFunction>
+             | <aggregateMathFunctions>
+             | <scalarMathFunctions>
+             | <collectionFunctions>
+             | <currentTimeFunctions>
              | "TO_DATE" "(" [colname]=<cident> ")"
              | "TO_TIMESTAMP" "(" [colname]=<cident> ")"
              | "TO_UNIX_TIMESTAMP" "(" [colname]=<cident> ")"
              | "TOKEN" "(" [colname]=<cident> ")"
              | "MAP_KEYS" "(" [colname]=<cident> ")"
              | "MAP_VALUES" "(" [colname]=<cident> ")"
-             | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
-             | "MAX_TIMEUUID" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
-             | "COLLECTION_AVG" "(" [colname]=<cident> ")"
-             | "COLLECTION_COUNT" "(" [colname]=<cident> ")"
-             | "COLLECTION_MIN" "(" [colname]=<cident> ")"
-             | "COLLECTION_MAX" "(" [colname]=<cident> ")"
-             | "COLLECTION_SUM" "(" [colname]=<cident> ")"
              | "MASK_NULL" "(" [colname]=<cident> ")"
              | "MASK_DEFAULT" "(" [colname]=<cident> ")"
              | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
@@ -800,19 +794,42 @@ syntax_rules += r'''
                             | <term>
                             ;
 
-<aggregateMathFunction> ::= "COUNT" "(" star=( "*" | "1" ) ")"
+<aggregateMathFunctions> ::= "COUNT" "(" star=( "*" | "1" ) ")"
              | "AVG" "(" star=( "*" | "1" ) ")"
              | "MIN" "(" star=( "*" | "1" ) ")"
              | "MAX" "(" star=( "*" | "1" ) ")"
              | "SUM" "(" star=( "*" | "1" ) ")"
              ;
 
-<scalarMathFunction> ::= "ABS" "(" [colname]=<cident> ")"
+<scalarMathFunctions> ::= "ABS" "(" [colname]=<cident> ")"
              | "EXP" "(" [colname]=<cident> ")"
              | "LOG" "(" [colname]=<cident> ")"
              | "LOG10" "(" [colname]=<cident> ")"
              | "ROUND" "(" [colname]=<cident> ")"
              ;
+
+<collectionFunctions> ::= "MAP_KEYS" "(" [colname]=<cident> ")"
+             | "MAP_VALUES" "(" [colname]=<cident> ")"
+             | "COLLECTION_AVG" "(" [colname]=<cident> ")"
+             | "COLLECTION_COUNT" "(" [colname]=<cident> ")"
+             | "COLLECTION_MIN" "(" [colname]=<cident> ")"
+             | "COLLECTION_MAX" "(" [colname]=<cident> ")"
+             | "COLLECTION_SUM" "(" [colname]=<cident> ")"
+             ;
+
+<currentTimeFunctions> ::= "CURRENT_DATE()"
+             | "CURRENT_TIME()"
+             | "CURRENT_TIMEUUID()"
+             | "CURRENT_TIMESTAMP()"
+             ;
+
+<timeuuidFunctions> ::= "MAX_TIMEUUID" "(" [colname]=<cident> ")"
+             | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
+             ;
+
+<rhsFunctions> ::= <currentTimeFunctions> | <timeuuidFunctions>
+             ;
+
 
 '''
 

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -808,18 +808,18 @@ syntax_rules += r'''
 
 <currentTimeFunctions> ::= "CURRENT_DATE()"
              | "CURRENT_TIME()"
-             | "CURRENT_TIMEUUID()"
              | "CURRENT_TIMESTAMP()"
+             | "CURRENT_TIMEUUID()"
              ;
 
-<maskFunctions> ::= "MASK_NULL" "(" [colname]=<cident> ")"
-             | "MASK_DEFAULT" "(" [colname]=<cident> ")"
-             | "MAP_KEYS" "(" [colname]=<cident> ")"
+<maskFunctions> ::= "MAP_KEYS" "(" [colname]=<cident> ")"
              | "MAP_VALUES" "(" [colname]=<cident> ")"
-             | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
+             | "MASK_DEFAULT" "(" [colname]=<cident> ")"
              | "MASK_HASH" "(" [colname]=<cident> ")"
-             | "MASK_INNER" "(" [colname]=<cident> "," <term> "," <term> ")"
-             | "MASK_OUTER" "(" [colname]=<cident> "," <term> "," <term> ")"
+             | "MASK_INNER" "(" [colname]=<cident> "," <wholenumber> "," <wholenumber> ")"
+             | "MASK_NULL" "(" [colname]=<cident> ")"
+             | "MASK_REPLACE" "(" [colname]=<cident> "," <propertyValue> ")"
+             | "MASK_OUTER" "(" [colname]=<cident> "," <wholenumber> "," <wholenumber> ")"
              ;
 
 <timeConversionFunctions> ::= "TO_DATE" "(" [colname]=<cident> ")"
@@ -831,13 +831,12 @@ syntax_rules += r'''
              | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
              ;
 
-<writetimeFunctions> ::= "WRITETIME" "(" [colname]=<cident> ")"
+<writetimeFunctions> ::= "MAX_WRITETIME" "(" [colname]=<cident> ")"
              | "MIN_WRITETIME" "(" [colname]=<cident> ")"
-             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
+             | "WRITETIME" "(" [colname]=<cident> ")"
              ;
 <operandFunctions> ::= <currentTimeFunctions> | <timeuuidFunctions>
              ;
-
 
 '''
 

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -764,19 +764,12 @@ syntax_rules += r'''
              | <scalarMathFunctions>
              | <collectionFunctions>
              | <currentTimeFunctions>
+             | <maskFunctions>
              | "TO_DATE" "(" [colname]=<cident> ")"
              | "TO_TIMESTAMP" "(" [colname]=<cident> ")"
              | "TO_UNIX_TIMESTAMP" "(" [colname]=<cident> ")"
              | "TOKEN" "(" [colname]=<cident> ")"
-             | "MAP_KEYS" "(" [colname]=<cident> ")"
-             | "MAP_VALUES" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
-             | "MASK_NULL" "(" [colname]=<cident> ")"
-             | "MASK_DEFAULT" "(" [colname]=<cident> ")"
-             | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
-             | "MASK_HASH" "(" [colname]=<cident> ")"
-             | "MASK_INNER" "(" [colname]=<cident> ")"
-             | "MASK_OUTER" "(" [colname]=<cident> ")"
              | <functionName> <selectionFunctionArguments>
              | <term>
              ;
@@ -822,6 +815,15 @@ syntax_rules += r'''
              | "CURRENT_TIMEUUID()"
              | "CURRENT_TIMESTAMP()"
              ;
+
+<maskFunctions> ::= "MASK_NULL" "(" [colname]=<cident> ")"
+             | "MASK_DEFAULT" "(" [colname]=<cident> ")"
+             | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
+             | "MASK_HASH" "(" [colname]=<cident> ")"
+             | "MASK_INNER" "(" [colname]=<cident> ")"
+             | "MASK_OUTER" "(" [colname]=<cident> ")"
+             ;
+
 
 <timeuuidFunctions> ::= "MAX_TIMEUUID" "(" [colname]=<cident> ")"
              | "MIN_TIMEUUID" "(" [colname]=<cident> ")"

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -602,7 +602,7 @@ def cf_prop_val_mapender_completer(ctxt, cass):
 
 @completer_for('tokenDefinition', 'token')
 def token_word_completer(ctxt, cass):
-    return ['token(']
+    return ['TOKEN']
 
 
 @completer_for('simpleStorageType', 'typename')
@@ -747,6 +747,8 @@ syntax_rules += r'''
                              ")" ("=" | "<" | ">" | "<=" | ">=") <tokenDefinition>
              | [rel_lhs]=<cident> (( "NOT" )? "IN" ) "(" <term> ( "," <term> )* ")"
              | [rel_lhs]=<cident> "BETWEEN" <term> "AND" <term>
+             | "MAX_TIMEUUID" "(" [colname]=<cident> ")"
+             | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
              ;
 <selectClause> ::= "DISTINCT"? <selector> ("AS" <cident>)? ("," <selector> ("AS" <cident>)?)*
                  | "*"
@@ -756,13 +758,35 @@ syntax_rules += r'''
 <selector> ::= [colname]=<cident> ( "[" ( <term> ( ".." <term> "]" )? | <term> ".." ) )?
              | <udtSubfieldSelection>
              | "WRITETIME" "(" [colname]=<cident> ")"
-             | "MAXWRITETIME" "(" [colname]=<cident> ")"
+             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
+             | "MIN_WRITETIME" "(" [colname]=<cident> ")"
              | "TTL" "(" [colname]=<cident> ")"
-             | "COUNT" "(" star=( "*" | "1" ) ")"
+             | <aggregateMathFunction>
+             | <scalarMathFunction>
+             | "TO_DATE" "(" [colname]=<cident> ")"
+             | "TO_TIMESTAMP" "(" [colname]=<cident> ")"
+             | "TO_UNIX_TIMESTAMP" "(" [colname]=<cident> ")"
+             | "TOKEN" "(" [colname]=<cident> ")"
+             | "MAP_KEYS" "(" [colname]=<cident> ")"
+             | "MAP_VALUES" "(" [colname]=<cident> ")"
+             | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
+             | "MAX_TIMEUUID" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
+             | "COLLECTION_AVG" "(" [colname]=<cident> ")"
+             | "COLLECTION_COUNT" "(" [colname]=<cident> ")"
+             | "COLLECTION_MIN" "(" [colname]=<cident> ")"
+             | "COLLECTION_MAX" "(" [colname]=<cident> ")"
+             | "COLLECTION_SUM" "(" [colname]=<cident> ")"
+             | "MASK_NULL" "(" [colname]=<cident> ")"
+             | "MASK_DEFAULT" "(" [colname]=<cident> ")"
+             | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
+             | "MASK_HASH" "(" [colname]=<cident> ")"
+             | "MASK_INNER" "(" [colname]=<cident> ")"
+             | "MASK_OUTER" "(" [colname]=<cident> ")"
              | <functionName> <selectionFunctionArguments>
              | <term>
              ;
+
 <selectionFunctionArguments> ::= "(" ( <selector> ( "," <selector> )* )? ")"
                           ;
 <orderByClause> ::= [ordercol]=<cident> ( "ASC" | "DESC" )?
@@ -775,6 +799,21 @@ syntax_rules += r'''
 <groupByFunctionArgument> ::= [groupcol]=<cident>
                             | <term>
                             ;
+
+<aggregateMathFunction> ::= "COUNT" "(" star=( "*" | "1" ) ")"
+             | "AVG" "(" star=( "*" | "1" ) ")"
+             | "MIN" "(" star=( "*" | "1" ) ")"
+             | "MAX" "(" star=( "*" | "1" ) ")"
+             | "SUM" "(" star=( "*" | "1" ) ")"
+             ;
+
+<scalarMathFunction> ::= "ABS" "(" [colname]=<cident> ")"
+             | "EXP" "(" [colname]=<cident> ")"
+             | "LOG" "(" [colname]=<cident> ")"
+             | "LOG10" "(" [colname]=<cident> ")"
+             | "ROUND" "(" [colname]=<cident> ")"
+             ;
+
 '''
 
 
@@ -867,7 +906,7 @@ def select_group_column_completer(ctxt, cass):
 
 @completer_for('relation', 'token')
 def relation_token_word_completer(ctxt, cass):
-    return ['TOKEN(']
+    return ['TOKEN']
 
 
 @completer_for('relation', 'rel_tokname')

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -759,17 +759,15 @@ syntax_rules += r'''
              | "WRITETIME" "(" [colname]=<cident> ")"
              | "MIN_WRITETIME" "(" [colname]=<cident> ")"
              | "MAX_WRITETIME" "(" [colname]=<cident> ")"
+             | "CAST" "(" <selector> "AS" <storageType> ")"
              | "TTL" "(" [colname]=<cident> ")"
+             | "TOKEN" "(" [colname]=<cident> ")"
              | <aggregateMathFunctions>
              | <scalarMathFunctions>
              | <collectionFunctions>
              | <currentTimeFunctions>
              | <maskFunctions>
-             | "TO_DATE" "(" [colname]=<cident> ")"
-             | "TO_TIMESTAMP" "(" [colname]=<cident> ")"
-             | "TO_UNIX_TIMESTAMP" "(" [colname]=<cident> ")"
-             | "TOKEN" "(" [colname]=<cident> ")"
-             | "CAST" "(" <selector> "AS" <storageType> ")"
+             | <timeConversionFunctions>
              | <functionName> <selectionFunctionArguments>
              | <term>
              ;
@@ -824,6 +822,10 @@ syntax_rules += r'''
              | "MASK_OUTER" "(" [colname]=<cident> ")"
              ;
 
+<timeConversionFunctions> ::= "TO_DATE" "(" [colname]=<cident> ")"
+             | "TO_TIMESTAMP" "(" [colname]=<cident> ")"
+             | "TO_UNIX_TIMESTAMP" "(" [colname]=<cident> ")"
+             ;
 
 <timeuuidFunctions> ::= "MAX_TIMEUUID" "(" [colname]=<cident> ")"
              | "MIN_TIMEUUID" "(" [colname]=<cident> ")"

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -741,13 +741,13 @@ syntax_rules += r'''
                     ;
 <whereClause> ::= <relation> ( "AND" <relation> )*
                 ;
-<relation> ::= [rel_lhs]=<cident> ( "[" <term> "]" )? ( "=" | "<" | ">" | "<=" | ">=" | "!=" | ( "NOT" )? "CONTAINS" ( "KEY" )? ) (<term> |  <rhsFunctions>)
+<relation> ::= [rel_lhs]=<cident> ( "[" <term> "]" )? ( "=" | "<" | ">" | "<=" | ">=" | "!=" | ( "NOT" )? "CONTAINS" ( "KEY" )? ) (<term> | <operandFunctions>)
              | token="TOKEN" "(" [rel_tokname]=<cident>
                                  ( "," [rel_tokname]=<cident> )*
                              ")" ("=" | "<" | ">" | "<=" | ">=") <tokenDefinition>
              | [rel_lhs]=<cident> (( "NOT" )? "IN" ) "(" <term> ( "," <term> )* ")"
              | [rel_lhs]=<cident> "BETWEEN" <term> "AND" <term>
-             | <timeuuidFunctions>
+             | <operandFunctions>
              ;
 <selectClause> ::= "DISTINCT"? <selector> ("AS" <cident>)? ("," <selector> ("AS" <cident>)?)*
                  | "*"
@@ -756,9 +756,6 @@ syntax_rules += r'''
                          ;
 <selector> ::= [colname]=<cident> ( "[" ( <term> ( ".." <term> "]" )? | <term> ".." ) )?
              | <udtSubfieldSelection>
-             | "WRITETIME" "(" [colname]=<cident> ")"
-             | "MIN_WRITETIME" "(" [colname]=<cident> ")"
-             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
              | "CAST" "(" <selector> "AS" <storageType> ")"
              | "TTL" "(" [colname]=<cident> ")"
              | "TOKEN" "(" [colname]=<cident> ")"
@@ -768,6 +765,7 @@ syntax_rules += r'''
              | <currentTimeFunctions>
              | <maskFunctions>
              | <timeConversionFunctions>
+             | <writetimeFunctions>
              | <functionName> <selectionFunctionArguments>
              | <term>
              ;
@@ -816,10 +814,12 @@ syntax_rules += r'''
 
 <maskFunctions> ::= "MASK_NULL" "(" [colname]=<cident> ")"
              | "MASK_DEFAULT" "(" [colname]=<cident> ")"
+             | "MAP_KEYS" "(" [colname]=<cident> ")"
+             | "MAP_VALUES" "(" [colname]=<cident> ")"
              | "MASK_REPLACE" "(" [colname]=<cident> "," <term> ")"
              | "MASK_HASH" "(" [colname]=<cident> ")"
-             | "MASK_INNER" "(" [colname]=<cident> ")"
-             | "MASK_OUTER" "(" [colname]=<cident> ")"
+             | "MASK_INNER" "(" [colname]=<cident> "," <term> "," <term> ")"
+             | "MASK_OUTER" "(" [colname]=<cident> "," <term> "," <term> ")"
              ;
 
 <timeConversionFunctions> ::= "TO_DATE" "(" [colname]=<cident> ")"
@@ -831,7 +831,11 @@ syntax_rules += r'''
              | "MIN_TIMEUUID" "(" [colname]=<cident> ")"
              ;
 
-<rhsFunctions> ::= <currentTimeFunctions> | <timeuuidFunctions>
+<writetimeFunctions> ::= "WRITETIME" "(" [colname]=<cident> ")"
+             | "MIN_WRITETIME" "(" [colname]=<cident> ")"
+             | "MAX_WRITETIME" "(" [colname]=<cident> ")"
+             ;
+<operandFunctions> ::= <currentTimeFunctions> | <timeuuidFunctions>
              ;
 
 
@@ -1061,7 +1065,7 @@ syntax_rules += r'''
 
 @completer_for('updateStatement', 'updateopt')
 def update_option_completer(ctxt, cass):
-    opts = set('TIMESTAMP TTL'.split())
+    opts = {'TIMESTAMP', 'TTL'}
     for opt in ctxt.get_binding('updateopt', ()):
         opts.discard(opt.split()[0])
     return opts

--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -784,10 +784,10 @@ syntax_rules += r'''
                             ;
 
 <aggregateMathFunctions> ::= "COUNT" "(" star=( "*" | "1" ) ")"
-             | "AVG" "(" star=( "*" | "1" ) ")"
-             | "MIN" "(" star=( "*" | "1" ) ")"
-             | "MAX" "(" star=( "*" | "1" ) ")"
-             | "SUM" "(" star=( "*" | "1" ) ")"
+             | "AVG" "(" [colname]=<cident> ")"
+             | "MIN" "(" [colname]=<cident> ")"
+             | "MAX" "(" [colname]=<cident> ")"
+             | "SUM" "(" [colname]=<cident> ")"
              ;
 
 <scalarMathFunctions> ::= "ABS" "(" [colname]=<cident> ")"

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -383,7 +383,7 @@ class Shell(cmd.Cmd):
             baseversion = baseversion[0:extra]
         if baseversion != build_version:
             print("WARNING: cqlsh was built against {}, but this server is {}.  All features may not work!"
-                  .format(build_version, baseversion))  # ToDo: use file=sys.stderr)
+                  .format(build_version, baseversion), file=sys.stderr)
 
     @property
     def batch_mode(self):

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -204,7 +204,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
 
     def test_complete_in_select_where(self):
         self.trycompletions('SELECT * FROM system.peers WHERE ',
-                            choices=('<identifier>', '<quotedName>', 'peer', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID')
+                            choices=('<identifier>', '<quotedName>', 'peer', 'CURRENT_DATE()', 'CURRENT_TIME()',
+                            'CURRENT_TIMEUUID()','CURRENT_TIMESTAMP()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID')
                             )
 
     def test_complete_in_select_where_equal(self):
@@ -213,7 +214,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
                                      '[', '{', 'false', 'true', 'NULL',
                                      'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID',
-                                     'CURRENT_TIME()', 'CURRENT_TIMEUUID()', 'CURRENT_DATE()', 'CURRENT_TIMESTAMP()'
+                                     'CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMEUUID()','CURRENT_TIMESTAMP()'
                                      )
                             )
 
@@ -416,7 +417,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs'",
                             choices=[',', 'WHERE'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE ",
-                            choices=['TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
+                            choices=['CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMESTAMP()',
+                            'CURRENT_TIMEUUID()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonel",
                             immediate='ykey ')
@@ -425,7 +427,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 ",
                             choices=['AND', 'IF', ';'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 AND ",
-                            choices=['TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
+                            choices=['CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMESTAMP()',
+                            'CURRENT_TIMEUUID()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey ",
                             choices=[',', ')'])
@@ -501,7 +504,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 ',
                             immediate='WHERE ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE ',
-                            choices=['a', 'b', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
+                            choices=['a', 'b', 'CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMESTAMP()',
+                            'CURRENT_TIMEUUID()', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
                             choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT', '[', '=', '<', '>', '!='])

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -188,9 +188,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      'ABS', 'AVG', 'CAST', 'COUNT', 'DISTINCT',
                                      'EXP', 'JSON', 'LOG', 'LOG10',
                                      'MAP_KEYS', 'MAP_VALUES',
-                                     'MAX', 'MAX_TIMEUUID', 'MIN_TIMEUUID',
-                                     'MIN', 'MIN_TIMEUUID', 'MIN_TIMEUUID',
-                                     'MAX_WRITETIME', 'MIN_WRITETIME',
+                                     'MIN', 'MAX',
+                                     'MIN_WRITETIME', 'MAX_WRITETIME',
                                      'ROUND', 'SUM', 'TOKEN',
                                      'TO_DATE', 'TO_TIMESTAMP', 'TO_UNIX_TIMESTAMP',
                                      'TTL', 'WRITETIME',
@@ -205,7 +204,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
 
     def test_complete_in_select_where(self):
         self.trycompletions('SELECT * FROM system.peers WHERE ',
-                            choices=('<identifier>', '<quotedName>', 'peer', 'TOKEN', 'MAX_TIMEUUID', 'MIN_TIMEUUID')
+                            choices=('<identifier>', '<quotedName>', 'peer', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID')
                             )
 
     def test_complete_in_select_where_equal(self):
@@ -213,7 +212,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=('-', '<blobLiteral>', '<float>', '<wholenumber>', '<uuid>',
                                      '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
                                      '[', '{', 'false', 'true', 'NULL',
-                                     'TOKEN'
+                                     'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID',
+                                     'CURRENT_TIME()', 'CURRENT_TIMEUUID()', 'CURRENT_DATE()', 'CURRENT_TIMESTAMP()'
                                      )
                             )
 

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -114,7 +114,8 @@ class CqlshCompletionCase(BaseTestCase):
 
     def _trycompletions_inner(self, inputstring, immediate='', choices=(),
                               other_choices_ok=False,
-                              split_completed_lines=True):
+                              split_completed_lines=True,
+                              ignore_system_keyspaces=False):
         """
         Test tab completion in cqlsh. Enters in the text in inputstring, then
         simulates a tab keypress to see what is immediately completed (this
@@ -132,17 +133,22 @@ class CqlshCompletionCase(BaseTestCase):
             self.assertEqual(completed, immediate, msg=msg)
             return
 
+        if ignore_system_keyspaces:
+            completed = list(filter(lambda s: not s.startswith('system'), completed))
+
         if other_choices_ok:
             self.assertEqual(set(choices), completed.intersection(choices))
         else:
             self.assertEqual(set(choices), set(completed))
 
     def trycompletions(self, inputstring, immediate='', choices=(),
-                       other_choices_ok=False, split_completed_lines=True):
+                       other_choices_ok=False, split_completed_lines=True,
+                       ignore_system_keyspaces=False):
         try:
             self._trycompletions_inner(inputstring, immediate, choices,
                                        other_choices_ok=other_choices_ok,
-                                       split_completed_lines=split_completed_lines)
+                                       split_completed_lines=split_completed_lines,
+                                       ignore_system_keyspaces=ignore_system_keyspaces)
         finally:
             try:
                 self.cqlsh.send(CTRL_C)  # cancel any current line
@@ -175,7 +181,41 @@ class TestCqlshCompletion(CqlshCompletionCase):
         pass
 
     def test_complete_in_select(self):
-        pass
+        self.trycompletions('SELECT ',
+                            choices=('*', '<colname>',
+                                     '-', '<blobLiteral>', '<float>', '<wholenumber>', '<uuid>',
+                                     '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
+                                     'ABS', 'AVG', 'CAST', 'COUNT', 'DISTINCT',
+                                     'EXP', 'JSON', 'LOG', 'LOG10',
+                                     'MAP_KEYS', 'MAP_VALUES',
+                                     'MAX', 'MAX_TIMEUUID', 'MIN_TIMEUUID',
+                                     'MIN', 'MIN_TIMEUUID', 'MIN_TIMEUUID',
+                                     'MAX_WRITETIME', 'MIN_WRITETIME',
+                                     'ROUND', 'SUM', 'TOKEN',
+                                     'TO_DATE', 'TO_TIMESTAMP', 'TO_UNIX_TIMESTAMP',
+                                     'TTL', 'WRITETIME',
+                                     'COLLECTION_AVG', 'COLLECTION_COUNT', 'COLLECTION_MAX',
+                                     'COLLECTION_MIN', 'COLLECTION_SUM',
+                                     'MASK_DEFAULT', 'MASK_HASH', 'MASK_INNER', 'MASK_NULL',
+                                     'MASK_OUTER', 'MASK_REPLACE',
+                                     '[', '{', 'false', 'true', 'NULL'
+                                     ),
+                            other_choices_ok=True
+                            )
+
+    def test_complete_in_select_where(self):
+        self.trycompletions('SELECT * FROM system.peers WHERE ',
+                            choices=('<identifier>', '<quotedName>', 'peer', 'TOKEN', 'MAX_TIMEUUID', 'MIN_TIMEUUID')
+                            )
+
+    def test_complete_in_select_where_equal(self):
+        self.trycompletions('SELECT * FROM system.peers WHERE rack = ',
+                            choices=('-', '<blobLiteral>', '<float>', '<wholenumber>', '<uuid>',
+                                     '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
+                                     '[', '{', 'false', 'true', 'NULL',
+                                     'TOKEN'
+                                     )
+                            )
 
     def test_complete_in_insert(self):
         self.trycompletions('INSERT INTO  ',
@@ -376,7 +416,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs'",
                             choices=[',', 'WHERE'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE ",
-                            choices=['TOKEN(', 'lonelykey'])
+                            choices=['TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonel",
                             immediate='ykey ')
@@ -385,7 +425,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 ",
                             choices=['AND', 'IF', ';'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 AND ",
-                            choices=['TOKEN(', 'lonelykey'])
+                            choices=['TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey ",
                             choices=[',', ')'])
@@ -397,7 +437,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['EXISTS', '<quotedName>', '<identifier>'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey) <= TOKEN(13) IF EXISTS ",
-                            choices=['>=', '!=', '<=', 'IN','[', ';', '=', '<', '>', '.', 'CONTAINS'])
+                            choices=['>=', '!=', '<=', 'IN', '[', ';', '=', '<', '>', '.', 'CONTAINS'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey) <= TOKEN(13) IF lonelykey ",
                             choices=['>=', '!=', '<=', 'IN', '=', '<', '>', 'CONTAINS'])
@@ -461,10 +501,10 @@ class TestCqlshCompletion(CqlshCompletionCase):
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 ',
                             immediate='WHERE ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE ',
-                            choices=['a', 'b', 'TOKEN('])
+                            choices=['a', 'b', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
-                            choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT' , '[', '=', '<', '>', '!='])
+                            choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT', '[', '=', '<', '>', '!='])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(',
                             immediate='a ')
@@ -476,7 +516,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['>=', '<=', '=', '<', '>'])
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE TOKEN(a) >= ',
                             choices=['false', 'true', '<pgStringLiteral>',
-                                     'token(', '-', '<float>', 'TOKEN',
+                                     '-', '<float>', 'TOKEN',
                                      '<identifier>', '<uuid>', '{', '[', 'NULL',
                                      '<quotedStringLiteral>', '<blobLiteral>',
                                      '<wholenumber>'])

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -205,7 +205,8 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_select_where(self):
         self.trycompletions('SELECT * FROM system.peers WHERE ',
                             choices=('<identifier>', '<quotedName>', 'peer', 'CURRENT_DATE()', 'CURRENT_TIME()',
-                            'CURRENT_TIMEUUID()','CURRENT_TIMESTAMP()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID')
+                                     'CURRENT_TIMEUUID()', 'CURRENT_TIMESTAMP()', 'TOKEN',
+                                     'MIN_TIMEUUID', 'MAX_TIMEUUID')
                             )
 
     def test_complete_in_select_where_equal(self):
@@ -214,7 +215,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                                      '<identifier>', '<pgStringLiteral>', '<quotedStringLiteral>',
                                      '[', '{', 'false', 'true', 'NULL',
                                      'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID',
-                                     'CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMEUUID()','CURRENT_TIMESTAMP()'
+                                     'CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMEUUID()', 'CURRENT_TIMESTAMP()'
                                      )
                             )
 
@@ -418,7 +419,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=[',', 'WHERE'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE ",
                             choices=['CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMESTAMP()',
-                            'CURRENT_TIMEUUID()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
+                                     'CURRENT_TIMEUUID()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonel",
                             immediate='ykey ')
@@ -428,7 +429,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             choices=['AND', 'IF', ';'])
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE lonelykey = 0.0 AND ",
                             choices=['CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMESTAMP()',
-                            'CURRENT_TIMEUUID()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
+                                     'CURRENT_TIMEUUID()', 'TOKEN', 'MIN_TIMEUUID', 'MAX_TIMEUUID', 'lonelykey'])
 
         self.trycompletions("UPDATE empty_table SET lonelycol = 'eggs' WHERE TOKEN(lonelykey ",
                             choices=[',', ')'])
@@ -505,7 +506,7 @@ class TestCqlshCompletion(CqlshCompletionCase):
                             immediate='WHERE ')
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE ',
                             choices=['a', 'b', 'CURRENT_DATE()', 'CURRENT_TIME()', 'CURRENT_TIMESTAMP()',
-                            'CURRENT_TIMEUUID()', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
+                                     'CURRENT_TIMEUUID()', 'MAX_TIMEUUID', 'MIN_TIMEUUID', 'TOKEN'])
 
         self.trycompletions('DELETE FROM twenty_rows_composite_table USING TIMESTAMP 0 WHERE a ',
                             choices=['<=', '>=', 'BETWEEN', 'CONTAINS', 'IN', 'NOT', '[', '=', '<', '>', '!='])


### PR DESCRIPTION
This PR adds CQL grammar to support the autocompletion of over two dozen built-in function. These include:

abs, exp, log, log10, round (scalar math functions)
avg, min, max, sum (aggregate math functions)
collection_{avg, min, max, sum} (collection aggregates)
to_data, to_timestamp, to_unix_timestamp
map_keys, map_values
min_timeuuid, max_timeuuid
min_writetime, max_writetime
mask_ {default, hash, inner, null, outer}

Unit tests have been updated to add:

test_complete_in_select
test_complete_in_select_where
test_complete_in_select_where_equal

Co-authored-by: Dhanush Ananthkar and Brad Schoening

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

