### PR TITLE
CASSANDRA-20103 Remove v30 and v3X from 5.x in-JVM upgrade tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.3
+ * Remove v30 and v3X from 5.x in-JVM upgrade tests (CASSANDRA-20103)
  * Avoid memory allocation in offheap_object's NativeCell.valueSize() and NativeClustering.dataSize() (CASSANDRA-20162)
  * Add flag to avoid invalidating key cache on sstable deletions (CASSANDRA-20068)
  * Interpret inet, bigint, varint, and decimal as non-reversed types for query construction and post-filtering (CASSANDRA-20100)

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStoragePagingWithProtocolTester.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/CompactStoragePagingWithProtocolTester.java
@@ -132,8 +132,7 @@ public abstract class CompactStoragePagingWithProtocolTester extends UpgradeTest
         String query = withKeyspace("SELECT * FROM %s.t");
         assertRows(query, ProtocolVersion.V3, rows);
         assertRows(query, ProtocolVersion.V4, rows);
-        if (initialVersion().isGreaterThanOrEqualTo(v3X))
-            assertRows(query, ProtocolVersion.V5, rows);
+        assertRows(query, ProtocolVersion.V5, rows);
     }
 
     private static void assertRows(String query, ProtocolVersion protocolVersion, Object[]... expectedRows)

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/CompactionHistorySystemTableUpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/CompactionHistorySystemTableUpgradeTest.java
@@ -47,7 +47,7 @@ public class CompactionHistorySystemTableUpgradeTest extends UpgradeTestBase
     @Parameters()
     public static ArrayList<Semver> versions()
     {
-        return Lists.newArrayList(v30, v3X, v40, v41);
+        return Lists.newArrayList(v40, v41);
     }
 
     @Test

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/ConfigCompatibilityTestGenerate.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/ConfigCompatibilityTestGenerate.java
@@ -33,8 +33,6 @@ import org.apache.cassandra.distributed.shared.Versions;
 import static org.apache.cassandra.config.ConfigCompatibilityTest.TEST_DIR;
 import static org.apache.cassandra.config.ConfigCompatibilityTest.dump;
 import static org.apache.cassandra.config.ConfigCompatibilityTest.toTree;
-import static org.apache.cassandra.distributed.upgrade.UpgradeTestBase.v30;
-import static org.apache.cassandra.distributed.upgrade.UpgradeTestBase.v3X;
 import static org.apache.cassandra.distributed.upgrade.UpgradeTestBase.v40;
 import static org.apache.cassandra.distributed.upgrade.UpgradeTestBase.v41;
 import static org.apache.cassandra.distributed.upgrade.UpgradeTestBase.v50;
@@ -48,7 +46,7 @@ public class ConfigCompatibilityTestGenerate
     {
         ICluster.setup();
         Versions versions = Versions.find();
-        for (Semver version : Arrays.asList(v30, v3X, v40, v41, v50))
+        for (Semver version : Arrays.asList(v40, v41, v50))
         {
             File path = new File(TEST_DIR, "version=" + version + ".yml");
             path.getParentFile().mkdirs();

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/DropCompactStorageNullClusteringValuesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/DropCompactStorageNullClusteringValuesTest.java
@@ -33,7 +33,7 @@ public class DropCompactStorageNullClusteringValuesTest extends UpgradeTestBase
     public void testNullClusteringValues() throws Throwable
     {
         new TestCase().nodes(1)
-                      .upgradesToCurrentFrom(v30)
+                      .upgradesToCurrentFrom(OLDEST)
                       .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL).set("enable_drop_compact_storage", true))
                       .setup(cluster -> {
                           String create = "CREATE TABLE %s.%s(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) " +

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/DropCompactStorageTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/DropCompactStorageTest.java
@@ -35,7 +35,7 @@ public class DropCompactStorageTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgrade(1, 2)
-        .upgradesToCurrentFrom(v30)
+        .upgradesToCurrentFrom(OLDEST)
         .withConfig(config -> config.with(GOSSIP, NETWORK).set("enable_drop_compact_storage", true))
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH COMPACT STORAGE");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/GroupByTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/GroupByTest.java
@@ -35,7 +35,7 @@ public class GroupByTest extends UpgradeTestBase
         // CASSANDRA-16582: group-by across mixed version cluster would fail with ArrayIndexOutOfBoundException
         new UpgradeTestBase.TestCase()
         .nodes(2)
-        .upgradesToCurrentFrom(v3X)
+        .upgradesToCurrentFrom(OLDEST)
         .nodesToUpgrade(1)
         .withConfig(config -> config.with(GOSSIP, NETWORK))
         .setup(cluster -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeAvailabilityTestBase.java
@@ -61,7 +61,7 @@ public abstract class MixedModeAvailabilityTestBase extends UpgradeTestBase
         new TestCase()
         .nodes(NUM_NODES)
         .nodesToUpgrade(upgradedCoordinator() ? 1 : 2)
-        .upgradesToCurrentFrom(v30)
+        .upgradesToCurrentFrom(OLDEST)
         .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL)
                                     .set("request_timeout_in_ms", MINUTES.toMillis(10))
                                     .set("read_request_timeout_in_ms", MINUTES.toMillis(10))

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeConsistencyTest.java
@@ -38,7 +38,7 @@ import static org.apache.cassandra.distributed.api.ConsistencyLevel.QUORUM;
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
 import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 
-public class MixedModeConsistencyV30Test extends UpgradeTestBase
+public class MixedModeConsistencyTest extends UpgradeTestBase
 {
     @Test
     public void testConsistency() throws Throwable
@@ -51,7 +51,7 @@ public class MixedModeConsistencyV30Test extends UpgradeTestBase
         new TestCase()
         .nodes(3)
         .nodesToUpgrade(1)
-        .upgradesToCurrentFrom(v30)
+        .upgradesToCurrentFrom(OLDEST)
         .withConfig(config -> config.set("read_request_timeout_in_ms", SECONDS.toMillis(30))
                                     .set("write_request_timeout_in_ms", SECONDS.toMillis(30)))
         .setup(cluster -> {

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeLoggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeLoggedBatchTest.java
@@ -20,17 +20,11 @@ package org.apache.cassandra.distributed.upgrade;
 
 import org.junit.Test;
 
-public class MixedModeFrom3UnloggedBatchTest extends MixedModeBatchTestBase
+public class MixedModeLoggedBatchTest extends MixedModeBatchTestBase
 {
-    @Test
-    public void testSimpleStrategy30to3X() throws Throwable
-    {
-        testSimpleStrategy(v30, v3X, false);
-    }
-
     @Test
     public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(v30, false);
+        testSimpleStrategy(OLDEST, true);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReplicationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeReplicationTest.java
@@ -28,7 +28,7 @@ import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import static org.apache.cassandra.distributed.shared.AssertUtils.assertRows;
 import static org.apache.cassandra.distributed.shared.AssertUtils.row;
 
-public class MixedModeFrom3ReplicationTest extends UpgradeTestBase
+public class MixedModeReplicationTest extends UpgradeTestBase
 {
     @Test
     public void testSimpleStrategy() throws Throwable
@@ -39,7 +39,7 @@ public class MixedModeFrom3ReplicationTest extends UpgradeTestBase
         new TestCase()
         .nodes(3)
         .nodesToUpgrade(1, 2)
-        .upgradesToCurrentFrom(v30)
+        .upgradesToCurrentFrom(OLDEST)
         .setup(cluster -> {
             cluster.schemaChange("CREATE KEYSPACE test_simple WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2};");
             cluster.schemaChange("CREATE TABLE test_simple.names (key int PRIMARY KEY, name text)");

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeUnloggedBatchTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeUnloggedBatchTest.java
@@ -20,17 +20,11 @@ package org.apache.cassandra.distributed.upgrade;
 
 import org.junit.Test;
 
-public class MixedModeFrom3LoggedBatchTest extends MixedModeBatchTestBase
+public class MixedModeUnloggedBatchTest extends MixedModeBatchTestBase
 {
-    @Test
-    public void testSimpleStrategy30to3X() throws Throwable
-    {
-        testSimpleStrategy(v30, v3X, true);
-    }
-
     @Test
     public void testSimpleStrategy() throws Throwable
     {
-        testSimpleStrategy(v30, true);
+        testSimpleStrategy(OLDEST, false);
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeWritetimeOrTTLTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/MixedModeWritetimeOrTTLTest.java
@@ -45,7 +45,7 @@ public class MixedModeWritetimeOrTTLTest extends UpgradeTestBase
         new TestCase()
         .nodes(2)
         .nodesToUpgradeOrdered(1, 2)
-        .upgradesToCurrentFrom(v30)
+        .upgradesToCurrentFrom(OLDEST)
         .setup(cluster -> {
 
             ICoordinator coordinator = cluster.coordinator(1);

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTest.java
@@ -34,7 +34,7 @@ public class UpgradeTest extends UpgradeTestBase
         .nodes(2)
         .nodesToUpgrade(1)
         .withConfig((cfg) -> cfg.with(Feature.NETWORK, Feature.GOSSIP))
-        .upgradesToCurrentFrom(v3X)
+        .upgradesToCurrentFrom(OLDEST)
         .setup((cluster) -> {
             cluster.schemaChange("CREATE TABLE " + KEYSPACE + ".tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
             cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + ".tbl (pk, ck, v) VALUES (1, 1, 1)", ConsistencyLevel.ALL);

--- a/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/upgrade/UpgradeTestBase.java
@@ -87,18 +87,11 @@ public class UpgradeTestBase extends DistributedTestBase
         public void run(UpgradeableCluster cluster, int node) throws Throwable;
     }
 
-    public static final Semver v30 = new Semver("3.0.0-alpha1", SemverType.LOOSE);
-    public static final Semver v3X = new Semver("3.11.0", SemverType.LOOSE);
     public static final Semver v40 = new Semver("4.0-alpha1", SemverType.LOOSE);
     public static final Semver v41 = new Semver("4.1-alpha1", SemverType.LOOSE);
     public static final Semver v50 = new Semver("5.0-alpha1", SemverType.LOOSE);
 
     protected static final SimpleGraph<Semver> SUPPORTED_UPGRADE_PATHS = new SimpleGraph.Builder<Semver>()
-                                                                         .addEdge(v30, v3X)
-                                                                         .addEdge(v30, v40)
-                                                                         .addEdge(v30, v41)
-                                                                         .addEdge(v3X, v40)
-                                                                         .addEdge(v3X, v41)
                                                                          .addEdge(v40, v41)
                                                                          .addEdge(v40, v50)
                                                                          .addEdge(v41, v50)
@@ -404,7 +397,7 @@ public class UpgradeTestBase extends DistributedTestBase
     protected TestCase allUpgrades(int nodes, int... toUpgrade)
     {
         return new TestCase().nodes(nodes)
-                             .upgradesToCurrentFrom(v30)
+                             .upgradesToCurrentFrom(OLDEST)
                              .nodesToUpgrade(toUpgrade);
     }
 


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by Mick Semb Wever for CASSANDRA-20103
