### PR TITLE
[CASSANDRA-20167][5.0][Subset] Reduce memory allocations in miscellaneous places along write path

### DIFF
--- a/src/java/org/apache/cassandra/concurrent/SEPWorker.java
+++ b/src/java/org/apache/cassandra/concurrent/SEPWorker.java
@@ -39,6 +39,7 @@ final class SEPWorker extends AtomicReference<SEPWorker.Work> implements Runnabl
     private static final boolean SET_THREAD_NAME = SET_SEP_THREAD_NAME.getBoolean();
 
     final Long workerId;
+    final String workerIdThreadSuffix;
     final Thread thread;
     final SharedExecutorPool pool;
 
@@ -55,6 +56,7 @@ final class SEPWorker extends AtomicReference<SEPWorker.Work> implements Runnabl
     {
         this.pool = pool;
         this.workerId = workerId;
+        this.workerIdThreadSuffix = '-' + workerId.toString();
         thread = new FastThreadLocalThread(threadGroup, this, threadGroup.getName() + "-Worker-" + workerId);
         thread.setDaemon(true);
         set(initialState);
@@ -122,7 +124,7 @@ final class SEPWorker extends AtomicReference<SEPWorker.Work> implements Runnabl
                 if (assigned == null)
                     continue;
                 if (SET_THREAD_NAME)
-                    Thread.currentThread().setName(assigned.name + '-' + workerId);
+                    Thread.currentThread().setName(assigned.name + workerIdThreadSuffix);
 
                 task = assigned.tasks.poll();
                 currentTask.lazySet(task);

--- a/src/java/org/apache/cassandra/cql3/Attributes.java
+++ b/src/java/org/apache/cassandra/cql3/Attributes.java
@@ -46,12 +46,14 @@ public class Attributes
      */
     public static final int MAX_TTL = 20 * 365 * 24 * 60 * 60; // 20 years in seconds
 
+    private static final Attributes NONE = new Attributes(null, null);
+
     private final Term timestamp;
     private final Term timeToLive;
 
     public static Attributes none()
     {
-        return new Attributes(null, null);
+        return NONE;
     }
 
     private Attributes(Term timestamp, Term timeToLive)

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -413,8 +413,10 @@ public class BatchStatement implements CQLStatement
             throw new InvalidRequestException("Invalid empty serial consistency level");
 
         ClientState clientState = queryState.getClientState();
-        Guardrails.writeConsistencyLevels.guard(EnumSet.of(options.getConsistency(), options.getSerialConsistency()),
-                                                clientState);
+        if (Guardrails.writeConsistencyLevels.enabled(clientState)) // to avoid EnumSet allocation
+            Guardrails.writeConsistencyLevels.guard(EnumSet.of(options.getConsistency(),
+                                                               options.getSerialConsistency()),
+                                                    clientState);
 
         for (int i = 0; i < statements.size(); i++ )
             statements.get(i).validateDiskUsage(options.forStatement(i), clientState);

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -103,6 +103,8 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
 
     private final RegularAndStaticColumns requiresRead;
 
+    private final List<Function> functions;
+
     public ModificationStatement(StatementType type,
                                  VariableSpecifications bindVariables,
                                  TableMetadata metadata,
@@ -156,6 +158,7 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         this.updatedColumns = modifiedColumns;
         this.conditionColumns = conditionColumnsBuilder.build();
         this.requiresRead = requiresReadBuilder.build();
+        this.functions = findAllFunctions();
     }
 
     @Override
@@ -173,8 +176,18 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
     @Override
     public Iterable<Function> getFunctions()
     {
+        return functions;
+    }
+
+    private List<Function> findAllFunctions()
+    {
         List<Function> functions = new ArrayList<>();
         addFunctionsTo(functions);
+        if (functions.isEmpty())
+        {
+            functions = Collections.emptyList(); // to avoid a new Iterator object creation during each authorization
+        }
+
         return functions;
     }
 
@@ -494,8 +507,9 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         if (options.getConsistency() == null)
             throw new InvalidRequestException("Invalid empty consistency level");
 
-        Guardrails.writeConsistencyLevels.guard(EnumSet.of(options.getConsistency(), options.getSerialConsistency()),
-                                                queryState.getClientState());
+        if (Guardrails.writeConsistencyLevels.enabled(queryState.getClientState())) // to avoid EnumSet allocation
+            Guardrails.writeConsistencyLevels.guard(EnumSet.of(options.getConsistency(), options.getSerialConsistency()),
+                                                    queryState.getClientState());
 
         return hasConditions()
              ? executeWithCondition(queryState, options, requestTime)

--- a/src/java/org/apache/cassandra/db/Keyspace.java
+++ b/src/java/org/apache/cassandra/db/Keyspace.java
@@ -159,6 +159,10 @@ public class Keyspace
 
     public static Keyspace open(String keyspaceName, SchemaProvider schema, boolean loadSSTables)
     {
+        // to avoid a capturing lamda allocation as an argument in maybeAddKeyspaceInstance
+        Keyspace keyspace = schema.getKeyspaceInstance(keyspaceName);
+        if (keyspace != null)
+            return keyspace;
         return schema.maybeAddKeyspaceInstance(keyspaceName, () -> new Keyspace(keyspaceName, schema, loadSSTables));
     }
 
@@ -532,7 +536,7 @@ public class Keyspace
 
         Lock[] locks = null;
 
-        boolean requiresViewUpdate = updateIndexes && viewManager.updatesAffectView(Collections.singleton(mutation), false);
+        boolean requiresViewUpdate = updateIndexes && viewManager.updatesAffectView(mutation, false);
 
         if (requiresViewUpdate)
         {
@@ -632,10 +636,11 @@ public class Keyspace
                     logger.error("Attempting to mutate non-existant table {} ({}.{})", upd.metadata().id, upd.metadata().keyspace, upd.metadata().name);
                     continue;
                 }
-                AtomicLong baseComplete = new AtomicLong(Long.MAX_VALUE);
+                AtomicLong baseComplete = null;
 
                 if (requiresViewUpdate)
                 {
+                    baseComplete = new AtomicLong(Long.MAX_VALUE);
                     try
                     {
                         Tracing.trace("Creating materialized view mutations from base table replica");

--- a/src/java/org/apache/cassandra/db/RegularAndStaticColumns.java
+++ b/src/java/org/apache/cassandra/db/RegularAndStaticColumns.java
@@ -153,6 +153,8 @@ public class RegularAndStaticColumns implements Iterable<ColumnMetadata>
         private BTree.Builder<ColumnMetadata> regularColumns;
         private BTree.Builder<ColumnMetadata> staticColumns;
 
+        private RegularAndStaticColumns lastAddedColumns;
+
         public Builder add(ColumnMetadata c)
         {
             if (c.isStatic())
@@ -180,18 +182,24 @@ public class RegularAndStaticColumns implements Iterable<ColumnMetadata>
 
         public Builder addAll(RegularAndStaticColumns columns)
         {
+            // for batch statements it is a frequent case when we have the same columns in each inner prepared statement
+            // we use == instead of uquals to make the optimization check cheap
+            if (lastAddedColumns != null && lastAddedColumns == columns) {
+                return this;
+            }
             if (regularColumns == null && !columns.regulars.isEmpty())
                 regularColumns = BTree.builder(naturalOrder());
 
-            for (ColumnMetadata c : columns.regulars)
-                regularColumns.add(c);
+            if (!columns.regulars.isEmpty())
+                regularColumns.addAll(columns.regulars);
 
             if (staticColumns == null && !columns.statics.isEmpty())
                 staticColumns = BTree.builder(naturalOrder());
 
-            for (ColumnMetadata c : columns.statics)
-                staticColumns.add(c);
+            if (!columns.statics.isEmpty())
+                staticColumns.addAll(columns.statics);
 
+            lastAddedColumns = columns;
             return this;
         }
 

--- a/src/java/org/apache/cassandra/db/partitions/PartitionUpdate.java
+++ b/src/java/org/apache/cassandra/db/partitions/PartitionUpdate.java
@@ -838,7 +838,11 @@ public class PartitionUpdate extends AbstractBTreePartition
         private final MutableDeletionInfo deletionInfo;
         private final boolean canHaveShadowedData;
         private Object[] tree = BTree.empty();
-        private final BTree.Builder<Row> rowBuilder;
+
+        private Row firstRow;
+        private BTree.Builder<Row> rowBuilder;
+
+        private final int initialRowCapacity;
         private Row staticRow = Rows.EMPTY_STATIC_ROW;
         private final RegularAndStaticColumns columns;
         private boolean isBuilt = false;
@@ -874,7 +878,7 @@ public class PartitionUpdate extends AbstractBTreePartition
             this.metadata = metadata;
             this.key = key;
             this.columns = columns;
-            this.rowBuilder = rowBuilder(initialRowCapacity);
+            this.initialRowCapacity = initialRowCapacity;
             this.canHaveShadowedData = canHaveShadowedData;
             this.deletionInfo = deletionInfo.mutableCopy();
             this.staticRow = staticRow;
@@ -917,19 +921,24 @@ public class PartitionUpdate extends AbstractBTreePartition
 
             if (row.isStatic())
             {
-                // this assert is expensive, and possibly of limited value; we should consider removing it
-                // or introducing a new class of assertions for test purposes
-                assert columns().statics.containsAll(row.columns()) : columns().statics + " is not superset of " + row.columns();
                 staticRow = staticRow.isEmpty()
                             ? row
                             : Rows.merge(staticRow, row);
             }
             else
             {
-                // this assert is expensive, and possibly of limited value; we should consider removing it
-                // or introducing a new class of assertions for test purposes
-                assert columns().regulars.containsAll(row.columns()) : columns().regulars + " is not superset of " + row.columns();
-                rowBuilder.add(row);
+                if (firstRow == null) {
+                    firstRow = row;
+                }
+                else
+                {
+                    if (rowBuilder == null)
+                    {
+                        rowBuilder = rowBuilder(initialRowCapacity);
+                        rowBuilder.add(firstRow);
+                    }
+                    rowBuilder.add(row);
+                }
             }
         }
 
@@ -953,13 +962,21 @@ public class PartitionUpdate extends AbstractBTreePartition
             return metadata;
         }
 
+        private static final UpdateFunction<Row, Row> ROWS_MERGE_FUNCTION = UpdateFunction.Simple.of(Rows::merge);
+
         public PartitionUpdate build()
         {
             // assert that we are not calling build() several times
             assert !isBuilt : "A PartitionUpdate.Builder should only get built once";
-            Object[] add = rowBuilder.build();
-            Object[] merged = BTree.<Row, Row, Row>update(tree, add, metadata.comparator,
-                                                          UpdateFunction.Simple.of(Rows::merge));
+            Object[] add;
+            if (rowBuilder == null) {
+                add = firstRow != null ? BTree.singleton(firstRow) : BTree.empty();
+            }
+            else
+            {
+                add = rowBuilder.build();
+            }
+            Object[] merged = BTree.<Row, Row, Row>update(tree, add, metadata.comparator, ROWS_MERGE_FUNCTION);
 
             EncodingStats newStats = EncodingStats.Collector.collect(staticRow, BTree.iterator(merged), deletionInfo);
 

--- a/src/java/org/apache/cassandra/db/rows/EncodingStats.java
+++ b/src/java/org/apache/cassandra/db/rows/EncodingStats.java
@@ -109,6 +109,13 @@ public class EncodingStats implements IMeasurableMemory
                      ? that.minTTL
                      : (that.minTTL == TTL_EPOCH ? this.minTTL : Math.min(this.minTTL, that.minTTL));
 
+        // EncodingStats is immutable, so if the result feilds are the same as in the current object we can avoid new object creation
+        // usually we merge an older object with a newer one and timestamp usually grows, so chances to reuse the object are high
+        if (this.minTimestamp == minTimestamp
+            && this.minLocalDeletionTime == minDelTime
+            && this.minTTL == minTTL) {
+            return this;
+        }
         return new EncodingStats(minTimestamp, minDelTime, minTTL);
     }
 

--- a/src/java/org/apache/cassandra/db/view/View.java
+++ b/src/java/org/apache/cassandra/db/view/View.java
@@ -238,6 +238,8 @@ public class View
     public static Iterable<ViewMetadata> findAll(String keyspace, String baseTable)
     {
         KeyspaceMetadata ksm = Schema.instance.getKeyspaceMetadata(keyspace);
+        if (ksm.views.isEmpty()) // memory optimization, to avoid a capturing lambda allocation
+            return Collections.emptyList();
         return Iterables.filter(ksm.views, view -> view.baseTableName.equals(baseTable));
     }
 

--- a/src/java/org/apache/cassandra/db/view/ViewManager.java
+++ b/src/java/org/apache/cassandra/db/view/ViewManager.java
@@ -70,9 +70,22 @@ public class ViewManager
         this.keyspace = keyspace;
     }
 
+    public boolean updatesAffectView(IMutation mutation, boolean coordinatorBatchlog)
+    {
+        if (!enableCoordinatorBatchlog && coordinatorBatchlog)
+            return false;
+
+        if (viewsByName.isEmpty())
+            return false;
+
+        return updatesAffectView(Collections.singleton(mutation), coordinatorBatchlog);
+    }
     public boolean updatesAffectView(Collection<? extends IMutation> mutations, boolean coordinatorBatchlog)
     {
         if (!enableCoordinatorBatchlog && coordinatorBatchlog)
+            return false;
+
+        if (viewsByName.isEmpty())
             return false;
 
         for (IMutation mutation : mutations)
@@ -84,7 +97,8 @@ public class ViewManager
                 if (coordinatorBatchlog && keyspace.getReplicationStrategy().getReplicationFactor().allReplicas == 1)
                     continue;
 
-                if (!forTable(update.metadata().id).updatedViews(update).isEmpty())
+                TableViews tableViews = forTable(update.metadata().id);
+                if (tableViews.hasViews() && !tableViews.updatedViews(update).isEmpty())
                     return true;
             }
         }

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -1324,6 +1324,8 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
     @Override
     public void validate(PartitionUpdate update, ClientState state) throws InvalidRequestException
     {
+        if (indexes.isEmpty())
+            return;
         for (Index index : indexes.values())
             index.validate(update, state);
     }

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -260,7 +260,8 @@ public abstract class SortedTableWriter<P extends SortedTablePartitionWriter, I 
 
     protected void onStartPartition(DecoratedKey key)
     {
-        notifyObservers(o -> o.startPartition(key, partitionWriter.getInitialPosition(), partitionWriter.getInitialPosition()));
+        if (hasObservers())
+            notifyObservers(o -> o.startPartition(key, partitionWriter.getInitialPosition(), partitionWriter.getInitialPosition()));
     }
 
     protected void onStaticRow(Row row)
@@ -270,20 +271,27 @@ public abstract class SortedTableWriter<P extends SortedTablePartitionWriter, I 
 
     protected void onRow(Row row)
     {
-        notifyObservers(o -> o.nextUnfilteredCluster(row));
+        if (hasObservers())
+            notifyObservers(o -> o.nextUnfilteredCluster(row));
     }
 
     protected void onRangeTombstoneMarker(RangeTombstoneMarker marker)
     {
-        notifyObservers(o -> o.nextUnfilteredCluster(marker));
+        if (hasObservers())
+            notifyObservers(o -> o.nextUnfilteredCluster(marker));
     }
 
     protected abstract AbstractRowIndexEntry createRowIndexEntry(DecoratedKey key, DeletionTime partitionLevelDeletion, long finishResult) throws IOException;
 
     protected final void notifyObservers(Consumer<SSTableFlushObserver> action)
     {
-        if (observers != null && !observers.isEmpty())
+        if (hasObservers())
             observers.forEach(action);
+    }
+
+    private boolean hasObservers()
+    {
+        return observers != null && !observers.isEmpty();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/locator/PendingRangeMaps.java
+++ b/src/java/org/apache/cassandra/locator/PendingRangeMaps.java
@@ -195,6 +195,14 @@ public class PendingRangeMaps implements Iterable<Map.Entry<Range<Token>, Endpoi
 
     public EndpointsForToken pendingEndpointsFor(Token token)
     {
+        // a fast path to avoid extra calculations/allocations
+        // for a typical case when we have a stable cluster
+        if (ascendingMap.isEmpty()
+            && descendingMap.isEmpty()
+            && ascendingMapForWrapAround.isEmpty()
+            && descendingMapForWrapAround.isEmpty())
+            return EndpointsForToken.empty(token);
+
         EndpointsForToken.Builder replicas = EndpointsForToken.builder(token);
 
         Range<Token> searchRange = new Range<>(token, token);

--- a/src/java/org/apache/cassandra/locator/ReplicaLayout.java
+++ b/src/java/org/apache/cassandra/locator/ReplicaLayout.java
@@ -272,6 +272,8 @@ public abstract class ReplicaLayout<E extends Endpoints<E>>
      */
     static <E extends Endpoints<E>> boolean haveWriteConflicts(E natural, E pending)
     {
+        if (pending.isEmpty())
+            return false;
         Set<InetAddressAndPort> naturalEndpoints = natural.endpoints();
         for (InetAddressAndPort pendingEndpoint : pending.endpoints())
         {

--- a/src/java/org/apache/cassandra/service/AbstractWriteResponseHandler.java
+++ b/src/java/org/apache/cassandra/service/AbstractWriteResponseHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,7 +77,7 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
     private static final AtomicIntegerFieldUpdater<AbstractWriteResponseHandler> failuresUpdater =
         AtomicIntegerFieldUpdater.newUpdater(AbstractWriteResponseHandler.class, "failures");
     private volatile int failures = 0;
-    private final Map<InetAddressAndPort, RequestFailureReason> failureReasonByEndpoint;
+    private volatile Map<InetAddressAndPort, RequestFailureReason> failureReasonByEndpoint;
     private final Dispatcher.RequestTime requestTime;
     private @Nullable final Supplier<Mutation> hintOnFailure;
 
@@ -105,7 +106,6 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
         this.callback = callback;
         this.writeType = writeType;
         this.hintOnFailure = hintOnFailure;
-        this.failureReasonByEndpoint = new ConcurrentHashMap<>();
         this.requestTime = requestTime;
     }
 
@@ -128,12 +128,12 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
 
         if (blockFor() + failures > candidateReplicaCount())
         {
-            if (RequestCallback.isTimeout(this.failureReasonByEndpoint.keySet().stream()
+            if (RequestCallback.isTimeout(this.getFailureReasonByEndpointMap().keySet().stream()
                                                                       .filter(this::waitingFor) // DatacenterWriteResponseHandler filters errors from remote DCs
-                                                                      .collect(Collectors.toMap(Function.identity(), this.failureReasonByEndpoint::get))))
+                                                                      .collect(Collectors.toMap(Function.identity(), this.getFailureReasonByEndpointMap()::get))))
                 throwTimeout();
 
-            throw new WriteFailureException(replicaPlan.consistencyLevel(), ackCount(), blockFor(), writeType, this.failureReasonByEndpoint);
+            throw new WriteFailureException(replicaPlan.consistencyLevel(), ackCount(), blockFor(), writeType, this.getFailureReasonByEndpointMap());
         }
     }
 
@@ -294,6 +294,12 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
                 ? failuresUpdater.incrementAndGet(this)
                 : failures;
 
+        if (failureReasonByEndpoint == null)
+            synchronized (this)
+            {
+                if (failureReasonByEndpoint == null)
+                    failureReasonByEndpoint = new ConcurrentHashMap<>();
+            }
         failureReasonByEndpoint.put(from, failureReason);
 
         logFailureOrTimeoutToIdealCLDelegate();
@@ -367,5 +373,10 @@ public abstract class AbstractWriteResponseHandler<T> implements RequestCallback
         {
             throw new UncheckedInterruptedException(e);
         }
+    }
+
+    private Map<InetAddressAndPort, RequestFailureReason> getFailureReasonByEndpointMap()
+    {
+        return failureReasonByEndpoint != null ? failureReasonByEndpoint : Collections.emptyMap();
     }
 }

--- a/src/java/org/apache/cassandra/service/ClientWarn.java
+++ b/src/java/org/apache/cassandra/service/ClientWarn.java
@@ -58,7 +58,7 @@ public class ClientWarn extends ExecutorLocals.Impl
     public List<String> getWarnings()
     {
         State state = get();
-        if (state == null || state.warnings.isEmpty())
+        if (state == null || state.warnings == null || state.warnings.isEmpty())
             return null;
         return state.warnings;
     }
@@ -72,10 +72,16 @@ public class ClientWarn extends ExecutorLocals.Impl
     {
         // This must be a thread-safe list. Even though it's wrapped in a ThreadLocal, it's propagated to each thread
         // from shared state, so multiple threads can reference the same State.
-        private final List<String> warnings = new CopyOnWriteArrayList<>();
+        private volatile List<String> warnings;
 
         private void add(String warning)
         {
+            if (warnings == null)
+                 synchronized (this) {
+                    if (warnings == null) {
+                        warnings = new CopyOnWriteArrayList<>();
+                    }
+                 }
             if (warnings.size() < FBUtilities.MAX_UNSIGNED_SHORT)
                 warnings.add(maybeTruncate(warning));
         }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -880,24 +880,25 @@ public class StorageProxy implements StorageProxyMBean
         Tracing.trace("Determining replicas for mutation");
         final String localDataCenter = DatabaseDescriptor.getEndpointSnitch().getLocalDatacenter();
 
-        List<AbstractWriteResponseHandler<IMutation>> responseHandlers = new ArrayList<>(mutations.size());
+        AbstractWriteResponseHandler<IMutation>[] responseHandlers = new AbstractWriteResponseHandler[mutations.size()];
         WriteType plainWriteType = mutations.size() <= 1 ? WriteType.SIMPLE : WriteType.UNLOGGED_BATCH;
 
         try
         {
+            int j = 0;
             for (IMutation mutation : mutations)
             {
                 if (mutation instanceof CounterMutation)
-                    responseHandlers.add(mutateCounter((CounterMutation)mutation, localDataCenter, requestTime));
+                    responseHandlers[j++] = mutateCounter((CounterMutation)mutation, localDataCenter, requestTime);
                 else
-                    responseHandlers.add(performWrite(mutation, consistencyLevel, localDataCenter, standardWritePerformer, null, plainWriteType, requestTime));
+                    responseHandlers[j++] = performWrite(mutation, consistencyLevel, localDataCenter, standardWritePerformer, null, plainWriteType, requestTime);
             }
 
             // upgrade to full quorum any failed cheap quorums
             for (int i = 0 ; i < mutations.size() ; ++i)
             {
                 if (!(mutations.get(i) instanceof CounterMutation)) // at the moment, only non-counter writes support cheap quorums
-                    responseHandlers.get(i).maybeTryAdditionalReplicas(mutations.get(i), standardWritePerformer, localDataCenter);
+                    responseHandlers[i].maybeTryAdditionalReplicas(mutations.get(i), standardWritePerformer, localDataCenter);
             }
 
             // wait for writes.  throws TimeoutException if necessary
@@ -1265,14 +1266,28 @@ public class StorageProxy implements StorageProxyMBean
         {
             //We could potentially pass a callback into performWrite. And add callback provision for mutateCounter or mutateAtomically (sendToHintedEndPoints)
             //However, Trade off between write metric per CF accuracy vs performance hit due to callbacks. Similar issue exists with CoordinatorReadLatency metric.
-            Set<ColumnFamilyStore> uniqueColumnFamilyStores = new HashSet<>();
+            Set<ColumnFamilyStore> uniqueColumnFamilyStores = null;
+            // very frequently we update just a single table
+            // so an allocation of uniqueColumnFamilyStores set can be avoided
+            ColumnFamilyStore firstColumnFamilyStore = null;
             for (IMutation mutation : mutations)
             {
+                Keyspace keyspace = Keyspace.open(mutation.getKeyspaceName());
                 for (TableId tableId : mutation.getTableIds())
                 {
-                    ColumnFamilyStore store = Keyspace.open(mutation.getKeyspaceName()).getColumnFamilyStore(tableId);
-                    if (uniqueColumnFamilyStores.add(store))
+                    ColumnFamilyStore store = keyspace.getColumnFamilyStore(tableId);
+                    if (firstColumnFamilyStore == null)
+                    {
                         store.metric.coordinatorWriteLatency.update(latency, NANOSECONDS);
+                        firstColumnFamilyStore = store;
+                    }
+                    else if (!firstColumnFamilyStore.equals(store))
+                    {
+                        if (uniqueColumnFamilyStores == null)
+                            uniqueColumnFamilyStores = new HashSet<>();
+                        if (uniqueColumnFamilyStores.add(store))
+                            store.metric.coordinatorWriteLatency.update(latency, NANOSECONDS);
+                    }
                 }
             }
         }

--- a/src/java/org/apache/cassandra/transport/Flusher.java
+++ b/src/java/org/apache/cassandra/transport/Flusher.java
@@ -156,8 +156,14 @@ abstract class Flusher implements Runnable
         }
         else
         {
-            payloads.computeIfAbsent(flush.channel, channel -> new FlushBuffer(channel, flush.allocator, 5))
-                    .add(flush.response);
+            FlushBuffer flushBuffer = payloads.get(flush.channel);
+            if (flushBuffer == null)
+            {
+                flushBuffer = new FlushBuffer(flush.channel, flush.allocator, 5);
+                payloads.put(flushBuffer.channel, flushBuffer);
+            }
+
+            flushBuffer.add(flush.response);
         }
     }
 
@@ -226,8 +232,9 @@ abstract class Flusher implements Runnable
     protected void flushWrittenChannels()
     {
         // flush the channels pre-V5 to which messages were written in writeSingleResponse
-        for (Channel channel : channels)
-            channel.flush();
+        if (!channels.isEmpty())
+            for (Channel channel : channels)
+                channel.flush();
 
         // Framed messages (V5) are grouped by channel, now encode them into payloads, write and flush
         for (FlushBuffer buffer : payloads.values())
@@ -247,8 +254,11 @@ abstract class Flusher implements Runnable
         // collated into frames, and so their buffers can be released immediately after flushing.
         // In V4 however, the buffers containing each CQL envelope are emitted from Envelope.Encoder
         // and so releasing them is handled by Netty internally.
-        for (FlushItem<?> item : processed)
+        for (int i = 0; i < processed.size(); i++)
+        {
+            FlushItem<?> item = processed.get(i);
             item.release();
+        }
 
         payloads.clear();
         channels.clear();
@@ -298,8 +308,9 @@ abstract class Flusher implements Runnable
             int writtenBytes = 0;
             int messagesToWrite = this.size();
             FrameEncoder.Payload sending = allocate(sizeInBytes, messagesToWrite);
-            for (Envelope f : this)
+            for (int i = 0; i < this.size(); i++)
             {
+                Envelope f = this.get(i);
                 messageSize = envelopeSize(f.header);
                 if (sending.remaining() < messageSize)
                 {


### PR DESCRIPTION
Reduce memory allocation for write hot path.

Avoid objects allocations used only in rarely invoked logic branches. Memorize things which can be computed once. Avoid unnecessary iterators for the write hot path. Do not recreate immutable objects with the same content.

Patch by Dmitry Konstantinov; reviewed by Chris Lohfink, Michael Semb Wever for CASSANDRA-20167