### PR TITLE
CASSANDRA-20201 - Reference list in the nav bar fix

### DIFF
--- a/doc/modules/cassandra/nav.adoc
+++ b/doc/modules/cassandra/nav.adoc
@@ -117,11 +117,9 @@
 *** xref:cassandra:troubleshooting/use_tools.adoc[Using external tools to deep-dive]
 
 ** xref:reference/index.adoc[]
-*** xref:reference/cql-commands/alter-table.adoc[]
-*** xref:reference/cql-commands/create-index.adoc[]
-*** xref:reference/cql-commands/create-custom-index.adoc[]
-*** xref:reference/cql-commands/create-table.adoc[]
-*** xref:reference/cql-commands/drop-index.adoc[]
-*** xref:reference/cql-commands/drop-table.adoc[]
+*** xref:reference/cql-commands/commands-toc.adoc[CQL commands]
+*** xref:reference/java17.adoc[Java 17]
+*** xref:reference/static.adoc[Static columns]
+*** xref:reference/sai-virtual-table-indexes.adoc[SAI virtual table]
 
 ** xref:integrating/plugins/index.adoc[]

--- a/doc/modules/cassandra/pages/reference/index.adoc
+++ b/doc/modules/cassandra/pages/reference/index.adoc
@@ -2,6 +2,5 @@
 
 * xref:reference/cql-commands/commands-toc.adoc[CQL commands]
 * xref:reference/java17.adoc[Java 17]
-* xref:reference/counter-type.adoc[Counter type]
 * xref:reference/static.adoc[Static columns]
 * xref:reference/sai-virtual-table-indexes.adoc[SAI virtual table]


### PR DESCRIPTION
This PR provides fix for the incorrect reference section appearance in the https://cassandra.apache.org/doc/latest/ nav bar.
![image](https://github.com/user-attachments/assets/0f2c4350-5247-4022-8934-d7141c70b83c)
![image](https://github.com/user-attachments/assets/36bed15f-1875-445c-a268-f164b99c0719)
The list was displaying the contents of the `CQL commands` (the first element of the list) instead of the list itself.

Also the `Counter type` line was removed because it links to a non-existing page.

