### PR TITLE
Adding metrics for SAI Index in Cassandra-5.0

### DIFF
--- a/src/java/org/apache/cassandra/index/sai/metrics/IndexGroupMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/IndexGroupMetrics.java
@@ -25,9 +25,10 @@ import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 
 public class IndexGroupMetrics extends AbstractMetrics
 {
+    public static final String INDEX_GROUP_METRICS_TYPE = "IndexGroupMetrics";
     public IndexGroupMetrics(TableMetadata table, StorageAttachedIndexGroup group)
     {
-        super(table.keyspace, table.name, "IndexGroupMetrics");
+        super(table.keyspace, table.name, INDEX_GROUP_METRICS_TYPE);
 
         Metrics.register(createMetricName("OpenIndexFiles"), (Gauge<Integer>) group::openIndexFiles);
         Metrics.register(createMetricName("DiskUsedBytes"), (Gauge<Long>) group::diskUsage);

--- a/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
+++ b/src/java/org/apache/cassandra/index/sai/metrics/TableQueryMetrics.java
@@ -71,6 +71,8 @@ public class TableQueryMetrics extends AbstractMetrics
 
     public class PerQueryMetrics extends AbstractMetrics
     {
+        public static final String PER_QUERY_METRICS_TYPE = "PerQuery";
+
         private final Timer queryLatency;
 
         /**
@@ -99,7 +101,7 @@ public class TableQueryMetrics extends AbstractMetrics
 
         public PerQueryMetrics(TableMetadata table)
         {
-            super(table.keyspace, table.name, "PerQuery");
+            super(table.keyspace, table.name, PER_QUERY_METRICS_TYPE);
 
             queryLatency = Metrics.timer(createMetricName("QueryLatency"));
 

--- a/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TableStats.java
@@ -60,8 +60,10 @@ public class TableStats extends NodeToolCmd
                         + "memtable_off_heap_memory_used, memtable_switch_count, number_of_partitions_estimate, "
                         + "off_heap_memory_used_total, pending_flushes, percent_repaired, read_latency, reads, "
                         + "space_used_by_snapshots_total, space_used_live, space_used_total, "
-                        + "sstable_compression_ratio, sstable_count, table_name, write_latency, writes, " +
-                          "max_sstable_size, local_read_write_ratio, twcs_max_duration)")
+                        + "sstable_compression_ratio, sstable_count, table_name, write_latency, writes, "
+                        + "max_sstable_size, local_read_write_ratio, twcs_max_duration, sai_local_query_latency_ms,"
+                        + "sai_post_filtering_read_latency, sai_disk_used_bytes, sai_sstable_indexes_hit, sai_index_segments_hit "
+                        + "sai_rows_filtered, sai_total_query_timeouts, sai_total_queryable_index_ratio)")
     private String sortKey = "";
 
     @Option(title = "top",

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
@@ -82,4 +82,14 @@ public class StatsTable
     public double localReadWriteRatio;
     public Long twcsDurationInMillis;
     public String twcs;
+
+    public double saiQueryLatencyMs;
+    public double saiPostFilteringReadLatencyMs;
+    public String saiDiskUsedBytes;
+    public double saiSSTableIndexesHit;
+    public double saiIndexSegmentsHit;
+    public double saiRowsFiltered;
+    public long saiTotalQueryTimeouts;
+    public int saiTotalIndexCount;
+    public String saiTotalQueryableIndexRatio;
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTableComparator.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTableComparator.java
@@ -66,7 +66,10 @@ public class StatsTableComparator implements Comparator<StatsTable>
                                                        "space_used_by_snapshots_total", "space_used_live",
                                                        "space_used_total", "sstable_compression_ratio", "sstable_count",
                                                        "table_name", "write_latency", "writes", "max_sstable_size",
-                                                       "local_read_write_ratio", "twcs_max_duration"};
+                                                       "local_read_write_ratio", "twcs_max_duration", "sai_local_query_latency_ms",
+                                                       "sai_post_filtering_read_latency","sai_disk_used_bytes","sai_sstable_indexes_hit",
+                                                       "sai_index_segments_hit","sai_rows_filtered","sai_total_query_timeouts",
+                                                       "sai_total_queryable_index_ratio"};
 
     public StatsTableComparator(String sortKey, boolean humanReadable)
     {
@@ -337,6 +340,47 @@ public class StatsTableComparator implements Comparator<StatsTable>
         else if (sortKey.equals("table_name"))
         {
             return sign * stx.tableName.compareTo(sty.tableName);
+        }
+        else if(sortKey.equals("sai_local_query_latency_ms"))
+        {
+            result = compareDoubles(stx.saiQueryLatencyMs, sty.saiQueryLatencyMs);
+        }
+        else if(sortKey.equals("sai_post_filtering_read_latency"))
+        {
+            result = compareDoubles(stx.saiPostFilteringReadLatencyMs, sty.saiPostFilteringReadLatencyMs);
+        }
+        else if(sortKey.equals("sai_disk_used_bytes"))
+        {
+            result = compareFileSizes(stx.saiDiskUsedBytes,
+                                      sty.saiDiskUsedBytes);
+        }
+        else if(sortKey.equals("sai_sstable_indexes_hit"))
+        {
+            result = compareDoubles(stx.saiSSTableIndexesHit, sty.saiSSTableIndexesHit);
+        }
+        else if(sortKey.equals("sai_index_segments_hit"))
+        {
+            result = compareDoubles(stx.saiIndexSegmentsHit, sty.saiIndexSegmentsHit);
+        }
+        else if(sortKey.equals("sai_rows_filtered"))
+        {
+            result = compareDoubles(stx.saiRowsFiltered, sty.saiRowsFiltered);
+        }
+        else if(sortKey.equals("sai_total_query_timeouts"))
+        {
+            result = sign * Long.valueOf(stx.saiTotalQueryTimeouts)
+                                .compareTo(Long.valueOf(sty.saiTotalQueryTimeouts));
+        }
+        else if(sortKey.equals("sai_total_queryable_index_ratio"))
+        {
+            if (stx.saiTotalQueryableIndexRatio == null && sty.saiTotalQueryableIndexRatio != null)
+                return sign * -1;
+            else if (stx.saiTotalQueryableIndexRatio != null && sty.saiTotalQueryableIndexRatio == null)
+                return sign;
+            else if (stx.saiTotalQueryableIndexRatio == null && sty.saiTotalQueryableIndexRatio == null)
+                return 0;
+
+            result = sign * stx.saiTotalQueryableIndexRatio.compareTo(sty.saiTotalQueryableIndexRatio);
         }
         else
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -22,6 +22,7 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.utils.FBUtilities;
 
 public class TableStatsPrinter<T extends StatsHolder>
@@ -163,6 +164,19 @@ public class TableStatsPrinter<T extends StatsHolder>
                 for (Map.Entry<String, Long> tombstonecnt : table.topTombstonePartitions.entrySet())
                     out.printf(indent + "  %-" + maxWidth + "s %s%n", tombstonecnt.getKey(), tombstonecnt.getValue());
             }
+
+            if (!SchemaConstants.isSystemKeyspace(table.keyspaceName) && table.saiTotalIndexCount > 0)
+            {
+                out.println(indent + "SAI local query latency (mean): " + String.format("%.3f ms", table.saiQueryLatencyMs));
+                out.println(indent + "SAI post-filtering latency (mean): " + String.format("%.3f ms",table.saiPostFilteringReadLatencyMs));
+                out.println(indent + "SAI space used (bytes): " + table.saiDiskUsedBytes);
+                out.println(indent + "SAI sstable indexes hit per query (mean): " + table.saiSSTableIndexesHit);
+                out.println(indent + "SAI index segments hit per query (mean): " + table.saiIndexSegmentsHit);
+                out.println(indent + "SAI rows filtered per query (mean): " + table.saiRowsFiltered);
+                out.println(indent + "SAI local query timeouts: " + table.saiTotalQueryTimeouts);
+                out.println(indent + "SAI queryable/total indexes: " + table.saiTotalQueryableIndexRatio);
+            }
+
             out.println("");
         }
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
@@ -112,7 +112,11 @@ public class TableStatsTest extends CQLTester
                         "            read_latency, reads, space_used_by_snapshots_total, space_used_live,\n" + 
                         "            space_used_total, sstable_compression_ratio, sstable_count,\n" + 
                         "            table_name, write_latency, writes, max_sstable_size,\n" +
-                        "            local_read_write_ratio, twcs_max_duration)\n" +
+                        "            local_read_write_ratio, twcs_max_duration,\n" +
+                        "            sai_local_query_latency_ms,sai_post_filtering_read_latency,\n" +
+                        "            sai_disk_used_bytes, sai_sstable_indexes_hit, sai_index_segments_hit\n" +
+                        "            sai_rows_filtered, sai_total_query_timeouts,\n" +
+                        "            sai_total_queryable_index_ratio)\n" +
                         "\n" + 
                         "        -t <top>, --top <top>\n" + 
                         "            Show only the top K tables for the sort key (specify the number K of\n" + 

--- a/test/unit/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinterTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinterTest.java
@@ -228,6 +228,14 @@ public class TableStatsPrinterTest extends TableStatsTestBase
         "\tAverage tombstones per slice (last five minutes): 4.01\n" +
         "\tMaximum tombstones per slice (last five minutes): 5\n" +
         "\tDroppable tombstone ratio: 0.55556\n" +
+        "\tSAI local query latency (mean): 10.000 ms\n" +
+        "\tSAI post-filtering latency (mean): 1.000 ms\n" +
+        "\tSAI space used (bytes): 40 bytes\n" +
+        "\tSAI sstable indexes hit per query (mean): 3.5\n" +
+        "\tSAI index segments hit per query (mean): 4.0\n" +
+        "\tSAI rows filtered per query (mean): 55.0\n" +
+        "\tSAI local query timeouts: 4\n" +
+        "\tSAI queryable/total indexes: 5/5\n" +
         "\n";
 
     public static final String expectedDefaultTable6Output =
@@ -412,48 +420,56 @@ public class TableStatsPrinterTest extends TableStatsTestBase
                                  "    \"write_latency_ms\" : null,\n" +
                                  "    \"tables\" : {\n" +
                                  "      \"table6\" : {\n" +
-                                 "        \"average_tombstones_per_slice_last_five_minutes\" : 6.0,\n" +
-                                 "        \"top_tombstone_partitions\" : null,\n" +
-                                 "        \"bloom_filter_off_heap_memory_used\" : \"667408\",\n" +
                                  "        \"twcs\" : null,\n" +
-                                 "        \"bytes_pending_repair\" : 0,\n" +
+                                 "        \"sai_total_queryable_index_ratio\" : \"0/0\",\n" +
                                  "        \"memtable_switch_count\" : 6,\n" +
+                                 "        \"sai_post_filtering_read_latency\" : \"NaN\",\n" +
                                  "        \"speculative_retries\" : 0,\n" +
-                                 "        \"maximum_tombstones_per_slice_last_five_minutes\" : 6,\n" +
-                                 "        \"memtable_cell_count\" : 6666,\n" +
-                                 "        \"memtable_data_size\" : \"1000000\",\n" +
                                  "        \"average_live_cells_per_slice_last_five_minutes\" : 5.0,\n" +
                                  "        \"local_read_latency_ms\" : \"1.000\",\n" +
                                  "        \"sstable_count\" : 1000,\n" +
-                                 "        \"local_write_latency_ms\" : \"0.500\",\n" +
-                                 "        \"pending_flushes\" : 66,\n" +
                                  "        \"compacted_partition_minimum_bytes\" : 6,\n" +
-                                 "        \"local_read_count\" : 5,\n" +
                                  "        \"sstable_compression_ratio\" : 0.68,\n" +
                                  "        \"max_sstable_size\" : 0,\n" +
+                                 "        \"sai_index_segments_hit\" : \"NaN\",\n" +
+                                 "        \"memtable_off_heap_memory_used\" : \"161803398\",\n" +
+                                 "        \"bloom_filter_space_used\" : \"101112\",\n" +
+                                 "        \"compacted_partition_maximum_bytes\" : 20,\n" +
+                                 "        \"sai_rows_filtered\" : \"NaN\",\n" +
+                                 "        \"droppable_tombstone_ratio\" : \"0.66667\",\n" +
+                                 "        \"compression_metadata_off_heap_memory_used\" : \"1\",\n" +
+                                 "        \"bloom_filter_false_ratio\" : \"0.03000\",\n" +
+                                 "        \"percent_repaired\" : 0.0,\n" +
+                                 "        \"average_tombstones_per_slice_last_five_minutes\" : 6.0,\n" +
+                                 "        \"top_tombstone_partitions\" : null,\n" +
+                                 "        \"sai_total_query_timeouts\" : 0,\n" +
+                                 "        \"bloom_filter_off_heap_memory_used\" : \"667408\",\n" +
+                                 "        \"bytes_pending_repair\" : 0,\n" +
+                                 "        \"maximum_tombstones_per_slice_last_five_minutes\" : 6,\n" +
+                                 "        \"memtable_cell_count\" : 6666,\n" +
+                                 "        \"memtable_data_size\" : \"1000000\",\n" +
+                                 "        \"local_write_latency_ms\" : \"0.500\",\n" +
+                                 "        \"pending_flushes\" : 66,\n" +
+                                 "        \"local_read_count\" : 5,\n" +
                                  "        \"top_size_partitions\" : null,\n" +
                                  "        \"bloom_filter_false_positives\" : 400,\n" +
                                  "        \"off_heap_memory_used_total\" : \"162470810\",\n" +
-                                 "        \"memtable_off_heap_memory_used\" : \"161803398\",\n" +
                                  "        \"index_summary_off_heap_memory_used\" : \"3\",\n" +
-                                 "        \"bloom_filter_space_used\" : \"101112\",\n" +
+                                 "        \"sai_local_query_latency_ms\" : \"NaN\",\n" +
                                  "        \"sstables_in_each_level\" : [ ],\n" +
-                                 "        \"compacted_partition_maximum_bytes\" : 20,\n" +
                                  "        \"sstable_bytes_in_each_level\" : [ ],\n" +
                                  "        \"space_used_total\" : \"0\",\n" +
                                  "        \"local_write_count\" : 0,\n" +
-                                 "        \"droppable_tombstone_ratio\" : \"0.66667\",\n" +
-                                 "        \"compression_metadata_off_heap_memory_used\" : \"1\",\n" +
+                                 "        \"sai_sstable_indexes_hit\" : \"NaN\",\n" +
                                  "        \"local_read_write_ratio\" : \"0.00000\",\n" +
                                  "        \"number_of_partitions_estimate\" : 6,\n" +
+                                 "        \"sai_disk_used_bytes\" : \"NaN\",\n" +
                                  "        \"bytes_repaired\" : 0,\n" +
                                  "        \"maximum_live_cells_per_slice_last_five_minutes\" : 2,\n" +
                                  "        \"space_used_live\" : \"666666\",\n" +
                                  "        \"compacted_partition_mean_bytes\" : 3,\n" +
-                                 "        \"bloom_filter_false_ratio\" : \"0.03000\",\n" +
                                  "        \"old_sstable_count\" : 0,\n" +
                                  "        \"bytes_unrepaired\" : 0,\n" +
-                                 "        \"percent_repaired\" : 0.0,\n" +
                                  "        \"space_used_by_snapshots_total\" : \"0\"\n" +
                                  "      }\n" +
                                  "    },\n" +
@@ -481,48 +497,56 @@ public class TableStatsPrinterTest extends TableStatsTestBase
                                  "  write_latency_ms: .NaN\n" +
                                  "  tables:\n" +
                                  "    table6:\n" +
-                                 "      average_tombstones_per_slice_last_five_minutes: 6.0\n" +
-                                 "      top_tombstone_partitions: null\n" +
-                                 "      bloom_filter_off_heap_memory_used: '667408'\n" +
                                  "      twcs: null\n" +
-                                 "      bytes_pending_repair: 0\n" +
+                                 "      sai_total_queryable_index_ratio: 0/0\n" +
                                  "      memtable_switch_count: 6\n" +
+                                 "      sai_post_filtering_read_latency: NaN\n" +
                                  "      speculative_retries: 0\n" +
-                                 "      maximum_tombstones_per_slice_last_five_minutes: 6\n" +
-                                 "      memtable_cell_count: 6666\n" +
-                                 "      memtable_data_size: '1000000'\n" +
                                  "      average_live_cells_per_slice_last_five_minutes: 5.0\n" +
                                  "      local_read_latency_ms: '1.000'\n" +
                                  "      sstable_count: 1000\n" +
-                                 "      local_write_latency_ms: '0.500'\n" +
-                                 "      pending_flushes: 66\n" +
                                  "      compacted_partition_minimum_bytes: 6\n" +
-                                 "      local_read_count: 5\n" +
                                  "      sstable_compression_ratio: 0.68\n" +
                                  "      max_sstable_size: 0\n" +
+                                 "      sai_index_segments_hit: .NaN\n" +
+                                 "      memtable_off_heap_memory_used: '161803398'\n" +
+                                 "      bloom_filter_space_used: '101112'\n" +
+                                 "      compacted_partition_maximum_bytes: 20\n" +
+                                 "      sai_rows_filtered: .NaN\n" +
+                                 "      droppable_tombstone_ratio: '0.66667'\n" +
+                                 "      compression_metadata_off_heap_memory_used: '1'\n" +
+                                 "      bloom_filter_false_ratio: '0.03000'\n" +
+                                 "      percent_repaired: 0.0\n" +
+                                 "      average_tombstones_per_slice_last_five_minutes: 6.0\n" +
+                                 "      top_tombstone_partitions: null\n" +
+                                 "      sai_total_query_timeouts: 0\n" +
+                                 "      bloom_filter_off_heap_memory_used: '667408'\n" +
+                                 "      bytes_pending_repair: 0\n" +
+                                 "      maximum_tombstones_per_slice_last_five_minutes: 6\n" +
+                                 "      memtable_cell_count: 6666\n" +
+                                 "      memtable_data_size: '1000000'\n" +
+                                 "      local_write_latency_ms: '0.500'\n" +
+                                 "      pending_flushes: 66\n" +
+                                 "      local_read_count: 5\n" +
                                  "      top_size_partitions: null\n" +
                                  "      bloom_filter_false_positives: 400\n" +
                                  "      off_heap_memory_used_total: '162470810'\n" +
-                                 "      memtable_off_heap_memory_used: '161803398'\n" +
                                  "      index_summary_off_heap_memory_used: '3'\n" +
-                                 "      bloom_filter_space_used: '101112'\n" +
+                                 "      sai_local_query_latency_ms: NaN\n" +
                                  "      sstables_in_each_level: []\n" +
-                                 "      compacted_partition_maximum_bytes: 20\n" +
                                  "      sstable_bytes_in_each_level: []\n" +
                                  "      space_used_total: '0'\n" +
                                  "      local_write_count: 0\n" +
-                                 "      droppable_tombstone_ratio: '0.66667'\n" +
-                                 "      compression_metadata_off_heap_memory_used: '1'\n" +
+                                 "      sai_sstable_indexes_hit: .NaN\n" +
                                  "      local_read_write_ratio: '0.00000'\n" +
                                  "      number_of_partitions_estimate: 6\n" +
+                                 "      sai_disk_used_bytes: NaN\n" +
                                  "      bytes_repaired: 0\n" +
                                  "      maximum_live_cells_per_slice_last_five_minutes: 2\n" +
                                  "      space_used_live: '666666'\n" +
                                  "      compacted_partition_mean_bytes: 3\n" +
-                                 "      bloom_filter_false_ratio: '0.03000'\n" +
                                  "      old_sstable_count: 0\n" +
                                  "      bytes_unrepaired: 0\n" +
-                                 "      percent_repaired: 0.0\n" +
                                  "      space_used_by_snapshots_total: '0'\n" +
                                  "  read_latency_ms: 0.0\n" +
                                  "  pending_flushes: 66\n" +

--- a/test/unit/org/apache/cassandra/tools/nodetool/stats/TableStatsTestBase.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/stats/TableStatsTestBase.java
@@ -102,6 +102,14 @@ public class TableStatsTestBase
         template.maximumTombstonesPerSliceLastFiveMinutes = 0L;
         template.twcs = null;
         template.twcsDurationInMillis = 0L;
+        template.saiQueryLatencyMs = Double.NaN;
+        template.saiPostFilteringReadLatencyMs = Double.NaN;
+        template.saiDiskUsedBytes = "NaN";
+        template.saiSSTableIndexesHit = Double.NaN;
+        template.saiIndexSegmentsHit = Double.NaN;
+        template.saiRowsFiltered = Double.NaN;
+        template.saiTotalQueryTimeouts = 0L;
+        template.saiTotalQueryableIndexRatio = "0/0";
         return template;
     }
 
@@ -337,6 +345,18 @@ public class TableStatsTestBase
         table2.twcsDurationInMillis = 2000L;
         table4.twcsDurationInMillis = 1000L;
         table5.twcsDurationInMillis = null;
+
+        // Table5 with 5 SAI.
+        table5.saiQueryLatencyMs = 10.000D;
+        table5.saiPostFilteringReadLatencyMs = 1.000D;
+        table5.saiDiskUsedBytes = "40 bytes";
+        table5.saiSSTableIndexesHit = 3.5D;
+        table5.saiIndexSegmentsHit = 4.0D;
+        table5.saiRowsFiltered = 55.0D;
+        table5.saiTotalQueryTimeouts = 4L;
+        table5.saiTotalIndexCount = 5;
+        table5.saiTotalQueryableIndexRatio = "5/5";
+
         // create test keyspaces from templates
         testKeyspaces = new ArrayList<>();
         StatsKeyspace keyspace1 = createStatsKeyspaceTemplate("keyspace1");
@@ -395,6 +415,10 @@ public class TableStatsTestBase
         humanReadableTable4.memtableDataSize = "999 bytes";
         humanReadableTable5.memtableDataSize = "3.14 MiB";
         humanReadableTable6.memtableDataSize = "0 bytes";
+
+        // cretae human-readable SAI disk space used size:
+        humanReadableTable5.saiDiskUsedBytes = "40 bytes";
+
         // create human readable keyspaces from template
         humanReadableKeyspaces = new ArrayList<>();
         StatsKeyspace humanReadableKeyspace1 = createStatsKeyspaceTemplate("keyspace1");


### PR DESCRIPTION
Cassandra-20026
Adding metrics in `nodetool tablestats` output for storage attached index.