### PR TITLE
CASSANDRA-20238 Correct the default behavior of compareTo() when comparing WIDE and STATIC PrimaryKeys

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -126,6 +126,7 @@
  * Add the ability to disable bulk loading of SSTables (CASSANDRA-18781)
  * Clean up obsolete functions and simplify cql_version handling in cqlsh (CASSANDRA-18787)
 Merged from 5.0:
+ * Correct the default behavior of compareTo() when comparing WIDE and STATIC PrimaryKeys (CASSANDRA-20238)
  * Make sure we can set parameters when configuring CassandraCIDRAuthorizer (CASSANDRA-20220)
  * Add selected SAI index state and query performance metrics to nodetool tablestats (CASSANDRA-20026)
  * Remove v30 and v3X from 5.x in-JVM upgrade tests (CASSANDRA-20103)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingListRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/postings/PostingListRangeIterator.java
@@ -89,7 +89,7 @@ public class PostingListRangeIterator extends KeyRangeIterator
     @Override
     protected void performSkipTo(PrimaryKey nextKey)
     {
-        if (skipToKey != null && skipToKey.compareTo(nextKey) > 0)
+        if (skipToKey != null && skipToKey.compareTo(nextKey, false) > 0)
             return;
 
         skipToKey = nextKey;
@@ -137,7 +137,7 @@ public class PostingListRangeIterator extends KeyRangeIterator
 
     private boolean exhausted()
     {
-        return needsSkipping && skipToKey.compareTo(getMaximum()) > 0;
+        return needsSkipping && skipToKey.compareTo(getMaximum(), false) > 0;
     }
 
     /**

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeConcatIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeConcatIterator.java
@@ -59,10 +59,10 @@ public class KeyRangeConcatIterator extends KeyRangeIterator
         {
             KeyRangeIterator currentIterator = ranges.get(current);
 
-            if (currentIterator.hasNext() && currentIterator.peek().compareTo(nextKey) >= 0)
+            if (currentIterator.hasNext() && currentIterator.peek().compareTo(nextKey, false) >= 0)
                 break;
 
-            if (currentIterator.getMaximum().compareTo(nextKey) >= 0)
+            if (currentIterator.getMaximum().compareTo(nextKey, false) >= 0)
             {
                 currentIterator.skipTo(nextKey);
                 break;
@@ -178,7 +178,7 @@ public class KeyRangeConcatIterator extends KeyRangeIterator
                 {
                     min = range.getMinimum();
                 }
-                else if (count > 0 && max.compareTo(range.getMinimum()) > 0)
+                else if (count > 0 && max.compareTo(range.getMinimum(), false) > 0)
                 {
                     throw new IllegalArgumentException(String.format(MUST_BE_SORTED_ERROR, max, range.getMinimum()));
                 }

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeListIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeListIterator.java
@@ -50,7 +50,7 @@ public class KeyRangeListIterator extends KeyRangeIterator
     {
         while (keyQueue.hasNext())
         {
-            if (keyQueue.peek().compareTo(nextKey) >= 0)
+            if (keyQueue.peek().compareTo(nextKey, false) >= 0)
                 break;
             keyQueue.next();
         }

--- a/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/iterators/KeyRangeUnionIterator.java
@@ -61,7 +61,7 @@ public class KeyRangeUnionIterator extends KeyRangeIterator
             {
                 PrimaryKey peeked = range.peek();
     
-                int cmp = candidateKey.compareTo(peeked);
+                int cmp = candidateKey.compareTo(peeked, false);
 
                 if (cmp == 0)
                 {
@@ -91,7 +91,7 @@ public class KeyRangeUnionIterator extends KeyRangeIterator
                 // Consume the remaining values equal to the candidate key:
                 candidate.next();
             }
-            while (candidate.hasNext() && candidate.peek().compareTo(candidateKey) == 0);
+            while (candidate.hasNext() && candidate.peek().compareTo(candidateKey, false) == 0);
         }
 
         return candidateKey;

--- a/src/java/org/apache/cassandra/index/sai/memory/InMemoryKeyRangeIterator.java
+++ b/src/java/org/apache/cassandra/index/sai/memory/InMemoryKeyRangeIterator.java
@@ -70,7 +70,7 @@ public class InMemoryKeyRangeIterator extends KeyRangeIterator
             if (uniqueKeys)
                 return key;
 
-            if (lastKey == null || lastKey.compareTo(key) != 0)
+            if (lastKey == null || lastKey.compareTo(key, false) != 0)
             {
                 next = key;
                 lastKey = key;
@@ -87,7 +87,7 @@ public class InMemoryKeyRangeIterator extends KeyRangeIterator
         while (!keys.isEmpty())
         {
             PrimaryKey key = keys.peek();
-            if (key.compareTo(nextKey) >= 0)
+            if (key.compareTo(nextKey, false) >= 0)
                 break;
 
             // consume smaller key

--- a/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/StorageAttachedIndexSearcher.java
@@ -316,7 +316,7 @@ public class StorageAttachedIndexSearcher implements Index.Searcher
          */
         private boolean isWithinUpperBound(PrimaryKey key)
         {
-            return lastPrimaryKey.token().isMinimum() || lastPrimaryKey.compareTo(key) >= 0;
+            return lastPrimaryKey.token().isMinimum() || lastPrimaryKey.compareTo(key, false) >= 0;
         }
 
         /**

--- a/test/unit/org/apache/cassandra/index/sai/iterators/LongIterator.java
+++ b/test/unit/org/apache/cassandra/index/sai/iterators/LongIterator.java
@@ -63,8 +63,8 @@ public class LongIterator extends KeyRangeIterator
     {
         for ( ; currentIdx < keys.size(); currentIdx++)
         {
-            PrimaryKey token = keys.get(currentIdx);
-            if (token.compareTo(nextKey) >= 0)
+            PrimaryKey key = keys.get(currentIdx);
+            if (key.compareTo(nextKey, false) >= 0)
                 break;
         }
     }

--- a/test/unit/org/apache/cassandra/index/sai/utils/PrimaryKeyTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/utils/PrimaryKeyTest.java
@@ -372,14 +372,9 @@ public class PrimaryKeyTest extends AbstractPrimaryKeyTester
             assertCompareToAndEquals(key, key, 0);
             assertCompareToAndEquals(tokenOnlyKey, tokenOnlyKey, 0);
 
-            // StaticPrimaryKey is a special case. All other keys in the partition are equal to it
-            boolean staticComparison = key.kind() == PrimaryKey.Kind.STATIC;
-            boolean inPartition = staticComparison;
             for (int comparisonIndex = index + 1; comparisonIndex < keys.length; comparisonIndex++)
             {
-                if (staticComparison && keys[comparisonIndex].kind() == PrimaryKey.Kind.STATIC)
-                    inPartition = false;
-                assertCompareToAndEquals(key, keys[comparisonIndex], inPartition ? 0 : -1);
+                assertCompareToAndEquals(key, keys[comparisonIndex], -1);
                 assertCompareToAndEquals(tokenOnlyKey, keys[comparisonIndex], tokenOnlyKey.token().equals(keys[comparisonIndex].token()) ? 0 : -1);
             }
         }


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by David Capwell for CASSANDRA-20238
