### PR TITLE
[CASSANDRA-20249][trunk] Check if properties defined in Config.java but not mentioned in cassandra.yaml/casssandra_latest.yaml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2092,6 +2092,18 @@
 
   </target>
 
+    <target name="config-sync-check" depends="build, build-test"
+            description="Check consistency between Config.java and cassandra.yaml / cassandra_latest.yaml">
+        <taskdef name="configCheck" classname="org.apache.cassandra.anttasks.ConfigCheckTask" classpath="${test.classes}">
+            <classpath>
+                <path refid="cassandra.classpath"/>
+            </classpath>
+        </taskdef>
+        <configCheck configToCheck="${basedir}/conf/cassandra.yaml"/>
+        <configCheck configToCheck="${basedir}/conf/cassandra_latest.yaml"/>
+
+    </target>
+
   <import file="${build.helpers.dir}/build-resolver.xml"/>
   <import file="${build.helpers.dir}/build-rat.xml"/>
   <import file="${build.helpers.dir}/build-owasp.xml"/>

--- a/src/java/org/apache/cassandra/config/HiddenInYaml.java
+++ b/src/java/org/apache/cassandra/config/HiddenInYaml.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation is used to mark particular properties in {@link org.apache.cassandra.config.Config}
+ *   as hidden in cassandra.yaml file.
+ * It means that such properties are ignored during a build-time check
+ * if all properties from Config are declared in cassandra.yaml/cassandra_latest.yaml.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface HiddenInYaml
+{
+}

--- a/test/anttasks/org/apache/cassandra/anttasks/ConfigCheckTask.java
+++ b/test/anttasks/org/apache/cassandra/anttasks/ConfigCheckTask.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.anttasks;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.cassandra.config.Config;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
+public class ConfigCheckTask extends Task
+{
+    private String configToCheck;
+
+    private int failThreshold = Integer.MAX_VALUE;
+
+    public void setConfigToCheck(String configToCheck)
+    {
+        this.configToCheck = configToCheck;
+    }
+
+    public void setFailThreshold(int failThreshold)
+    {
+        this.failThreshold = failThreshold;
+    }
+
+    public void execute()
+    {
+        try
+        {
+            Field[] allFields = Config.class.getFields();
+            List<String> topLevelPropertyNames = new ArrayList<>();
+            for (Field field : allFields)
+            {
+                if (!Modifier.isStatic(field.getModifiers()))
+                {
+                    topLevelPropertyNames.add(field.getName());
+                }
+            }
+
+            List<String> lines = Files.readAllLines(Paths.get(configToCheck));
+
+            int missedCount = 0;
+            log("The following Config.java properties are not described in " + configToCheck);
+            for (String propertyName : topLevelPropertyNames)
+            {
+                Pattern propertyRegexp = Pattern.compile("^#?\\s*" + propertyName + ":.*");
+                boolean found = false;
+                for (String line : lines)
+                {
+                    if (propertyRegexp.matcher(line).find())
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    missedCount++;
+                    log(propertyName);
+                }
+            }
+            log("Total missed properties: " + missedCount);
+            if (missedCount > failThreshold)
+                throw new BuildException(missedCount + " properties are not described in " + configToCheck);
+        } catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/anttasks/org/apache/cassandra/anttasks/ConfigCheckTask.java
+++ b/test/anttasks/org/apache/cassandra/anttasks/ConfigCheckTask.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.HiddenInYaml;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
@@ -54,7 +55,8 @@ public class ConfigCheckTask extends Task
             List<String> topLevelPropertyNames = new ArrayList<>();
             for (Field field : allFields)
             {
-                if (!Modifier.isStatic(field.getModifiers()))
+                if (!Modifier.isStatic(field.getModifiers())
+                    && field.getAnnotation(HiddenInYaml.class) == null)
                 {
                     topLevelPropertyNames.add(field.getName());
                 }
@@ -63,7 +65,7 @@ public class ConfigCheckTask extends Task
             List<String> lines = Files.readAllLines(Paths.get(configToCheck));
 
             int missedCount = 0;
-            log("The following Config.java properties are not described in " + configToCheck);
+            log("The following Config.java properties are not described in " + configToCheck + ':');
             for (String propertyName : topLevelPropertyNames)
             {
                 Pattern propertyRegexp = Pattern.compile("^#?\\s*" + propertyName + ":.*");


### PR DESCRIPTION
Add an ant target to check if properties defined in Config.java but not mentioned in cassandra.yaml/casssandra_latest.yaml

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20249