### PR TITLE
  Fix 0xe299233a8efdcefd seed for ShortAccordSimulationTest

### DIFF
--- a/src/java/org/apache/cassandra/service/accord/serializers/LatestDepsSerializers.java
+++ b/src/java/org/apache/cassandra/service/accord/serializers/LatestDepsSerializers.java
@@ -44,6 +44,9 @@ public class LatestDepsSerializers
         public void serialize(LatestDeps t, DataOutputPlus out, int version) throws IOException
         {
             out.writeUnsignedVInt32(t.size());
+            if (t.size() == 0)
+                return;
+
             for (int i = 0 ; i < t.size() ; ++i)
             {
                 RoutingKey start = t.startAt(i);
@@ -68,6 +71,9 @@ public class LatestDepsSerializers
         public LatestDeps deserialize(DataInputPlus in, int version) throws IOException
         {
             int size = in.readUnsignedVInt32();
+            if (size == 0)
+                return LatestDeps.EMPTY;
+
             RoutingKey[] starts = new RoutingKey[size + 1];
             LatestDeps.LatestEntry[] values = new LatestDeps.LatestEntry[size];
             for (int i = 0 ; i < size ; ++i)
@@ -92,6 +98,8 @@ public class LatestDepsSerializers
         {
             long size = 0;
             size += TypeSizes.sizeofUnsignedVInt(t.size());
+            if (t.size() == 0)
+                return size;
             for (int i = 0 ; i < t.size() ; ++i)
             {
                 RoutingKey start = t.startAt(i);

--- a/test/unit/org/apache/cassandra/service/accord/serializers/LatestDepsSerializerTest.java
+++ b/test/unit/org/apache/cassandra/service/accord/serializers/LatestDepsSerializerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service.accord.serializers;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import accord.primitives.LatestDeps;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.io.util.DataInputBuffer;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+
+import org.apache.cassandra.net.MessagingService.Version;
+
+import static org.apache.cassandra.net.MessagingService.Version.VERSION_51;
+
+public class LatestDepsSerializerTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.clientInitialization();
+        DatabaseDescriptor.setPartitionerUnsafe(Murmur3Partitioner.instance);
+    }
+
+    private static final List<Version> SUPPORTED_VERSIONS = VERSION_51.greaterThanOrEqual();
+
+    @Test
+    public void emptySerializerTest() throws Throwable
+    {
+        for (Version ver : SUPPORTED_VERSIONS)
+        {
+            ByteBuffer bb = null;
+            try (DataOutputBuffer buf = new DataOutputBuffer())
+            {
+                long expected = LatestDepsSerializers.latestDeps.serializedSize(LatestDeps.EMPTY, ver.value);
+                LatestDepsSerializers.latestDeps.serialize(LatestDeps.EMPTY, buf, ver.value);
+                bb = buf.asNewBuffer();
+                Assert.assertEquals(expected, bb.capacity());
+            }
+
+            try (DataInputBuffer in = new DataInputBuffer(bb, false))
+            {
+                LatestDeps roundTrip = LatestDepsSerializers.latestDeps.deserialize(in, ver.value);
+                Assert.assertEquals(roundTrip, LatestDeps.EMPTY);
+            }
+        }
+    }
+}


### PR DESCRIPTION
   Failed on seed 0xe299233a8efdcefd-org.apache.cassandra.simulator.SimulationException: Failed on seed 0xe299233a8efdcefd Caused by: java.lang.AssertionError: Saw errors in node1: Unexpected exception: ERROR [AccordExecutor[1,4]:1] node1 2025-01-24 11:56:59,628 Uncaught accord exception java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0 at accord.utils.ReducingIntervalMap.startAt(ReducingIntervalMap.java:169) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$1.serializedSize(LatestDepsSerializers.java:111) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$1.serializedSize(LatestDepsSerializers.java:41) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$3.serializedSize(LatestDepsSerializers.java:155) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$3.serializedSize(LatestDepsSerializers.java:139) at org.apache.cassandra.net.Message$Serializer.payloadSize(Message.java:1250) at org.apache.cassandra.net.Message.payloadSize(Message.java:1307) at org.apache.cassandra.net.Message$Serializer.serialize(Message.java:877) at org.apache.cassandra.distributed.impl.Instance.serializeMessage(Instance.java:456) at org.apache.cassandra.distributed.impl.Instance.lambda$registerOutboundFilter$5(Instance.java:398) at org.apache.cassandra.net.OutboundSink$Filtered.accept(OutboundSink.java:54) at org.apache.cassandra.net.OutboundSink.accept(OutboundSink.java:70) at org.apache.cassandra.net.MessagingService.send(MessagingService.java:536) at org.apache.cassandra.net.MessagingService.send(MessagingService.java:474) at org.apache.cassandra.service.accord.AccordMessageSink.reply(AccordMessageSink.java:318) at accord.local.Node.reply(Node.java:680) at accord.messages.AbstractRequest.acceptInternal(AbstractRequest.java:112) at accord.messages.AbstractRequest.accept(AbstractRequest.java:102) at accord.messages.AbstractRequest.accept(AbstractRequest.java:36) at org.apache.cassandra.service.accord.AccordTask.finish(AccordTask.java:792) at org.apache.cassandra.service.accord.AccordTask.lambda$run$2(AccordTask.java:685) at org.apache.cassandra.service.accord.AccordJournal.saveCommand(AccordJournal.java:290) at org.apache.cassandra.service.accord.AccordCommandStore.appendCommands(AccordCommandStore.java:443) at org.apache.cassandra.service.accord.AccordTask.save(AccordTask.java:627) at org.apache.cassandra.service.accord.AccordTask.run(AccordTask.java:689) at org.apache.cassandra.service.accord.AccordExecutor$CommandStoreQueueTask.run(AccordExecutor.java:741) at org.apache.cassandra.service.accord.AccordExecutorAbstractLockLoop.runWithoutLock(AccordExecutorAbstractLockLoop.java:249) at org.apache.cassandra.concurrent.InfiniteLoopExecutor.loop(InfiniteLoopExecutor.java:125) at org.apache.cassandra.simulator.systems.InterceptedExecution$InterceptedThreadStart.run(InterceptedExecution.java:216) at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) at java.base/java.lang.Thread.run(Thread.java:829) Unexpected exception: ERROR [AccordExecutor[1,4]:1] node1 2025-01-24 11:56:59,629 Exception in thread Thread[AccordExecutor[1,4]:1,5,node1] org.apache.cassandra.service.accord.AccordExecutorAbstractSemiSyncSubmit$$Lambda$2172/0x0000000840db5440@31e49a0b java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0 at accord.utils.ReducingIntervalMap.startAt(ReducingIntervalMap.java:169) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$1.serializedSize(LatestDepsSerializers.java:111) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$1.serializedSize(LatestDepsSerializers.java:41) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$3.serializedSize(LatestDepsSerializers.java:155) at org.apache.cassandra.service.accord.serializers.LatestDepsSerializers$3.serializedSize(LatestDepsSerializers.java:139) at org.apache.cassandra.net.Message$Serializer.payloadSize(Message.java:1250) at org.apache.cassandra.net.Message.payloadSize(Message.java:1307) at org.apache.cassandra.net.Message$Serializer.serialize(Message.java:877) at org.apache.cassandra.distributed.impl.Instance.serializeMessage(Instance.java:456) at org.apache.cassandra.distributed.impl.Instance.lambda$registerOutboundFilter$5(Instance.java:398) at org.apache.cassandra.net.OutboundSink$Filtered.accept(OutboundSink.java:54) at org.apache.cassandra.net.OutboundSink.accept(OutboundSink.java:70) at org.apache.cassandra.net.MessagingService.send(MessagingService.java:536) at org.apache.cassandra.net.MessagingService.send(MessagingService.java:474) at org.apache.cassandra.service.accord.AccordMessageSink.reply(AccordMessageSink.java:318) at accord.local.Node.reply(Node.java:680) at accord.messages.AbstractRequest.acceptInternal(AbstractRequest.java:112) at accord.messages.AbstractRequest.accept(AbstractRequest.java:102) at accord.messages.AbstractRequest.accept(AbstractRequest.java:36) at org.apache.cassandra.service.accord.AccordTask.finish(AccordTask.java:792) at org.apache.cassandra.service.accord.AccordTask.lambda$run$2(AccordTask.java:685) at org.apache.cassandra.service.accord.AccordJournal.saveCommand(AccordJournal.java:290) at org.apache.cassandra.service.accord.AccordCommandStore.appendCommands(AccordCommandStore.java:443) at org.apache.cassandra.service.accord.AccordTask.save(AccordTask.java:627) at org.apache.cassandra.service.accord.AccordTask.run(AccordTask.java:689) at org.apache.cassandra.service.accord.AccordExecutor$CommandStoreQueueTask.run(AccordExecutor.java:741) at org.apache.cassandra.service.accord.AccordExecutorAbstractLockLoop.runWithoutLock(AccordExecutorAbstractLockLoop.java:249) at org.apache.cassandra.concurrent.InfiniteLoopExecutor.loop(InfiniteLoopExecutor.java:125) at org.apache.cassandra.simulator.systems.InterceptedExecution$InterceptedThreadStart.run(InterceptedExecution.java:216) at

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

