### PR TITLE
CASSANDRA-20175 4.1 cqlsh autocompletion for role names/user names is broken

### DIFF
--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -1481,9 +1481,9 @@ syntax_rules += r'''
 '''
 
 syntax_rules += r'''
-<rolename> ::= <identifier>
+<rolename> ::= role=( <identifier>
              | <quotedName>
-             | <unreservedKeyword>
+             | <unreservedKeyword> )
              ;
 
 <createRoleStatement> ::= "CREATE" "ROLE" ( "IF" "NOT" "EXISTS" )? <rolename>
@@ -1584,32 +1584,22 @@ def permission_completer(ctxt, _):
 
 @completer_for('username', 'name')
 def username_name_completer(ctxt, cass):
-    def maybe_quote(name):
-        if CqlRuleSet.is_valid_cql3_name(name):
-            return name
-        return "'%s'" % name
-
     # disable completion for CREATE USER.
     if ctxt.matched[0][1].upper() == 'CREATE':
         return [Hint('<username>')]
 
     session = cass.session
-    return [maybe_quote(list(row.values())[0].replace("'", "''")) for row in session.execute("LIST USERS")]
+    return map(maybe_escape_name, [row['name'] for row in session.execute("LIST USERS")])
 
 
 @completer_for('rolename', 'role')
 def rolename_completer(ctxt, cass):
-    def maybe_quote(name):
-        if CqlRuleSet.is_valid_cql3_name(name):
-            return name
-        return "'%s'" % name
-
     # disable completion for CREATE ROLE.
     if ctxt.matched[0][1].upper() == 'CREATE':
         return [Hint('<rolename>')]
 
     session = cass.session
-    return [maybe_quote(row[0].replace("'", "''")) for row in session.execute("LIST ROLES")]
+    return map(maybe_escape_name, [row['role'] for row in session.execute("LIST ROLES")])
 
 
 syntax_rules += r'''

--- a/pylib/cqlshlib/test/test_cqlsh_completion.py
+++ b/pylib/cqlshlib/test/test_cqlsh_completion.py
@@ -950,6 +950,10 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_alter_user(self):
         self.trycompletions('ALTER USER ', choices=['<identifier>', 'IF', '<pgStringLiteral>', '<quotedStringLiteral>'])
 
+    def test_complete_in_create_role(self):
+        self.trycompletions('CREATE ROLE ', choices=['<rolename>', 'IF'])
+        self.trycompletions('CREATE ROLE IF ', immediate='NOT EXISTS ')
+
     def test_complete_in_alter_role(self):
         self.trycompletions('ALTER ROLE ', choices=['<identifier>', 'IF', '<quotedName>'])
         self.trycompletions('ALTER ROLE IF ', immediate='EXISTS ')
@@ -957,7 +961,3 @@ class TestCqlshCompletion(CqlshCompletionCase):
     def test_complete_in_create_user(self):
         self.trycompletions('CREATE USER ', choices=['<username>', 'IF'])
         self.trycompletions('CREATE USER IF ', immediate='NOT EXISTS ')
-
-    def test_complete_in_create_role(self):
-        self.trycompletions('CREATE ROLE ', choices=['<identifier>', '<quotedName>', 'IF'])
-        self.trycompletions('CREATE ROLE IF ', immediate='NOT EXISTS ')


### PR DESCRIPTION
Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

