### PR TITLE
Fix paging with Accord range reads

### DIFF
--- a/src/java/org/apache/cassandra/service/accord/txn/TxnNamedRead.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnNamedRead.java
@@ -105,10 +105,11 @@ public class TxnNamedRead extends AbstractSerialized<ReadCommand>
         PartitionPosition startPP = range.left;
         boolean startIsMinKeyBound = startPP.getClass() == KeyBound.class ? ((KeyBound)startPP).isMinimumBound : false;
         Token startToken = startPP.getToken();
+        Token stopToken = range.right.getToken();
         AccordRoutingKey startAccordRoutingKey;
         if (startToken.isMinimum() && inclusiveLeft)
             startAccordRoutingKey = SentinelKey.min(tableId);
-        else if (inclusiveLeft || startIsMinKeyBound)
+        else if (inclusiveLeft || startIsMinKeyBound || startToken.equals(stopToken))
             startAccordRoutingKey = new MinTokenKey(tableId, startToken);
         else
             startAccordRoutingKey = new TokenKey(tableId, startToken);
@@ -116,7 +117,6 @@ public class TxnNamedRead extends AbstractSerialized<ReadCommand>
         boolean inclusiveRight = range.inclusiveRight();
         PartitionPosition endPP = range.right;
         boolean endIsMinKeyBound = endPP.getClass() == KeyBound.class ? ((KeyBound)endPP).isMinimumBound : false;
-        Token stopToken = range.right.getToken();
         AccordRoutingKey stopAccordRoutingKey;
         if (stopToken.isMinimum())
             stopAccordRoutingKey = SentinelKey.max(tableId);

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/InteropTokenRangeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/InteropTokenRangeTest.java
@@ -40,7 +40,7 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ICoordinator;
-import org.apache.cassandra.distributed.api.SimpleQueryResult;
+import org.apache.cassandra.distributed.api.QueryResult;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.service.consensus.TransactionalMode;
 import org.assertj.core.api.Assertions;
@@ -93,6 +93,10 @@ public class InteropTokenRangeTest extends TestBaseImpl
                     Assertions.assertThat(tokens(node.executeWithResult(withKeyspace("SELECT * FROM %s.tbl WHERE " + op.condition), QUORUM, pk)))
                               .describedAs("Token %d with operator %s", token, op.condition)
                               .isEqualTo(op.expected(token, tokens));
+
+                    Assertions.assertThat(tokens(node.executeWithPagingWithResult(withKeyspace("SELECT * FROM %s.tbl WHERE " + op.condition), QUORUM, 1, pk)))
+                              .describedAs("Token %d with operator %s", token, op.condition)
+                              .isEqualTo(op.expected(token, tokens));
                 }
 
                 for (TokenOperator lt : Arrays.asList(TokenOperator.lt, TokenOperator.lte))
@@ -112,7 +116,7 @@ public class InteropTokenRangeTest extends TestBaseImpl
         }
     }
 
-    public static NavigableSet<Long> tokens(SimpleQueryResult result)
+    public static NavigableSet<Long> tokens(QueryResult result)
     {
         NavigableSet<Long> set = new TreeSet<>();
         while (result.hasNext())


### PR DESCRIPTION
With paging it's possible for the range Accord needs to read from to have the start and end token be the same in which case the LHS token needs to be converted to a MinTokenKey

Patch by Ariel Weisberg; Reviewed by David Capwell for CASSANDRA-20262