### PR TITLE
CASSANDRA-20258 Avoid under-skipping during intersections when an iterator has mixed STATIC and WIDE keys

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -128,6 +128,7 @@
  * Add the ability to disable bulk loading of SSTables (CASSANDRA-18781)
  * Clean up obsolete functions and simplify cql_version handling in cqlsh (CASSANDRA-18787)
 Merged from 5.0:
+ * Avoid underskipping during intersections when an iterator has mixed STATIC and WIDE keys (CASSANDRA-20258)
  * Correct the default behavior of compareTo() when comparing WIDE and STATIC PrimaryKeys (CASSANDRA-20238)
  * Make sure we can set parameters when configuring CassandraCIDRAuthorizer (CASSANDRA-20220)
  * Add selected SAI index state and query performance metrics to nodetool tablestats (CASSANDRA-20026)

--- a/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
+++ b/src/java/org/apache/cassandra/index/sai/StorageAttachedIndexGroup.java
@@ -176,8 +176,10 @@ public class StorageAttachedIndexGroup implements Index.Group, INotificationCons
             @Override
             public void insertRow(Row row)
             {
-                for (Index.Indexer indexer : indexers)
-                    indexer.insertRow(row);
+                // SAI does not index deletions, as these are resolved during post-filtering.
+                if (row.deletion().isLive())
+                    for (Index.Indexer indexer : indexers)
+                        indexer.insertRow(row);
             }
 
             @Override


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by David Capwell for CASSANDRA-20258