### PR TITLE
In-jvm dtest flush should run on instance instead of calling thread

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -554,7 +554,10 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
 
     public void flush(String keyspace)
     {
-        Util.flushKeyspace(keyspace);
+        sync(() -> {
+            inInstancelogger.info("In-jvm dtest flushing keyspace {}", keyspace);
+            Util.flushKeyspace(keyspace);
+        }).run();
     }
 
     public void forceCompact(String keyspace, String table)


### PR DESCRIPTION
See [CASSANDRA-20290](https://issues.apache.org/jira/browse/CASSANDRA-20290)

