### PR TITLE
[CASSANDRA-20298][5.0] Wait for completion of async dumpMemtable logic to avoid pathological test behaviour 

### DIFF
--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogCQLTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogCQLTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.utils.FBUtilities;
 
 public class CommitLogCQLTest extends CQLTester
 {
@@ -89,7 +90,7 @@ public class CommitLogCQLTest extends CQLTester
                             {
                                 QueryProcessor.executeInternal(stmt, i, Integer.toString(i));
                             }
-                            cfs.dumpMemtable();
+                            FBUtilities.waitOnFuture(cfs.dumpMemtable());
                         }
                     }
                     catch (Throwable t)


### PR DESCRIPTION
Wait for completion of async dumpMemtable logic to avoid pathological test behaviour when an abnormal amount of memtables are flushing for the same table

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20298

