### PR TITLE
Invalidate affected prepared stmts on every metadata change

### DIFF
--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -668,19 +668,14 @@ public class TableMetadata implements SchemaElement
     }
 
     /**
-     * @return true if the change as made impacts queries/updates on the table,
-     *         e.g. any columns or indexes were added, removed, or altered; otherwise, false is returned.
+     * @return true if the change as made impacts queries/updates on the table, effectively this is
+     *              true if the metadata has changed in any way, as replicas compare metadata epochs
+     *              when performing reads & writes.
      *         Used to determine whether prepared statements against this table need to be re-prepared.
      */
     boolean changeAffectsPreparedStatements(TableMetadata updated)
     {
-        return !partitionKeyColumns.equals(updated.partitionKeyColumns)
-            || !clusteringColumns.equals(updated.clusteringColumns)
-            || !regularAndStaticColumns.equals(updated.regularAndStaticColumns)
-            || !indexes.equals(updated.indexes)
-            || params.defaultTimeToLive != updated.params.defaultTimeToLive
-            || params.gcGraceSeconds != updated.params.gcGraceSeconds
-            || ( !Flag.isCQLTable(flags) && Flag.isCQLTable(updated.flags) );
+        return epoch.isBefore(updated.epoch);
     }
 
     /**

--- a/src/java/org/apache/cassandra/schema/Views.java
+++ b/src/java/org/apache/cassandra/schema/Views.java
@@ -68,6 +68,11 @@ public final class Views implements Iterable<ViewMetadata>
         return NONE;
     }
 
+    public static Views of(Iterable<ViewMetadata> views)
+    {
+        return builder().put(views).build();
+    }
+
     public Iterator<ViewMetadata> iterator()
     {
         return views.values().iterator();
@@ -232,7 +237,7 @@ public final class Views implements Iterable<ViewMetadata>
         return ViewsDiff.diff(before, after);
     }
 
-    static final class ViewsDiff extends Diff<Views, ViewMetadata>
+    public static final class ViewsDiff extends Diff<Views, ViewMetadata>
     {
         private static final ViewsDiff NONE = new ViewsDiff(Views.none(), Views.none(), ImmutableList.of());
 

--- a/test/distributed/org/apache/cassandra/distributed/test/PreparedStatementInvalidationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/PreparedStatementInvalidationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.Test;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import org.apache.cassandra.distributed.api.ICluster;
+import org.apache.cassandra.distributed.api.IInvokableInstance;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+public class PreparedStatementInvalidationTest extends TestBaseImpl
+{
+    @Test
+    public void testInvalidation() throws Exception
+    {
+        try (ICluster<IInvokableInstance> c = init(builder().withNodes(2)
+                                                            .withConfig(config -> config.with(GOSSIP, NETWORK, NATIVE_PROTOCOL))
+                                                            .start()))
+        {
+            try (com.datastax.driver.core.Cluster cluster = com.datastax.driver.core.Cluster.builder()
+                                                                                            .addContactPoint("127.0.0.1")
+                                                                                            .build();
+                 Session s = cluster.connect())
+            {
+                s.execute(withKeyspace("CREATE TABLE %s.tbl (pk int primary key)"));
+                PreparedStatement prepared = s.prepare(withKeyspace("select pk from %s.tbl where pk = ?"));
+                s.execute(prepared.bind(1));
+                s.execute(withKeyspace("alter table %s.tbl with speculative_retry='none'"));
+                s.execute(prepared.bind(2));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Where MVs are also affected by a table alteration make sure we correctly set the epoch of the TableMetadata enclosed in the ViewMetadata

Patch by Sam Tunnicliffe and Marcus Eriksson; reviewed by XXX for CASSANDRA-20318

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

