### PR TITLE
[CASSANDRA-20251][trunk] Fix flaky ReadSpeculationTest

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -713,6 +713,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
             startJmx();
         LoggingSupportFactory.getLoggingSupport().onStartup();
         logSystemInfo(inInstancelogger);
+        Config.log(DatabaseDescriptor.getRawConfig());
 
         FileUtils.setFSErrorHandler(new DefaultFSErrorHandler());
         DatabaseDescriptor.createAllDirectories();


### PR DESCRIPTION
Fix flaky ReadSpeculationTest: with TCM the second replica in a read plan can be different, it depends on an order of adding nodes to a cluster. The test is adjusted to use the actual information from a read plan to emulate network connectivity issues for the right node.

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20251
