### PR TITLE
CASSANDRA-20357- Avoids using mutable object for constraints

### DIFF
--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -989,7 +989,7 @@ alterTableStatement returns [AlterTableStatement.Raw stmt]
       | K_ALTER ( K_IF K_EXISTS { $stmt.ifColumnExists(true); } )? id=cident
               ( mask=columnMask { $stmt.mask(id, mask); }
               | K_DROP K_MASKED { $stmt.mask(id, null); }
-              | K_DROP K_CHECK { $stmt.dropConstraints(id); }
+              | K_DROP K_CHECK { $stmt.alterConstraints(id, null); }
               | (constraints=columnConstraints) { $stmt.alterConstraints(id, constraints); })
 
       | K_ADD ( K_IF K_NOT K_EXISTS { $stmt.ifColumnNotExists(true); } )?

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -989,8 +989,8 @@ alterTableStatement returns [AlterTableStatement.Raw stmt]
       | K_ALTER ( K_IF K_EXISTS { $stmt.ifColumnExists(true); } )? id=cident
               ( mask=columnMask { $stmt.mask(id, mask); }
               | K_DROP K_MASKED { $stmt.mask(id, null); }
-              | K_DROP K_CHECK { $stmt.alterConstraints(id, null); }
-              | (constraints=columnConstraints) { $stmt.alterConstraints(id, constraints); })
+              | K_DROP K_CHECK { $stmt.constraint(id, null); }
+              | (constraints=columnConstraints) { $stmt.constraint(id, constraints); })
 
       | K_ADD ( K_IF K_NOT K_EXISTS { $stmt.ifColumnNotExists(true); } )?
               (        id=ident  v=comparatorType  b=isStaticColumn (m=columnMask)? { $stmt.add(id,  v,  b, m);  }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -739,9 +739,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     public static class AlterConstraints extends AlterTableStatement
     {
         final ColumnIdentifier columnName;
-        final ColumnConstraints constraints;
+        final ColumnConstraints.Raw constraints;
 
-        AlterConstraints(String keyspaceName, String tableName, boolean ifTableExists, ColumnIdentifier columnName, ColumnConstraints constraints)
+        AlterConstraints(String keyspaceName, String tableName, boolean ifTableExists, ColumnIdentifier columnName, ColumnConstraints.Raw constraints)
         {
             super(keyspaceName, tableName, ifTableExists);
             this.columnName = columnName;
@@ -751,24 +751,25 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         @Override
         public KeyspaceMetadata apply(Epoch epoch, KeyspaceMetadata keyspace, TableMetadata table, ClusterMetadata metadata)
         {
-            TableMetadata.Builder tableBuilder = table.unbuild().epoch(epoch);
-
-            for (ColumnMetadata column : tableBuilder.columns())
+            for (ColumnMetadata column : table.columns())
             {
                 if (column.name == columnName)
                 {
-                    constraints.validate(column);
-                    column.setColumnConstraints(constraints);
-                    break;
+                    ColumnConstraints oldConstraints = column.getColumnConstraints();
+                    ColumnConstraints newConstraints = constraints == null ? ColumnConstraints.NO_OP : constraints.prepare();
+                    if (Objects.equals(oldConstraints, newConstraints))
+                        return keyspace;
+                    newConstraints.validate(column);
+                    TableMetadata.Builder tableBuilder = table.unbuild().epoch(epoch);
+                    tableBuilder.alterColumnConstraints(columnName, newConstraints);
+
+                    TableMetadata newTable = tableBuilder.build();
+                    newTable.validate();
+
+                    return keyspace.withSwapped(keyspace.tables.withSwapped(newTable));
                 }
             }
-
-            Views.Builder viewsBuilder = keyspace.views.unbuild();
-            TableMetadata tableMetadata = tableBuilder.build();
-            tableMetadata.validate();
-
-            return keyspace.withSwapped(keyspace.tables.withSwapped(tableMetadata))
-                           .withSwapped(viewsBuilder.build());
+            return keyspace;
         }
     }
 
@@ -783,7 +784,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             RENAME_COLUMNS,
             ALTER_OPTIONS,
             DROP_COMPACT_STORAGE,
-            DROP_CONSTRAINTS,
             ALTER_CONSTRAINTS
         }
 
@@ -792,7 +792,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         private boolean ifColumnExists;
         private boolean ifColumnNotExists;
         private ColumnIdentifier constraintName;
-        private ColumnConstraints constraints;
+        private ColumnConstraints.Raw constraints;
 
         private Kind kind;
 
@@ -839,7 +839,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                 case        RENAME_COLUMNS: return new RenameColumns(keyspaceName, tableName, renamedColumns, ifTableExists, ifColumnExists);
                 case         ALTER_OPTIONS: return new AlterOptions(keyspaceName, tableName, attrs, ifTableExists);
                 case  DROP_COMPACT_STORAGE: return new DropCompactStorage(keyspaceName, tableName, ifTableExists);
-                case      DROP_CONSTRAINTS: return new DropConstraints(keyspaceName, tableName, ifTableExists, constraintName);
                 case     ALTER_CONSTRAINTS: return new AlterConstraints(keyspaceName, tableName, ifTableExists, constraintName, constraints);
             }
 
@@ -885,17 +884,11 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             kind = Kind.DROP_COMPACT_STORAGE;
         }
 
-        public void dropConstraints(ColumnIdentifier name)
-        {
-            kind = Kind.DROP_CONSTRAINTS;
-            this.constraintName = name;
-        }
-
         public void alterConstraints(ColumnIdentifier name, ColumnConstraints.Raw rawConstraints)
         {
             kind = Kind.ALTER_CONSTRAINTS;
             this.constraintName = name;
-            this.constraints = rawConstraints.prepare();
+            this.constraints = rawConstraints;
         }
 
         public void timestamp(long timestamp)

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -714,17 +714,20 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
     {
         final ColumnIdentifier columnName;
         final ColumnConstraints.Raw constraints;
+        final boolean ifColumnExists;
 
-        AlterConstraints(String keyspaceName, String tableName, boolean ifTableExists, ColumnIdentifier columnName, ColumnConstraints.Raw constraints)
+        AlterConstraints(String keyspaceName, String tableName, boolean ifTableExists, boolean ifColumnExists, ColumnIdentifier columnName, ColumnConstraints.Raw constraints)
         {
             super(keyspaceName, tableName, ifTableExists);
             this.columnName = columnName;
             this.constraints = constraints;
+            this.ifColumnExists = ifColumnExists;
         }
 
         @Override
         public KeyspaceMetadata apply(Epoch epoch, KeyspaceMetadata keyspace, TableMetadata table, ClusterMetadata metadata)
         {
+
             if (table.containtsColumn(columnName))
             {
                 ColumnMetadata column = table.getColumn(columnName);
@@ -740,6 +743,11 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                 newTable.validate();
 
                 return keyspace.withSwapped(keyspace.tables.withSwapped(newTable));
+            }
+            else
+            {
+                if (!ifColumnExists)
+                    throw ire("Column '%s' doesn't exist", columnName);
             }
             return keyspace;
         }
@@ -811,7 +819,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                 case        RENAME_COLUMNS: return new RenameColumns(keyspaceName, tableName, renamedColumns, ifTableExists, ifColumnExists);
                 case         ALTER_OPTIONS: return new AlterOptions(keyspaceName, tableName, attrs, ifTableExists);
                 case  DROP_COMPACT_STORAGE: return new DropCompactStorage(keyspaceName, tableName, ifTableExists);
-                case     ALTER_CONSTRAINTS: return new AlterConstraints(keyspaceName, tableName, ifTableExists, constraintName, constraints);
+                case     ALTER_CONSTRAINTS: return new AlterConstraints(keyspaceName, tableName, ifTableExists, ifColumnExists, constraintName, constraints);
             }
 
             throw new AssertionError();
@@ -856,7 +864,7 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             kind = Kind.DROP_COMPACT_STORAGE;
         }
 
-        public void alterConstraints(ColumnIdentifier name, ColumnConstraints.Raw rawConstraints)
+        public void constraint(ColumnIdentifier name, ColumnConstraints.Raw rawConstraints)
         {
             kind = Kind.ALTER_CONSTRAINTS;
             this.constraintName = name;

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -728,9 +728,9 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         public KeyspaceMetadata apply(Epoch epoch, KeyspaceMetadata keyspace, TableMetadata table, ClusterMetadata metadata)
         {
 
-            if (table.containtsColumn(columnName))
+            ColumnMetadata column = table.getColumn(columnName);
+            if (column != null)
             {
-                ColumnMetadata column = table.getColumn(columnName);
                 ColumnConstraints oldConstraints = column.getColumnConstraints();
                 ColumnConstraints newConstraints = constraints == null ? ColumnConstraints.NO_OP : constraints.prepare();
                 if (Objects.equals(oldConstraints, newConstraints))

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -725,7 +725,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         @Override
         public KeyspaceMetadata apply(Epoch epoch, KeyspaceMetadata keyspace, TableMetadata table, ClusterMetadata metadata)
         {
-
             if (table.containtsColumn(columnName))
             {
                 ColumnMetadata column = table.getColumn(columnName);

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -710,32 +710,6 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         }
     }
 
-    public static class DropConstraints extends AlterTableStatement
-    {
-        final ColumnIdentifier columnName;
-
-        DropConstraints(String keyspaceName, String tableName, boolean ifTableExists, ColumnIdentifier columnName)
-        {
-            super(keyspaceName, tableName, ifTableExists);
-            this.columnName = columnName;
-        }
-
-        @Override
-        public KeyspaceMetadata apply(Epoch epoch, KeyspaceMetadata keyspace, TableMetadata table, ClusterMetadata metadata)
-        {
-            ColumnMetadata columnMetadata = table.getColumn(columnName);
-            columnMetadata.removeColumnConstraints();
-
-            TableMetadata.Builder tableBuilder = table.unbuild().epoch(epoch);
-            Views.Builder viewsBuilder = keyspace.views.unbuild();
-            TableMetadata tableMetadata = tableBuilder.build();
-            tableMetadata.validate();
-
-            return keyspace.withSwapped(keyspace.tables.withSwapped(tableMetadata))
-                           .withSwapped(viewsBuilder.build());
-        }
-    }
-
     public static class AlterConstraints extends AlterTableStatement
     {
         final ColumnIdentifier columnName;
@@ -751,23 +725,22 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
         @Override
         public KeyspaceMetadata apply(Epoch epoch, KeyspaceMetadata keyspace, TableMetadata table, ClusterMetadata metadata)
         {
-            for (ColumnMetadata column : table.columns())
+
+            if (table.containtsColumn(columnName))
             {
-                if (column.name == columnName)
-                {
-                    ColumnConstraints oldConstraints = column.getColumnConstraints();
-                    ColumnConstraints newConstraints = constraints == null ? ColumnConstraints.NO_OP : constraints.prepare();
-                    if (Objects.equals(oldConstraints, newConstraints))
-                        return keyspace;
-                    newConstraints.validate(column);
-                    TableMetadata.Builder tableBuilder = table.unbuild().epoch(epoch);
-                    tableBuilder.alterColumnConstraints(columnName, newConstraints);
+                ColumnMetadata column = table.getColumn(columnName);
+                ColumnConstraints oldConstraints = column.getColumnConstraints();
+                ColumnConstraints newConstraints = constraints == null ? ColumnConstraints.NO_OP : constraints.prepare();
+                if (Objects.equals(oldConstraints, newConstraints))
+                    return keyspace;
+                newConstraints.validate(column);
+                TableMetadata.Builder tableBuilder = table.unbuild().epoch(epoch);
+                tableBuilder.alterColumnConstraints(columnName, newConstraints);
 
-                    TableMetadata newTable = tableBuilder.build();
-                    newTable.validate();
+                TableMetadata newTable = tableBuilder.build();
+                newTable.validate();
 
-                    return keyspace.withSwapped(keyspace.tables.withSwapped(newTable));
-                }
+                return keyspace.withSwapped(keyspace.tables.withSwapped(newTable));
             }
             return keyspace;
         }

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -348,16 +348,14 @@ public final class CreateTableStatement extends AlterSchemaStatement
         {
             ColumnProperties properties = partitionKeyColumnProperties.get(i);
             ColumnIdentifier columnIdentifier = partitionKeyColumns.get(i);
-            builder.addPartitionKeyColumn(columnIdentifier, properties.type, properties.mask);
-            builder.getColumn(columnIdentifier).setColumnConstraints(columnConstraints.get(columnIdentifier));
+            builder.addPartitionKeyColumn(columnIdentifier, properties.type, properties.mask, columnConstraints.get(columnIdentifier));
         }
 
         for (int i = 0; i < clusteringColumns.size(); i++)
         {
             ColumnProperties properties = clusteringColumnProperties.get(i);
             ColumnIdentifier columnIdentifier = clusteringColumns.get(i);
-            builder.addClusteringColumn(columnIdentifier, properties.type, properties.mask);
-            builder.getColumn(columnIdentifier).setColumnConstraints(columnConstraints.get(columnIdentifier));
+            builder.addClusteringColumn(columnIdentifier, properties.type, properties.mask, columnConstraints.get(columnIdentifier));
         }
 
         if (useCompactStorage)
@@ -368,13 +366,11 @@ public final class CreateTableStatement extends AlterSchemaStatement
         {
             columns.forEach((column, properties) -> {
                 if (staticColumns.contains(column))
-                    builder.addStaticColumn(column, properties.type, properties.mask);
+                    builder.addStaticColumn(column, properties.type, properties.mask, columnConstraints.get(column));
                 else
-                    builder.addRegularColumn(column, properties.type, properties.mask);
+                    builder.addRegularColumn(column, properties.type, properties.mask, columnConstraints.get(column));
             });
         }
-
-        columns.keySet().forEach(id -> builder.getColumn(id).setColumnConstraints(columnConstraints.get(id)));
 
         return builder;
     }

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -363,9 +363,14 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         return columnConstraints;
     }
 
+    public ColumnConstraints setColumnConstraints()
+    {
+        return columnConstraints;
+    }
+
     public ColumnMetadata withNewColumnConstraints(ColumnConstraints constraints)
     {
-        constraints.checkInvalidConstraintsCombinations(name);
+        constraints.validate(this);
         return new ColumnMetadata(ksName, cfName, name, type, position, kind, mask, constraints);
     }
 

--- a/src/java/org/apache/cassandra/schema/ColumnMetadata.java
+++ b/src/java/org/apache/cassandra/schema/ColumnMetadata.java
@@ -363,10 +363,10 @@ public final class ColumnMetadata extends ColumnSpecification implements Selecta
         return columnConstraints;
     }
 
-    public void setColumnConstraints(ColumnConstraints constraints)
+    public ColumnMetadata withNewColumnConstraints(ColumnConstraints constraints)
     {
-        constraints.validate(this);
-        this.columnConstraints = constraints;
+        constraints.checkInvalidConstraintsCombinations(name);
+        return new ColumnMetadata(ksName, cfName, name, type, position, kind, mask, constraints);
     }
 
     public void removeColumnConstraints()

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -455,6 +455,14 @@ public class TableMetadata implements SchemaElement
     {
         return columns.get(name.bytes);
     }
+
+    /**
+     * Returns if {@code name} is in ColumnMetadata.
+     */
+    public boolean containtsColumn(ColumnIdentifier name)
+    {
+        return columns.containsKey(name.bytes);
+    }
     /**
      * Returns the column of the provided name if it exists, but throws a user-visible exception if that column doesn't
      * exist.

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -457,13 +457,6 @@ public class TableMetadata implements SchemaElement
     }
 
     /**
-     * Returns if {@code name} is in ColumnMetadata.
-     */
-    public boolean containtsColumn(ColumnIdentifier name)
-    {
-        return columns.containsKey(name.bytes);
-    }
-    /**
      * Returns the column of the provided name if it exists, but throws a user-visible exception if that column doesn't
      * exist.
      *

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -1294,6 +1294,19 @@ public class TableMetadata implements SchemaElement
             return this;
         }
 
+        public Builder alterColumnConstraints(ColumnIdentifier name, ColumnConstraints constraints)
+        {
+            ColumnMetadata column = columns.get(name.bytes);
+            if (column == null)
+                throw new IllegalArgumentException();
+
+            ColumnMetadata newColumn = column.withNewColumnConstraints(constraints);
+
+            updateColumn(column, newColumn);
+
+            return this;
+        }
+
         Builder alterColumnType(ColumnIdentifier name, AbstractType<?> type)
         {
             ColumnMetadata column = columns.get(name.bytes);

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnConstraintsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnConstraintsTest.java
@@ -52,7 +52,12 @@ public class ColumnConstraintsTest extends TestBaseImpl
         {
             assertThrowsInvalidConstraintException(cluster, String.format("CREATE TABLE %s (pk int, ck1 text CHECK ck1 < 100, ck2 int, v int, " +
                                                                           "PRIMARY KEY ((pk), ck1, ck2));", tableName),
-                                                   "Column 'ck1' is not a number type.");
+                                                   "Constraint 'ck1 <' can be used only for columns of type " +
+                                                   "[org.apache.cassandra.db.marshal.ByteType, org.apache.cassandra.db.marshal.CounterColumnType, " +
+                                                   "org.apache.cassandra.db.marshal.DecimalType, org.apache.cassandra.db.marshal.DoubleType, " +
+                                                   "org.apache.cassandra.db.marshal.FloatType, org.apache.cassandra.db.marshal.Int32Type, " +
+                                                   "org.apache.cassandra.db.marshal.IntegerType, org.apache.cassandra.db.marshal.LongType, " +
+                                                   "org.apache.cassandra.db.marshal.ShortType] but it was class org.apache.cassandra.db.marshal.UTF8Type");
 
             assertThrowsInvalidConstraintException(cluster, String.format("CREATE TABLE %s (pk int, ck1 int CHECK LENGTH(ck1) < 100, ck2 int, v int, " +
                                                                           "PRIMARY KEY ((pk), ck1, ck2));", tableName),
@@ -320,6 +325,6 @@ public class ColumnConstraintsTest extends TestBaseImpl
         assertThatThrownBy(() -> cluster.schemaChange(statement))
                   .describedAs(description)
                   .has(new Condition<Throwable>(t -> t.getClass().getCanonicalName()
-                                                      .equals(InvalidConstraintDefinitionException.class.getCanonicalName()), description));
+                                                      .equals(InvalidRequestException.class.getCanonicalName()), description));
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnConstraintsTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnConstraintsTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.cassandra.cql3.constraints.ConstraintViolationException;
-import org.apache.cassandra.cql3.constraints.InvalidConstraintDefinitionException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.junit.Test;
 

--- a/test/unit/org/apache/cassandra/contraints/AlterTableWithTableConstraintValidationTest.java
+++ b/test/unit/org/apache/cassandra/contraints/AlterTableWithTableConstraintValidationTest.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.contraints;
 
 import org.junit.Test;
 
+import org.apache.cassandra.exceptions.InvalidRequestException;
+
 
 public class AlterTableWithTableConstraintValidationTest extends CqlConstraintValidationTester
 {
@@ -228,5 +230,13 @@ public class AlterTableWithTableConstraintValidationTest extends CqlConstraintVa
     {
         createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
         execute("ALTER TABLE %s ALTER IF EXISTS foo CHECK foo < 100");
+    }
+
+    @Test
+    public void testCreateTableAddConstraintWithNonExistingColumn() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+        String expectedErrorMessage = "Column 'foo' doesn't exist";
+        assertInvalidThrowMessage(expectedErrorMessage, InvalidRequestException.class, "ALTER TABLE %s ALTER foo CHECK foo < 100");
     }
 }

--- a/test/unit/org/apache/cassandra/contraints/AlterTableWithTableConstraintValidationTest.java
+++ b/test/unit/org/apache/cassandra/contraints/AlterTableWithTableConstraintValidationTest.java
@@ -222,4 +222,11 @@ public class AlterTableWithTableConstraintValidationTest extends CqlConstraintVa
         // It works
         execute("ALTER TABLE %s WITH cdc = true");
     }
+
+    @Test
+    public void testCreateTableAddConstraintWithIfExists() throws Throwable
+    {
+        createTable("CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck1 ASC);");
+        execute("ALTER TABLE %s ALTER IF EXISTS foo CHECK foo < 100");
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-20357

When altering a table, ColumnMetadata is using a mutable object for representing constraints, and when changing that object, it changes in Metadata objects with old epochs as well. This leads to problems with how diff between alters is calculated.
