### PR TITLE
CASSANDRA-20359 5.0 Fix unparseable YAML in default cassandra.yaml when uncommented for downstream tooling

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -199,8 +199,8 @@ authenticator: AllowAllAuthenticator
 # MutualTlsAuthenticator can be configured using the following configuration. One can add their own validator
 # which implements MutualTlsCertificateValidator class and provide logic for extracting identity out of certificates
 # and validating certificates.
-#  class_name : org.apache.cassandra.auth.MutualTlsAuthenticator
-#  parameters :
+#  class_name: org.apache.cassandra.auth.MutualTlsAuthenticator
+#  parameters:
 #    validator_class_name: org.apache.cassandra.auth.SpiffeCertificateValidator
 
 # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
@@ -1005,13 +1005,13 @@ listen_address: localhost
 # Internode authentication backend, implementing IInternodeAuthenticator;
 # used to allow/disallow connections from peer nodes.
 #internode_authenticator:
-#  class_name : org.apache.cassandra.auth.AllowAllInternodeAuthenticator
-#  parameters :
+#  class_name: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+#  parameters:
 # MutualTlsInternodeAuthenticator can be configured using the following configuration.One can add their own validator
 # which implements MutualTlsCertificateValidator class and provide logic for extracting identity out of certificates
 # and validating certificates.
-#  class_name : org.apache.cassandra.auth.MutualTlsInternodeAuthenticator
-#  parameters :
+#  class_name: org.apache.cassandra.auth.MutualTlsInternodeAuthenticator
+#  parameters:
 #    validator_class_name: org.apache.cassandra.auth.SpiffeCertificateValidator
 #    trusted_peer_identities: "spiffe1,spiffe2"
 #    node_identity: "spiffe1"

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -199,12 +199,12 @@ batchlog_endpoint_strategy: dynamic_remote
 #   Please increase system_auth keyspace replication factor if you use this authenticator.
 #   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
 authenticator:
-  class_name : AllowAllAuthenticator
+  class_name: AllowAllAuthenticator
 # MutualTlsAuthenticator can be configured using the following configuration. One can add their own validator
 # which implements MutualTlsCertificateValidator class and provide logic for extracting identity out of certificates
 # and validating certificates.
-#  class_name : org.apache.cassandra.auth.MutualTlsAuthenticator
-#  parameters :
+#  class_name: org.apache.cassandra.auth.MutualTlsAuthenticator
+#  parameters:
 #    validator_class_name: org.apache.cassandra.auth.SpiffeCertificateValidator
 
 # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
@@ -998,13 +998,13 @@ listen_address: localhost
 # Internode authentication backend, implementing IInternodeAuthenticator;
 # used to allow/disallow connections from peer nodes.
 #internode_authenticator:
-#  class_name : org.apache.cassandra.auth.AllowAllInternodeAuthenticator
-#  parameters :
+#  class_name: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+#  parameters:
 # MutualTlsInternodeAuthenticator can be configured using the following configuration.One can add their own validator
 # which implements MutualTlsCertificateValidator class and provide logic for extracting identity out of certificates
 # and validating certificates.
-#  class_name : org.apache.cassandra.auth.MutualTlsInternodeAuthenticator
-#  parameters :
+#  class_name: org.apache.cassandra.auth.MutualTlsInternodeAuthenticator
+#  parameters:
 #    validator_class_name: org.apache.cassandra.auth.SpiffeCertificateValidator
 #    trusted_peer_identities: "spiffe1,spiffe2"
 #    node_identity: "spiffe1"


### PR DESCRIPTION
…ownstream tooling

The presence of an extra space the `:` in `key: value` pairs makes the default `conf/cassandra.yaml` file included in this repository unparseable and non-functional for some downstream tooling.

patch by Daniel Lenski; reviewed by Stefan Miklosovic for CASSANDRA-20359
