### PR TITLE
CASSANDRA-20391: add native-protocol.adoc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ Thumbs.db
 
 # Generated files from the documentation
 doc/modules/cassandra/pages/managing/configuration/cass_yaml_file.adoc
+doc/modules/cassandra/pages/reference/native-protocol.adoc
+doc/modules/cassandra/attachments/
 doc/modules/cassandra/pages/managing/tools/nodetool/
 doc/modules/cassandra/examples/TEXT/NODETOOL/
 


### PR DESCRIPTION
- more details in the [CASSANDRA-20391](https://issues.apache.org/jira/browse/CASSANDRA-20391)