### PR TITLE
[CASSANDRA-20396][trunk ]Mark a sstable as suspected if CorruptSSTableException thrown by dfile.seek() in SSTableSimpleScanner

### DIFF
--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -161,8 +161,17 @@ public class ChunkCache implements CacheLoader<ChunkCache.Key, ChunkCache.Buffer
     {
         ByteBuffer buffer = bufferPool.get(key.file.chunkSize(), key.file.preferredBufferType());
         assert buffer != null;
-        key.file.readChunk(key.position, buffer);
-        return new Buffer(buffer, key.position);
+        try
+        {
+            key.file.readChunk(key.position, buffer);
+            return new Buffer(buffer, key.position);
+        }
+        catch (Throwable t)
+        {
+            if (buffer != null)
+                bufferPool.put(buffer);
+            throw t;
+        }
     }
 
     @Override

--- a/src/java/org/apache/cassandra/cache/ChunkCache.java
+++ b/src/java/org/apache/cassandra/cache/ChunkCache.java
@@ -168,8 +168,7 @@ public class ChunkCache implements CacheLoader<ChunkCache.Key, ChunkCache.Buffer
         }
         catch (Throwable t)
         {
-            if (buffer != null)
-                bufferPool.put(buffer);
+            bufferPool.put(buffer);
             throw t;
         }
     }

--- a/src/java/org/apache/cassandra/io/sstable/SSTableIdentityIterator.java
+++ b/src/java/org/apache/cassandra/io/sstable/SSTableIdentityIterator.java
@@ -76,6 +76,11 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
             sstable.markSuspect();
             throw new CorruptSSTableException(e, file.getPath());
         }
+        catch (CorruptSSTableException e) // to ensure that we marked the sstable as suspected if CorruptSSTableException is thrown from lower levels
+        {
+            sstable.markSuspect();
+            throw e;
+        }
     }
 
     public static SSTableIdentityIterator create(SSTableReader sstable, FileDataInput dfile, long dataPosition, DecoratedKey key, boolean tombstoneOnly)
@@ -99,6 +104,11 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
             sstable.markSuspect();
             throw new CorruptSSTableException(e, dfile.getPath());
         }
+        catch (CorruptSSTableException e) // to ensure that we marked the sstable as suspected if CorruptSSTableException is thrown from lower levels
+        {
+            sstable.markSuspect();
+            throw e;
+        }
     }
 
     public static SSTableIdentityIterator create(SSTableReader sstable, FileDataInput dfile, boolean tombstoneOnly)
@@ -120,6 +130,11 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
         {
             sstable.markSuspect();
             throw new CorruptSSTableException(e, dfile.getPath());
+        }
+        catch (CorruptSSTableException e) // to ensure that we marked the sstable as suspected if CorruptSSTableException is thrown from lower levels
+        {
+            sstable.markSuspect();
+            throw e;
         }
     }
 
@@ -164,6 +179,11 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
             sstable.markSuspect();
             throw new CorruptSSTableException(e, filename);
         }
+        catch (CorruptSSTableException e) // to ensure that we marked the sstable as suspected if CorruptSSTableException is thrown from lower levels
+        {
+            sstable.markSuspect();
+            throw e;
+        }
         catch (IOError e)
         {
             if (e.getCause() instanceof IOException)
@@ -191,6 +211,11 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
         {
             sstable.markSuspect();
             throw new CorruptSSTableException(e, filename);
+        }
+        catch (CorruptSSTableException e) // to ensure that we marked the sstable as suspected if CorruptSSTableException is thrown from lower levels
+        {
+            sstable.markSuspect();
+            throw e;
         }
         catch (IOError e)
         {
@@ -239,6 +264,11 @@ public class SSTableIdentityIterator implements Comparable<SSTableIdentityIterat
         {
             sstable.markSuspect();
             throw new CorruptSSTableException(e, filename);
+        }
+        catch (CorruptSSTableException e) // to ensure that we marked the sstable as suspected if CorruptSSTableException is thrown from lower levels
+        {
+            sstable.markSuspect();
+            throw e;
         }
         catch (IOError e)
         {


### PR DESCRIPTION
Mark a sstable as suspected if CorruptSSTableException thrown by dfile.seek() in SSTableSimpleScanner. Fix leakage of byte buffer from BufferPool in case of a corrupted read.

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20396