### PR TITLE
Fix scrub_test.py

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
@@ -474,7 +474,7 @@ public abstract class SSTableReader extends SSTable implements UnfilteredSource,
         this.openReason = builder.getOpenReason();
         this.first = builder.getFirst();
         this.last = builder.getLast();
-        this.interval = Interval.create(first, last, this);
+        this.interval = first == null || last == null ? null : Interval.create(first, last, this);
         this.bounds = first == null || last == null || AbstractBounds.strictlyWrapsAround(first.getToken(), last.getToken())
                       ? null // this will cause the validation to fail, but the reader is opened with no validation,
                              // e.g. for scrubbing, we should accept screwed bounds

--- a/src/java/org/apache/cassandra/utils/Interval.java
+++ b/src/java/org/apache/cassandra/utils/Interval.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.utils;
 
 import com.google.common.base.Objects;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class Interval<C, D>
 {
     public final C min;
@@ -27,6 +29,8 @@ public class Interval<C, D>
 
     public Interval(C min, C max, D data)
     {
+        checkNotNull(min, "min is null");
+        checkNotNull(max, "max is null");
         this.min = min;
         this.max = max;
         this.data = data;


### PR DESCRIPTION
This test was broken by the recent IntervalTree change. Scrub tool opens sstables without populating the first and last key fields which causes IntervalTree to fail to build. The original IntervalTree silently built a corrupt unsearchable tree in this scenario which was fine because it was never used.