### PR TITLE
[ CASSANDRA-20423][4.0] Disable role and network permission caches to avoid interference between test methods

### DIFF
--- a/test/unit/org/apache/cassandra/auth/GrantAndRevokeTest.java
+++ b/test/unit/org/apache/cassandra/auth/GrantAndRevokeTest.java
@@ -60,6 +60,7 @@ public class GrantAndRevokeTest extends CQLTester
         DatabaseDescriptor.setAuthorizer(new CassandraAuthorizer());
         DatabaseDescriptor.setRoleManager(new CassandraRoleManager());
         DatabaseDescriptor.setPermissionsValidity(0);
+        DatabaseDescriptor.setRolesValidity(0);
         CQLTester.setUpClass();
         requireNetworkWithoutDriver();
         DatabaseDescriptor.getRoleManager().setup();


### PR DESCRIPTION
Disable role and network permission caches to avoid interference between test methods

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20423

