### PR TITLE
CASSANDRA-20368 Improves error messages when initializing auth* classes (trunk)

### DIFF
--- a/src/java/org/apache/cassandra/auth/AuthConfig.java
+++ b/src/java/org/apache/cassandra/auth/AuthConfig.java
@@ -82,7 +82,7 @@ public final class AuthConfig
         IRoleManager roleManager = authInstantiate(conf.role_manager, CassandraRoleManager.class);
 
         if (authenticator instanceof PasswordAuthenticator && !(roleManager instanceof CassandraRoleManager))
-            throw new ConfigurationException("CassandraRoleManager must be used with PasswordAuthenticator", false);
+            throw new ConfigurationException(authenticator.getClass().getName() + " requires CassandraRoleManager", false);
 
         DatabaseDescriptor.setRoleManager(roleManager);
 

--- a/src/java/org/apache/cassandra/auth/AuthConfig.java
+++ b/src/java/org/apache/cassandra/auth/AuthConfig.java
@@ -73,7 +73,10 @@ public final class AuthConfig
         IAuthorizer authorizer = authInstantiate(conf.authorizer, AllowAllAuthorizer.class);
 
         if (!authenticator.requireAuthentication() && authorizer.requireAuthorization())
-            throw new ConfigurationException(conf.authenticator.class_name + " can't be used with " + conf.authorizer, false);
+        {
+            throw new ConfigurationException(authorizer.getClass().getName() + " has authorization enabled which requires " +
+                    authenticator.getClass().getName() + " to enable authentication", false);
+        }
 
         DatabaseDescriptor.setAuthorizer(authorizer);
 

--- a/src/java/org/apache/cassandra/auth/AuthConfig.java
+++ b/src/java/org/apache/cassandra/auth/AuthConfig.java
@@ -75,7 +75,7 @@ public final class AuthConfig
         if (!authenticator.requireAuthentication() && authorizer.requireAuthorization())
         {
             throw new ConfigurationException(authorizer.getClass().getName() + " has authorization enabled which requires " +
-                    authenticator.getClass().getName() + " to enable authentication", false);
+                                             authenticator.getClass().getName() + " to enable authentication", false);
         }
 
         DatabaseDescriptor.setAuthorizer(authorizer);
@@ -85,7 +85,7 @@ public final class AuthConfig
         IRoleManager roleManager = authInstantiate(conf.role_manager, CassandraRoleManager.class);
 
         if (authenticator instanceof PasswordAuthenticator && !(roleManager instanceof CassandraRoleManager))
-            throw new ConfigurationException(authenticator.getClass().getName() + " requires CassandraRoleManager", false);
+            throw new ConfigurationException(authenticator.getClass().getName() + " requires " + CassandraRoleManager.class.getName(), false);
 
         DatabaseDescriptor.setRoleManager(roleManager);
 

--- a/src/java/org/apache/cassandra/config/ParameterizedClass.java
+++ b/src/java/org/apache/cassandra/config/ParameterizedClass.java
@@ -18,9 +18,12 @@
 package org.apache.cassandra.config;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Objects;
 
@@ -36,7 +39,7 @@ public class ParameterizedClass
     public static final String PARAMETERS = "parameters";
 
     public String class_name;
-    public Map<String, String> parameters;
+    public Map<String, String> parameters = Collections.emptyMap();
 
     public ParameterizedClass()
     {
@@ -46,25 +49,24 @@ public class ParameterizedClass
     public ParameterizedClass(String class_name)
     {
         this.class_name = class_name;
-        this.parameters = Collections.emptyMap();
     }
 
     public ParameterizedClass(String class_name, Map<String, String> parameters)
     {
         this.class_name = class_name;
-        this.parameters = parameters;
+        this.parameters = parameters == null ? Collections.emptyMap() : parameters;
     }
 
     @SuppressWarnings("unchecked")
     public ParameterizedClass(Map<String, ?> p)
     {
         this((String)p.get(CLASS_NAME),
-             p.containsKey(PARAMETERS) ? (Map<String, String>)((List<?>)p.get(PARAMETERS)).get(0) : null);
+             p.containsKey(PARAMETERS) ? (Map<String, String>)((List<?>)p.get(PARAMETERS)).get(0) : Collections.emptyMap());
     }
 
     static public <K> K newInstance(ParameterizedClass parameterizedClass, List<String> searchPackages)
     {
-        Exception last = null;
+        Class<?> providerClass = null;
         if (searchPackages == null || searchPackages.isEmpty())
             searchPackages = Collections.singletonList("");
         for (String searchPackage : searchPackages)
@@ -74,32 +76,61 @@ public class ParameterizedClass
                 if (!searchPackage.isEmpty() && !searchPackage.endsWith("."))
                     searchPackage = searchPackage + '.';
                 String name = searchPackage + parameterizedClass.class_name;
-                Class<?> providerClass = Class.forName(name);
-                try
-                {
-                    Constructor<?> constructor = providerClass.getConstructor(Map.class);
-                    K instance = (K) constructor.newInstance(parameterizedClass.parameters);
-                    return instance;
-                }
-                catch (Exception constructorEx)
-                {
-                    //no-op
-                }
-                // fallback to no arg constructor if no params present
-                if (parameterizedClass.parameters == null || parameterizedClass.parameters.isEmpty())
-                {
-                    Constructor<?> constructor = providerClass.getConstructor();
-                    K instance = (K) constructor.newInstance();
-                    return instance;
-                }
+                providerClass = Class.forName(name);
             }
-            // there are about 5 checked exceptions that could be thrown here.
-            catch (Exception e)
+            catch (ClassNotFoundException e)
             {
-                last = e;
+                //no-op
             }
         }
-        throw new ConfigurationException("Unable to create parameterized class " + parameterizedClass.class_name, last);
+
+        if (providerClass == null)
+        {
+            String pkgList = '[' + searchPackages.stream().map(p -> '"' + p + '"').collect(Collectors.joining(",")) + ']';
+            String error = "Unable to find class " + parameterizedClass.class_name + " in packages " + pkgList;
+            throw new ConfigurationException(error);
+        }
+
+        try
+        {
+            Constructor<?> mapConstructor = filterConstructor(providerClass, c -> c.getParameterTypes().length == 1 && c.getParameterTypes()[0].equals(Map.class));
+            if (mapConstructor != null)
+                return (K) mapConstructor.newInstance(parameterizedClass.parameters == null ? Collections.emptyMap() : parameterizedClass.parameters);
+
+            // Falls-back to no-arg constructor
+            Constructor<?> noArgsConstructor = filterConstructor(providerClass, c -> c.getParameterTypes().length == 0);
+            if (noArgsConstructor != null)
+            {
+                if (parameterizedClass.parameters != null && !parameterizedClass.parameters.isEmpty())
+                    throw new ConfigurationException("Invalid parameters for class " + parameterizedClass.class_name);
+
+                return (K) noArgsConstructor.newInstance();
+            }
+
+            throw new ConfigurationException("No valid constructor found for class " + parameterizedClass.class_name);
+        }
+        catch (IllegalAccessException | InstantiationException | ExceptionInInitializerError e)
+        {
+            throw new ConfigurationException("Unable to instantiate parameterized class " + parameterizedClass.class_name, e);
+        }
+        catch (InvocationTargetException e)
+        {
+            Throwable cause = e.getCause();
+            String error = "Failed to instantiate class " + parameterizedClass.class_name +
+                           (cause.getMessage() != null ? ": " + cause.getMessage() : "");
+            throw new ConfigurationException(error, cause);
+        }
+    }
+
+    private static Constructor<?> filterConstructor(Class<?> providerClass, Predicate<Constructor<?>> filter)
+    {
+        for (Constructor<?> constructor : providerClass.getDeclaredConstructors())
+        {
+            if (filter.test(constructor))
+                return constructor;
+        }
+
+        return null;
     }
 
     @Override
@@ -122,6 +153,6 @@ public class ParameterizedClass
     @Override
     public String toString()
     {
-        return class_name + (parameters == null ? "" : parameters.toString());
+        return class_name + parameters;
     }
 }

--- a/test/unit/org/apache/cassandra/audit/AuditLoggerAuthTest.java
+++ b/test/unit/org/apache/cassandra/audit/AuditLoggerAuthTest.java
@@ -23,6 +23,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 
+import org.apache.cassandra.auth.CassandraAuthorizer;
+import org.apache.cassandra.auth.CassandraRoleManager;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -69,11 +73,11 @@ public class AuditLoggerAuthTest
     public static void setup() throws Exception
     {
         OverrideConfigurationLoader.override((config) -> {
-            config.authenticator = new ParameterizedClass("PasswordAuthenticator");
-            config.role_manager = new ParameterizedClass("CassandraRoleManager");
-            config.authorizer = new ParameterizedClass("CassandraAuthorizer");
+            config.authenticator = new ParameterizedClass(PasswordAuthenticator.class.getName());
+            config.role_manager = new ParameterizedClass(CassandraRoleManager.class.getName());
+            config.authorizer = new ParameterizedClass(CassandraAuthorizer.class.getName());
             config.audit_logging_options.enabled = true;
-            config.audit_logging_options.logger = new ParameterizedClass("InMemoryAuditLogger", null);
+            config.audit_logging_options.logger = new ParameterizedClass(InMemoryAuditLogger.class.getName());
         });
 
         SUPERUSER_SETUP_DELAY_MS.setLong(0);

--- a/test/unit/org/apache/cassandra/config/ParameterizedClassExample.java
+++ b/test/unit/org/apache/cassandra/config/ParameterizedClassExample.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.config;
+
+import java.util.Map;
+
+import org.junit.Assert;
+
+public class ParameterizedClassExample
+{
+    public ParameterizedClassExample()
+    {
+        Assert.fail("This constructor should not be called");
+    }
+
+    public ParameterizedClassExample(Map<String, String> parameters)
+    {
+        if (parameters == null)
+            throw new IllegalArgumentException("Parameters must not be null");
+
+        boolean simulateFailure = Boolean.parseBoolean(parameters.getOrDefault("fail", "false"));
+        if (simulateFailure)
+        {
+            throw new IllegalArgumentException("Simulated failure");
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/config/ParameterizedClassTest.java
+++ b/test/unit/org/apache/cassandra/config/ParameterizedClassTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.config;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.cassandra.auth.AllowAllAuthorizer;
+import org.apache.cassandra.auth.IAuthorizer;
+import org.apache.cassandra.exceptions.ConfigurationException;
+
+public class ParameterizedClassTest
+{
+    @Test
+    public void testParameterizedClassEmptyConstructorHasNonNullParameters()
+    {
+        ParameterizedClass parameterizedClass = new ParameterizedClass();
+        assertNotNull(parameterizedClass.parameters);
+    }
+
+    @Test
+    public void testParameterizedClassConstructorWithClassNameHasNonNullParameters() {
+        ParameterizedClass parameterizedClass = new ParameterizedClass("TestClass");
+        assertNotNull(parameterizedClass.parameters);
+    }
+
+    @Test
+    public void testParameterizedClassConstructorWithClassNameAndParametersHasNonNullParamters() {
+        ParameterizedClass parameterizedClass = new ParameterizedClass("TestClass", null);
+        assertNotNull(parameterizedClass.parameters);
+    }
+
+    @Test
+    public void testNewInstanceWithNonExistentClassFailsWithConfigurationException()
+    {
+        assertThatThrownBy(() -> ParameterizedClass.newInstance(new ParameterizedClass("NonExistentClass"),
+                                                                List.of("org.apache.cassandra.config")))
+        .hasMessage("Unable to find class NonExistentClass in packages [\"org.apache.cassandra.config\"]")
+        .isInstanceOf(ConfigurationException.class);
+    }
+
+    @Test
+    public void testNewInstanceWithSingleEmptyConstructorUsesEmptyConstructor()
+    {
+        ParameterizedClass parameterizedClass = new ParameterizedClass(AllowAllAuthorizer.class.getName());
+        IAuthorizer instance = ParameterizedClass.newInstance(parameterizedClass, null);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void testNewInstanceWithSingleEmptyConstructorWithParametersFailsWithConfigurationException()
+    {
+        assertThatThrownBy(() -> ParameterizedClass.newInstance(new ParameterizedClass(AllowAllAuthorizer.class.getName(),
+                                                                                       Map.of("key", "value")), null))
+        .hasMessageStartingWith("Invalid parameters for class")
+        .isInstanceOf(ConfigurationException.class);
+    }
+
+    @Test
+    public void testNewInstanceWithValidConstructorsFavorsMapConstructor()
+    {
+        ParameterizedClass parameterizedClass = new ParameterizedClass(ParameterizedClassExample.class.getName());
+        ParameterizedClassExample instance = ParameterizedClass.newInstance(parameterizedClass, null);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void testNewInstanceWithValidConstructorsUsingNullParamtersFavorsMapConstructor()
+    {
+        ParameterizedClass parameterizedClass = new ParameterizedClass(ParameterizedClassExample.class.getName());
+        parameterizedClass.parameters = null;
+
+        ParameterizedClassExample instance = ParameterizedClass.newInstance(parameterizedClass, null);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void testNewInstanceWithConstructorExceptionPreservesOriginalFailure()
+    {
+        assertThatThrownBy(() -> ParameterizedClass.newInstance(new ParameterizedClass(ParameterizedClassExample.class.getName(),
+                                                                                       Map.of("fail", "true")), null))
+        .hasMessageStartingWith("Failed to instantiate class")
+        .hasMessageContaining("Simulated failure")
+        .isInstanceOf(ConfigurationException.class);
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/CQLUserAuditTest.java
+++ b/test/unit/org/apache/cassandra/transport/CQLUserAuditTest.java
@@ -29,6 +29,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.apache.cassandra.audit.DiagnosticEventAuditLogger;
+import org.apache.cassandra.auth.CassandraRoleManager;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -64,11 +68,11 @@ public class CQLUserAuditTest
     public static void setup() throws Exception
     {
         OverrideConfigurationLoader.override((config) -> {
-            config.authenticator = new ParameterizedClass("PasswordAuthenticator");
-            config.role_manager = new ParameterizedClass("CassandraRoleManager");
+            config.authenticator = new ParameterizedClass(PasswordAuthenticator.class.getName());
+            config.role_manager = new ParameterizedClass(CassandraRoleManager.class.getName());
             config.diagnostic_events_enabled = true;
             config.audit_logging_options.enabled = true;
-            config.audit_logging_options.logger = new ParameterizedClass("DiagnosticEventAuditLogger", null);
+            config.audit_logging_options.logger = new ParameterizedClass(DiagnosticEventAuditLogger.class.getName());
         });
 
         SUPERUSER_SETUP_DELAY_MS.setLong(0);


### PR DESCRIPTION
Failures when setting up auth/authz in Cassandra show be more made more clear.

Issues noticed are:
 * When configuring `PasswordAuthenticator` with a custom IRoleManager implementation, the message will report "CassandraRoleManager must be used with PasswordAuthenticator". "CassandraRoleManager" can be used with any `IAuthenticator` implementation. The issue here is that `PasswordAuthenticator` requires using `CassandraRoleManager` because it has an implicit dependency on how passwords are created by it.
 * If we're configuring `MutualTlsWithPasswordFallbackAuthenticator` with another `IRoleManager` implementation we'll see a message that we're using `PasswordAuthenticator` which is incorrect.
 * When enabling authorization without enabling authentication, error message just says that "[IAuhtenticator] can't be used with [IAuthorizer]" without explaining why
 * Exceptions thrown when instantiating auth* classes are swallowed preventing users to understand what the issue was.
 