### PR TITLE
CASSANDRA-20497: Update generate-eclipse-files to work for JDK 11

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1998,7 +1998,7 @@
     </path>
     <pathconvert property="eclipse-libs-list" refid="eclipse-project-libs-path" pathsep="${line.separator}">
         <mapper>
-            <regexpmapper from="^(.*)$$" to='&lt;classpathentry kind="lib" path="\1\" \/&gt;'/>
+            <regexpmapper from="^(.*)$$" to='  &lt;classpathentry kind="lib" path="\1" /&gt;'/>
         </mapper>
     </pathconvert>
     <property name="eclipse-project-libs" refid="eclipse-project-libs-path"/>
@@ -2014,6 +2014,7 @@
   <classpathentry kind="src" output="${test.classes}" path="test/memory"/>
   <classpathentry kind="src" output="${test.classes}" path="test/burn"/>
   <classpathentry kind="src" output="${test.classes}" path="test/anttasks"/>
+  <classpathentry kind="src" output="${test.classes}" path="test/harry/main" />
   <classpathentry kind="src" output="${test.classes}" path="test/distributed"/>
   <classpathentry kind="src" output="${test.classes}" path="test/simulator/asm"/>
   <classpathentry kind="src" output="${test.classes}" path="test/simulator/main"/>
@@ -2022,10 +2023,15 @@
   <classpathentry kind="src" path="tools/fqltool/src"/>
   <classpathentry kind="src" output="build/test/stress-classes" path="tools/stress/test/unit" />
   <classpathentry kind="src" output="build/test/fqltool-classes" path="tools/fqltool/test/unit" />
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+      <attributes>
+        <attribute name="module" value="true"/>
+          <attribute name="add-exports" value="java.base/jdk.internal.misc=ALL-UNNAMED:java.base/jdk.internal.ref=ALL-UNNAMED:java.base/jdk.internal.util=ALL-UNNAMED:java.base/sun.nio.ch=ALL-UNNAMED:java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED:java.rmi/sun.rmi.registry=ALL-UNNAMED:java.rmi/sun.rmi.server=ALL-UNNAMED:java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED:java.sql/java.sql=ALL-UNNAMED"/>
+	  <attribute name="add-opens" value="java.base/java.lang.module=ALL-UNNAMED:java.base/java.net=ALL-UNNAMED:java.base/jdk.internal.loader=ALL-UNNAMED:java.base/jdk.internal.ref=ALL-UNNAMED:java.base/jdk.internal.reflect=ALL-UNNAMED:java.base/jdk.internal.math=ALL-UNNAMED:java.base/jdk.internal.module=ALL-UNNAMED:java.base/jdk.internal.util.jar=ALL-UNNAMED:jdk.management/com.sun.management.internal=ALL-UNNAMED"/>
+      </attributes>
+  </classpathentry>
   <classpathentry kind="output" path="build/classes/eclipse"/>
   <classpathentry kind="lib" path="test/conf"/>
-  <classpathentry kind="lib" path="${java.home}/../lib/tools.jar"/>
   ${eclipse-libs-list}
 </classpath>
 ]]>
@@ -2037,6 +2043,12 @@
         </classpath>
     </taskdef>
     <mkdir dir=".settings" />
+    <echo file=".settings/org.eclipse.jdt.core.prefs"><![CDATA[eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.source=11]]>
+    </echo>
   </target>
 
   <pathconvert property="eclipse.project.name">

--- a/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SortedTableWriter.java
@@ -435,7 +435,7 @@ public abstract class SortedTableWriter<P extends SortedTablePartitionWriter, I 
         }
     }
 
-    protected static abstract class AbstractIndexWriter extends AbstractTransactional implements Transactional
+    public static abstract class AbstractIndexWriter extends AbstractTransactional implements Transactional
     {
         protected final Descriptor descriptor;
         protected final TableMetadataRef metadata;

--- a/test/burn/org/apache/cassandra/utils/LongBTreeTest.java
+++ b/test/burn/org/apache/cassandra/utils/LongBTreeTest.java
@@ -157,7 +157,7 @@ public class LongBTreeTest
     @Test
     public void testToArray() throws InterruptedException
     {
-        testRandomSelection(randomSeed(), perThreadTrees, 4,
+        testRandomSelectionWithConsumer(randomSeed(), perThreadTrees, 4,
                             (selection) ->
                             {
                                 Integer[] array = new Integer[selection.canonicalList.size() + 1];
@@ -325,14 +325,14 @@ public class LongBTreeTest
 
     private void testRandomSelection(long seed, int perThreadTrees, int perTreeSelections, BTreeTestFactory testRun) throws InterruptedException
     {
-        testRandomSelection(seed, perThreadTrees, perTreeSelections, (selection) -> {
+        testRandomSelectionWithConsumer(seed, perThreadTrees, perTreeSelections, (selection) -> {
             TestEachKey testEachKey = testRun.get(selection);
             for (Integer key : selection.testKeys)
                 testEachKey.testOne(key);
         });
     }
 
-    private void testRandomSelection(long seed, int perThreadTrees, int perTreeSelections, Consumer<RandomSelection> testRun) throws InterruptedException
+    private void testRandomSelectionWithConsumer(long seed, int perThreadTrees, int perTreeSelections, Consumer<RandomSelection> testRun) throws InterruptedException
     {
         testRandomSelection(seed, perThreadTrees, perTreeSelections, true, true, true, testRun);
     }

--- a/test/distributed/org/apache/cassandra/fuzz/topology/Schema.java
+++ b/test/distributed/org/apache/cassandra/fuzz/topology/Schema.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.fuzz.topology;
 
-
 public interface Schema
 {
     String table();

--- a/test/distributed/org/apache/cassandra/fuzz/topology/Schema.java
+++ b/test/distributed/org/apache/cassandra/fuzz/topology/Schema.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.fuzz.topology;
+
+
+public interface Schema
+{
+    String table();
+    String keyspace();
+    String createSchema();
+}

--- a/test/distributed/org/apache/cassandra/fuzz/topology/TopologyMixupTestBase.java
+++ b/test/distributed/org/apache/cassandra/fuzz/topology/TopologyMixupTestBase.java
@@ -103,7 +103,7 @@ import static org.apache.cassandra.harry.model.TokenPlacementModel.SimpleReplica
  * <p>
  * {@code for id in $(seq 0 15); do sudo ifconfig lo0 alias "127.0.0.$id"; done;}
  */
-public abstract class TopologyMixupTestBase<S extends TopologyMixupTestBase.Schema> extends TestBaseImpl
+public abstract class TopologyMixupTestBase<S extends Schema> extends TestBaseImpl
 {
     private static final Logger logger = LoggerFactory.getLogger(TopologyMixupTestBase.class);
 
@@ -467,13 +467,6 @@ public abstract class TopologyMixupTestBase<S extends TopologyMixupTestBase.Sche
         for (int i : array)
             set.add(i);
         return set;
-    }
-
-    public interface Schema
-    {
-        String table();
-        String keyspace();
-        String createSchema();
     }
 
     protected interface CommandGen<S extends Schema>


### PR DESCRIPTION
As JDK 8 is no longer supported, generate-eclipse-files no longer works.

Updates the build to work with JDK 11 and updates several source files with trivial changes to avoid confusing the eclipse compiler.

Patch by Andy Tolbert for CASSANDRA-20497

---

Note:  Just about everything seems functional, except when running any code, one must add `-Djdk.attach.allowAttachSelf=true`;  There doesn't seem to be an easy way to override this for run configurations at a project level, but I see that [the IDE documentation on the website](https://github.com/apache/cassandra-website/blob/4e9ffaca669c49be79ffe1b2dabd152950a94781/site-content/source/modules/ROOT/pages/development/ide.adoc#setting-up-cassandra-in-eclipse) references adding some runtime arguments already, so I can always follow up and update that after this is merged.
