### PR TITLE
CASSANDRA-18297: Updated Documentation

### DIFF
--- a/doc/modules/cassandra/pages/getting-started/configuring.adoc
+++ b/doc/modules/cassandra/pages/getting-started/configuring.adoc
@@ -14,7 +14,7 @@ to various Cassandra configuration files. Some examples that require
 non-default configuration are deploying a multi-node cluster or using
 clients that are not running on a cluster node.
 
-* `cassandra.yaml`: the main configuration file for Cassandra
+* `cassandra.yaml`: the main configuration file for Cassandra contains sensitive settings and therefore should not be accessed or modified by untrusted users
 * `cassandra-env.sh`: environment variables can be set
 * `cassandra-rackdc.properties` OR `cassandra-topology.properties`: set
 rack and datacenter information for a cluster


### PR DESCRIPTION
Updated configuring.adoc  (doc/modules/cassandra/pages/getting-started/configuring.adoc) with a clarified note for cassandra.yaml, suggesting to not allow untrusted users to access or modify your cassandra.yaml.

