### PR TITLE
WEBSITE ninjafix cqlversion update to match OSS 5.0

### DIFF
--- a/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
+++ b/doc/modules/cassandra/examples/BASH/docker-run-cqlsh-quickstart.sh
@@ -1,3 +1,3 @@
 docker run --rm -it --network \
 cassandra nuvo/docker-cqlsh cqlsh cassandra \
-9042 --cqlversion='3.4.5' 
+9042 --cqlversion='3.4.7'


### PR DESCRIPTION
### What is the issue
Today, when we follow the instructions at [the docs page](https://cassandra.apache.org/_/quickstart.html), we get the following error:
```
% docker run --rm -it --network cassandra nuvo/docker-cqlsh cqlsh cassandra 9042 --cqlversion='3.4.5'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Connection error: ('Unable to connect to any servers', {'172.18.0.2': ProtocolError("cql_version '3.4.5' is not supported by remote (w/ native protocol). Supported versions: [u'3.4.7']",)})
```

### What does this PR fix and why was it fixed
Fix the above experience.