### PR TITLE
CASSANDRA-20566 Ensure RowFilter#isMutableIntersection() properly evaluates numeric ranges on a single column

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.5
+ * Ensure RowFilter#isMutableIntersection() properly evaluates numeric ranges on a single column (CASSANDRA-20566)
  * Grant permission on keyspaces system_views and system_virtual_schema not possible (CASSANDRA-20171)
  * Fix marking an SSTable as suspected and BufferPool leakage in case of a corrupted SSTable read during a compaction (CASSANDRA-20396)
  * Introduce SSTableSimpleScanner for compaction (CASSANDRA-20092)

--- a/src/java/org/apache/cassandra/db/filter/RowFilter.java
+++ b/src/java/org/apache/cassandra/db/filter/RowFilter.java
@@ -21,13 +21,16 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.base.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,15 +176,21 @@ public class RowFilter implements Iterable<RowFilter.Expression>
      */
     public boolean isMutableIntersection()
     {
-        int count = 0;
+        Set<ColumnMetadata> columns = null;
         for (Expression e : expressions)
         {
             if (e.column.isStatic() && expressions.size() > 1)
                 return true;
 
             if (!e.column.isPrimaryKeyColumn())
-                if (++count > 1)
+            {
+                if (columns == null)
+                    columns = new HashSet<>(expressions.size());
+
+                columns.add(e.column);
+                if (columns.size() > 1)
                     return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by Ariel Weisberg for CASSANDRA-20566