### PR TITLE
Increasing default for auto_repair.sstable_upper_threshold considering large Cassandra tables + Revert three lines removed from CHANGES.txt due to a merge

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,12 @@
 5.1
+ * Increasing default for auto_repair.sstable_upper_threshold considering large Cassandra tables & revert three lines removed from CHANGES.txt due to a merge mistake (CASSANDRA-20586)
  * Fix token restrictions with MIN_TOKEN (CASSANDRO-20557)
  * Upgrade logback version to 1.5.18 and slf4j dependencies to 2.0.17 (CASSANDRA-20429)
  * Switch memtable-related off-heap objects to Native Endian and Memory to Little Endian (CASSANDRA-20190)
  * Change SSTableSimpleScanner to use SSTableReader#openDataReaderForScan (CASSANDRA-20538)
  * Automated Repair Inside Cassandra [CEP-37] (CASSANDRA-19918)
+ * Implement appender of slow queries to system_views.slow_queries table (CASSANDRA-13001)
+ * Add autocompletion in CQLSH for built-in functions (CASSANDRA-19631)
  * Grant permission on keyspaces system_views and system_virtual_schema not possible (CASSANDRA-20171)
  * General Purpose Transactions (Accord) [CEP-15] (CASSANDRA-17092)
  * Improve performance when getting writePlacementsAllSettled from ClusterMetadata (CASSANDRA-20526)
@@ -242,6 +245,7 @@ Merged from 4.1:
  * Enforce CQL message size limit on multiframe messages (CASSANDRA-20052)
  * Fix race condition in DecayingEstimatedHistogramReservoir during rescale (CASSANDRA-19365)
 Merged from 4.0:
+ * Updating a column with a new TTL but same expiration time is non-deterministic and causes repair mismatches. (CASSANDRA-20561)
  * Avoid computing prepared statement size for unprepared batches (CASSANDRA-20556)
  * Fix Dropwizard Meter causes timeouts when infrequently used (CASSANDRA-19332)
  * Update OWASP dependency checker to version 12.1.0 (CASSANDRA-20501)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2810,7 +2810,7 @@ storage_compatibility_mode: NONE
 #     force_repair_new_node: false
 #     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
 #     # tables.
-#     sstable_upper_threshold: 10000
+#     sstable_upper_threshold: 50000
 #     # Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
 #     # next table.
 #     table_max_repair_time: 6h

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2499,7 +2499,7 @@ storage_compatibility_mode: NONE
 #     force_repair_new_node: false
 #     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
 #     # tables.
-#     sstable_upper_threshold: 10000
+#     sstable_upper_threshold: 50000
 #     # Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
 #     # next table.
 #     table_max_repair_time: 6h

--- a/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
@@ -207,7 +207,7 @@ node. Defaults to true and is only evaluated when allow_parallel_replica_repair 
 immediately after a restart.
 | repair_session_timeout | 3h | Timeout for retrying stuck repair sessions.
 | force_repair_new_node | false | Force immediate repair on new nodes after they join the ring.
-| sstable_upper_threshold | 10000 | Threshold to skip repairing tables with too many SSTables.
+| sstable_upper_threshold | 50000 | Threshold to skip repairing tables with too many SSTables.
 | table_max_repair_time | 6h | Maximum time allowed for repairing one table on a given node. If exceeded, the repair
 proceeds to the next table.
 | ignore_dcs | [] | Avoid running repairs in specific data centers. By default, repairs run in all data centers. Specify
@@ -365,7 +365,7 @@ configuration for repair_type: full
 	min_repair_interval: 24h
 	repair_by_keyspace: true
 	number_of_repair_threads: 1
-	sstable_upper_threshold: 10000
+	sstable_upper_threshold: 50000
 	table_max_repair_time: 6h
 	ignore_dcs: []
 	repair_primary_token_range_only: true
@@ -387,7 +387,7 @@ configuration for repair_type: incremental
 	min_repair_interval: 1h
 	repair_by_keyspace: true
 	number_of_repair_threads: 1
-	sstable_upper_threshold: 10000
+	sstable_upper_threshold: 50000
 	table_max_repair_time: 6h
 	ignore_dcs: []
 	repair_primary_token_range_only: true

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -452,7 +452,7 @@ public class AutoRepairConfig implements Serializable
             opts.parallel_repair_percentage = 3;
             opts.allow_parallel_replica_repair = false;
             opts.allow_parallel_replica_repair_across_schedules = true;
-            opts.sstable_upper_threshold = 10000;
+            opts.sstable_upper_threshold = 50000;
             opts.ignore_dcs = new HashSet<>();
             opts.repair_primary_token_range_only = true;
             opts.force_repair_new_node = false;

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -474,7 +474,7 @@ public class AutoRepairConfigTest extends CQLTester
         assertEquals(Integer.valueOf(1), options.number_of_repair_threads);
         assertEquals(Integer.valueOf(3), options.parallel_repair_count);
         assertEquals(Integer.valueOf(3), options.parallel_repair_percentage);
-        assertEquals(Integer.valueOf(10000), options.sstable_upper_threshold);
+        assertEquals(Integer.valueOf(50000), options.sstable_upper_threshold);
         assertEquals(new HashSet<>(), options.ignore_dcs);
         assertTrue(options.repair_primary_token_range_only);
         assertFalse(options.force_repair_new_node);
@@ -495,7 +495,7 @@ public class AutoRepairConfigTest extends CQLTester
         assertEquals(Integer.valueOf(1), config.global_settings.number_of_repair_threads);
         assertEquals(Integer.valueOf(3), config.global_settings.parallel_repair_count);
         assertEquals(Integer.valueOf(3), config.global_settings.parallel_repair_percentage);
-        assertEquals(Integer.valueOf(10000), config.global_settings.sstable_upper_threshold);
+        assertEquals(Integer.valueOf(50000), config.global_settings.sstable_upper_threshold);
         assertEquals(new HashSet<>(), config.global_settings.ignore_dcs);
         assertTrue(config.global_settings.repair_primary_token_range_only);
         assertFalse(config.global_settings.force_repair_new_node);


### PR DESCRIPTION
1) Increasing default for auto_repair.sstable_upper_threshold considering large Cassandra tables
2) Revert three lines removed from CHANGES.txt due to a merge [mistake](https://github.com/apache/cassandra/commit/6753fb49dcba6af6cccc02e62a5d425704d45b20)

```
Auto repair's sstable_upper_threshold default is currently defined as:
#     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
#     # tables.
#     sstable_upper_threshold: 10000
For clusters with denser nodes (multi-TB) and with LCS, 10k+ SSTables for a given table is not unusual. It's probably best to have a higher threshold so repairs don't completely stop working for a table, so maybe we should perhaps set this to a default value that is higher and operators can decrease it selectively?
A default between 30000-50000 would probably be more sensible.

patch by jaydeepkumar1984 <chovatia.jaydeep@gmail.com>; reviewed by <Reviewers> for CASSANDRA-20586
```



The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20586)

