### PR TITLE
[CASSANDRA-20173][trunk] Introduce NativeAccessor to avoid new ByteBuffer allocation on flush for each NativeCell

### DIFF
--- a/src/java/org/apache/cassandra/db/ArrayClustering.java
+++ b/src/java/org/apache/cassandra/db/ArrayClustering.java
@@ -48,6 +48,12 @@ public class ArrayClustering extends AbstractArrayClusteringPrefix implements Cl
         return EMPTY_SIZE + ObjectSizes.sizeOfArray(values);
     }
 
+    @Override
+    public Clustering<?> ensureAccessorFactorySupport()
+    {
+        return this;
+    }
+
     public static ArrayClustering make(byte[]... values)
     {
         return new ArrayClustering(values);

--- a/src/java/org/apache/cassandra/db/BufferClustering.java
+++ b/src/java/org/apache/cassandra/db/BufferClustering.java
@@ -59,4 +59,10 @@ public class BufferClustering extends AbstractBufferClusteringPrefix implements 
     {
         return new BufferClustering(values);
     }
+
+    @Override
+    public Clustering<?> ensureAccessorFactorySupport()
+    {
+        return this;
+    }
 }

--- a/src/java/org/apache/cassandra/db/Clustering.java
+++ b/src/java/org/apache/cassandra/db/Clustering.java
@@ -190,4 +190,11 @@ public interface Clustering<V> extends ClusteringPrefix<V>, IMeasurableMemory
             }
         }
     }
+
+    /**
+     * @return a Clustering with the same values but using an implementation
+     *  which supports ValueAccessor.factory() logic
+     */
+
+    Clustering<?> ensureAccessorFactorySupport();
 }

--- a/src/java/org/apache/cassandra/db/ClusteringPrefix.java
+++ b/src/java/org/apache/cassandra/db/ClusteringPrefix.java
@@ -258,6 +258,25 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
      */
     public V get(int i);
 
+    /**
+     * The method is introduced to allow to avoid a value object retrieval/allocation for simple checks
+     */
+    public default boolean isNull(int i)
+    {
+        return get(i) == null;
+    }
+
+    /**
+     * The method is introduced to allow to avoid a value object retrieval/allocation for simple checks
+     */
+    public default boolean isEmpty(int i)
+    {
+        V v = get(i);
+        if (v == null)
+            return true;
+        return accessor().isEmpty(v);
+    }
+
     public ValueAccessor<V> accessor();
 
     default ByteBuffer bufferAt(int i)
@@ -402,7 +421,7 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
      * memory (i.e. in memtables) to minimized on-heap versions.
      * If the object is already in minimal form, no action will be taken.
      */
-    public ClusteringPrefix<V> retainable();
+    public ClusteringPrefix<?> retainable();
 
     public static class Serializer
     {
@@ -549,14 +568,12 @@ public interface ClusteringPrefix<V> extends IMeasurableMemory, Clusterable<V>
         private static <V> long makeHeader(ClusteringPrefix<V> clustering, int offset, int limit)
         {
             long header = 0;
-            ValueAccessor<V> accessor = clustering.accessor();
             for (int i = offset ; i < limit ; i++)
             {
-                V v = clustering.get(i);
                 // no need to do modulo arithmetic for i, since the left-shift execute on the modulus of RH operand by definition
-                if (v == null)
+                if (clustering.isNull(i))
                     header |= (1L << (i * 2) + 1);
-                else if (accessor.isEmpty(v))
+                else if (clustering.isEmpty(i))
                     header |= (1L << (i * 2));
             }
             return header;

--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -198,6 +198,12 @@ public class NativeClustering implements Clustering<NativeData>
     }
 
     @Override
+    public Clustering<?> ensureAccessorFactorySupport()
+    {
+        return retainable();
+    }
+
+    @Override
     public final int hashCode()
     {
         return ClusteringPrefix.hashCode(this);
@@ -211,7 +217,7 @@ public class NativeClustering implements Clustering<NativeData>
 
     // data are copied to heap byte buffers to detach from a NativeAllocator lifecycle
     @Override
-    public ClusteringPrefix<?> retainable()
+    public Clustering<?> retainable()
     {
         assert kind() == Kind.CLUSTERING; // tombstones are never stored natively
 

--- a/src/java/org/apache/cassandra/db/NativeClustering.java
+++ b/src/java/org/apache/cassandra/db/NativeClustering.java
@@ -21,7 +21,10 @@ package org.apache.cassandra.db;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.cassandra.db.marshal.AddressBasedNativeData;
 import org.apache.cassandra.db.marshal.ByteBufferAccessor;
+import org.apache.cassandra.db.marshal.NativeAccessor;
+import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.ObjectSizes;
@@ -31,7 +34,7 @@ import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.apache.cassandra.utils.memory.NativeEndianMemoryUtil;
 import org.apache.cassandra.utils.memory.NativeAllocator;
 
-public class NativeClustering implements Clustering<ByteBuffer>
+public class NativeClustering implements Clustering<NativeData>
 {
     private static final long EMPTY_SIZE = ObjectSizes.measure(new NativeClustering());
 
@@ -84,7 +87,7 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return Kind.CLUSTERING;
     }
 
-    public ClusteringPrefix<ByteBuffer> clustering()
+    public ClusteringPrefix<NativeData> clustering()
     {
         return this;
     }
@@ -100,9 +103,50 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return NativeEndianMemoryUtil.getUnsignedShort(peer + dataSizeOffset);
     }
 
-    public ByteBuffer get(int i)
+    public NativeData get(int i)
     {
-        // offset at which we store the dataOffset
+        return buildDataObject(i, AddressBasedNativeData::new);
+    }
+
+    public boolean isNull(int i)
+    {
+        return isNull(peer, size(), i);
+    }
+
+    private static boolean isNull(long peer, int size, int i)
+    {
+        if (i >= size)
+            throw new IndexOutOfBoundsException();
+
+        int metadataSize = (size * 2) + 4;
+        long bitmapStart = peer + metadataSize;
+        int b = NativeEndianMemoryUtil.getByte(bitmapStart + (i >>> 3));
+        return ((b & (1 << (i & 7))) != 0);
+    }
+
+    public boolean isEmpty(int i)
+    {
+        int size = size();
+        if (isNull(peer, size, i))
+            return true;
+
+        int startOffset = NativeEndianMemoryUtil.getUnsignedShort(peer + 2 + i * 2);
+        int endOffset = NativeEndianMemoryUtil.getUnsignedShort(peer + 4 + i * 2);
+        return (endOffset - startOffset) == 0;
+    }
+
+
+    private ByteBuffer getByteBuffer(int i)
+    {
+        return buildDataObject(i, (long address, int length) -> MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN));
+    }
+
+    private interface DataObjectBuilder<D> {
+        D build(long address, int length);
+    }
+
+    private <D> D buildDataObject(int i, DataObjectBuilder<D> builder)
+    {
         int size = size();
         if (i >= size)
             throw new IndexOutOfBoundsException();
@@ -116,14 +160,15 @@ public class NativeClustering implements Clustering<ByteBuffer>
 
         int startOffset = NativeEndianMemoryUtil.getUnsignedShort(peer + 2 + i * 2);
         int endOffset = NativeEndianMemoryUtil.getUnsignedShort(peer + 4 + i * 2);
-        return MemoryUtil.getByteBuffer(bitmapStart + bitmapSize + startOffset,
-                                        endOffset - startOffset,
-                                        ByteOrder.BIG_ENDIAN);
+
+        long address = bitmapStart + bitmapSize + startOffset;
+        int length = endOffset - startOffset;
+        return builder.build(address, length);
     }
 
-    public ByteBuffer[] getRawValues()
+    public NativeData[] getRawValues()
     {
-        ByteBuffer[] values = new ByteBuffer[size()];
+        NativeData[] values = new NativeData[size()];
         for (int i = 0 ; i < values.length ; i++)
             values[i] = get(i);
         return values;
@@ -131,13 +176,15 @@ public class NativeClustering implements Clustering<ByteBuffer>
 
     public ByteBuffer[] getBufferArray()
     {
-        return getRawValues();
+        ByteBuffer[] values = new ByteBuffer[size()];
+        for (int i = 0 ; i < values.length ; i++)
+            values[i] = getByteBuffer(i);
+        return values;
     }
 
-    public ValueAccessor<ByteBuffer> accessor()
+    public ValueAccessor<NativeData> accessor()
     {
-        // TODO: add a native accessor
-        return ByteBufferAccessor.instance;
+        return NativeAccessor.instance;
     }
 
     public long unsharedHeapSize()
@@ -162,8 +209,9 @@ public class NativeClustering implements Clustering<ByteBuffer>
         return ClusteringPrefix.equals(this, o);
     }
 
+    // data are copied to heap byte buffers to detach from a NativeAllocator lifecycle
     @Override
-    public ClusteringPrefix<ByteBuffer> retainable()
+    public ClusteringPrefix<?> retainable()
     {
         assert kind() == Kind.CLUSTERING; // tombstones are never stored natively
 
@@ -171,10 +219,10 @@ public class NativeClustering implements Clustering<ByteBuffer>
         ByteBuffer[] values = new ByteBuffer[size()];
         for (int i = 0; i < values.length; ++i)
         {
-            ByteBuffer value = get(i);
+            ByteBuffer value = getByteBuffer(i);
             values[i] = value != null ? HeapCloner.instance.clone(value) : null;
         }
 
-        return accessor().factory().clustering(values);
+        return ByteBufferAccessor.instance.factory().clustering(values);
     }
 }

--- a/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
@@ -56,9 +56,15 @@ public class AddressBasedNativeData implements NativeData
     public NativeData slice(int offset, int length)
     {
         if (offset < 0 || offset > this.length)
-            throw new IllegalArgumentException("offset must but be >= 0 and < parent length");
+            throw new IllegalArgumentException("offset must but be >= 0 and < parent length; " +
+                                               "offset: " + offset +
+                                               ", slice length: " + length +
+                                               ", data length: " + this.length);
         if (length < 0 || offset + length > this.length) {
-            throw new IllegalArgumentException("length must but be >= 0 and offset + length > parent length");
+            throw new IllegalArgumentException("length must but be >= 0 and offset + length > parent length; " +
+                                               "offset: " + offset +
+                                               ", slice length: " + length +
+                                               ", data length: " + this.length);
         }
 
         if (length == 0) {

--- a/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/AddressBasedNativeData.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.apache.cassandra.utils.memory.MemoryUtil;
+
+public class AddressBasedNativeData implements NativeData
+{
+    // use a real address, just in case
+    private static final ByteBuffer EMPTY_NATIVE_BUFFER = ByteBuffer.allocateDirect(1);
+    private static final long EMPTY_VALUE_ADDRESS = MemoryUtil.getAddress(EMPTY_NATIVE_BUFFER);
+    public static final AddressBasedNativeData EMPTY = new AddressBasedNativeData(EMPTY_VALUE_ADDRESS, 0);
+
+    private final long address;
+    private final int length;
+
+    public AddressBasedNativeData(long address, int length)
+    {
+        this.address = address;
+        this.length = length;
+    }
+
+
+    @Override
+    public int nativeDataSize()
+    {
+        return length;
+    }
+
+    @Override
+    public ByteBuffer asByteBuffer()
+    {
+        return MemoryUtil.getByteBuffer(address, length, ByteOrder.BIG_ENDIAN);
+    }
+
+    @Override
+    public NativeData slice(int offset, int length)
+    {
+        if (offset < 0 || offset > this.length)
+            throw new IllegalArgumentException("offset must but be >= 0 and < parent length");
+        if (length < 0 || offset + length > this.length) {
+            throw new IllegalArgumentException("length must but be >= 0 and offset + length > parent length");
+        }
+
+        if (length == 0) {
+            return EMPTY;
+        }
+        return new AddressBasedNativeData(address + offset, length);
+    }
+
+    @Override
+    public long getAddress()
+    {
+        return address;
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeAccessor.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.util.UUID;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.db.Digest;
+import org.apache.cassandra.db.TypeSizes;
+import org.apache.cassandra.io.util.DataInputPlus;
+import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.service.paxos.Ballot;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.FastByteOperations;
+import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.UUIDGen;
+import org.apache.cassandra.utils.memory.BigEndianMemoryUtil;
+import org.apache.cassandra.utils.memory.MemoryUtil;
+
+/**
+ * ValueAccessor has a lot of different methods are grouped together in a single interface.
+ * Technically the methods can be classfied to 4 categories:
+ * 1) basic methods to deal with the existing data as an abstract read-only container of bytes
+ * 2) deserialization methods to decode the data into different data types
+ * 3) serialization methods to encode and write different data types into the value entity
+ * 4) Value object creation methods
+ *
+ *  NativeAccessor provides a support for real NativeData objects (on top of off-heap memory) for 1-3 categories
+ *  with a focus on 1) category and only emulates 4th category using ByteBufferSliceNativeData on top of heap ByteBuffers.
+ *  We expect NativeData is used only to store data in Memtables with an explicit allocator and memory regions lifecycle
+ *  and not used to create short-living Mutation requests and transfer them between nodes.
+ */
+public class NativeAccessor implements ValueAccessor<NativeData>
+{
+    public static final ValueAccessor<NativeData> instance = new NativeAccessor();
+
+    // -----------------------------------------------------------------------------
+    // basic methods to deal with data as a read-only container of bytes
+
+    @Override
+    public int size(NativeData value)
+    {
+        return value.nativeDataSize();
+    }
+
+    @Override
+    public void write(NativeData sourceValue, DataOutputPlus out) throws IOException
+    {
+        out.writeMemory(sourceValue.getAddress(), sourceValue.nativeDataSize());
+    }
+
+    @Override
+    public ByteBuffer toBuffer(NativeData value)
+    {
+        if (value == null)
+            return null;
+        return value.asByteBuffer();
+    }
+
+    @Override
+    public void write(NativeData value, ByteBuffer out)
+    {
+        int size = value.nativeDataSize();
+        MemoryUtil.getBytes(value.getAddress(), out, size);
+        out.position(out.position() + size);
+
+    }
+
+    @Override
+    public <V2> int copyTo(NativeData src, int srcOffset, V2 dst, ValueAccessor<V2> dstAccessor, int dstOffset, int size)
+    {
+        if (dstAccessor == ByteArrayAccessor.instance)
+            MemoryUtil.getBytes(src.getAddress() + srcOffset, dstAccessor.toArray(dst), dstOffset, size);
+        else if (dstAccessor == ByteBufferAccessor.instance)
+        {
+            ByteBuffer dstBuffer = dstAccessor.toBuffer(dst);
+            MemoryUtil.getBytes(src.getAddress() + srcOffset, dstBuffer, dstOffset, size);
+            // note: position of dstBuffer expected to stay the same
+        }
+        else if (dstAccessor == NativeAccessor.instance)
+            MemoryUtil.setBytes(src.getAddress() + srcOffset, ((NativeData) dst).getAddress() + dstOffset, size);
+        else // just in case of new implementations of ValueAccessor appear
+            dstAccessor.copyByteBufferTo(src.asByteBuffer(), srcOffset, dst, dstOffset, size);
+
+        return size;
+    }
+
+    @Override
+    public int copyByteArrayTo(byte[] src, int srcOffset, NativeData dstNative, int dstOffset, int size)
+    {
+        MemoryUtil.setBytes(src, srcOffset, dstNative.getAddress() + dstOffset, size);
+        return size;
+    }
+
+    @Override
+    public int copyByteBufferTo(ByteBuffer src, int srcOffset, NativeData dstNative, int dstOffset, int size)
+    {
+        MemoryUtil.setBytes(dstNative.getAddress() + dstOffset, src, srcOffset, size);
+        return size;
+    }
+
+    @Override
+    public void digest(NativeData value, int offset, int size, Digest digest)
+    {
+        // not used for NativeData (we copy data to heap during a select)
+        // so, there is no much reason to optimize to avoid a ByteBuffer object allocation
+        ByteBuffer byteBuffer = value.asByteBuffer();
+        digest.update(byteBuffer, byteBuffer.position() + offset, size);
+    }
+
+    @Override
+    public NativeData slice(NativeData input, int offset, int length)
+    {
+        return input.slice(offset, length);
+    }
+
+    @Override
+    public <VR> int compare(NativeData left, VR right, ValueAccessor<VR> accessorR)
+    {
+
+        if (accessorR == ByteArrayAccessor.instance)
+            return -compareByteArrayTo(accessorR.toArray(right), left);
+        else if (accessorR == ByteBufferAccessor.instance)
+            return -compareByteBufferTo(accessorR.toBuffer(right), left);
+        if (accessorR == NativeAccessor.instance)
+        {
+            NativeData rightNative = (NativeData) right;
+            int leftSize = left.nativeDataSize();
+            int rightSize = rightNative.nativeDataSize();
+            return FastByteOperations.compareMemoryUnsigned(left.getAddress(), leftSize, rightNative.getAddress(), rightSize);
+        } else // just in case of new implementations of ValueAccessor appear
+            return ByteBufferUtil.compareUnsigned(left.asByteBuffer(), accessorR.toBuffer(right));
+    }
+
+    @Override
+    public int compareByteArrayTo(byte[] left, NativeData right)
+    {
+        return FastByteOperations.compareWithMemoryUnsigned(left, 0, left.length, right.getAddress(), right.nativeDataSize());
+    }
+
+    @Override
+    public int compareByteBufferTo(ByteBuffer left, NativeData right)
+    {
+        return FastByteOperations.compareWithMemoryUnsigned(left, right.getAddress(), right.nativeDataSize());
+    }
+
+     // -----------------------------------------------------------------------------
+     // Data deserialization methods
+
+    @Override
+    public byte[] toArray(NativeData value)
+    {
+        if (value == null)
+            return null;
+        int size = value.nativeDataSize();
+        byte[] result = new byte[size];
+        MemoryUtil.getBytes(value.getAddress(), result, 0, size);
+        return result;
+    }
+
+    @Override
+    public byte[] toArray(NativeData value, int offset, int length)
+    {
+        if (value == null)
+            return null;
+        int size = value.nativeDataSize();
+        if (length > size)
+            throw new IllegalArgumentException("length (" + length + ") cannot be more than the value size (" + size + ")");
+
+        byte[] result = new byte[length];
+        MemoryUtil.getBytes(value.getAddress() + offset, result, 0, length);
+        return result;
+    }
+
+    @Override
+    public String toString(NativeData value, Charset charset) throws CharacterCodingException
+    {
+        return ByteBufferUtil.string(value.asByteBuffer(), charset);
+    }
+
+    @Override
+    public String toHex(NativeData value)
+    {
+        return ByteBufferUtil.bytesToHex(value.asByteBuffer());
+    }
+
+    @Override
+    public byte toByte(NativeData value)
+    {
+        return getByte(value, 0);
+    }
+
+    @Override
+    public byte getByte(NativeData value, int offset)
+    {
+        return MemoryUtil.getByte(value.getAddress() + offset);
+    }
+
+    @Override
+    public short toShort(NativeData value)
+    {
+        return getShort(value, 0);
+    }
+
+    @Override
+    public short getShort(NativeData value, int offset)
+    {
+        return (short) BigEndianMemoryUtil.getUnsignedShort(value.getAddress() + offset);
+    }
+
+    @Override
+    public int getUnsignedShort(NativeData value, int offset)
+    {
+        return BigEndianMemoryUtil.getUnsignedShort(value.getAddress() + offset);
+    }
+
+    @Override
+    public int toInt(NativeData value)
+    {
+        return getInt(value, 0);
+    }
+
+    @Override
+    public int getInt(NativeData value, int offset)
+    {
+        return BigEndianMemoryUtil.getInt(value.getAddress() + offset);
+    }
+
+    @Override
+    public long toLong(NativeData value)
+    {
+        return getLong(value, 0);
+    }
+
+    @Override
+    public long getLong(NativeData value, int offset)
+    {
+        return BigEndianMemoryUtil.getLong(value.getAddress() + offset);
+    }
+
+    @Override
+    public float getFloat(NativeData value, int offset)
+    {
+        return Float.intBitsToFloat(BigEndianMemoryUtil.getInt(value.getAddress() + offset));
+    }
+
+    @Override
+    public double getDouble(NativeData value, int offset)
+    {
+        return Double.longBitsToDouble(BigEndianMemoryUtil.getLong(value.getAddress() + offset));
+    }
+
+    @Override
+    public float toFloat(NativeData value)
+    {
+        return getFloat(value, 0);
+    }
+
+    @Override
+    public double toDouble(NativeData value)
+    {
+        return getDouble(value, 0);
+    }
+
+    @Override
+    public UUID toUUID(NativeData value)
+    {
+        long mostSigBits = getLong(value, 0);
+        long leastSigBits = getLong(value, 8);
+
+        return UUIDGen.getUUID(mostSigBits, leastSigBits);
+    }
+
+    @Override
+    public TimeUUID toTimeUUID(NativeData value)
+    {
+        long mostSigBits = getLong(value, 0);
+        long leastSigBits = getLong(value, 8);
+        return TimeUUID.fromBytes(mostSigBits, leastSigBits);
+    }
+
+    @Override
+    public Ballot toBallot(NativeData value)
+    {
+        long mostSigBits = getLong(value, 0);
+        long leastSigBits = getLong(value, 8);
+        return Ballot.fromBytes(mostSigBits, leastSigBits);
+    }
+
+    @Override
+    public float[] toFloatArray(NativeData value, int dimension)
+    {
+        int arraySize = value.nativeDataSize() / Float.BYTES;
+        if (arraySize != dimension)
+            throw new IllegalArgumentException(String.format("Could not convert to a float[] with different dimension. " +
+                                                             "Was expecting %d but got %d", dimension, arraySize));
+        float[] floatArray = new float[arraySize];
+        for (int i = 0; i < arraySize; i++)
+        {
+            floatArray[i] = Float.intBitsToFloat(getInt(value, i * Float.BYTES));
+        }
+        return floatArray;
+    }
+
+
+    // -----------------------------------------------------------------------------
+    // Data serialization methods
+    @Override
+    public int putByte(NativeData dstNative, int offset, byte value)
+    {
+        BigEndianMemoryUtil.setByte(dstNative.getAddress() + offset, value);
+        return TypeSizes.BYTE_SIZE;
+    }
+
+    @Override
+    public int putShort(NativeData dstNative, int offset, short value)
+    {
+        BigEndianMemoryUtil.setShort(dstNative.getAddress() + offset, value);
+        return TypeSizes.SHORT_SIZE;
+    }
+
+    @Override
+    public int putInt(NativeData dstNative, int offset, int value)
+    {
+        BigEndianMemoryUtil.setInt(dstNative.getAddress() + offset, value);
+        return TypeSizes.INT_SIZE;
+    }
+
+    @Override
+    public int putLong(NativeData dstNative, int offset, long value)
+    {
+        BigEndianMemoryUtil.setLong(dstNative.getAddress() + offset, value);
+        return TypeSizes.LONG_SIZE;
+    }
+
+    @Override
+    public int putFloat(NativeData dstNative, int offset, float value)
+    {
+        putInt(dstNative, offset, Float.floatToIntBits(value));
+        return TypeSizes.FLOAT_SIZE;
+    }
+
+    @Override
+    public NativeData[] createArray(int length)
+    {
+        return new NativeData[length];
+    }
+
+    // -----------------------------------------------------------------------------
+    // Value object creation methods
+    // We do not expect the methods are used in real logic for NativeData,
+    // but they are needed to reuse existing unit tests written for other implementation of ValueAccessor.
+    
+    private static NativeDataAllocator allocator = NativeDataAllocator.UNSUPPORTED;
+
+    @VisibleForTesting
+    public static void setNativeMemoryAllocator(NativeDataAllocator allocatorToSet)
+    {
+        allocator = allocatorToSet;
+    }
+
+    @Override
+    public NativeData read(DataInputPlus in, int length) throws IOException
+    {
+        ByteBuffer data = ByteBufferUtil.read(in, length);
+        return allocator.allocateBasedOnBuffer(data);
+    }
+
+    @Override
+    public NativeData empty()
+    {
+        return AddressBasedNativeData.EMPTY;
+    }
+
+    @Override
+    public NativeData valueOf(byte[] bytes)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(bytes));
+    }
+
+    @Override
+    public NativeData valueOf(ByteBuffer bytes)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(bytes));
+    }
+
+    @Override
+    public NativeData valueOf(String s, Charset charset)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(s, charset));
+    }
+
+    @Override
+    public NativeData valueOf(UUID v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(boolean v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(byte v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(short v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(int v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(long v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(float v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public NativeData valueOf(double v)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.valueOf(v));
+    }
+
+    @Override
+    public <V2> NativeData convert(V2 src, ValueAccessor<V2> accessor)
+    {
+        if (accessor == NativeAccessor.instance)
+            return (NativeData) src;
+        return allocator.allocateBasedOnBuffer(accessor.toBuffer(src));
+    }
+
+    @Override
+    public NativeData allocate(int size)
+    {
+        return allocator.allocateBasedOnBuffer(ByteBufferAccessor.instance.allocate(size));
+    }
+
+    @Override
+    public ObjectFactory<NativeData> factory()
+    {
+        // The method is used to de-serialize and create different parts of a Mutation object
+        // to transfer it between Cassandra nodes.
+        // The current implementation of NativeData does not support creating of such objects in-flight
+        // because it requires to have a native memory pool/allocator and manage its lifecycle.
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/java/org/apache/cassandra/db/marshal/NativeData.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeData.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+
+public interface NativeData
+{
+    int nativeDataSize();
+
+    ByteBuffer asByteBuffer();
+
+    NativeData slice(int offset, int length);
+
+    public long getAddress();
+}

--- a/src/java/org/apache/cassandra/db/marshal/NativeDataAllocator.java
+++ b/src/java/org/apache/cassandra/db/marshal/NativeDataAllocator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.nio.ByteBuffer;
+
+public interface NativeDataAllocator extends AutoCloseable
+{
+    NativeDataAllocator UNSUPPORTED = data -> {
+        throw new UnsupportedOperationException("The method is not expected to be used by NativeAccessor outside of tests. " +
+                                                "NativeData can be allocated only by a memtable NativeAllocator");
+    };
+
+    NativeData allocateBasedOnBuffer(ByteBuffer data);
+
+    @Override
+    default void close() {};
+}

--- a/src/java/org/apache/cassandra/db/rows/NativeCell.java
+++ b/src/java/org/apache/cassandra/db/rows/NativeCell.java
@@ -20,7 +20,9 @@ package org.apache.cassandra.db.rows;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import org.apache.cassandra.db.marshal.ByteBufferAccessor;
+import org.apache.cassandra.db.marshal.AddressBasedNativeData;
+import org.apache.cassandra.db.marshal.NativeAccessor;
+import org.apache.cassandra.db.marshal.NativeData;
 import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -30,7 +32,7 @@ import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.apache.cassandra.utils.memory.NativeAllocator;
 import org.apache.cassandra.utils.memory.NativeEndianMemoryUtil;
 
-public class NativeCell extends AbstractCell<ByteBuffer>
+public class NativeCell extends AbstractCell<NativeData> implements NativeData
 {
     private static final long EMPTY_SIZE = ObjectSizes.measure(new NativeCell());
 
@@ -135,15 +137,20 @@ public class NativeCell extends AbstractCell<ByteBuffer>
         return NativeEndianMemoryUtil.getInt(peer + TTL);
     }
 
-    public ByteBuffer value()// FIXME: add native accessor
+    public NativeData value()
     {
-        int length = NativeEndianMemoryUtil.getInt(peer + LENGTH);
-        return MemoryUtil.getByteBuffer(peer + VALUE, length, ByteOrder.BIG_ENDIAN);
+        return this;
     }
 
-    public ValueAccessor<ByteBuffer> accessor()
+    public ByteBuffer byteBufferValue()
     {
-        return ByteBufferAccessor.instance;  // FIXME: add native accessor
+        int length = valueSize();
+        return MemoryUtil.getByteBuffer(getAddress(), length, ByteOrder.BIG_ENDIAN);
+    }
+
+    public ValueAccessor<NativeData> accessor()
+    {
+        return NativeAccessor.instance;
     }
 
     public int valueSize()
@@ -156,7 +163,7 @@ public class NativeCell extends AbstractCell<ByteBuffer>
         if (!hasPath())
             return null;
 
-        long offset = peer + VALUE + NativeEndianMemoryUtil.getInt(peer + LENGTH);
+        long offset = getAddress() + valueSize();
         int size = NativeEndianMemoryUtil.getInt(offset);
         return CellPath.create(MemoryUtil.getByteBuffer(offset + 4, size, ByteOrder.BIG_ENDIAN));
     }
@@ -169,17 +176,17 @@ public class NativeCell extends AbstractCell<ByteBuffer>
     @Override
     public Cell<?> withUpdatedTimestamp(long newTimestamp)
     {
-        return new BufferCell(column, newTimestamp, ttl(), localDeletionTime(), value(), path());
+        return new BufferCell(column, newTimestamp, ttl(), localDeletionTime(), byteBufferValue(), path());
     }
 
     public Cell<?> withUpdatedTimestampAndLocalDeletionTime(long newTimestamp, long newLocalDeletionTime)
     {
-        return new BufferCell(column, newTimestamp, ttl(), newLocalDeletionTime, value(), path());
+        return new BufferCell(column, newTimestamp, ttl(), newLocalDeletionTime, byteBufferValue(), path());
     }
 
     public Cell<?> withUpdatedColumn(ColumnMetadata column)
     {
-        return new BufferCell(column, timestamp(), ttl(), localDeletionTimeAsUnsignedInt(), value(), path());
+        return new BufferCell(column, timestamp(), ttl(), localDeletionTimeAsUnsignedInt(), byteBufferValue(), path());
     }
 
     public Cell<?> withSkippedValue()
@@ -216,5 +223,29 @@ public class NativeCell extends AbstractCell<ByteBuffer>
     protected int localDeletionTimeAsUnsignedInt()
     {
         return NativeEndianMemoryUtil.getInt(peer + DELETION);
+    }
+
+
+    @Override
+    public int nativeDataSize()
+    {
+        return valueSize();
+    }
+
+    @Override
+    public ByteBuffer asByteBuffer()
+    {
+        return byteBufferValue();
+    }
+    @Override
+    public NativeData slice(int offset, int length)
+    {
+        return new AddressBasedNativeData(getAddress() + offset, length);
+    }
+
+    @Override
+    public long getAddress()
+    {
+        return peer + VALUE;
     }
 }

--- a/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
+++ b/src/java/org/apache/cassandra/index/sai/plan/QueryController.java
@@ -455,7 +455,12 @@ public class QueryController
         {
             nextClusterings.clear();
             for (PrimaryKey key : keys)
-                nextClusterings.add(key.clustering());
+            {
+                // primary keys privided by SAI may contain NativeCustering
+                // filter logic may use ValueAccessor.factory() for slicing, which is not supported for NativeCustering
+                Clustering<?> clustering = key.clustering().ensureAccessorFactorySupport();
+                nextClusterings.add(clustering);
+            }
             return new ClusteringIndexNamesFilter(nextClusterings, clusteringIndexFilter.isReversed());
         }
     }

--- a/src/java/org/apache/cassandra/io/util/BufferedDataOutputStreamPlus.java
+++ b/src/java/org/apache/cassandra/io/util/BufferedDataOutputStreamPlus.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 
 import net.nicoulaj.compilecommand.annotations.DontInline;
 import org.apache.cassandra.utils.FastByteOperations;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.NIO_DATA_OUTPUT_STREAM_PLUS_BUFFER_SIZE;
 
@@ -135,6 +136,25 @@ public class BufferedDataOutputStreamPlus extends DataOutputStreamPlus
             doFlush(src.limit() - srcPos);
         }
         FastByteOperations.copy(src, srcPos, buffer, buffer.position(), srcCount);
+        buffer.position(buffer.position() + srcCount);
+    }
+
+    @Override
+    public void writeMemory(long address, int length) throws IOException
+    {
+        assert buffer != null : "Attempt to use a closed data output";
+        long srcPos = address;
+        int srcCount = length;
+        int trgAvailable;
+        while (srcCount > (trgAvailable = buffer.remaining()))
+        {
+            MemoryUtil.getBytes(srcPos, buffer, trgAvailable);
+            buffer.position(buffer.position() + trgAvailable);
+            srcPos += trgAvailable;
+            srcCount -= trgAvailable;
+            doFlush(srcCount);
+        }
+        MemoryUtil.getBytes(srcPos, buffer, srcCount);
         buffer.position(buffer.position() + srcCount);
     }
 

--- a/src/java/org/apache/cassandra/io/util/DataOutputPlus.java
+++ b/src/java/org/apache/cassandra/io/util/DataOutputPlus.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.io.util;
 
 import org.apache.cassandra.utils.Shared;
+import org.apache.cassandra.utils.memory.MemoryUtil;
 import org.apache.cassandra.utils.vint.VIntCoding;
 
 import java.io.DataOutput;
@@ -42,6 +43,11 @@ public interface DataOutputPlus extends DataOutput
     {
         for (ByteBuffer buffer : memory.asByteBuffers(offset, length))
             write(buffer);
+    }
+
+    default void writeMemory(long address, int length) throws IOException
+    {
+        write(MemoryUtil.getByteBuffer(address, length));
     }
 
     default void writeVInt(long i) throws IOException

--- a/src/java/org/apache/cassandra/utils/FastByteOperations.java
+++ b/src/java/org/apache/cassandra/utils/FastByteOperations.java
@@ -70,6 +70,21 @@ public class FastByteOperations
         return BestHolder.BEST.compare(b1, b2);
     }
 
+    public static int compareWithMemoryUnsigned(ByteBuffer b1, long address2, int length2)
+    {
+        return BestHolder.BEST.compare(b1, address2, length2);
+    }
+
+    public static int compareWithMemoryUnsigned(byte[] b1, int s1, int l1, long address2, int length2)
+    {
+        return BestHolder.BEST.compare(b1, s1,l1, address2, length2);
+    }
+
+    public static int compareMemoryUnsigned(long address1, int length1, long address2, int length2)
+    {
+        return BestHolder.BEST.compare(address1, length1, address2, length2);
+    }
+
     public static int compareUnsigned(byte[] b1, byte[] b2)
     {
         return compareUnsigned(b1, 0, b1.length, b2, 0, b2.length);
@@ -101,6 +116,12 @@ public class FastByteOperations
                                     byte[] buffer2, int offset2, int length2);
 
         abstract public int compare(ByteBuffer buffer1, byte[] buffer2, int offset2, int length2);
+
+        abstract public int compare(ByteBuffer buffer1, long address2, int length2);
+
+        abstract public int compare(long address1, int length1, long address2, int length2);
+
+        abstract public int compare(byte[] buffer1, int offset1, int length1, long address2, int length2);
 
         abstract public int compare(ByteBuffer buffer1, int offset1, int length1, byte[] buffer2, int offset2, int length2);
 
@@ -221,6 +242,44 @@ public class FastByteOperations
             return compare(buffer1, buffer1.position(), buffer1.remaining(), buffer2, offset2, length2);
         }
 
+        @Override
+        public int compare(ByteBuffer buffer1, long address2, int length2)
+        {
+            return compare(buffer1, buffer1.position(), buffer1.remaining(), address2, length2);
+        }
+
+        public int compare(ByteBuffer buffer1, int position1, int length1, long address2, int length2)
+        {
+            {
+                Object obj1;
+                long offset1;
+                if (buffer1.hasArray())
+                {
+                    obj1 = buffer1.array();
+                    offset1 = BYTE_ARRAY_BASE_OFFSET + buffer1.arrayOffset() + position1;
+                }
+                else
+                {
+                    obj1 = null;
+                    offset1 = theUnsafe.getLong(buffer1, DIRECT_BUFFER_ADDRESS_OFFSET) + position1;
+                }
+
+                return compareTo(obj1, offset1, length1, null, address2, length2);
+            }
+        }
+        @Override
+        public int compare(long address1, int length1, long address2, int length2)
+        {
+            return compareTo(null, address1, length1, null, address2, length2);
+        }
+
+        @Override
+        public int compare(byte[] buffer1, int offset1, int length1, long address2, int length2)
+        {
+            return compareTo(buffer1, BYTE_ARRAY_BASE_OFFSET + offset1, length1,
+                             null, address2, length2);
+        }
+
         public int compare(ByteBuffer buffer1, int position1, int length1, byte[] buffer2, int offset2, int length2)
         {
             Object obj1;
@@ -262,7 +321,7 @@ public class FastByteOperations
             if (trg.hasArray())
                 System.arraycopy(src, srcPosition, trg.array(), trg.arrayOffset() + trgPosition, length);
             else
-                copy(null, srcPosition + theUnsafe.getLong(src, Unsafe.ARRAY_BYTE_BASE_OFFSET), trg, trgPosition, length);
+                copy(src, (long) srcPosition + Unsafe.ARRAY_BYTE_BASE_OFFSET, trg, trgPosition, length);
         }
 
         public void copy(ByteBuffer srcBuf, int srcPosition, ByteBuffer trgBuf, int trgPosition, int length)
@@ -463,6 +522,24 @@ public class FastByteOperations
             }
 
             return compare(buffer1, ByteBuffer.wrap(buffer2, offset2, length2));
+        }
+
+        @Override
+        public int compare(ByteBuffer b1, long address2, int length2)
+        {
+            throw new UnsupportedOperationException("native memory address is an argument, we cannot do it using a pure Java");
+        }
+
+        @Override
+        public int compare(long address1, int length1, long address2, int length2)
+        {
+            throw new UnsupportedOperationException("native memory address is an argument, we cannot do it using a pure Java");
+        }
+
+        @Override
+        public int compare(byte[] b1, int s1, int l1, long address2, int length2)
+        {
+            throw new UnsupportedOperationException("native memory address is an argument, we cannot do it using a pure Java");
         }
 
         public int compare(ByteBuffer buffer1, ByteBuffer buffer2)

--- a/src/java/org/apache/cassandra/utils/FastByteOperations.java
+++ b/src/java/org/apache/cassandra/utils/FastByteOperations.java
@@ -321,7 +321,7 @@ public class FastByteOperations
             if (trg.hasArray())
                 System.arraycopy(src, srcPosition, trg.array(), trg.arrayOffset() + trgPosition, length);
             else
-                copy(src, (long) srcPosition + Unsafe.ARRAY_BYTE_BASE_OFFSET, trg, trgPosition, length);
+                copy((Object) src, (long) srcPosition + Unsafe.ARRAY_BYTE_BASE_OFFSET, trg, trgPosition, length);
         }
 
         public void copy(ByteBuffer srcBuf, int srcPosition, ByteBuffer trgBuf, int trgPosition, int length)

--- a/src/java/org/apache/cassandra/utils/UUIDGen.java
+++ b/src/java/org/apache/cassandra/utils/UUIDGen.java
@@ -30,7 +30,12 @@ public class UUIDGen
     /** creates a type 1 uuid from raw bytes. */
     public static UUID getUUID(ByteBuffer raw)
     {
-        return new UUID(raw.getLong(raw.position()), raw.getLong(raw.position() + 8));
+        return getUUID(raw.getLong(raw.position()), raw.getLong(raw.position() + 8));
+    }
+
+    public static UUID getUUID(long mostSigBits, long leastSigBits)
+    {
+        return new UUID(mostSigBits, leastSigBits);
     }
 
     public static ByteBuffer toByteBuffer(UUID uuid)

--- a/src/java/org/apache/cassandra/utils/memory/BigEndianMemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/BigEndianMemoryUtil.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.utils.Architecture;
+
+public class BigEndianMemoryUtil extends MemoryUtil
+{
+    public static int getUnsignedShort(long address)
+    {
+        if (Architecture.IS_UNALIGNED || (address & 0b1) == 0L)
+            return (Architecture.BIG_ENDIAN ? unsafe.getShort(address) : Short.reverseBytes(unsafe.getShort(address))) & 0xffff;
+        else
+            return getShortByByte(address) & 0xffff;
+    }
+
+    public static int getInt(long address)
+    {
+        if (Architecture.IS_UNALIGNED || (address & 0b11) == 0L)
+            return Architecture.BIG_ENDIAN ? unsafe.getInt(address) : Integer.reverseBytes(unsafe.getInt(address));
+        else
+            return getIntByByte(address);
+    }
+
+    public static long getLong(long address)
+    {
+        if (Architecture.IS_UNALIGNED || (address & 0b111) == 0L)
+            return Architecture.BIG_ENDIAN ? unsafe.getLong(address) : Long.reverseBytes(unsafe.getLong(address));
+        else
+            return getLongByByte(address);
+    }
+
+    public static void setShort(long address, short s)
+    {
+        if (Architecture.IS_UNALIGNED || (address & 0b1) == 0L)
+            unsafe.putShort(address, Architecture.BIG_ENDIAN ? s : Short.reverseBytes(s));
+        else
+            putShortByByte(address, s);
+    }
+
+    public static void setInt(long address, int l)
+    {
+        if (Architecture.IS_UNALIGNED || (address & 0b11) == 0L)
+            unsafe.putInt(address, Architecture.BIG_ENDIAN ? l : Integer.reverseBytes(l));
+        else
+            putIntByByte(address, l);
+    }
+
+    public static void setLong(long address, long l)
+    {
+        if (Architecture.IS_UNALIGNED || (address & 0b111) == 0L)
+            unsafe.putLong(address, Architecture.BIG_ENDIAN ? l : Long.reverseBytes(l));
+        else
+            putLongByByte(address, l);
+    }
+
+    @VisibleForTesting
+    static long getLongByByte(long address)
+    {
+        return  (((long) unsafe.getByte(address    )       ) << 56) |
+                (((long) unsafe.getByte(address + 1) & 0xff) << 48) |
+                (((long) unsafe.getByte(address + 2) & 0xff) << 40) |
+                (((long) unsafe.getByte(address + 3) & 0xff) << 32) |
+                (((long) unsafe.getByte(address + 4) & 0xff) << 24) |
+                (((long) unsafe.getByte(address + 5) & 0xff) << 16) |
+                (((long) unsafe.getByte(address + 6) & 0xff) <<  8) |
+                (((long) unsafe.getByte(address + 7) & 0xff)      );
+    }
+
+    @VisibleForTesting
+    static int getIntByByte(long address)
+    {
+        return  (((int) unsafe.getByte(address    )       ) << 24) |
+                (((int) unsafe.getByte(address + 1) & 0xff) << 16) |
+                (((int) unsafe.getByte(address + 2) & 0xff) <<  8) |
+                (((int) unsafe.getByte(address + 3) & 0xff)      );
+    }
+
+    @VisibleForTesting
+    static int getShortByByte(long address)
+    {
+        return  (((int) unsafe.getByte(address    )       ) << 8) |
+                (((int) unsafe.getByte(address + 1) & 0xff)     );
+    }
+
+    @VisibleForTesting
+    static void putLongByByte(long address, long value)
+    {
+        unsafe.putByte(address    , (byte) (value >> 56));
+        unsafe.putByte(address + 1, (byte) (value >> 48));
+        unsafe.putByte(address + 2, (byte) (value >> 40));
+        unsafe.putByte(address + 3, (byte) (value >> 32));
+        unsafe.putByte(address + 4, (byte) (value >> 24));
+        unsafe.putByte(address + 5, (byte) (value >> 16));
+        unsafe.putByte(address + 6, (byte) (value >>  8));
+        unsafe.putByte(address + 7, (byte) (value      ));
+    }
+
+    @VisibleForTesting
+    static void putIntByByte(long address, int value)
+    {
+        unsafe.putByte(address    , (byte) (value >> 24));
+        unsafe.putByte(address + 1, (byte) (value >> 16));
+        unsafe.putByte(address + 2, (byte) (value >>  8));
+        unsafe.putByte(address + 3, (byte) (value      ));
+    }
+
+    @VisibleForTesting
+    static void putShortByByte(long address, short value)
+    {
+        unsafe.putByte(address    , (byte) (value >> 8));
+        unsafe.putByte(address + 1, (byte) (value     ));
+    }
+
+    public static ByteBuffer getByteBuffer(long address, int length)
+    {
+        return getByteBuffer(address, length, ByteOrder.BIG_ENDIAN);
+    }
+
+    public static ByteBuffer getHollowDirectByteBuffer()
+    {
+        return getHollowDirectByteBuffer(ByteOrder.BIG_ENDIAN);
+    }
+}

--- a/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
+++ b/src/java/org/apache/cassandra/utils/memory/MemoryUtil.java
@@ -184,6 +184,26 @@ public abstract class MemoryUtil
         unsafe.putInt(instance, DIRECT_BYTE_BUFFER_CAPACITY_OFFSET, capacity);
     }
 
+    /**
+     * Transfers count bytes to Memory starting at memoryOffset from ByteBuffer starting at bufferOffset
+     *
+     * @param targetAddress target start offset in the memory
+     * @param sourceBuffer the source data buffer
+     * @param bufferOffset start offset of the buffer
+     * @param count number of bytes to transfer
+     */
+    public static void setBytes(long targetAddress, ByteBuffer sourceBuffer, int bufferOffset, int count)
+    {
+        if (count == 0)
+            return;
+        int start = sourceBuffer.position() + bufferOffset;
+
+        if (sourceBuffer.isDirect())
+            setBytes(getAddress(sourceBuffer) + start, targetAddress, count);
+        else
+            setBytes(targetAddress, sourceBuffer.array(), sourceBuffer.arrayOffset() + start, count);
+    }
+
     public static void setBytes(long address, ByteBuffer buffer)
     {
         int start = buffer.position();
@@ -254,5 +274,52 @@ public abstract class MemoryUtil
             return;
 
         unsafe.copyMemory(null, address, buffer, BYTE_ARRAY_BASE_OFFSET + bufferOffset, count);
+    }
+
+    /**
+     * Transfers count bytes from Memory starting at address to ByteBuffer starting at bufferOffset
+     *
+     * @param sourceAddress start offset in the memory
+     * @param targetBuffer the target data buffer
+     * @param bufferOffset start offset of the buffer
+     * @param length number of bytes to transfer
+     */
+    public static void getBytes(long sourceAddress, ByteBuffer targetBuffer, int bufferOffset, int length)
+    {
+        if (targetBuffer == null)
+            throw new NullPointerException();
+        else if (length < 0 || length > targetBuffer.remaining())
+            throw new IndexOutOfBoundsException();
+        else if (length == 0)
+            return;
+
+        Object obj;
+        long offset;
+        if (targetBuffer.hasArray())
+        {
+            obj = targetBuffer.array();
+            offset = BYTE_ARRAY_BASE_OFFSET + targetBuffer.arrayOffset();
+        }
+        else
+        {
+            obj = null;
+            offset = unsafe.getLong(targetBuffer, DIRECT_BYTE_BUFFER_ADDRESS_OFFSET);
+        }
+        offset += targetBuffer.position();
+        offset += bufferOffset;
+
+        unsafe.copyMemory(null, sourceAddress, obj, offset, length);
+    }
+
+    /**
+     * Transfers count bytes from Memory starting at address to ByteBuffer
+     *
+     * @param sourceAddress start offset in the memory
+     * @param targetBuffer the target data buffer
+     * @param length number of bytes to transfer
+     */
+    public static void getBytes(long sourceAddress, ByteBuffer targetBuffer, int length)
+    {
+        getBytes(sourceAddress, targetBuffer, 0, length);
     }
 }

--- a/test/unit/org/apache/cassandra/db/ClusteringHeapSizeTest.java
+++ b/test/unit/org/apache/cassandra/db/ClusteringHeapSizeTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.cassandra.db.marshal.NativeAccessor;
+import org.apache.cassandra.db.marshal.ValueAccessor;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.concurrent.ImmediateFuture;
 import org.apache.cassandra.utils.concurrent.OpOrder;
@@ -65,15 +65,14 @@ public class ClusteringHeapSizeTest
     @Test
     public void testSingletonClusteringHeapSize()
     {
-        if (this.clustering.accessor() == NativeAccessor.instance)
-            return; // factory logic is not supported for NativeAccessor, it is read-only
-        Clustering<?> clustering = this.clustering.accessor().factory().staticClustering();
+        ValueAccessor.ObjectFactory<?> factory = this.clustering.ensureAccessorFactorySupport().accessor().factory();
+        Clustering<?> clustering = factory.staticClustering();
         Assertions.assertThat(clustering.unsharedHeapSize())
                   .isEqualTo(0);
         Assertions.assertThat(clustering.unsharedHeapSizeExcludingData())
                   .isEqualTo(0);
 
-        clustering = this.clustering.accessor().factory().clustering();
+        clustering = factory.clustering();
         Assertions.assertThat(clustering.unsharedHeapSize())
                   .isEqualTo(0);
         Assertions.assertThat(clustering.unsharedHeapSizeExcludingData())

--- a/test/unit/org/apache/cassandra/db/ClusteringHeapSizeTest.java
+++ b/test/unit/org/apache/cassandra/db/ClusteringHeapSizeTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.cassandra.db.marshal.NativeAccessor;
 import org.apache.cassandra.utils.ObjectSizes;
 import org.apache.cassandra.utils.concurrent.ImmediateFuture;
 import org.apache.cassandra.utils.concurrent.OpOrder;
@@ -64,6 +65,8 @@ public class ClusteringHeapSizeTest
     @Test
     public void testSingletonClusteringHeapSize()
     {
+        if (this.clustering.accessor() == NativeAccessor.instance)
+            return; // factory logic is not supported for NativeAccessor, it is read-only
         Clustering<?> clustering = this.clustering.accessor().factory().staticClustering();
         Assertions.assertThat(clustering.unsharedHeapSize())
                   .isEqualTo(0);

--- a/test/unit/org/apache/cassandra/db/ClusteringPrefixTest.java
+++ b/test/unit/org/apache/cassandra/db/ClusteringPrefixTest.java
@@ -180,7 +180,7 @@ public class ClusteringPrefixTest
 
     public <V> void testRetainable(ValueAccessor.ObjectFactory<V> factory,
                                    Function<String, V[]> allocator,
-                                   Function<ClusteringPrefix<V>, ClusteringPrefix<V>> mapper)
+                                   Function<ClusteringPrefix<?>, ClusteringPrefix<?>> mapper)
     {
         ClusteringPrefix<V>[] clusterings = new ClusteringPrefix[]
         {

--- a/test/unit/org/apache/cassandra/db/NativeCellTest.java
+++ b/test/unit/org/apache/cassandra/db/NativeCellTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.cassandra.db;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Random;
@@ -30,6 +31,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -37,6 +39,7 @@ import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.db.marshal.SetType;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.rows.*;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.concurrent.ImmediateFuture;
 import org.apache.cassandra.utils.concurrent.OpOrder;
 import org.apache.cassandra.utils.memory.HeapCloner;
@@ -63,7 +66,7 @@ public class NativeCellTest extends CQLTester
     }
 
     @Test
-    public void testCells()
+    public void testCells() throws Exception
     {
         for (int run = 0 ; run < 1000 ; run++)
         {
@@ -153,7 +156,7 @@ public class NativeCellTest extends CQLTester
         return Math.min(Math.max(1, randomsize), 1 << 26);
     }
 
-    private static void test(Row row)
+    private static void test(Row row)  throws Exception
     {
         Row nrow = row.clone(nativeAllocator.cloner(group));
         Row brow = row.clone(HeapCloner.instance);
@@ -161,21 +164,170 @@ public class NativeCellTest extends CQLTester
         Assert.assertEquals(row, brow);
         Assert.assertEquals(nrow, brow);
 
-        Assert.assertEquals(row.clustering(), nrow.clustering());
-        Assert.assertEquals(row.clustering(), brow.clustering());
-        Assert.assertEquals(nrow.clustering(), brow.clustering());
+        Digest rowDigest = Digest.forReadResponse();
+        Digest nativeRowDigest = Digest.forReadResponse();
+        Digest byteBufferRowDigest = Digest.forReadResponse();
+        row.digest(rowDigest);
+        nrow.digest(nativeRowDigest);
+        brow.digest(byteBufferRowDigest);
+        byte[] rowDigestValue = rowDigest.digest();
+        Assert.assertArrayEquals(rowDigestValue, nativeRowDigest.digest());
+        Assert.assertArrayEquals(rowDigestValue, byteBufferRowDigest.digest());
 
-        Assert.assertEquals(row.clustering().dataSize(), nrow.clustering().dataSize());
-        Assert.assertEquals(row.clustering().dataSize(), brow.clustering().dataSize());
+        Assert.assertEquals(row.dataSize(), nrow.dataSize());
+        Assert.assertEquals(row.dataSize(), brow.dataSize());
 
-        ClusteringComparator comparator = new ClusteringComparator(UTF8Type.instance);
-        Assert.assertEquals(0, comparator.compare(row.clustering(), nrow.clustering()));
-        Assert.assertEquals(0, comparator.compare(row.clustering(), brow.clustering()));
-        Assert.assertEquals(0, comparator.compare(nrow.clustering(), brow.clustering()));
+        assertClustering(row, brow, nrow);
 
         assertCellsDataSize(row, nrow);
         assertCellsDataSize(row, brow);
 
+        assertCellsWrittenToOutput(row, nrow);
+        assertCellsWrittenToOutput(row, brow);
+
+        assertCellsSlicing(row, nrow);
+        assertCellsSlicing(row, brow);
+    }
+
+    private static void assertClustering(Row row, Row byteBufferRow, Row nativeRow) throws Exception
+    {
+        Assert.assertEquals(row.clustering(), nativeRow.clustering());
+        Assert.assertEquals(row.clustering(), byteBufferRow.clustering());
+        Assert.assertEquals(nativeRow.clustering(), byteBufferRow.clustering());
+
+        ClusteringComparator comparator = new ClusteringComparator(UTF8Type.instance);
+        Assert.assertEquals(0, comparator.compare(row.clustering(), nativeRow.clustering()));
+        Assert.assertEquals(0, comparator.compare(row.clustering(), byteBufferRow.clustering()));
+        Assert.assertEquals(0, comparator.compare(nativeRow.clustering(), byteBufferRow.clustering()));
+        Assert.assertEquals(0, comparator.compare(nativeRow.clustering(), row.clustering()));
+        Assert.assertEquals(0, comparator.compare(nativeRow.clustering(), nativeRow.clustering()));
+
+
+        Assert.assertEquals(row.clustering().size(), nativeRow.clustering().size());
+        Assert.assertEquals(row.clustering().size(), byteBufferRow.clustering().size());
+
+        assertByteBufferArrayEquals(row.clustering().getBufferArray(), nativeRow.clustering().getBufferArray());
+        assertByteBufferArrayEquals(row.clustering().getBufferArray(), byteBufferRow.clustering().getBufferArray());
+
+        assertRawValuesEquals(row.clustering(), nativeRow.clustering());
+        assertRawValuesEquals(row.clustering(), byteBufferRow.clustering());
+
+
+        for (int i = 0; i < row.clustering().size(); i++)
+        {
+            Assert.assertEquals(row.clustering().isEmpty(i), byteBufferRow.clustering().isEmpty(i));
+            Assert.assertEquals(row.clustering().isEmpty(i), nativeRow.clustering().isEmpty(i));
+
+            Assert.assertEquals(row.clustering().isNull(i), byteBufferRow.clustering().isNull(i));
+            Assert.assertEquals(row.clustering().isNull(i), nativeRow.clustering().isNull(i));
+        }
+
+        assertClusteringElementSizes(row.clustering(), byteBufferRow.clustering());
+        assertClusteringElementSizes(row.clustering(), nativeRow.clustering());
+
+        assertClusteringElementWrittenToOutput(row.clustering(), byteBufferRow.clustering());
+        assertClusteringElementWrittenToOutput(row.clustering(), nativeRow.clustering());
+
+        assertClusteringSlicing(row.clustering(), byteBufferRow.clustering());
+        assertClusteringSlicing(row.clustering(), nativeRow.clustering());
+
+    }
+
+    private static <V1, V2> void assertRawValuesEquals(Clustering<V1> c1, Clustering<V2> c2)
+    {
+        V1[] rawValues1 = c1.getRawValues();
+        V2[] rawValues2 = c2.getRawValues();
+        Assert.assertEquals(rawValues1.length, rawValues2.length);
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (rawValues1[i] != null)
+                Assert.assertEquals(0, c1.accessor().compare(rawValues1[i], rawValues2[i], c2.accessor()));
+        }
+    }
+
+    private static <V1, V2> void assertClusteringElementSizes(Clustering<V1> c1, Clustering<V2> c2)
+    {
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (c1.get(i) != null)
+            {
+                int sizeC1 = c1.accessor().size(c1.get(i));
+                int sizeC2 = c2.accessor().size(c2.get(i));
+                Assert.assertEquals(sizeC1, sizeC2);
+            }
+        }
+    }
+
+    private static <V1, V2> void assertClusteringElementWrittenToOutput(Clustering<V1> c1, Clustering<V2> c2) throws IOException
+    {
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (c1.get(i) != null)
+            {
+                DataOutputBuffer outputC1 = new DataOutputBuffer(c1.dataSize());
+                DataOutputBuffer outputC2 = new DataOutputBuffer(c2.dataSize());
+                c1.accessor().write(c1.get(i), outputC1);
+                c2.accessor().write(c2.get(i), outputC2);
+                Assert.assertArrayEquals(outputC1.toByteArray(), outputC2.toByteArray());
+            }
+        }
+    }
+
+    private static <V1, V2> void assertClusteringSlicing(Clustering<V1> c1, Clustering<V2> c2) throws IOException
+    {
+        for (int i = 0; i < c1.size(); i++)
+        {
+            if (c1.get(i) != null)
+            {
+                int offset = c1.accessor().size(c1.get(i)) / 3;
+                int length = c1.accessor().size(c1.get(i)) / 2;
+                V1 slice1 = c1.accessor().slice(c1.get(i), offset, length);
+                V2 slice2 = c2.accessor().slice(c2.get(i), offset, length);
+                Assert.assertEquals(0, c1.accessor().compare(slice1, slice2, c2.accessor()));
+                Assert.assertEquals(0, c2.accessor().compare(slice2, slice1, c1.accessor()));
+            }
+        }
+    }
+
+    private static void assertByteBufferArrayEquals(ByteBuffer[] array1, ByteBuffer[] array2) {
+        Assert.assertEquals(array1.length, array2.length);
+        for (int i = 0; i < array1.length; i++) {
+            if (array1[i] != null)
+                Assert.assertEquals(0, ByteBufferUtil.compareUnsigned(array1[i], array2[i]));
+        }
+    }
+
+    private static void assertCellsWrittenToOutput(Row row1, Row row2) throws IOException
+    {
+        Iterator<Cell<?>> row1Iterator = row1.cells().iterator();
+        Iterator<Cell<?>> row2Iterator = row2.cells().iterator();
+        while (row1Iterator.hasNext())
+        {
+            Cell cell1 = row1Iterator.next();
+            Cell cell2 = row2Iterator.next();
+            DataOutputBuffer output1 = new DataOutputBuffer(cell1.dataSize());
+            DataOutputBuffer output2 = new DataOutputBuffer(cell2.dataSize());
+            cell1.accessor().write(cell1.value(), output1);
+            cell2.accessor().write(cell2.value(), output2);
+            Assert.assertArrayEquals(output1.toByteArray(), output2.toByteArray());
+        }
+    }
+
+    private static void assertCellsSlicing(Row row1, Row row2)
+    {
+        Iterator<Cell<?>> row1Iterator = row1.cells().iterator();
+        Iterator<Cell<?>> row2Iterator = row2.cells().iterator();
+        while (row1Iterator.hasNext())
+        {
+            Cell cell1 = row1Iterator.next();
+            Cell cell2 = row2Iterator.next();
+            int offset = cell1.accessor().size(cell1.value()) / 3;
+            int length = cell1.accessor().size(cell1.value()) / 2;
+            Object slice1 = cell1.accessor().slice(cell1.value(), offset, length);
+            Object slice2 = cell2.accessor().slice(cell2.value(), offset, length);
+            Assert.assertEquals(0, cell1.accessor().compare(slice1, slice2, cell2.accessor()));
+            Assert.assertEquals(0, cell2.accessor().compare(slice2, slice1, cell1.accessor()));
+        }
     }
 
     private static void assertCellsDataSize(Row row1, Row row2)

--- a/test/unit/org/apache/cassandra/db/marshal/ByteBufferAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ByteBufferAccessorTest.java
@@ -20,7 +20,9 @@ package org.apache.cassandra.db.marshal;
 
 import java.nio.ByteBuffer;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -29,6 +31,21 @@ import static org.quicktheories.QuickTheory.qt;
 
 public class ByteBufferAccessorTest extends ValueAccessorTester
 {
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
+
     private static byte[] array(int start, int size)
     {
         byte[] a = new byte[size];

--- a/test/unit/org/apache/cassandra/db/marshal/CollectionTypesTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CollectionTypesTest.java
@@ -27,7 +27,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQL3Type;
@@ -36,6 +38,20 @@ import static org.apache.cassandra.db.marshal.ValueAccessors.ACCESSORS;
 
 public class CollectionTypesTest
 {
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
     interface TypeFactory<T extends CollectionType> { T createType(AbstractType<?> keyType, AbstractType<?> valType); }
     interface ValueFactory<T> { T createValue(ValueGenerator keyGen, ValueGenerator valGen, int size, Random random); }
 
@@ -68,6 +84,7 @@ public class CollectionTypesTest
                         Assert.assertEquals(srcString, dstString);
                     }
                 }
+                allocator.releaseMemory();
             }
         }
     }

--- a/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CompositeAndTupleTypesTest.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.FieldIdentifier;
@@ -34,6 +36,20 @@ import static org.apache.cassandra.db.marshal.ValueAccessors.ACCESSORS;
 
 public class CompositeAndTupleTypesTest
 {
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
     interface TypeFactory<T extends AbstractType<?>> { T createType(List<AbstractType<?>> types); }
     interface ValueCombiner<V> { V combine(AbstractType<?> type, ValueAccessor<V> accessor, V[] values); }
 
@@ -107,6 +123,7 @@ public class CompositeAndTupleTypesTest
                         Assert.assertEquals(srcString, dstString);
                     }
                 }
+                allocator.releaseMemory();
             }
         }
     }

--- a/test/unit/org/apache/cassandra/db/marshal/CompositeTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/CompositeTypeTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.CharacterCodingException;
 import java.util.*;
 
 import com.google.common.collect.Lists;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -68,6 +69,20 @@ public class CompositeTypeTest
     {
         for (int i = 0; i < UUID_COUNT; ++i)
             uuids[i] = nextTimeUUID();
+    }
+
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
     }
 
     @BeforeClass

--- a/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/NativeAccessorTest.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.google.common.primitives.UnsignedBytes;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.db.Digest;
+import org.apache.cassandra.io.util.DataOutputBuffer;
+import org.apache.cassandra.service.paxos.Ballot;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.UUIDGen;
+import org.apache.cassandra.utils.memory.BigEndianMemoryUtil;
+
+import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.integers;
+
+public class NativeAccessorTest extends ValueAccessorTester
+{
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
+    }
+
+    private final ValueAccessor<NativeData> nativeAccessor = NativeAccessor.instance;
+    private final ValueAccessor<ByteBuffer> bufferAccessor = ByteBufferAccessor.instance;
+
+    @Test
+    public void testCompare()
+    {
+        qt().forAll(accessors(),
+                    byteArrays(integers().between(0, 200)),
+                    byteArrays(integers().between(0, 200))
+            ).checkAssert(this::testCompare);
+    }
+
+    private <V> void testCompare(ValueAccessor<V> rightAccessor, byte[] leftArray, byte[] rightArray)
+    {
+        NativeData left = NativeAccessor.instance.valueOf(leftArray);
+        V right = rightAccessor.valueOf(rightArray);
+        int expectedResult = Integer.signum(UnsignedBytes.lexicographicalComparator().compare(leftArray, rightArray));
+        int actualResult = Integer.signum(NativeAccessor.instance.compare(left, right, rightAccessor));
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testCopy()
+    {
+        qt().forAll(accessors(),
+                    byteArrays(integers().between(10, 100)),
+                    integers().between(0, 9),
+                    integers().between(0, 9)
+        ).checkAssert(this::testCopy);
+    }
+
+    private <V> void testCopy(ValueAccessor<V> dstAccessor, byte[] dataToCopy, int srcOffset, int dstOffset)
+    {
+        ValueAccessor<NativeData> srcAcccessor = NativeAccessor.instance;
+        NativeData src = srcAcccessor.valueOf(dataToCopy);
+        V dst = dstAccessor.valueOf(new byte[dataToCopy.length + dstOffset - srcOffset]);
+        NativeAccessor.instance.copyTo(src, srcOffset, dst, dstAccessor, dstOffset,  dataToCopy.length - srcOffset);
+        V dstSlice = dstAccessor.slice(dst, dstOffset, dataToCopy.length - srcOffset);
+        NativeData expectedData = srcAcccessor.slice(src, srcOffset, dataToCopy.length - srcOffset);
+
+        Assert.assertArrayEquals(srcAcccessor.toArray(src, srcOffset, dataToCopy.length - srcOffset), dstAccessor.toArray(dstSlice));
+        Assert.assertArrayEquals(srcAcccessor.toArray(expectedData), dstAccessor.toArray(dstSlice));
+    }
+
+    @Test
+    public void testPutMethods()
+    {
+        testNativePut((byte) 42, nativeAccessor::putByte, bufferAccessor::getByte);
+
+        testNativePut((short )(Short.MAX_VALUE - 3), nativeAccessor::putShort, bufferAccessor::getShort);
+
+        testNativePut(Integer.MAX_VALUE - 5, nativeAccessor::putInt, bufferAccessor::getInt);
+
+        testNativePut((float) Math.PI, nativeAccessor::putFloat, bufferAccessor::getFloat);
+
+        testNativePut(Long.MAX_VALUE - 2, nativeAccessor::putLong, bufferAccessor::getLong);
+
+        testNativePut(0L, nativeAccessor::putVInt, bufferAccessor::getVInt);
+        testNativePut(42L, nativeAccessor::putVInt, bufferAccessor::getVInt);
+        testNativePut(0xFFFFFFL, nativeAccessor::putVInt, bufferAccessor::getVInt);
+        testNativePut(Long.MAX_VALUE - 1, nativeAccessor::putVInt, bufferAccessor::getVInt);
+
+        testNativePut(42, nativeAccessor::putVInt32, bufferAccessor::getVInt32);
+        testNativePut(0xFFFFF, nativeAccessor::putVInt32, bufferAccessor::getVInt32);
+        testNativePut(Integer.MAX_VALUE - 1, nativeAccessor::putVInt32, bufferAccessor::getVInt32);
+
+        testNativePut(42L, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+        testNativePut(0xFFFFFL, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+        testNativePut(0xFFFFFFFL, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+        testNativePut(Long.MAX_VALUE - 1, nativeAccessor::putUnsignedVInt, bufferAccessor::getUnsignedVInt);
+    }
+
+    @Test
+    public void testPutDouble() // there is no putDouble method to test it like others
+    {
+        Double originalValue = Math.PI; // Double conversion is used to compare values as bit values
+        NativeData nativeData = nativeAccessor.allocate(25);
+        ByteBuffer bufferData = bufferAccessor.allocate(25);
+        int offset = 7;
+        bufferData.putDouble(offset, originalValue);
+        nativeAccessor.copyByteBufferTo(bufferData, 0, nativeData, 0, bufferAccessor.size(bufferData));
+        Double getValue = nativeAccessor.getDouble(nativeData, offset);
+        Assert.assertEquals(originalValue, getValue);
+
+        NativeData nativeDataSlice = nativeAccessor.slice(nativeData, offset, nativeData.nativeDataSize() - offset);
+        Double toValue = nativeAccessor.toDouble(nativeDataSlice);
+        Assert.assertEquals(originalValue, toValue);
+
+    }
+
+    private <V> void testNativePut(V originalValue, TriFunction<NativeData, Integer, V, Integer> putMethod,
+                                   BiFunction<ByteBuffer, Integer, V> getMethod)
+    {
+        NativeData nativeData = nativeAccessor.allocate(25);
+        int offset = 2;
+        putMethod.apply(nativeData, offset, originalValue);
+        ByteBuffer buffer = nativeAccessor.toBuffer(nativeData);
+        V getValue = getMethod.apply(buffer, offset);
+        Assert.assertEquals(originalValue, getValue);
+    }
+
+    @Test
+    public void testGetMethods()
+    {
+        testNativeGet((byte) 42, bufferAccessor::putByte, nativeAccessor::getByte, nativeAccessor::toByte);
+
+        testNativeGet((short )(Short.MAX_VALUE - 3), bufferAccessor::putShort, nativeAccessor::getShort, nativeAccessor::toShort);
+
+        // nativeAccessor::getUnsignedShort is already tested by org.apache.cassandra.db.marshal.ValueAccessorTest.testUnsignedShort()
+
+        testNativeGet(Integer.MAX_VALUE - 5, bufferAccessor::putInt, nativeAccessor::getInt, nativeAccessor::toInt);
+
+        testNativeGet((float) Math.PI, bufferAccessor::putFloat, nativeAccessor::getFloat, nativeAccessor::toFloat);
+
+        testNativeGet(Long.MAX_VALUE - 2, bufferAccessor::putLong, nativeAccessor::getLong, nativeAccessor::toLong);
+
+        testNativeGet(0L, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+        testNativeGet(42L, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+        testNativeGet(0xFFFFFFL, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+        testNativeGet(Long.MAX_VALUE - 1, bufferAccessor::putVInt, nativeAccessor::getVInt, null);
+
+        testNativeGet(42, bufferAccessor::putVInt32, nativeAccessor::getVInt32, null);
+        testNativeGet(0xFFFFF, bufferAccessor::putVInt32, nativeAccessor::getVInt32, null);
+        testNativeGet(Integer.MAX_VALUE - 1, bufferAccessor::putVInt32, nativeAccessor::getVInt32, null);
+
+        testNativeGet(42L, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+        testNativeGet(0xFFFFFL, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+        testNativeGet(0xFFFFFFFL, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+        testNativeGet(Long.MAX_VALUE - 1, bufferAccessor::putUnsignedVInt, nativeAccessor::getUnsignedVInt, null);
+    }
+
+    private <V> void testNativeGet(V originalValue, TriFunction<ByteBuffer, Integer, V, Integer> putMethod,
+                                   BiFunction<NativeData, Integer, V> getMethod, Function<NativeData, V> toMethod)
+    {
+        ByteBuffer bufferData = bufferAccessor.allocate(25);
+        NativeData nativeData = nativeAccessor.allocate(25);
+        int offset = 2;
+        putMethod.apply(bufferData, offset, originalValue);
+        nativeAccessor.copyByteBufferTo(bufferData, 0, nativeData, 0, bufferAccessor.size(bufferData));
+        V getValue = getMethod.apply(nativeData, offset);
+        Assert.assertEquals(originalValue, getValue);
+
+        if (toMethod != null)
+        {
+            NativeData nativeDataSlice = nativeAccessor.slice(nativeData, offset, nativeData.nativeDataSize() - offset);
+            V toValue = toMethod.apply(nativeDataSlice);
+            Assert.assertEquals(originalValue, toValue);
+        }
+    }
+
+    @Test
+    public void testToUUID() {
+        UUID originalValue = UUID.randomUUID();
+        ByteBuffer encodedOriginalValue = UUIDGen.toByteBuffer(originalValue);
+        int size = encodedOriginalValue.remaining();
+        NativeData nativeData = nativeAccessor.allocate(size);
+        nativeAccessor.copyByteBufferTo(encodedOriginalValue, 0, nativeData, 0, size);
+
+        UUID nativeUUID = nativeAccessor.toUUID(nativeData);
+        Assert.assertEquals(originalValue, nativeUUID);
+    }
+
+    @Test
+    public void testToTimeUUID() {
+        TimeUUID originalValue = nextTimeUUID();
+        ByteBuffer encodedOriginalValue = originalValue.toBytes();
+        int size = encodedOriginalValue.remaining();
+        NativeData nativeData = nativeAccessor.allocate(size);
+        nativeAccessor.copyByteBufferTo(encodedOriginalValue, 0, nativeData, 0, size);
+
+        TimeUUID nativeUUID = nativeAccessor.toTimeUUID(nativeData);
+        Assert.assertEquals(originalValue, nativeUUID);
+    }
+
+    @Test
+    public void testToBullot() {
+        Ballot originalValue = Ballot.fromUuid(nextTimeUUID().asUUID());
+        ByteBuffer encodedOriginalValue = originalValue.toBytes();
+        int size = encodedOriginalValue.remaining();
+        NativeData nativeData = nativeAccessor.allocate(size);
+        nativeAccessor.copyByteBufferTo(encodedOriginalValue, 0, nativeData, 0, size);
+
+        Ballot nativeBallot = nativeAccessor.toBallot(nativeData);
+        Assert.assertEquals(originalValue, nativeBallot);
+    }
+
+    @Test
+    public void testToHex() {
+        int valueSize = 42;
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+
+        ByteBuffer bufferData = bufferAccessor.valueOf(originalData);
+        String bufferHex = bufferAccessor.toHex(bufferData);
+
+        NativeData nativeData = nativeAccessor.valueOf(originalData);
+        String nativeHex = nativeAccessor.toHex(nativeData);
+        Assert.assertEquals(bufferHex, nativeHex);
+    }
+
+    @Test
+    public void test() {
+        NativeData nativeData = nativeAccessor.allocate(4);
+        BigEndianMemoryUtil.setInt(nativeData.getAddress(), 0x00FF);
+
+        String nativeHex = nativeAccessor.toHex(nativeData);
+        System.out.println(nativeHex);
+    }
+
+    @Test
+    public void testToString() throws CharacterCodingException
+    {
+        String originalData = "test string value";
+        NativeData nativeData = nativeAccessor.valueOf(originalData, StandardCharsets.UTF_8);
+        String nativeToString = nativeAccessor.toString(nativeData, StandardCharsets.UTF_8);
+        Assert.assertEquals(originalData, nativeToString);
+    }
+
+    @Test
+    public void testToFloatArray() {
+        int valueSize = 42;
+        ByteBuffer buffer = ByteBuffer.allocate(valueSize * Float.BYTES);
+        FloatBuffer floatBuffer = buffer.asFloatBuffer();
+        for (int i = 0; i < valueSize; i++)
+            floatBuffer.put((float) i);
+
+        NativeData nativeData = nativeAccessor.valueOf(buffer);
+        float[] decodedFloatArray = nativeAccessor.toFloatArray(nativeData, valueSize);
+
+        for (int i = 0; i < valueSize; i++)
+            Assert.assertEquals((Float) floatBuffer.get(i), (Float) decodedFloatArray[i]);
+        // Float conversion is used to compare values as bit values
+    }
+
+    @Test
+    public void testDataOutputPlusWrite() throws IOException
+    {
+        int valueSize = 25;
+        NativeData nativeData = nativeAccessor.allocate(valueSize);
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+        nativeAccessor.putBytes(nativeData, 0, originalData);
+
+        try(DataOutputBuffer dataOutput = new DataOutputBuffer())
+        {
+            nativeAccessor.write(nativeData, dataOutput);
+            byte[] writenData = dataOutput.toByteArray();
+            Assert.assertArrayEquals(originalData, writenData);
+        }
+    }
+
+    @Test
+    public void testHeapByteBufferWrite()
+    {
+        testHeapByteBufferWrite(ByteBuffer.allocate(25), 23);
+    }
+
+    @Test
+    public void testDirectByteBufferWrite()
+    {
+        testHeapByteBufferWrite(ByteBuffer.allocateDirect(25), 23);
+    }
+
+    private void testHeapByteBufferWrite(ByteBuffer buffer, int valueSize)
+    {
+        NativeData nativeData = nativeAccessor.allocate(valueSize);
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+        nativeAccessor.putBytes(nativeData, 0, originalData);
+
+        int initialPosition = buffer.position();
+        nativeAccessor.write(nativeData, buffer);
+        Assert.assertEquals(valueSize, buffer.position() - initialPosition);
+        buffer.flip();
+        Assert.assertArrayEquals(originalData, ByteBufferUtil.getArray(buffer));
+    }
+
+    @Test
+    public void testDigest()
+    {
+        int valueSize = 25;
+        NativeData nativeData = nativeAccessor.allocate(valueSize);
+        byte[] originalData = new byte[valueSize];
+        for (int i = 0; i < valueSize; i++)
+            originalData[i] = (byte) i;
+        nativeAccessor.putBytes(nativeData, 0, originalData);
+
+        Digest byteArrayDigest = Digest.forReadResponse();
+        byteArrayDigest.update(originalData, 0, originalData.length);
+
+        Digest nativeDigest = Digest.forReadResponse();
+        nativeAccessor.digest(nativeData, nativeDigest);
+
+        Assert.assertArrayEquals(byteArrayDigest.digest(), nativeDigest.digest());
+    }
+
+    @FunctionalInterface
+    interface TriFunction<A,B,C,R>
+    {
+        R apply(A a, B b, C c);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/marshal/TestNativeDataAllocator.java
+++ b/test/unit/org/apache/cassandra/db/marshal/TestNativeDataAllocator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.marshal;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
+import org.apache.cassandra.utils.concurrent.OpOrder;
+import org.apache.cassandra.utils.memory.MemoryUtil;
+import org.apache.cassandra.utils.memory.NativeAllocator;
+import org.apache.cassandra.utils.memory.NativePool;
+
+/**
+ * A primitive NativeData allocator is used for test purposes only
+ * It releases memory only when releaseMemory() or close() are called
+ */
+public class TestNativeDataAllocator implements NativeDataAllocator, Closeable
+{
+    private final NativePool nativePool = new NativePool(0, 10 * 1024 * 1024, 1.0f,
+                                                         () -> ImmediateFuture.success(true));
+    private NativeAllocator nativeAllocator = nativePool.newAllocator("test");
+    private final OpOrder order = new OpOrder();
+
+    @Override
+    public NativeData allocateBasedOnBuffer(ByteBuffer data)
+    {
+        try(OpOrder.Group group = order.start())
+        {
+            long address = nativeAllocator.allocate(data.remaining(), group);
+            MemoryUtil.setBytes(address, data);
+            return new AddressBasedNativeData(address, data.remaining());
+        }
+    }
+
+    public void releaseMemory() {
+        nativeAllocator.setDiscarding();
+        nativeAllocator.setDiscarded();
+        nativeAllocator = nativePool.newAllocator("test");
+    }
+
+    public void close() {
+        nativeAllocator.setDiscarding();
+        nativeAllocator.setDiscarded();
+        try
+        {
+            nativePool.shutdownAndWait(5, TimeUnit.SECONDS);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/test/unit/org/apache/cassandra/db/marshal/ValueAccessorTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ValueAccessorTest.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.io.util.DataOutputBuffer;
@@ -67,6 +69,19 @@ public class ValueAccessorTest extends ValueAccessorTester
         ByteBuffer buffer2 = accessor2.toBuffer(value2);
         Assert.assertEquals(String.format("Inconsistent byte buffers (%s != %s)", bytesToHex(buffer1), bytesToHex(buffer1)),
                             buffer1, buffer2);
+    }
+
+    private static final TestNativeDataAllocator allocator = new TestNativeDataAllocator();
+    @BeforeClass
+    public static void setSetMemoryAllocator()
+    {
+        NativeAccessor.setNativeMemoryAllocator(allocator);
+    }
+
+    @AfterClass
+    public static void releaseMemory()
+    {
+        allocator.close();
     }
 
     /**

--- a/test/unit/org/apache/cassandra/db/marshal/ValueAccessors.java
+++ b/test/unit/org/apache/cassandra/db/marshal/ValueAccessors.java
@@ -22,7 +22,8 @@ import java.nio.ByteBuffer;
 
 public class ValueAccessors
 {
-    public static final ValueAccessor[] ACCESSORS = new ValueAccessor[]{ ByteBufferAccessor.instance, ByteArrayAccessor.instance };
+    public static final ValueAccessor[] ACCESSORS = new ValueAccessor[]{ ByteBufferAccessor.instance, ByteArrayAccessor.instance, NativeAccessor.instance };
+    public static final ValueAccessor[] FACTORY_SUPPORTED_ACCESSORS = new ValueAccessor[]{ ByteBufferAccessor.instance, ByteArrayAccessor.instance };
 
     public static <V1, V2> void assertDataEquals(V1 expected, ValueAccessor<V1> expectedAccessor, V2 actual, ValueAccessor<V2> actualAccessor)
     {

--- a/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceConversionTest.java
+++ b/test/unit/org/apache/cassandra/utils/bytecomparable/ByteSourceConversionTest.java
@@ -341,7 +341,7 @@ public class ByteSourceConversionTest extends ByteSourceTestBase
 
     void assertClusteringPairConvertsSame(AbstractType t1, AbstractType t2, Object o1, Object o2)
     {
-        for (ValueAccessor<?> accessor : ValueAccessors.ACCESSORS)
+        for (ValueAccessor<?> accessor : ValueAccessors.FACTORY_SUPPORTED_ACCESSORS)
             assertClusteringPairConvertsSame(accessor, t1, t2, o1, o2, AbstractType::decompose);
     }
 

--- a/test/unit/org/apache/cassandra/utils/memory/BigEndianMemoryUtilTest.java
+++ b/test/unit/org/apache/cassandra/utils/memory/BigEndianMemoryUtilTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.utils.memory;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BigEndianMemoryUtilTest
+{
+    private static final int TEST_BUFFER_LENGTH = 8;
+    private final ByteBuffer directBuffer = ByteBuffer.allocateDirect(TEST_BUFFER_LENGTH);
+    {
+        directBuffer.order(ByteOrder.BIG_ENDIAN);
+    }
+    private final long address = BigEndianMemoryUtil.getAddress(directBuffer);
+
+    @Test
+    public void testGetSetLong()
+    {
+        long originalValue = 0xAB_CD_EF_12_34_56_78_90L;
+        directBuffer.putLong(originalValue);
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getLong(address));
+
+        directBuffer.rewind();
+        directBuffer.putLong(0);
+        BigEndianMemoryUtil.setLong(address, originalValue);
+
+        Assert.assertEquals(originalValue, directBuffer.getLong(0));
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getLong(address));
+
+    }
+
+    @Test
+    public void testGetSetInt()
+    {
+        int originalValue = 0xAB_CD_EF_12;
+        directBuffer.putInt(originalValue);
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getInt(address));
+
+        directBuffer.rewind();
+        directBuffer.putInt(0);
+        BigEndianMemoryUtil.setInt(address, originalValue);
+
+        Assert.assertEquals(originalValue, directBuffer.getInt(0));
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getInt(address));
+
+    }
+
+    @Test
+    public void testGetSetUnsighedShort()
+    {
+        short originalValue = (short) 0xAB_CD;
+        directBuffer.putShort(originalValue);
+        Assert.assertEquals(originalValue & 0xffff, BigEndianMemoryUtil.getUnsignedShort(address));
+
+        directBuffer.rewind();
+        directBuffer.putShort((short) 0);
+        BigEndianMemoryUtil.setShort(address, originalValue);
+
+        Assert.assertEquals(originalValue, directBuffer.getShort(0));
+        Assert.assertEquals(originalValue & 0xffff, BigEndianMemoryUtil.getUnsignedShort(address));
+    }
+
+    @Test
+    public void testGetSetLongByBytes()
+    {
+        long originalValue = 0xAB_CD_EF_12_34_56_78_90L;
+        directBuffer.putLong(originalValue);
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getLongByByte(address));
+
+        directBuffer.rewind();
+        directBuffer.putLong(0);
+        BigEndianMemoryUtil.putLongByByte(address, originalValue);
+
+        Assert.assertEquals(originalValue, directBuffer.getLong(0));
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getLongByByte(address));
+
+    }
+
+    @Test
+    public void testGetSetIntByBytes()
+    {
+        int originalValue = 0xAB_CD_EF_12;
+        directBuffer.putInt(originalValue);
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getIntByByte(address));
+
+        directBuffer.rewind();
+        directBuffer.putInt(0);
+        BigEndianMemoryUtil.putIntByByte(address, originalValue);
+
+        Assert.assertEquals(originalValue, directBuffer.getInt(0));
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getIntByByte(address));
+
+    }
+
+    @Test
+    public void testGetSetShortByBytes()
+    {
+        short originalValue = (short) 0xAB_CD;
+        directBuffer.putShort(originalValue);
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getShortByByte(address));
+
+        directBuffer.rewind();
+        directBuffer.putShort((short) 0);
+        BigEndianMemoryUtil.putShortByByte(address, originalValue);
+
+        Assert.assertEquals(originalValue, directBuffer.getShort(0));
+        Assert.assertEquals(originalValue, BigEndianMemoryUtil.getShortByByte(address));
+    }
+
+
+    @Test
+    public void testGetHollowDirectByteBuffer()
+    {
+        ByteBuffer byteBuffer = BigEndianMemoryUtil.getHollowDirectByteBuffer();
+        Assert.assertEquals(directBuffer.getClass(), byteBuffer.getClass());
+        Assert.assertEquals(ByteOrder.BIG_ENDIAN, byteBuffer.order());
+    }
+
+    @Test
+    public void testGetByteBuffer()
+    {
+        ByteBuffer byteBuffer = BigEndianMemoryUtil.getByteBuffer(address, TEST_BUFFER_LENGTH);
+        Assert.assertEquals(directBuffer.getClass(), byteBuffer.getClass());
+        Assert.assertEquals(ByteOrder.BIG_ENDIAN, byteBuffer.order());
+        Assert.assertEquals(TEST_BUFFER_LENGTH, byteBuffer.capacity());
+        Assert.assertEquals(0, byteBuffer.position());
+    }
+}


### PR DESCRIPTION
Introduce NativeAccessor to avoid new ByteBuffer allocation on flush for each NativeCell

Patch by Dmitry Konstantinov; reviewed by Branimir Lambov for CASSANDRA-20173