### PR TITLE
Fix a bug in AutoRepair duration metric calculation if schedule finishes quickly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Fix a bug in AutoRepair duration metric calculation if schedule finishes quickly (CASSANDRA-20622)
  * Fix AutoRepair flaky InJvm dtest (CASSANDRA-20620)
  * Increasing default for auto_repair.sstable_upper_threshold considering large Cassandra tables & revert three lines removed from CHANGES.txt due to a merge mistake (CASSANDRA-20586)
  * Fix token restrictions with MIN_TOKEN (CASSANDRO-20557)

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -469,7 +469,7 @@ public class AutoRepair
         repairState.setSucceededTokenRangesCount(collectedRepairStats.succeededTokenRanges);
         repairState.setSkippedTokenRangesCount(collectedRepairStats.skippedTokenRanges);
         repairState.setSkippedTablesCount(collectedRepairStats.skippedTables);
-        repairState.setNodeRepairTimeInSec((int) TimeUnit.MILLISECONDS.toSeconds(repairScheduleElapsedInMillis));
+        repairState.setNodeRepairTimeInSec((int) TimeUnit.MILLISECONDS.toSeconds(timeFunc.get() - startTimeInMillis));
         long timeInHours = TimeUnit.SECONDS.toHours(repairState.getNodeRepairTimeInSec());
         logger.info("Local {} repair time {} hour(s), stats: repairKeyspaceCount {}, " +
                     "repairTokenRangesSuccessCount {}, repairTokenRangesFailureCount {}, " +

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.schema.SchemaConstants.DISTRIBUTED_KEYSPACE_NAME;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -145,8 +146,11 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
             AutoRepair.SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("2s");
 
             AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
+            // Since the AutoRepair sleeps up to SLEEP_IF_REPAIR_FINISHES_QUICKLY if the repair finishes quickly,
+            // so the "nodeRepairTimeInSec" metric should at least be greater than or equal to
+            // SLEEP_IF_REPAIR_FINISHES_QUICKLY
             Util.spinAssert(String.format("%s: AutoRepair has not yet completed one INCREMENTAL repair cycle", broadcastAddress),
-                            greaterThan(0L),
+                            greaterThanOrEqualTo(2L),
                             () -> incrementalMetrics.nodeRepairTimeInSec.getValue().longValue(),
                             5,
                             TimeUnit.MINUTES);
@@ -163,7 +167,7 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
 
             AutoRepairMetrics fullMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.FULL);
             Util.spinAssert(String.format("%s: AutoRepair has not yet completed one FULL repair cycle", broadcastAddress),
-                            greaterThan(0L),
+                            greaterThanOrEqualTo(2L),
                             () -> fullMetrics.nodeRepairTimeInSec.getValue().longValue(),
                             5,
                             TimeUnit.MINUTES);


### PR DESCRIPTION
The [CASSANDRA-20620](https://issues.apache.org/jira/browse/CASSANDRA-20620) was trying to fix the flaky test, but the fix missed refreshing the duration calculation when setting the metric. We would have to recalculate the duration after the _sleep_ interval has elapsed.
This ticket is to fix that bug in the code.

```
Fix a bug in AutoRepair duration metric calculation if schedule finishes quickly

patch by Jaydeepkumar Chovatia; reviewed by Andy Tolbert for CASSANDRA-20622


```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-20622)

