### PR TITLE
(CASSANDRA-20596) Ensuring Row reference is only used for IS Null/IS Not Null conditions

### DIFF
--- a/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/transactions/ConditionStatement.java
@@ -100,12 +100,16 @@ public class ConditionStatement
             
             if (lhs instanceof RowDataReference.Raw)
             {
+                if (((RowDataReference.Raw) lhs).column() == null)
+                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", lhs.getText()));
                 reference = ((RowDataReference.Raw) lhs).prepareAsReceiver();
                 ColumnSpecification receiver = reference.getValueReceiver();
                 value = rhs.prepare(keyspace, receiver);
             }
             else if (rhs instanceof RowDataReference.Raw)
             {
+                if (((RowDataReference.Raw) rhs).column() == null)
+                    throw new IllegalStateException(String.format("Row reference (%s) can only be used with IS NULL/IS NOT NULL conditions", rhs.getText()));
                 reference = ((RowDataReference.Raw) rhs).prepareAsReceiver();
                 ColumnSpecification receiver = reference.getValueReceiver();
                 value = lhs.prepare(keyspace, receiver);

--- a/test/unit/org/apache/cassandra/cql3/statements/TransactionStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/TransactionStatementTest.java
@@ -561,6 +561,55 @@ public class TransactionStatementTest
                 .hasMessageContaining(String.format(TRANSACTIONS_DISABLED_ON_TABLE_MESSAGE, "INSERT", "at [2:3]"));
     }
 
+    @Test
+    public void shouldRejectRowReferenceOnLHSExceptIsNullAndIsNotNull() 
+    {
+        String query = "BEGIN TRANSACTION\n" +
+                       "  LET row1 = (SELECT * FROM ks.tbl1 WHERE k=1 AND c=1);\n" +
+                       "  IF row1 = 1 THEN\n" +
+                       "    UPDATE ks.tbl1 SET v=1 WHERE k=1 AND c=1;\n" +
+                       "  END IF\n" +
+                       "COMMIT TRANSACTION";
+
+        Assertions.assertThatThrownBy(() -> prepare(query))
+                  .isInstanceOf(IllegalStateException.class)
+                  .hasMessageContaining("Row reference (row1) can only be used with IS NULL/IS NOT NULL conditions");
+    }
+
+    @Test
+    public void shouldRejectRowReferenceOnRHSExceptIsNullAndIsNotNull() 
+    {
+        String query = "BEGIN TRANSACTION\n" +
+                       "  LET row1 = (SELECT * FROM ks.tbl1 WHERE k=1 AND c=1);\n" +
+                       "  IF 100 = row1 THEN\n" +
+                       "    UPDATE ks.tbl1 SET v=1 WHERE k=1 AND c=1;\n" +
+                       "  END IF\n" +
+                       "COMMIT TRANSACTION";
+
+        Assertions.assertThatThrownBy(() -> prepare(query))
+                  .isInstanceOf(IllegalStateException.class)
+                  .hasMessageContaining("Row reference (row1) can only be used with IS NULL/IS NOT NULL conditions");
+    }
+
+    @Test
+    public void shouldAcceptRowReferenceWithIsNullAndIsNotNull() 
+    {
+        String query = "BEGIN TRANSACTION\n" +
+                       "  LET row1 = (SELECT * FROM ks.tbl1 WHERE k=1 AND c=1);\n" +
+                       "  IF row1 IS NULL THEN\n" +
+                       "    UPDATE ks.tbl1 SET v=1 WHERE k=1 AND c=1;\n" +
+                       "  END IF\n" +
+                       "COMMIT TRANSACTION";
+        Assertions.assertThat(prepare(query)).isNotNull();
+        query = "BEGIN TRANSACTION\n" +
+                       "  LET row1 = (SELECT * FROM ks.tbl1 WHERE k=1 AND c=1);\n" +
+                       "  IF row1 IS NOT NULL THEN\n" +
+                       "    UPDATE ks.tbl1 SET v=1 WHERE k=1 AND c=1;\n" +
+                       "  END IF\n" +
+                       "COMMIT TRANSACTION";
+        Assertions.assertThat(prepare(query)).isNotNull();
+    }
+
     private static CQLStatement prepare(String query)
     {
         TransactionStatement.Parsed parsed = (TransactionStatement.Parsed) QueryProcessor.parseStatement(query);


### PR DESCRIPTION
In the bug CASSANDRA-20596, row reference was mistakenly used instead of a column which caused NPE. 

This fix checks if lhs or rhs in a condition is referring to a column and not a row. 

Tested it locally and got the following: 

`NoHostAvailable: ('Unable to complete the operation against any hosts', {<Host: 127.0.0.1:9042 datacenter1>: <Error from server: code=0000 [Server error] message="java.lang.IllegalStateException: Row reference (high_score) can only be used with IS NULL/IS NOT NULL conditions">})`

patch by Pranav Shenoy; reviewed by TBD for CASSANDRA-20596


Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

