### PR TITLE
CASSANDRA-20642: Add NativeTransportMaxConcurrentConnectionsPerIp to StorageProxyMBean

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.0.19
+ * Add NativeTransportMaxConcurrentConnectionsPerIp to StorageProxyMBean (CASSANDRA-20642)
  * Make secondary index implementations notified about rows in fully expired SSTables in compaction (CASSANDRA-20829)
  * Ensure prepared_statement INSERT timestamp precedes eviction DELETE (CASSANDRA-19703)
  * Gossip doesn't converge due to race condition when updating EndpointStates multiple fields (CASSANDRA-20659)

--- a/src/java/org/apache/cassandra/service/StorageProxyMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageProxyMBean.java
@@ -54,6 +54,9 @@ public interface StorageProxyMBean
     public void setNativeTransportMaxConcurrentConnections(Long nativeTransportMaxConcurrentConnections);
     public Long getNativeTransportMaxConcurrentConnections();
 
+    public void setNativeTransportMaxConcurrentConnectionsPerIp(Long nativeTransportMaxConcurrentConnections);
+    public Long getNativeTransportMaxConcurrentConnectionsPerIp();
+
     public void reloadTriggerClasses();
 
     public long getReadRepairAttempted();


### PR DESCRIPTION
Adds setNativeTransportMaxConcurrentConnectionsPerIp and getNativeTransportMaxConcurrentConnectionsPerIp to StorageProxyMBean so these methods can be used from JMX like the
*NativeTransportMaxConcurrentConnections methods.

patch by Andy Tolbert; reviewed by Chris Lohfink for CASSANDRA-20642
