### PR TITLE
5.0: Ensure prepared_statement INSERT timestamp precedes eviction DELETE

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@
  * Avoid purging deletions in RowFilter when reconciliation is required (CASSANDRA-20541)
  * Fixed multiple single-node SAI query bugs relating to static columns (CASSANDRA-20338)
  * Upgrade com.datastax.cassandra:cassandra-driver-core:3.11.5 to org.apache.cassandra:cassandra-driver-core:3.12.1 (CASSANDRA-17231)
+Merged from 4.1:
+ * Ensure prepared_statement INSERT timestamp precedes eviction DELETE (CASSANDRA-19703)
 Merged from 4.0:
  * Honor MAX_PARALLEL_TRANSFERS correctly (CASSANDRA-20532)
  * Updating a column with a new TTL but same expiration time is non-deterministic and causes repair mismatches. (CASSANDRA-20561)

--- a/doc/modules/cassandra/pages/developing/cql/cql_singlefile.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/cql_singlefile.adoc
@@ -273,6 +273,28 @@ provide values for `LIMIT`, `TIMESTAMP`, and `TTL` clauses. If anonymous
 bind markers are used, the names for the query parameters will be
 `[limit]`, `[timestamp]`, and `[ttl]`, respectively.
 
+===== Prepared Statement Caching
+
+Prepared Statements are cached by cassandra in-memory using a
+https://github.com/ben-manes/caffeine[Caffeine]-managed cache which
+can be configured using
+xref:managing/configuration/cass_yaml_file.adoc#_prepared_statements_cache_size[`prepared_statements_cache_size`].
+The cache is also persisted to the `system.prepared_statements` table
+so it can be preloaded into memory on startup.
+
+To ensure optimal performance, it's important to use a bind `<variable>`
+for *all non-constant values* in your CQL statements. If you include
+literal values directly in the query instead, each variation will be
+treated as a unique statement that must be prepared and cached
+separately. This will soon overflow the prepared statement cache,
+which is small by design.
+
+When the cache reaches its maximum size, older or less frequently
+used statements are
+https://github.com/ben-manes/caffeine/wiki/Eviction[evicted],
+leading to additional overhead as previously prepared statements must
+be re-prepared.
+
 [[dataDefinition]]
 == Data Definition
 

--- a/src/java/org/apache/cassandra/cql3/QueryHandler.java
+++ b/src/java/org/apache/cassandra/cql3/QueryHandler.java
@@ -67,6 +67,12 @@ public interface QueryHandler
         public final MD5Digest resultMetadataId;
 
         /**
+         * Timestamp of when this prepared statement was created.  Used in QueryProcessor.preparedStatements cache
+         * to ensure that the deletion timestamp always succeeds the insert timestamp.
+         */
+        public final long timestamp;
+
+        /**
          * Contains the CQL statement source if the statement has been "regularly" perpared via
          * {@link QueryHandler#prepare(String, ClientState, Map)}.
          * Other usages of this class may or may not contain the CQL statement source.
@@ -82,6 +88,7 @@ public interface QueryHandler
             this.resultMetadataId = ResultSet.ResultMetadata.fromPrepared(statement).getResultMetadataId();
             this.fullyQualified = fullyQualified;
             this.keyspace = keyspace;
+            this.timestamp = ClientState.getTimestamp();
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/MixedModeFuzzTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/MixedModeFuzzTest.java
@@ -49,7 +49,7 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
 import org.apache.cassandra.cql3.CQLStatement;
-import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.QueryHandler.Prepared;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
@@ -268,9 +268,10 @@ public class MixedModeFuzzTest extends TestBaseImpl
 
                                     c.get(nodeWithFix.get() ? 1 : 2).runOnInstance(() -> {
                                         SystemKeyspace.loadPreparedStatements((id, query, keyspace) -> {
+                                            Prepared prepared = QueryProcessor.instance.getPrepared(id);
                                             if (rng.nextBoolean())
                                                 QueryProcessor.instance.evictPrepared(id);
-                                            return true;
+                                            return prepared;
                                         });
                                     });
                                     break;
@@ -450,7 +451,7 @@ public class MixedModeFuzzTest extends TestBaseImpl
             if (existing != null)
                 return existing;
 
-            QueryHandler.Prepared prepared = QueryProcessor.parseAndPrepare(queryString, clientState, false);
+            Prepared prepared = QueryProcessor.parseAndPrepare(queryString, clientState, false);
             CQLStatement statement = prepared.statement;
 
             int boundTerms = statement.getBindVariables().size();

--- a/test/distributed/org/apache/cassandra/distributed/test/ReprepareFuzzTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ReprepareFuzzTest.java
@@ -43,6 +43,7 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodDelegation;
+import org.apache.cassandra.cql3.QueryHandler.Prepared;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
@@ -226,9 +227,10 @@ public class ReprepareFuzzTest extends TestBaseImpl
                                 case CLEAR_CACHES:
                                     c.get(1).runOnInstance(() -> {
                                         SystemKeyspace.loadPreparedStatements((id, query, keyspace) -> {
+                                            Prepared prepared = QueryProcessor.instance.getPrepared(id);
                                             if (rng.nextBoolean())
                                                 QueryProcessor.instance.evictPrepared(id);
-                                            return true;
+                                            return prepared;
                                         });
                                     });
                                     break;

--- a/test/unit/org/apache/cassandra/cql3/PstmtPersistenceTest.java
+++ b/test/unit/org/apache/cassandra/cql3/PstmtPersistenceTest.java
@@ -21,34 +21,65 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import org.apache.cassandra.db.ReadQuery;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.marshal.Int32Type;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.SchemaKeyspaceTables;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.MD5Digest;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 
 import static java.util.Collections.emptyMap;
 import static org.apache.cassandra.service.QueryState.forInternalCalls;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(BMUnitRunner.class)
 public class PstmtPersistenceTest extends CQLTester
 {
+    private static final CompletableFuture<?>[] futureArray = new CompletableFuture[0];
+
+    private static final ConcurrentMap<MD5Digest, Long> preparedStatementLoadTimestamps = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<MD5Digest, Long> preparedStatementRemoveTimestamps = new ConcurrentHashMap<>();
+
+    // page size passed to preloadPreparedStatements
+    private static final int PRELOAD_PAGE_SIZE = 100;
+
+    // recorded page invocations in preloadPreparedStatements
+    private static final AtomicInteger pageInvocations = new AtomicInteger();
+
     @Before
     public void setUp()
     {
+        preparedStatementLoadTimestamps.clear();
+        preparedStatementRemoveTimestamps.clear();
+
         QueryProcessor.clearPreparedStatements(false);
     }
- 
+
     @Test
     public void testCachedPreparedStatements() throws Throwable
     {
@@ -105,7 +136,7 @@ public class PstmtPersistenceTest extends CQLTester
             Assert.assertNotNull(prepared);
         }
 
-        // add anther prepared statement and sync it to table
+        // add another prepared statement and sync it to table
         prepareStatement(statement2, "foo", "bar", clientState);
 
         // statement1 will have two statements prepared because of `setKeyspace` usage
@@ -143,17 +174,219 @@ public class PstmtPersistenceTest extends CQLTester
 
         createTable("CREATE TABLE %s (key int primary key, val int)");
 
+        long initialEvicted = numberOfEvictedStatements();
+
         for (int cnt = 1; cnt < 10000; cnt++)
         {
             prepareStatement("INSERT INTO %s (key, val) VALUES (?, ?) USING TIMESTAMP " + cnt, clientState);
 
-            if (numberOfEvictedStatements() > 0)
+            if (numberOfEvictedStatements() - initialEvicted > 0)
             {
+                assertEquals("Number of statements in table and in cache don't match", numberOfStatementsInMemory(), numberOfStatementsOnDisk());
+
+                // prepare more statements to trigger more evictions
+                for (int cnt2 = cnt + 1; cnt2 < cnt + 10; cnt2++)
+                    prepareStatement("INSERT INTO %s (key, val) VALUES (?, ?) USING TIMESTAMP " + cnt2, clientState);
+
+                // each new prepared statement should have caused an eviction
+                assertEquals("eviction count didn't increase by the expected number", 10, numberOfEvictedStatements() - initialEvicted);
+                assertEquals("Number of statements in memory (expected) and table (actual) don't match", numberOfStatementsInMemory(), numberOfStatementsOnDisk());
+
                 return;
             }
         }
 
         fail("Prepared statement eviction does not work");
+    }
+
+    @Test
+    @BMRules(rules= {
+             @BMRule(name = "CaptureWriteTimestamps",
+                     targetClass = "SystemKeyspace",
+                     targetMethod = "writePreparedStatement(String, MD5Digest, String, long)",
+                     targetLocation = "AT INVOKE executeInternal",
+                     action = "org.apache.cassandra.cql3.PstmtPersistenceTest.preparedStatementLoadTimestamps.put($key, $timestamp);"
+             ),
+             @BMRule(name = "CaptureEvictTimestamps",
+                     targetClass = "QueryProcessor",
+                     targetMethod = "evictPreparedStatement(MD5Digest, RemovalCause)",
+                     action = "org.apache.cassandra.cql3.PstmtPersistenceTest.preparedStatementRemoveTimestamps.put($key, org.apache.cassandra.service.ClientState.getTimestamp());"
+             )
+    })
+    public void testAsyncPstmtInvalidation() throws Throwable
+    {
+        ClientState clientState = ClientState.forInternalCalls();
+        createTable("CREATE TABLE %s (key int primary key, val int)");
+
+        // prepare statements concurrently in a thread pool to exercise bug encountered in CASSANDRA-19703 where
+        // delete from table occurs before the insert due to early eviction.
+        final ExecutorService executor = Executors.newFixedThreadPool(10);
+
+        long initialEvicted = numberOfEvictedStatements();
+        try
+        {
+            int initialMaxStatementsToPrepare = 10000;
+            int maxStatementsToPrepare = initialMaxStatementsToPrepare;
+            boolean hasEvicted = false;
+            int concurrency = 100;
+            List<CompletableFuture<MD5Digest>> prepareFutures = new ArrayList<>(concurrency);
+
+            for (int cnt = 1; cnt <= maxStatementsToPrepare; cnt++)
+            {
+                final int localCnt = cnt;
+                prepareFutures.add(CompletableFuture.supplyAsync(() -> prepareStatement("INSERT INTO %s (key, val) VALUES (?, ?) USING TIMESTAMP " + localCnt, clientState), executor));
+
+                if (prepareFutures.size() == concurrency)
+                {
+                    // Await completion of current inflight futures
+                    CompletableFuture.allOf(prepareFutures.toArray(futureArray)).get(10, TimeUnit.SECONDS);
+                    prepareFutures.clear();
+                }
+
+                // Once we've detected evictions, prepare as many statements as we've prepared so far to initialMaxStatementsToPrepare and then stop.
+                if (!hasEvicted && numberOfEvictedStatements() - initialEvicted > 0)
+                {
+                    maxStatementsToPrepare = Math.min(cnt * 2, initialMaxStatementsToPrepare);
+                    hasEvicted = true;
+                }
+            }
+
+            long evictedStatements = numberOfEvictedStatements() - initialEvicted;
+            assertNotEquals("Should have evicted some prepared statements", 0, evictedStatements);
+
+            // Recorded prepared statement removals should match metrics
+            assertEquals("Actual evicted statements does not match metrics", evictedStatements, preparedStatementRemoveTimestamps.size());
+
+            // For each prepared statement evicted, assert the time it was deleted is greater than the timestamp
+            // used for when it was loaded.
+            for (Map.Entry<MD5Digest, Long> evictedStatementEntry : preparedStatementRemoveTimestamps.entrySet())
+            {
+                MD5Digest key = evictedStatementEntry.getKey();
+                long deletionTimestamp = evictedStatementEntry.getValue();
+                long insertionTimestamp = preparedStatementLoadTimestamps.get(key);
+
+                assertTrue(String.format("Expected deletion timestamp for prepared statement (%d) to be greater than insertion timestamp (%d)",
+                                         deletionTimestamp, insertionTimestamp),
+                           deletionTimestamp > insertionTimestamp);
+            }
+
+            // ensure the number of statements on disk match the number in memory, if number of statements on disk eclipses in memory, there was a leak.
+            assertEquals("Number of statements in memory (expected) and table (actual) don't match", numberOfStatementsInMemory(), numberOfStatementsOnDisk());
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * Invoked whenever paging happens in testPreloadPreparedStatements, increments PAGE_INVOCATIONS when we detect
+     * paging happening in the path of QueryProcessor.preloadPreparedStatements with the expected page size.
+     */
+    @SuppressWarnings("unused")
+    private static void nextPageReadQuery(ReadQuery query, int pageSize)
+    {
+        TableMetadata metadata = query.metadata();
+        if (metadata.keyspace.equals(SchemaConstants.SYSTEM_KEYSPACE_NAME) &&
+            metadata.name.equals(SystemKeyspace.PREPARED_STATEMENTS) &&
+            pageSize == PRELOAD_PAGE_SIZE)
+        {
+            for (StackTraceElement stackTraceElement : Thread.currentThread().getStackTrace())
+            {
+                if (stackTraceElement.getClassName().equals(QueryProcessor.class.getName()) && stackTraceElement.getMethodName().equals("preloadPreparedStatements"))
+                {
+                    pageInvocations.incrementAndGet();
+                    return;
+                }
+            }
+        }
+    }
+
+    @Test
+    @BMRule(name = "CapturePageInvocations",
+            targetClass = "PartitionRangeQueryPager",
+            targetMethod = "nextPageReadQuery(int)",
+            action = "org.apache.cassandra.cql3.PstmtPersistenceTest.nextPageReadQuery($this.query, $pageSize)")
+    public void testPreloadPreparedStatements() throws Throwable
+    {
+        ClientState clientState = ClientState.forInternalCalls();
+        createTable("CREATE TABLE %s (key int primary key, val int)");
+
+        // Prepare more statements than the paging size to ensure paging works properly.
+        int statementsToPrepare = 750;
+
+        for (int cnt = 1; cnt <= statementsToPrepare; cnt++)
+        {
+            prepareStatement("INSERT INTO %s (key, val) VALUES (?, ?) USING TIMESTAMP " + cnt, clientState);
+        }
+
+        // Capture how many statements are in memory before clearing cache.
+        long statementsInMemory = numberOfStatementsInMemory();
+        long statementsOnDisk = numberOfStatementsOnDisk();
+        assertEquals(statementsOnDisk, statementsInMemory);
+
+        // Drop prepared statements from cache only and ensure the cache empties out.
+        QueryProcessor.clearPreparedStatements(true);
+        assertEquals(0, numberOfStatementsInMemory());
+
+        // Load prepared statements and ensure the cache size matches max
+        QueryProcessor.instance.preloadPreparedStatements(PRELOAD_PAGE_SIZE);
+
+        long statementsInMemoryAfterLoading = numberOfStatementsInMemory();
+        // Ensure size of cache matches statements that were on disk before preload
+        assertEquals("Statements prepared - evicted (expected) does not match statements in memory (actual)",
+                     statementsOnDisk, statementsInMemoryAfterLoading);
+
+        // Number of statements on disk shold match memory
+        assertEquals(statementsInMemoryAfterLoading, numberOfStatementsOnDisk());
+
+        // Ensure only executed the expected amount of pages.
+        int expectedPageInvocations = (int) Math.ceil(statementsInMemoryAfterLoading / (double) PRELOAD_PAGE_SIZE);
+        assertEquals(expectedPageInvocations, pageInvocations.get());
+    }
+
+    @Test
+    public void testPreloadPreparedStatementsUntilCacheFull()
+    {
+        QueryHandler handler = ClientState.getCQLQueryHandler();
+        ClientState clientState = ClientState.forInternalCalls();
+        createTable("CREATE TABLE %s (key int primary key, val int)");
+
+        // Fill up and clear the prepared statement cache several times to load up the system.prepared_statements table.
+        // This simulates a 'leak' of prepared statements akin to CASSANDRA-19703 as the system.prepared_statements
+        // table is able to grow to a larger size than the in memory prepared statement cache.  In such a case we
+        // should detect a possible leak and defer paging indefinitely by returning early in preloadPreparedStatements.
+        int statementsLoadedWhenFull = -1;
+        long accumulatedSize = 0;
+        // load enough prepared statements to fill the cache 5 times.
+        for (int cnt = 0; accumulatedSize < QueryProcessor.PREPARED_STATEMENT_CACHE_SIZE_BYTES * 5; cnt++)
+        {
+            MD5Digest id = prepareStatement("INSERT INTO %s (key, val) VALUES (?, ?) USING TIMESTAMP " + cnt, clientState);
+            QueryHandler.Prepared prepared = handler.getPrepared(id);
+            assertTrue(prepared.pstmntSize > -1);
+            accumulatedSize += prepared.pstmntSize;
+            if (statementsLoadedWhenFull == -1 && accumulatedSize > QueryProcessor.PREPARED_STATEMENT_CACHE_SIZE_BYTES)
+            {
+                statementsLoadedWhenFull = cnt;
+            }
+            // clear cache repeatedly to avoid eviction.
+            QueryProcessor.clearPreparedStatements(true);
+        }
+
+
+        int preloadedStatements = QueryProcessor.instance.preloadPreparedStatements(PRELOAD_PAGE_SIZE);
+
+        // Should have loaded as many statements as we detected were loaded before cache would be full.
+        assertTrue(String.format("Preloaded %d statements, expected at least %d",
+                                 preloadedStatements, statementsLoadedWhenFull),
+                   preloadedStatements > statementsLoadedWhenFull);
+
+        // We should only expect to load how many statements we were able to load before filling the cache
+        // + a buffer of 110%, set to 1.5x just to deal with sensitivity of detecting cache filling up.
+        int atMostPreloadedExpected = (int) (statementsLoadedWhenFull * 1.5);
+        assertTrue(String.format("Preloaded %d statements, but only expected that we'd load at most %d",
+                                 preloadedStatements, atMostPreloadedExpected),
+                   preloadedStatements <= atMostPreloadedExpected);
     }
 
     private long numberOfStatementsOnDisk() throws Throwable
@@ -179,7 +412,6 @@ public class PstmtPersistenceTest extends CQLTester
 
     private MD5Digest prepareStatement(String stmt, String keyspace, String table, ClientState clientState)
     {
-        System.out.println(stmt + String.format(stmt, keyspace + "." + table));
-        return QueryProcessor.instance.prepare(String.format(stmt, keyspace + "." + table), clientState).statementId;
+        return QueryProcessor.instance.prepare(String.format(stmt, keyspace + '.' + table), clientState).statementId;
     }
 }


### PR DESCRIPTION
Updates SystemKeyspace.writePreparedStatement to accept a timestamp associated with the Prepared creation time. Using this timestamp will ensure that an INSERT into system.prepared_statements will always precede the timestamp for the same Prepared in SystemKeyspace.removePreparedStatement.

This is needed because Caffeine 2.9.2 may evict an entry as soon as it is inserted if the maximum weight of the cache is exceeded causing the DELETE to be executed before the INSERT.

Additionally, any clusters currently experiencing a leaky system.prepared_statements table from this bug may struggle to bounce into a version with this fix as
SystemKeyspace.loadPreparedPreparedStatements currently does not paginate the query to system.prepared_statements, causing heap OOMs.  To fix this this patch adds pagination at 5000 rows and aborts loading once the cache size is loaded. This should allow nodes to come up and delete older prepared statements that may no longer be used as the cache fills up (which should happen immediately).

This patch does not address the issue of Caffeine immediately evicting a prepared statement, however it will prevent the
system.prepared_statements table from growing unbounded.  For most users this should be adequate, as the cache should only be filled when there are erroneously many unique prepared statements. In such a case we can expect that clients will constantly prepare statements regardless of whether or not the cache is evicting statements.

patch by Andy Tolbert; reviewed by Berenguer Blasi and Caleb Rackliffe for CASSANDRA-19703