### PR TITLE
[CASSANDRA-20649][5.0] Relax validation of snapshot name as a part of SSTable files path validation

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/Descriptor.java
+++ b/src/java/org/apache/cassandra/io/sstable/Descriptor.java
@@ -64,14 +64,14 @@ public class Descriptor
     // to the SSTable naming.
     static final Pattern SSTABLE_DIR_PATTERN = Pattern.compile(".*/(?<keyspace>\\w+)/" +
                                                                "(?<tableName>\\w+)-(?<tableId>[0-9a-f]{32})/" +
-                                                               "(backups/|snapshots/(?<tag>[\\w-]+)/)?" +
+                                                               "(backups/|snapshots/(?<tag>[^/]+)/)?" +
                                                                "(\\.(?<indexName>[\\w-]+)/)?" +
                                                                "(?<component>[\\w-\\+]+)\\.(?<ext>[\\w]+)$");
 
     // Pre 2.1 SSTable directory format is {keyspace}/{tableName}-{tableId}[/backups|/snapshots/{tag}][/.{indexName}]/{component}.db
     static final Pattern LEGACY_SSTABLE_DIR_PATTERN = Pattern.compile(".*/(?<keyspace>\\w+)/" +
                                                                       "(?<tableName>\\w+)/" +
-                                                                      "(backups/|snapshots/(?<tag>[\\w-]+)/)?" +
+                                                                      "(backups/|snapshots/(?<tag>[^/]+)/)?" +
                                                                       "(\\.(?<indexName>[\\w-]+)/)?" +
                                                                       "(?<component>[\\w-]+)\\.(?<ext>[\\w]+)$");
 

--- a/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/DescriptorTest.java
@@ -169,6 +169,7 @@ public class DescriptorTest
         "/path/to/cassandra/data/dir2/dir5/dir6/ks1/tab1-34234234234234234234234234234234/backups/na-1-big-Index.db",
         "/path/to/cassandra/data/dir2/dir5/dir6/ks1/tab1-34234234234234234234234234234234/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
         "/path/to/cassandra/data/dir2/dir5/dir6/ks1/tab1-34234234234234234234234234234234/snapshots/snapshot/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
+        "/path/to/cassandra/data/dir2/dir5/dir6/ks1/tab1-34234234234234234234234234234234/snapshots/snapshot-12345-1.2.3_TEST#=/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
         "/path/to/cassandra/data/dir2/dir5/dir6/ks1/tab1-34234234234234234234234234234234/backups/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
         };
 
@@ -230,6 +231,7 @@ public class DescriptorTest
         "/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/na-1-big-Index.db",
         "/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/nb-1-big-TOC.txt",
         //"/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/snapshots/snapshots/na-1-big-Index.db", #not supported (CASSANDRA-14013)
+        "/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/snapshots/snapshot-12345-1.2.3_TEST#=/na-1-big-Index.db",
         "/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/backups/na-1-big-Index.db",
         "/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db",
         //"/path/to/cassandra/data/dir2/dir5/dir6/backups/backups/snapshots/snapshots/nb-3g1m_0nuf_3vj5m2k1125165rxa7-big-Index.db", #not supported (CASSANDRA-14013)


### PR DESCRIPTION
Relax validation of snapshot name as a part of SSTable files path validation

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20649
