### PR TITLE
[CASSANDRA-20457] Limit number of OOM heap dumps to avoid full disk issue

### DIFF
--- a/bin/cassandra
+++ b/bin/cassandra
@@ -174,6 +174,23 @@ case "`uname -s`" in
     ;;
 esac
 
+clean_heap_dump_files()
+{
+    if [ "$CASSANDRA_HEAPDUMP_CLEAN" != "" ] && \
+        [ "$CASSANDRA_HEAPDUMP_CLEAN" -ge 0 ] && \
+        [ -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
+        # find all files under CASSANDRA_HEAPDUMP_DIR,
+        # sort by last modification date descending,
+        # print those, that need to be removed
+        ls -pt1 "$CASSANDRA_HEAPDUMP_DIR" | grep -v / | \
+        grep "^cassandra-.*-pid.*[.]hprof$" | \
+        awk "{ if (NR > $CASSANDRA_HEAPDUMP_CLEAN) print \$0}" | \
+        while IFS= read -r file; do
+          rm -f "$CASSANDRA_HEAPDUMP_DIR/$file"
+        done
+    fi
+}
+
 launch_service()
 {
     pidpath="$1"
@@ -188,9 +205,7 @@ launch_service()
         cassandra_parms="$cassandra_parms -Dcassandra-pidfile=$pidpath"
     fi
 
-    if [ "$should_clean_heap_dump_files" = "1" ]; then
-      clean_heap_dump_files
-    fi
+    clean_heap_dump_files
 
     # The cassandra-foreground option will tell CassandraDaemon not
     # to close stdout/stderr, but it's up to us not to background.
@@ -252,7 +267,7 @@ while true; do
         -H)
             properties="$properties -XX:HeapDumpPath=$2"
             # disable automatic heap dump files management as HeapDumpPath was overridden
-            CASSANDRA_HEAPDUMP_CLEAN=0
+            CASSANDRA_HEAPDUMP_CLEAN=-1
             shift 2
         ;;
         -E)

--- a/bin/cassandra
+++ b/bin/cassandra
@@ -176,15 +176,15 @@ esac
 
 clean_heap_dump_files()
 {
-    if [ "$CASSANDRA_HEAPDUMP_CLEAN" != "" ] && \
-        [ "$CASSANDRA_HEAPDUMP_CLEAN" -ge 0 ] && \
+    if [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" != "" ] && \
+        [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" -ge 0 ] && \
         [ -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
         # find all files under CASSANDRA_HEAPDUMP_DIR,
         # sort by last modification date descending,
         # print those, that need to be removed
         ls -pt1 "$CASSANDRA_HEAPDUMP_DIR" | grep -v / | \
         grep "^cassandra-.*-pid.*[.]hprof$" | \
-        awk "{ if (NR > $CASSANDRA_HEAPDUMP_CLEAN) print \$0}" | \
+        awk "{ if (NR > $CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES) print \$0}" | \
         while IFS= read -r file; do
           rm -f "$CASSANDRA_HEAPDUMP_DIR/$file"
         done
@@ -267,7 +267,7 @@ while true; do
         -H)
             properties="$properties -XX:HeapDumpPath=$2"
             # disable automatic heap dump files management as HeapDumpPath was overridden
-            CASSANDRA_HEAPDUMP_CLEAN=-1
+            CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES=-1
             shift 2
         ;;
         -E)

--- a/bin/cassandra
+++ b/bin/cassandra
@@ -188,8 +188,8 @@ launch_service()
         cassandra_parms="$cassandra_parms -Dcassandra-pidfile=$pidpath"
     fi
 
-    if [ "x$call_clean_heap_dump_files" != "x" ]; then
-        clean_heap_dump_files || true
+    if [ "x$clean_heap_dump_files_defined" = "x1" ]; then
+      clean_heap_dump_files
     fi
 
     # The cassandra-foreground option will tell CassandraDaemon not
@@ -252,7 +252,7 @@ while true; do
         -H)
             properties="$properties -XX:HeapDumpPath=$2"
             # disable automatic heap dump files management as HeapDumpPath was overridden
-            call_clean_heap_dump_files=
+            CASSANDRA_HEAPDUMP_CLEAN=0
             shift 2
         ;;
         -E)

--- a/bin/cassandra
+++ b/bin/cassandra
@@ -188,6 +188,10 @@ launch_service()
         cassandra_parms="$cassandra_parms -Dcassandra-pidfile=$pidpath"
     fi
 
+    if [ "x$call_clean_heap_dump_files" != "x" ]; then
+        clean_heap_dump_files || true
+    fi
+
     # The cassandra-foreground option will tell CassandraDaemon not
     # to close stdout/stderr, but it's up to us not to background.
     if [ "x$foreground" != "x" ]; then
@@ -247,6 +251,8 @@ while true; do
         ;;
         -H)
             properties="$properties -XX:HeapDumpPath=$2"
+            # disable automatic heap dump files management as HeapDumpPath was overridden
+            call_clean_heap_dump_files=
             shift 2
         ;;
         -E)

--- a/bin/cassandra
+++ b/bin/cassandra
@@ -188,7 +188,7 @@ launch_service()
         cassandra_parms="$cassandra_parms -Dcassandra-pidfile=$pidpath"
     fi
 
-    if [ "x$clean_heap_dump_files_defined" = "x1" ]; then
+    if [ "$should_clean_heap_dump_files" = "1" ]; then
       clean_heap_dump_files
     fi
 

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -204,21 +204,21 @@ JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s
 #  - enable heap dump files clean up
 #  - keeping last 2 files
 #  - keeping 1 oldest file to help identify first OOM incident
-if [ "x$CASSANDRA_HEAPDUMP_CLEAN" = "x" ]; then
+if [ "$CASSANDRA_HEAPDUMP_CLEAN" = "" ]; then
     CASSANDRA_HEAPDUMP_CLEAN=1
 fi
-if [ "x$CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES" = "x" ]; then
-    CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES=2
+if [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" = "" ]; then
+    CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES=2
 fi
-if [ "x$CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES" = "x" ]; then
-    CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES=1
+if [ "$CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES" = "" ]; then
+    CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES=1
 fi
 
 clean_heap_dump_files()
 {
     if [ "$CASSANDRA_HEAPDUMP_CLEAN" -eq 1 ] && \
-           [ "$CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES" -ge 0 ] && \
-           [ "$CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES" -ge 0 ] && \
+           [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" -ge 0 ] && \
+           [ "$CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES" -ge 0 ] && \
            [ -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
         # find all files under CASSANDRA_HEAPDUMP_DIR,
         # sort by last modification date descending,
@@ -226,7 +226,7 @@ clean_heap_dump_files()
         ls -pt1 "$CASSANDRA_HEAPDUMP_DIR" | grep -v / | \
         grep "^cassandra-.*-pid.*[.]hprof$" | \
         awk "BEGIN{ f=0; }{ files[f]=\$0; f+=1; }END{
-            for(i = $CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES; i < f - $CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES; i++) {
+            for(i = $CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES; i < f - $CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES; i++) {
               print files[i];
             }
           }" | while IFS= read -r file; do
@@ -235,7 +235,7 @@ clean_heap_dump_files()
     fi
 }
 
-clean_heap_dump_files_defined=1
+should_clean_heap_dump_files=1
 
 # stop the jvm on OutOfMemoryError as it can result in some data corruption
 # uncomment the preferred option

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -202,7 +202,7 @@ JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s
 # Cassandra heap dump files management options:
 # if not set externally, this script assigns defauls:
 #  - enable heap dump files clean up
-#  - keeping last 2 files
+#  - keeping 2 newest files
 #  - keeping 1 oldest file to help identify first OOM incident
 if [ "$CASSANDRA_HEAPDUMP_CLEAN" = "" ]; then
     CASSANDRA_HEAPDUMP_CLEAN=1

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -199,6 +199,45 @@ if [ "x$CASSANDRA_HEAPDUMP_DIR" = "x" ]; then
 fi
 JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
 
+# by default, enable cassandra heapdump files clean up, keeping 2 latest files
+# and 1 oldest heap dump file (this may help identify the earliest OOM issue)
+if [ "x$CASSANDRA_HEAPDUMP_CLEAN" = "x" ]; then
+    CASSANDRA_HEAPDUMP_CLEAN=1
+fi
+if [ "x$CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES" = "x" ]; then
+    CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES=2
+fi
+if [ "x$CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES" = "x" ]; then
+    CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES=1
+fi
+
+# this flag identifies that 'cassandra-env.sh' function
+# clean_heap_dump_files has been loaded and should be called.
+# this flag can be reset in bin/cassandra if -H option is passed.
+call_clean_heap_dump_files=1
+
+clean_heap_dump_files()
+{
+    if [ "x$CASSANDRA_HEAPDUMP_CLEAN" = "x1" ] && \
+           [ "$CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES" -ge 0 ] && \
+           [ "$CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES" -ge 0 ] && \
+           [ -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
+        # find heap dump files, take not more than 100 of them (in order not to overload xargs),
+        # sort by last modification date descending
+        # print those, that need to be removed
+        find "$CASSANDRA_HEAPDUMP_DIR" -name "cassandra-*-pid*.hprof" -type f | \
+        head -n 100 | \
+        xargs ls -t1 2>/dev/null | \
+        awk "BEGIN{ f=0; }{ files[f]=\$0; f+=1; }END{
+            for(i = $CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES; i < f - $CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES; i++) {
+              print files[i];
+            }
+          }" | while IFS= read -r file; do
+          rm -f "$file" || true
+        done
+    fi
+}
+
 # stop the jvm on OutOfMemoryError as it can result in some data corruption
 # uncomment the preferred option
 # ExitOnOutOfMemoryError and CrashOnOutOfMemoryError require a JRE greater or equals to 1.7 update 101 or 1.8 update 92

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -199,8 +199,11 @@ if [ "x$CASSANDRA_HEAPDUMP_DIR" = "x" ]; then
 fi
 JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
 
-# by default, enable cassandra heapdump files clean up, keeping 2 latest files
-# and 1 oldest heap dump file (this may help identify the earliest OOM issue)
+# Cassandra heap dump files management options:
+# if not set externally, this script assigns defauls:
+#  - enable heap dump files clean up
+#  - keeping last 2 files
+#  - keeping 1 oldest file to help identify first OOM incident
 if [ "x$CASSANDRA_HEAPDUMP_CLEAN" = "x" ]; then
     CASSANDRA_HEAPDUMP_CLEAN=1
 fi
@@ -211,32 +214,28 @@ if [ "x$CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES" = "x" ]; then
     CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES=1
 fi
 
-# this flag identifies that 'cassandra-env.sh' function
-# clean_heap_dump_files has been loaded and should be called.
-# this flag can be reset in bin/cassandra if -H option is passed.
-call_clean_heap_dump_files=1
-
 clean_heap_dump_files()
 {
-    if [ "x$CASSANDRA_HEAPDUMP_CLEAN" = "x1" ] && \
+    if [ "$CASSANDRA_HEAPDUMP_CLEAN" -eq 1 ] && \
            [ "$CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES" -ge 0 ] && \
            [ "$CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES" -ge 0 ] && \
            [ -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
-        # find heap dump files, take not more than 100 of them (in order not to overload xargs),
-        # sort by last modification date descending
+        # find all files under CASSANDRA_HEAPDUMP_DIR,
+        # sort by last modification date descending,
         # print those, that need to be removed
-        find "$CASSANDRA_HEAPDUMP_DIR" -name "cassandra-*-pid*.hprof" -type f | \
-        head -n 100 | \
-        xargs ls -t1 2>/dev/null | \
+        ls -pt1 "$CASSANDRA_HEAPDUMP_DIR" | grep -v / | \
+        grep "^cassandra-.*-pid.*[.]hprof$" | \
         awk "BEGIN{ f=0; }{ files[f]=\$0; f+=1; }END{
             for(i = $CASSANDRA_HEAPDUMP_KEEP_LAST_N_FILES; i < f - $CASSANDRA_HEAPDUMP_KEEP_FIRST_N_FILES; i++) {
               print files[i];
             }
           }" | while IFS= read -r file; do
-          rm -f "$file" || true
+          rm -f "$CASSANDRA_HEAPDUMP_DIR/$file"
         done
     fi
 }
+
+clean_heap_dump_files_defined=1
 
 # stop the jvm on OutOfMemoryError as it can result in some data corruption
 # uncomment the preferred option

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -200,42 +200,12 @@ fi
 JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
 
 # Cassandra heap dump files management options:
-# if not set externally, this script assigns defauls:
-#  - enable heap dump files clean up
-#  - keeping 2 newest files
-#  - keeping 1 oldest file to help identify first OOM incident
+# 0..N > 0 - keep N newest files
+# -1 or empty - disable clean up
+# default: 2 - keep 2 newest files
 if [ "$CASSANDRA_HEAPDUMP_CLEAN" = "" ]; then
-    CASSANDRA_HEAPDUMP_CLEAN=1
+    CASSANDRA_HEAPDUMP_CLEAN=2
 fi
-if [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" = "" ]; then
-    CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES=2
-fi
-if [ "$CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES" = "" ]; then
-    CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES=1
-fi
-
-clean_heap_dump_files()
-{
-    if [ "$CASSANDRA_HEAPDUMP_CLEAN" -eq 1 ] && \
-           [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" -ge 0 ] && \
-           [ "$CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES" -ge 0 ] && \
-           [ -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
-        # find all files under CASSANDRA_HEAPDUMP_DIR,
-        # sort by last modification date descending,
-        # print those, that need to be removed
-        ls -pt1 "$CASSANDRA_HEAPDUMP_DIR" | grep -v / | \
-        grep "^cassandra-.*-pid.*[.]hprof$" | \
-        awk "BEGIN{ f=0; }{ files[f]=\$0; f+=1; }END{
-            for(i = $CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES; i < f - $CASSANDRA_HEAPDUMP_KEEP_OLDEST_N_FILES; i++) {
-              print files[i];
-            }
-          }" | while IFS= read -r file; do
-          rm -f "$CASSANDRA_HEAPDUMP_DIR/$file"
-        done
-    fi
-}
-
-should_clean_heap_dump_files=1
 
 # stop the jvm on OutOfMemoryError as it can result in some data corruption
 # uncomment the preferred option

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -203,8 +203,8 @@ JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s
 #  N >= 0 - keep N newest files
 # -1 - disable clean up
 # defaults to 2 if not set
-if [ "$CASSANDRA_HEAPDUMP_CLEAN" = "" ]; then
-    CASSANDRA_HEAPDUMP_CLEAN=2
+if [ "$CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES" = "" ]; then
+    CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES=2
 fi
 
 # stop the jvm on OutOfMemoryError as it can result in some data corruption

--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -200,9 +200,9 @@ fi
 JVM_OPTS="$JVM_OPTS -XX:HeapDumpPath=$CASSANDRA_HEAPDUMP_DIR/cassandra-`date +%s`-pid$$.hprof"
 
 # Cassandra heap dump files management options:
-# 0..N > 0 - keep N newest files
-# -1 or empty - disable clean up
-# default: 2 - keep 2 newest files
+#  N >= 0 - keep N newest files
+# -1 - disable clean up
+# defaults to 2 if not set
 if [ "$CASSANDRA_HEAPDUMP_CLEAN" = "" ]; then
     CASSANDRA_HEAPDUMP_CLEAN=2
 fi


### PR DESCRIPTION
New env var is introduced:
  CASSANDRA_HEAPDUMP_KEEP_NEWEST_N_FILES:
   -1 - do not clean
   N >= 0 - retain N newest files
   default: 2 (applies when CASSANDRA_HEAPDUMP_CLEAN is not set)


----
test script for generating hprof files under CASSANDRA_HEAPDUMP_DIR:
```
#!/bin/sh

export CASSANDRA_HEAPDUMP_DIR=/tmp/hd
export CASSANDRA_HEAPDUMP_CLEAN=

create_hprof_files()
{
  rm -rf "$CASSANDRA_HEAPDUMP_DIR"
  mkdir -p "$CASSANDRA_HEAPDUMP_DIR"
  if [ ! -d "$CASSANDRA_HEAPDUMP_DIR" ]; then
      echo "was not able to create dir $CASSANDRA_HEAPDUMP_DIR"
  fi

  for i in $(seq 1 1000); do echo 1 > "$CASSANDRA_HEAPDUMP_DIR/cassandra-$i-pid$i.hprof"; sleep 0.005; done;
  echo 1 > "$CASSANDRA_HEAPDUMP_DIR/cassandra-1-pid1.hprofX"
  echo 1 > "$CASSANDRA_HEAPDUMP_DIR/Xcassandra-1-pid1.hprof"
  mkdir -p "$CASSANDRA_HEAPDUMP_DIR/cassandra-1001-pid1001.hprof"
  if [ ! -d "$CASSANDRA_HEAPDUMP_DIR/cassandra-1001-pid1001.hprof" ]; then
      echo "was not able to create dir $CASSANDRA_HEAPDUMP_DIR/cassandra-1001-pid1001.hprof"
  fi
  if ! ls -pt1 "$CASSANDRA_HEAPDUMP_DIR" | wc -l | awk '{if ($0 != 1003) exit 1}'; then
    echo "wrong content created under $CASSANDRA_HEAPDUMP_DIR"
  fi
}
```