### PR TITLE
CASSANDRA-20668 Avoid lambda usage in TrieMemoryIndex range queries and ensure queue size tracking is per column

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.5
+ * Avoid lambda usage in TrieMemoryIndex range queries and ensure queue size tracking is per column (CASSANDRA-20668)
  * Avoid CQLSH throwing an exception loading .cqlshrc on non-supported platforms (CASSANDRA-20478)
  * Relax validation of snapshot name as a part of SSTable files path validation (CASSANDRA-20649)
  * Optimize initial skipping logic for SAI queries on large partitions (CASSANDRA-20191)


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by David Capwell for CASSANDRA-20668
