### PR TITLE
CASSANDRA-20639 Replica filtering protection can trigger short-read protection too aggressively when the LIMIT is less than the number of results in a partition

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.5
+ * Ensure replica filtering protection does not trigger unnecessary short read protection reads (CASSANDRA-20639)
  * Unified Compaction does not properly validate min and target sizes (CASSANDRA-20398)
  * Avoid lambda usage in TrieMemoryIndex range queries and ensure queue size tracking is per column (CASSANDRA-20668)
  * Avoid CQLSH throwing an exception loading .cqlshrc on non-supported platforms (CASSANDRA-20478)

--- a/src/java/org/apache/cassandra/db/partitions/PartitionIterators.java
+++ b/src/java/org/apache/cassandra/db/partitions/PartitionIterators.java
@@ -94,21 +94,6 @@ public abstract class PartitionIterators
     }
 
     /**
-     * Consumes all rows in the next partition of the provided partition iterator.
-     */
-    public static void consumeNext(PartitionIterator iterator)
-    {
-        if (iterator.hasNext())
-        {
-            try (RowIterator partition = iterator.next())
-            {
-                while (partition.hasNext())
-                    partition.next();
-            }
-        }
-    }
-
-    /**
      * Wraps the provided iterator so it logs the returned rows for debugging purposes.
      * <p>
      * Note that this is only meant for debugging as this can log a very large amount of

--- a/src/java/org/apache/cassandra/service/reads/repair/PartitionIteratorMergeListener.java
+++ b/src/java/org/apache/cassandra/service/reads/repair/PartitionIteratorMergeListener.java
@@ -49,7 +49,7 @@ public class PartitionIteratorMergeListener<E extends Endpoints<E>>
         return new RowIteratorMergeListener<>(partitionKey, columns(versions), isReversed(versions), replicaPlan, command, readRepair);
     }
 
-    protected RegularAndStaticColumns columns(List<UnfilteredRowIterator> versions)
+    public static RegularAndStaticColumns columns(List<UnfilteredRowIterator> versions)
     {
         Columns statics = Columns.NONE;
         Columns regulars = Columns.NONE;


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by Blake Eggleston and Zhao Yang for CASSANDRA-20639
