### PR TITLE
[CASSANDRA-20681][5.0] Mark JDK 17 as production ready for Cassandra 5.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.5
+ * Full Java 17 support (CASSANDRA-20681)
  * Ensure replica filtering protection does not trigger unnecessary short read protection reads (CASSANDRA-20639)
  * Unified Compaction does not properly validate min and target sizes (CASSANDRA-20398)
  * Avoid lambda usage in TrieMemoryIndex range queries and ensure queue size tracking is per column (CASSANDRA-20668)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -65,6 +65,13 @@ restore snapshots created with the previous major version using the
 'sstableloader' tool. You can upgrade the file format of your snapshots
 using the provided 'sstableupgrade' tool.
 
+5.0.5
+=====
+
+New features
+------------
+    - Full support for Java 17, it is not experimental anymore.
+
 5.0.4
 =====
 

--- a/doc/modules/cassandra/pages/reference/java17.adoc
+++ b/doc/modules/cassandra/pages/reference/java17.adoc
@@ -8,7 +8,7 @@ the vertical axis and the run version is along the horizontal axis.
 [width="68%",cols="34%,30%,36%",]
 |===
 | | Java 11 (Run) | Java 17 (Run)
-| Java 11 (Build) | Supported | Experimental Support
+| Java 11 (Build) | Supported | Supported
 | Java 17(Build) | Not Supported | Experimental in CI
 |===
 


### PR DESCRIPTION
Mark JDK 17 as production ready for Cassandra 5.0

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20681