### PR TITLE
[CASSANDRA-20681][trunk] Mark JDK 17 as production ready since Cassandra 5.0.5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -195,6 +195,7 @@
  * Add the ability to disable bulk loading of SSTables (CASSANDRA-18781)
  * Clean up obsolete functions and simplify cql_version handling in cqlsh (CASSANDRA-18787)
 Merged from 5.0:
+ * Full Java 17 support (CASSANDRA-20681)
  * Ensure replica filtering protection does not trigger unnecessary short read protection reads (CASSANDRA-20639)
  * Unified Compaction does not properly validate min and target sizes (CASSANDRA-20398)
  * Avoid lambda usage in TrieMemoryIndex range queries and ensure queue size tracking is per column (CASSANDRA-20668)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -206,6 +206,13 @@ Deprecation
       the new interfaces so that their functionality can also be used via the new `initial_location_provider`,
       `node_proximity` and `address_config` settings.
 
+5.0.5
+=====
+
+New features
+------------
+    - Full support for Java 17, it is not experimental anymore.
+
 5.0
 ===
 

--- a/doc/modules/cassandra/pages/reference/java17.adoc
+++ b/doc/modules/cassandra/pages/reference/java17.adoc
@@ -8,7 +8,7 @@ the vertical axis and the run version is along the horizontal axis.
 [width="68%",cols="34%,30%,36%",]
 |===
 | | Java 11 (Run) | Java 17 (Run)
-| Java 11 (Build) | Supported | Experimental Support
+| Java 11 (Build) | Supported | Supported
 | Java 17(Build) | Not Supported | Experimental in CI
 |===
 


### PR DESCRIPTION
Mark JDK 17 as production ready since Cassandra 5.0.5

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20681