### PR TITLE
CASSANDRA-20636 - Fix: handle MAX_SEGMENT_SIZE < chunkSize for MmappedRegions::updateState

### DIFF
--- a/src/java/org/apache/cassandra/io/util/MmappedRegions.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedRegions.java
@@ -183,7 +183,7 @@ public class MmappedRegions extends SharedCloseableImpl
     private void updateState(long length, int chunkSize)
     {
         // make sure the regions span whole chunks
-        long maxSize = (long) (MAX_SEGMENT_SIZE / chunkSize) * chunkSize;
+        long maxSize = Math.max(chunkSize, (long) (MAX_SEGMENT_SIZE / chunkSize) * chunkSize);
         state.length = length;
         long pos = state.getPosition();
         while (pos < length)

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -373,12 +373,22 @@ public class SSTableReaderTest
         return s.substring(0, s.length() - n);
     }
 
-
     @Test
     public void testSpannedIndexPositions() throws IOException
     {
+        doTestSpannedIndexPositions(PageAware.PAGE_SIZE);
+    }
+
+    @Test
+    public void testSpannedIndexPositionsWithMaxSegmentSizeSmallerThanPageSize() throws IOException
+    {
+        doTestSpannedIndexPositions(PageAware.PAGE_SIZE - 1);
+    }
+
+    public void doTestSpannedIndexPositions(int maxSegmentSize) throws IOException
+    {
         int originalMaxSegmentSize = MmappedRegions.MAX_SEGMENT_SIZE;
-        MmappedRegions.MAX_SEGMENT_SIZE = PageAware.PAGE_SIZE;
+        MmappedRegions.MAX_SEGMENT_SIZE = maxSegmentSize;
 
         try
         {

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -310,7 +310,6 @@ public class SSTableReaderTest
         }
     }
 
-
     @Test
     public void testOnDiskSizeCompressedBoundaries()
     {
@@ -343,7 +342,6 @@ public class SSTableReaderTest
                          sstable.getCompressionMetadata().chunkFor(sstable.getPosition(dk0(k), SSTableReader.Operator.EQ)).offset,
                          onDiskSizeForRanges(sstable, Collections.singleton(new Range<>(partitioner.getMinimumToken(), t0(k - 1)))));   // inclusive end
     }
-
 
     long onDiskSizeForRanges(SSTableReader sstable, Collection<Range<Token>> ranges)
     {
@@ -653,8 +651,9 @@ public class SSTableReaderTest
         assertEquals(2, sstable.getFilterTracker().getTruePositiveCount());
         assertEquals(1, sstable.getFilterTracker().getTrueNegativeCount());
         assertEquals(fpCount + 2, sstable.getFilterTracker().getFalsePositiveCount());
-    }
 
+        sstable.selfRef().release();
+    }
 
     @Test
     public void testGetPositionsListenerCalls()
@@ -746,6 +745,8 @@ public class SSTableReaderTest
         sstable.getPosition(dk(81), SSTableReader.Operator.GE, listener);
         Mockito.verify(listener).onSSTableSelected(sstable, SSTableReadsListener.SelectionReason.INDEX_ENTRY_FOUND);
         Mockito.reset(listener);
+
+        sstable.selfRef().release();
     }
 
     private SSTableReaderWithFilter prepareGetPositions()
@@ -779,7 +780,6 @@ public class SSTableReaderTest
         sstable = (SSTableReaderWithFilter) sstable.cloneWithNewStart(dk(3));
         return sstable;
     }
-
 
     @Test
     public void testOpeningSSTable() throws Exception
@@ -1065,7 +1065,7 @@ public class SSTableReaderTest
      * see CASSANDRA-5407
      */
     @Test
-    public void testGetScannerForNoIntersectingRanges() throws Exception
+    public void testGetScannerForNoIntersectingRanges()
     {
         ColumnFamilyStore store = discardSSTables(KEYSPACE1, CF_STANDARD);
         partitioner = store.getPartitioner();
@@ -1242,6 +1242,7 @@ public class SSTableReaderTest
         }
         R reopen = (R) SSTableReader.open(store, sstable.descriptor);
         assert reopen.getIndexSummary().getSamplingLevel() == sstable.getIndexSummary().getSamplingLevel() + 1;
+        reopen.selfRef().release();
     }
 
     private void assertIndexQueryWorks(ColumnFamilyStore indexedCFS)
@@ -1325,7 +1326,7 @@ public class SSTableReaderTest
             assertFalse(f.exists());
             assertTrue(sstable.descriptor.fileFor(c).exists());
         }
-        SSTableReader.moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
+        SSTableReader reader = SSTableReader.moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
         // make sure the files were moved:
         for (Component c : sstable.components)
         {
@@ -1335,6 +1336,7 @@ public class SSTableReaderTest
             f.deleteOnExit();
             assertFalse(sstable.descriptor.fileFor(c).exists());
         }
+        reader.selfRef().release();
     }
 
     private SSTableReader getNewSSTable(ColumnFamilyStore cfs)

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -41,9 +42,8 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.ServerTestUtils;
@@ -91,7 +91,9 @@ import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Throwables;
 import org.apache.cassandra.utils.concurrent.Ref;
+import org.apache.cassandra.utils.concurrent.SelfRefCounted;
 import org.mockito.Mockito;
 
 import static java.lang.String.format;
@@ -105,7 +107,6 @@ import static org.junit.Assume.assumeTrue;
 
 public class SSTableReaderTest
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SSTableReaderTest.class);
 
     public static final String KEYSPACE1 = "SSTableReaderTest";
     public static final String CF_STANDARD = "Standard1";
@@ -153,17 +154,22 @@ public class SSTableReaderTest
     @After
     public void teardown()
     {
+        Throwable exceptions = null;
         for (Ref<?> ref : refsToRelease)
         {
             try
             {
                 ref.release();
             }
-            catch (Exception exc)
+            catch (Throwable exc)
             {
-                LOGGER.error("Error releasing ref during teardown: {}", ref, exc);
+                exceptions = Throwables.merge(exceptions, exc);
             }
         }
+
+        if (exceptions != null)
+            Assertions.fail("Unable to release all tracked references", exceptions);
+
         refsToRelease.clear();
     }
 
@@ -806,10 +812,10 @@ public class SSTableReaderTest
         Util.flush(store);
         CompactionManager.instance.performMaximal(store, false);
 
-        SSTableReaderWithFilter sstable = (SSTableReaderWithFilter) store.getLiveSSTables().iterator().next();
-        sstable = (SSTableReaderWithFilter) sstable.cloneWithNewStart(dk(3));
-        trackReleaseableRef(sstable.selfRef());
-        return sstable;
+        return (SSTableReaderWithFilter) trackReleaseableRef(() -> {
+            SSTableReader reader = store.getLiveSSTables().iterator().next();
+            return reader.cloneWithNewStart(dk(3));
+        });
     }
 
     @Test
@@ -926,7 +932,8 @@ public class SSTableReaderTest
         components.remove(Components.SUMMARY);
 
         target = SSTableReader.open(store, desc, components, store.metadata);
-        try {
+        try
+        {
             assertTrue("Bloomfilter was not recreated", bloomModified < bloomFile.lastModified());
             assertTrue("Summary was not recreated", summaryModified < summaryFile.lastModified());
         }
@@ -1085,8 +1092,7 @@ public class SSTableReaderTest
             if (sstable instanceof IndexSummarySupport<?>)
             {
                 new IndexSummaryComponent(((IndexSummarySupport<?>) sstable).getIndexSummary(), sstable.getFirst(), sstable.getLast()).save(sstable.descriptor.fileFor(Components.SUMMARY), true);
-                SSTableReader reopened = SSTableReader.open(store, sstable.descriptor);
-                trackReleaseableRef(sstable.selfRef());
+                SSTableReader reopened = trackReleaseableRef(() -> SSTableReader.open(store, sstable.descriptor));
                 assert reopened.getFirst().getToken() instanceof LocalToken;
             }
         }
@@ -1271,8 +1277,7 @@ public class SSTableReaderTest
             txn.update(replacement, true);
             txn.finish();
         }
-        R reopen = (R) SSTableReader.open(store, sstable.descriptor);
-        trackReleaseableRef(reopen.selfRef());
+        R reopen = (R) trackReleaseableRef(() -> SSTableReader.open(store, sstable.descriptor));
         assert reopen.getIndexSummary().getSamplingLevel() == sstable.getIndexSummary().getSamplingLevel() + 1;
     }
 
@@ -1343,8 +1348,7 @@ public class SSTableReaderTest
     {
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_MOVE_AND_OPEN);
-        SSTableReader sstable = getNewSSTable(cfs);
-        trackReleaseableRef(sstable.selfRef());
+        SSTableReader sstable = trackReleaseableRef(() -> getNewSSTable(cfs));
 
         cfs.clearUnsafe();
         File tmpdir = new File(Files.createTempDirectory("testMoveAndOpen"));
@@ -1358,8 +1362,7 @@ public class SSTableReaderTest
             assertFalse(f.exists());
             assertTrue(sstable.descriptor.fileFor(c).exists());
         }
-        SSTableReader reader = SSTableReader.moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
-        trackReleaseableRef(reader.selfRef());
+        trackReleaseableRef(() -> SSTableReader.moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false));
 
         // make sure the files were moved:
         for (Component c : sstable.components)
@@ -1471,8 +1474,10 @@ public class SSTableReaderTest
         return cfs;
     }
 
-    private void trackReleaseableRef(Ref<?> ref)
+    private <T extends SelfRefCounted<T>> T trackReleaseableRef(Supplier<T> refSupplier)
     {
-        refsToRelease.add(ref);
+        T ref = refSupplier.get();
+        refsToRelease.add(ref.selfRef());
+        return ref;
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -36,11 +36,14 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
+import org.junit.After;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.ServerTestUtils;
@@ -88,6 +91,7 @@ import org.apache.cassandra.schema.CompressionParams;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.concurrent.Ref;
 import org.mockito.Mockito;
 
 import static java.lang.String.format;
@@ -101,6 +105,8 @@ import static org.junit.Assume.assumeTrue;
 
 public class SSTableReaderTest
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SSTableReaderTest.class);
+
     public static final String KEYSPACE1 = "SSTableReaderTest";
     public static final String CF_STANDARD = "Standard1";
     public static final String CF_STANDARD2 = "Standard2";
@@ -111,6 +117,7 @@ public class SSTableReaderTest
     public static final String CF_STANDARD_LOW_INDEX_INTERVAL = "StandardLowIndexInterval";
     public static final String CF_STANDARD_SMALL_BLOOM_FILTER = "StandardSmallBloomFilter";
 
+    private final List<Ref<?>> refsToRelease = new ArrayList<>();
     private IPartitioner partitioner;
 
     Token t(int i)
@@ -141,6 +148,23 @@ public class SSTableReaderTest
         
         // All tests in this class assume auto-compaction is disabled.
         CompactionManager.instance.disableAutoCompaction();
+    }
+
+    @After
+    public void teardown()
+    {
+        for (Ref<?> ref : refsToRelease)
+        {
+            try
+            {
+                ref.release();
+            }
+            catch (Exception exc)
+            {
+                LOGGER.error("Error releasing ref during teardown: {}", ref, exc);
+            }
+        }
+        refsToRelease.clear();
     }
 
     @Test
@@ -661,8 +685,6 @@ public class SSTableReaderTest
         assertEquals(2, sstable.getFilterTracker().getTruePositiveCount());
         assertEquals(1, sstable.getFilterTracker().getTrueNegativeCount());
         assertEquals(fpCount + 2, sstable.getFilterTracker().getFalsePositiveCount());
-
-        sstable.selfRef().release();
     }
 
     @Test
@@ -755,8 +777,6 @@ public class SSTableReaderTest
         sstable.getPosition(dk(81), SSTableReader.Operator.GE, listener);
         Mockito.verify(listener).onSSTableSelected(sstable, SSTableReadsListener.SelectionReason.INDEX_ENTRY_FOUND);
         Mockito.reset(listener);
-
-        sstable.selfRef().release();
     }
 
     private SSTableReaderWithFilter prepareGetPositions()
@@ -788,6 +808,7 @@ public class SSTableReaderTest
 
         SSTableReaderWithFilter sstable = (SSTableReaderWithFilter) store.getLiveSSTables().iterator().next();
         sstable = (SSTableReaderWithFilter) sstable.cloneWithNewStart(dk(3));
+        trackReleaseableRef(sstable.selfRef());
         return sstable;
     }
 
@@ -1065,8 +1086,8 @@ public class SSTableReaderTest
             {
                 new IndexSummaryComponent(((IndexSummarySupport<?>) sstable).getIndexSummary(), sstable.getFirst(), sstable.getLast()).save(sstable.descriptor.fileFor(Components.SUMMARY), true);
                 SSTableReader reopened = SSTableReader.open(store, sstable.descriptor);
+                trackReleaseableRef(sstable.selfRef());
                 assert reopened.getFirst().getToken() instanceof LocalToken;
-                reopened.selfRef().release();
             }
         }
     }
@@ -1251,8 +1272,8 @@ public class SSTableReaderTest
             txn.finish();
         }
         R reopen = (R) SSTableReader.open(store, sstable.descriptor);
+        trackReleaseableRef(reopen.selfRef());
         assert reopen.getIndexSummary().getSamplingLevel() == sstable.getIndexSummary().getSamplingLevel() + 1;
-        reopen.selfRef().release();
     }
 
     private void assertIndexQueryWorks(ColumnFamilyStore indexedCFS)
@@ -1323,8 +1344,9 @@ public class SSTableReaderTest
         Keyspace keyspace = Keyspace.open(KEYSPACE1);
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(CF_MOVE_AND_OPEN);
         SSTableReader sstable = getNewSSTable(cfs);
+        trackReleaseableRef(sstable.selfRef());
+
         cfs.clearUnsafe();
-        sstable.selfRef().release();
         File tmpdir = new File(Files.createTempDirectory("testMoveAndOpen"));
         tmpdir.deleteOnExit();
         SSTableId id = SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get();
@@ -1337,6 +1359,8 @@ public class SSTableReaderTest
             assertTrue(sstable.descriptor.fileFor(c).exists());
         }
         SSTableReader reader = SSTableReader.moveAndOpenSSTable(cfs, sstable.descriptor, notLiveDesc, sstable.components, false);
+        trackReleaseableRef(reader.selfRef());
+
         // make sure the files were moved:
         for (Component c : sstable.components)
         {
@@ -1346,7 +1370,6 @@ public class SSTableReaderTest
             f.deleteOnExit();
             assertFalse(sstable.descriptor.fileFor(c).exists());
         }
-        reader.selfRef().release();
     }
 
     private SSTableReader getNewSSTable(ColumnFamilyStore cfs)
@@ -1446,5 +1469,10 @@ public class SSTableReaderTest
         ColumnFamilyStore cfs = keyspace.getColumnFamilyStore(cf);
         cfs.discardSSTables(System.currentTimeMillis());
         return cfs;
+    }
+
+    private void trackReleaseableRef(Ref<?> ref)
+    {
+        refsToRelease.add(ref);
     }
 }

--- a/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
+++ b/test/unit/org/apache/cassandra/io/sstable/SSTableReaderTest.java
@@ -42,7 +42,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
 
 import org.apache.cassandra.SchemaLoader;
@@ -103,6 +102,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 public class SSTableReaderTest
@@ -168,7 +168,7 @@ public class SSTableReaderTest
         }
 
         if (exceptions != null)
-            Assertions.fail("Unable to release all tracked references", exceptions);
+            fail("Unable to release all tracked references " + exceptions);
 
         refsToRelease.clear();
     }


### PR DESCRIPTION
- Fix: handle MAX_SEGMENT_SIZE < chunkSize for MmappedRegions::updateState
- Resolve ref leaks seen in SSTableReaderTest

Targeting 5.0

patch by Sam Lightfoot; reviewed by <> for CASSANDRA-20636

https://issues.apache.org/jira/browse/CASSANDRA-20636
