### PR TITLE
Direct IO commit log does not flush data safely

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -177,7 +177,11 @@ public class DirectIOSegment extends CommitLogSegment
         public DirectIOSegment build()
         {
             return new DirectIOSegment(segmentManager,
-                                       path -> FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE, ExtendedOpenOption.DIRECT),
+                                       path -> FileChannel.open(path, StandardOpenOption.WRITE,
+                                                                      StandardOpenOption.READ,
+                                                                      StandardOpenOption.CREATE,
+                                                                      StandardOpenOption.DSYNC,
+                                                                      ExtendedOpenOption.DIRECT),
                                        fsBlockSize);
         }
 


### PR DESCRIPTION


```
Make Commitlog flush data safely in Direct IO mode

patch by mawellguo; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

