### PR TITLE
DB Crashes on startup if accord tables exist but accord is disabled

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateTableStatement.java
@@ -179,10 +179,6 @@ public final class CreateTableStatement extends AlterSchemaStatement
         if (table.params.transactionalMode.accordIsEnabled && SchemaConstants.isSystemKeyspace(keyspaceName))
             throw ire("Cannot enable accord on system tables (%s.%s)", keyspaceName, tableName);
 
-        if (table.params.transactionalMode.accordIsEnabled && !DatabaseDescriptor.getAccordTransactionsEnabled())
-            throw ire(format("Cannot create table %s.%s with transactional mode %s with accord.enabled set to false",
-                             keyspaceName, tableName, table.params.transactionalMode));
-
         if (table.params.transactionalMigrationFrom.isMigrating())
             throw ire("Cannot set transactional migration on new tables (%s.%s), %s", keyspaceName, tableName, table.params.transactionalMigrationFrom);
 
@@ -193,7 +189,6 @@ public final class CreateTableStatement extends AlterSchemaStatement
     public void validate(ClientState state)
     {
         super.validate(state);
-
         // If a memtable configuration is specified, validate it against config
         if (attrs.hasOption(TableParams.Option.MEMTABLE))
             MemtableParams.get(attrs.getString(TableParams.Option.MEMTABLE.toString()));
@@ -203,7 +198,14 @@ public final class CreateTableStatement extends AlterSchemaStatement
 
         // Guardrail on columns per table
         Guardrails.columnsPerTable.guard(rawColumns.size(), tableName, false, state);
+        TableParams params = attrs.asNewTableParams(keyspaceName);
 
+        // Guardrail on Accord
+        if (params.transactionalMode.accordIsEnabled && !DatabaseDescriptor.getAccordTransactionsEnabled()) 
+        {
+            throw ire(format("Cannot create table %s with transactional mode set to full and accord disabled. Enable Accord in cassandra.yaml",
+                             tableName));
+        }
         // Guardrail on number of tables
         if (Guardrails.tables.enabled(state))
         {

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -23,6 +23,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.RequestValidationException;
 import org.apache.cassandra.utils.BloomCalculations;
+import org.apache.cassandra.config.DatabaseDescriptor;
 
 import org.junit.Test;
 
@@ -89,6 +90,14 @@ public class CreateTableValidationTest extends CQLTester
     {
         expectedFailure(InvalidRequestException.class, "CREATE TABLE %s (pk int, ck1 int, ck2 int, v int, PRIMARY KEY ((pk),ck1, ck2)) WITH CLUSTERING ORDER BY (ck2 ASC);",
                         "Missing CLUSTERING ORDER for column ck1");
+    }
+
+    @Test
+    public void testCreateAccordTableWithAccordDisabled()
+    {
+        DatabaseDescriptor.setAccordTransactionsEnabled(false);
+        expectedFailure(InvalidRequestException.class, "CREATE TABLE test_accord_disabled (a int PRIMARY KEY, b int) WITH transactional_mode = full",
+                        "Cannot create table test_accord_disabled with transactional mode set to full and accord disabled. Enable Accord in cassandra.yaml");
     }
 
     private void expectedFailure(final Class<? extends RequestValidationException> exceptionType, String statement, String errorMsg)


### PR DESCRIPTION
Moved the check to validate. This ensures accord flag is checked only during table creation and not during replay.

patch by Pranav Shenoy; reviewed David by TBD for CASSANDRA-20600