### PR TITLE
Make Commitlog flush data safely in Direct IO mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.5
+ * Make Commitlog flush data safely in Direct IO mode (CASSANDRA-20692)
  * Get SAI MemtableIndex refs before SSTableIndex refs at query time (CASSANDRA-20709)
  * Fix MAX_SEGMENT_SIZE < chunkSize in MmappedRegions::updateState (CASSANDRA-20636)
  * Full Java 17 support (CASSANDRA-20681)

--- a/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/DirectIOSegment.java
@@ -177,7 +177,12 @@ public class DirectIOSegment extends CommitLogSegment
         public DirectIOSegment build()
         {
             return new DirectIOSegment(segmentManager,
-                                       path -> FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE, ExtendedOpenOption.DIRECT),
+                                       path -> FileChannel.open(path,
+                                                                StandardOpenOption.WRITE,
+                                                                StandardOpenOption.READ,
+                                                                StandardOpenOption.CREATE,
+                                                                StandardOpenOption.DSYNC,
+                                                                ExtendedOpenOption.DIRECT),
                                        fsBlockSize);
         }
 


### PR DESCRIPTION
```
Make Commitlog flush data safely in Direct IO mode

patch by Maxwell Guo; reviewed by Ariel Weisberg for CASSANDRA-20692

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

