### PR TITLE
CASSANDRA-20732 Avoid availability gap between UP and queryability marking for already built SAI indexes on bounce

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2029,6 +2029,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         setMode(Mode.NORMAL, true);
     }
 
+    @VisibleForTesting
+    public void setStartingModeUnsafe()
+    {
+        setMode(Mode.STARTING, true);
+    }
+
     private void setMode(Mode m, boolean log)
     {
         setMode(m, null, log);

--- a/test/unit/org/apache/cassandra/index/sai/cql/EmptyStringLifecycleTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/cql/EmptyStringLifecycleTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.index.sai.cql;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
@@ -25,6 +26,13 @@ import org.apache.cassandra.index.sai.SAITester;
 
 public class EmptyStringLifecycleTest extends SAITester
 {
+    @BeforeClass
+    public static void setup()
+    {
+        setUpClass();
+        requireNetwork(); // Ensure the node has advanced out of STARTING mode
+    }
+
     @Test
     public void testBeforeAndAfterFlush()
     {

--- a/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/functional/FailureTest.java
@@ -20,6 +20,7 @@
  */
 package org.apache.cassandra.index.sai.functional;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.db.marshal.Int32Type;
@@ -36,6 +37,13 @@ import static org.junit.Assert.assertEquals;
 
 public class FailureTest extends SAITester
 {
+    @BeforeClass
+    public static void setup()
+    {
+        setUpClass();
+        requireNetwork(); // Ensure the node has advanced out of STARTING mode
+    }
+
     @Test
     public void shouldMakeIndexNonQueryableOnSSTableContextFailureDuringFlush() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/index/sai/virtual/IndexesSystemViewTest.java
+++ b/test/unit/org/apache/cassandra/index/sai/virtual/IndexesSystemViewTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.virtual.VirtualKeyspace;
 import org.apache.cassandra.db.virtual.VirtualKeyspaceRegistry;
@@ -60,7 +59,8 @@ public class IndexesSystemViewTest extends SAITester
     {
         VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(SchemaConstants.VIRTUAL_VIEWS, ImmutableList.of(new ColumnIndexesSystemView(SchemaConstants.VIRTUAL_VIEWS))));
 
-        CQLTester.setUpClass();
+        setUpClass();
+        requireNetwork(); // Ensure the node has advanced out of STARTING mode
     }
 
     @Test


### PR DESCRIPTION
On startup, already built SAI indexes are made queryable in two distinct ways. The first is asynchronous, as the secondary index initialization task is run. (SAI automatically repairs local column indexes that are incomplete and marks them queryable when this finishes.) The second is synchronous, in what are called "pre-join tasks". These run before a node is marked NORMAL after bootstrap. The problem with this design is that, on a node that is already NORMAL/bootstrapped, we don't actually attempt to make already built indexes queryable before the node starts accepting requests. The problem is transient, but it should also be easy to address, at least for SAI, by synchronously validating the index when the initialization task is requested and marking it queryable, if possible, before CFS initialization finishes.