### PR TITLE
CASSANDRA-20695 SSTableIndexWriter#abort() should log more quietly in cases where an exception is not provided

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -201,6 +201,7 @@
  * Add the ability to disable bulk loading of SSTables (CASSANDRA-18781)
  * Clean up obsolete functions and simplify cql_version handling in cqlsh (CASSANDRA-18787)
 Merged from 5.0:
+ * SSTableIndexWriter#abort() should log more quietly in cases where an exception is not provided (CASSANDRA-20695)
  * Avoid availability gap between UP and queryability marking for already built SAI indexes on bounce (CASSANDRA-20732)
  * Make Commitlog flush data safely in Direct IO mode (CASSANDRA-20692)
  * Get SAI MemtableIndex refs before SSTableIndex refs at query time (CASSANDRA-20709)

--- a/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
+++ b/src/java/org/apache/cassandra/index/sai/disk/v1/SSTableIndexWriter.java
@@ -152,7 +152,12 @@ public class SSTableIndexWriter implements PerColumnIndexWriter
     {
         aborted = true;
 
-        logger.warn(index.identifier().logMessage("Aborting SSTable index flush for {}..."), indexDescriptor.sstableDescriptor, cause);
+        String message = index.identifier().logMessage("Aborting SSTable index flush for {}...");
+
+        if (cause == null)
+            logger.debug(message, indexDescriptor.sstableDescriptor);
+        else 
+            logger.warn(message, indexDescriptor.sstableDescriptor, cause);
 
         // It's possible for the current builder to be unassigned after we flush a final segment.
         if (currentBuilder != null)


### PR DESCRIPTION
patch by Caleb Rackliffe; reviewed by Jon Meredith for CASSANDRA-20695
