### PR TITLE
CASSANDRA-20785: Journal.TopologyUpdate should not store the local topology as it can be inferred from the global on

### DIFF
--- a/src/java/org/apache/cassandra/service/accord/AccordService.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordService.java
@@ -186,16 +186,19 @@ public class AccordService implements IAccordService, Shutdownable
     private static final IAccordService NOOP_SERVICE = new NoOpAccordService();
 
     private static volatile IAccordService instance = null;
+    private static volatile Id nodeId = null;
 
     @VisibleForTesting
-    public static void unsafeSetNewAccordService(IAccordService service)
+    public synchronized static void unsafeSetNewAccordService(IAccordService service)
     {
+        nodeId = service.nodeId();
         instance = service;
     }
 
     @VisibleForTesting
-    public static void unsafeSetNoop()
+    public synchronized static void unsafeSetNoop()
     {
+        nodeId = null;
         instance = NOOP_SERVICE;
     }
 
@@ -227,6 +230,7 @@ public class AccordService implements IAccordService, Shutdownable
     {
         if (!DatabaseDescriptor.getAccordTransactionsEnabled())
         {
+            nodeId = null; // its already null, just doing this to be consistent
             instance = NOOP_SERVICE;
             return;
         }
@@ -234,7 +238,8 @@ public class AccordService implements IAccordService, Shutdownable
         if (instance != null)
             return;
 
-        AccordService as = new AccordService(AccordTopology.tcmIdToAccord(tcmId));
+        Id myId = nodeId = AccordTopology.tcmIdToAccord(tcmId);
+        AccordService as = new AccordService(myId);
         as.startup();
         if (StorageService.instance.isReplacingSameAddress())
         {
@@ -285,6 +290,13 @@ public class AccordService implements IAccordService, Shutdownable
     public boolean shouldAcceptMessages()
     {
         return state == State.STARTED && journal.started();
+    }
+
+    public static Id id()
+    {
+        Id id = nodeId;
+        Invariants.require(id != null, "AccordService was not started");
+        return id;
     }
 
     public static IAccordService instance()

--- a/src/java/org/apache/cassandra/service/accord/journal/AccordTopologyUpdate.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/AccordTopologyUpdate.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.service.accord.AccordConfigurationService;
 import org.apache.cassandra.service.accord.AccordJournalValueSerializers;
+import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.accord.JournalKey;
 import org.apache.cassandra.service.accord.serializers.KeySerializers;
 import org.apache.cassandra.service.accord.serializers.TopologySerializers;
@@ -112,9 +113,6 @@ public interface AccordTopologyUpdate
                 out.writeUnsignedVInt32(e.getKey());
                 RangesForEpochSerializer.instance.serialize(e.getValue(), out);
             }
-            //TODO (desired): local to what?  Rather than serializing local we can serialize the node its relative too?  that why when we deserialize we do globa.forNode(node)
-            // this also decreases the size as we don't have redundent shards
-            TopologySerializers.compactTopology.serialize(from.local, out);
             TopologySerializers.compactTopology.serialize(from.global, out);
         }
 
@@ -129,8 +127,8 @@ public interface AccordTopologyUpdate
                 CommandStores.RangesForEpoch rangesForEpoch = RangesForEpochSerializer.instance.deserialize(in);
                 commandStores.put(commandStoreId, rangesForEpoch);
             }
-            Topology local = TopologySerializers.compactTopology.deserialize(in);
             Topology global = TopologySerializers.compactTopology.deserialize(in);
+            Topology local = global.forNode(AccordService.instance().nodeId());
             return new Journal.TopologyUpdate(commandStores, local, global);
         }
 
@@ -144,7 +142,6 @@ public interface AccordTopologyUpdate
                 size += RangesForEpochSerializer.instance.serializedSize(e.getValue());
             }
 
-            size += TopologySerializers.compactTopology.serializedSize(from.local);
             size += TopologySerializers.compactTopology.serializedSize(from.global);
             return size;
         }

--- a/src/java/org/apache/cassandra/service/accord/journal/AccordTopologyUpdate.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/AccordTopologyUpdate.java
@@ -128,7 +128,7 @@ public interface AccordTopologyUpdate
                 commandStores.put(commandStoreId, rangesForEpoch);
             }
             Topology global = TopologySerializers.compactTopology.deserialize(in);
-            Topology local = global.forNode(AccordService.instance().nodeId());
+            Topology local = global.forNode(AccordService.instance().nodeId()).trim();
             return new Journal.TopologyUpdate(commandStores, local, global);
         }
 

--- a/src/java/org/apache/cassandra/service/accord/journal/AccordTopologyUpdate.java
+++ b/src/java/org/apache/cassandra/service/accord/journal/AccordTopologyUpdate.java
@@ -128,7 +128,7 @@ public interface AccordTopologyUpdate
                 commandStores.put(commandStoreId, rangesForEpoch);
             }
             Topology global = TopologySerializers.compactTopology.deserialize(in);
-            Topology local = global.forNode(AccordService.instance().nodeId()).trim();
+            Topology local = global.forNode(AccordService.id()).trim();
             return new Journal.TopologyUpdate(commandStores, local, global);
         }
 


### PR DESCRIPTION
This patch was written by Claude