### PR TITLE
CASSANDRA-20787: [4.1] Cassandra crashes on first boot with data_disk_usage_max_disk_size set when data directory is not created

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -392,6 +392,8 @@ public class DatabaseDescriptor
 
         applySslContext();
 
+        createAllDirectories();
+
         applyGuardrails();
 
         applyStartupChecks();

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -606,7 +606,6 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                         System.setProperty("cassandra.consistent.simultaneousmoves.allow", "true");
                 }
 
-                mkdirs();
 
                 assert config.networkTopology().contains(config.broadcastAddress()) : String.format("Network topology %s doesn't contain the address %s",
                                                                                                     config.networkTopology(), config.broadcastAddress());
@@ -617,7 +616,6 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
 
                 DatabaseDescriptor.daemonInitialization();
                 FileUtils.setFSErrorHandler(new DefaultFSErrorHandler());
-                DatabaseDescriptor.createAllDirectories();
                 CassandraDaemon.getInstanceForTesting().migrateSystemDataIfNeeded();
                 CommitLog.instance.start();
 

--- a/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailDiskUsageTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailDiskUsageTest.java
@@ -72,6 +72,7 @@ public class GuardrailDiskUsageTest extends GuardrailTester
         cluster = init(Cluster.build(2)
                               .withInstanceInitializer(DiskStateInjection::install)
                               .withConfig(c -> c.with(Feature.GOSSIP, Feature.NATIVE_PROTOCOL)
+                                                .set("data_disk_usage_max_disk_size", "10GiB")
                                                 .set("data_disk_usage_percentage_warn_threshold", 98)
                                                 .set("data_disk_usage_percentage_fail_threshold", 99)
                                                 .set("authenticator", "PasswordAuthenticator"))


### PR DESCRIPTION
This PR addresses a crash on startup when verifying `data_disk_usage_max_disk_size` before any data directories have been created by moving directory creation to occur before verifying guardrail configs. 