### PR TITLE
CASSANDRA-20787: [5.0] Cassandra crashes on first boot with data_disk_usage_max_disk_size set when data directory is not created

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -467,6 +467,8 @@ public class DatabaseDescriptor
 
         applySslContext();
 
+        createAllDirectories();
+
         applyGuardrails();
 
         applyStartupChecks();

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -608,7 +608,6 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                         CONSISTENT_SIMULTANEOUS_MOVES_ALLOW.setBoolean(true);
                 }
 
-                mkdirs();
 
                 assert config.networkTopology().contains(config.broadcastAddress()) : String.format("Network topology %s doesn't contain the address %s",
                                                                                                     config.networkTopology(), config.broadcastAddress());
@@ -621,7 +620,6 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                 LoggingSupportFactory.getLoggingSupport().onStartup();
 
                 FileUtils.setFSErrorHandler(new DefaultFSErrorHandler());
-                DatabaseDescriptor.createAllDirectories();
                 CassandraDaemon.getInstanceForTesting().migrateSystemDataIfNeeded();
                 CassandraDaemon.logSystemInfo(inInstancelogger);
                 CommitLog.instance.start();

--- a/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailDiskUsageTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailDiskUsageTest.java
@@ -72,6 +72,7 @@ public class GuardrailDiskUsageTest extends GuardrailTester
         cluster = init(Cluster.build(2)
                               .withInstanceInitializer(DiskStateInjection::install)
                               .withConfig(c -> c.with(Feature.GOSSIP, Feature.NATIVE_PROTOCOL)
+                                                .set("data_disk_usage_max_disk_size", "10GiB")
                                                 .set("data_disk_usage_percentage_warn_threshold", 98)
                                                 .set("data_disk_usage_percentage_fail_threshold", 99)
                                                 .set("authenticator", "PasswordAuthenticator"))


### PR DESCRIPTION
Same as https://github.com/apache/cassandra/pull/4272, but for 5.0. Addresses this issue by moving directory creation to occur before checking the `data_disk_usage_max_disk_size` value. 