### PR TITLE
CASSANDRA-20787: [trunk] Cassandra crashes on first boot with data_disk_usage_max_disk_size set when data directory is not created 

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -557,6 +557,8 @@ public class DatabaseDescriptor
 
         applySslContext();
 
+        createAllDirectories();
+
         applyGuardrails();
 
         applyStartupChecks();

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -254,7 +254,6 @@ public class CassandraDaemon
 
         NativeLibrary.tryMlockall();
 
-        DatabaseDescriptor.createAllDirectories();
         Keyspace.setInitialized();
         CommitLog.instance.start();
 

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -758,8 +758,6 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
             CONSISTENT_SIMULTANEOUS_MOVES_ALLOW.setBoolean(true);
         }
 
-        mkdirs();
-
         assert config.networkTopology().contains(config.broadcastAddress()) : String.format("Network topology %s doesn't contain the address %s",
                                                                                             config.networkTopology(), config.broadcastAddress());
         DistributedTestInitialLocationProvider.assign(config.networkTopology());
@@ -773,7 +771,6 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
         Config.log(DatabaseDescriptor.getRawConfig());
 
         DiskErrorsHandlerService.configure();
-        DatabaseDescriptor.createAllDirectories();
         CassandraDaemon.getInstanceForTesting().migrateSystemDataIfNeeded();
 
         CommitLog.instance.start();

--- a/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailDiskUsageTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/guardrails/GuardrailDiskUsageTest.java
@@ -73,6 +73,7 @@ public class GuardrailDiskUsageTest extends GuardrailTester
         cluster = init(Cluster.build(2)
                               .withInstanceInitializer(DiskStateInjection::install)
                               .withConfig(c -> c.with(Feature.GOSSIP, Feature.NATIVE_PROTOCOL)
+                                                .set("data_disk_usage_max_disk_size", "10GiB")
                                                 .set("data_disk_usage_percentage_warn_threshold", 98)
                                                 .set("data_disk_usage_percentage_fail_threshold", 99)
                                                 .set("authenticator", "PasswordAuthenticator"))


### PR DESCRIPTION
Similar to https://github.com/apache/cassandra/pull/4273, this addresses the startup issue when checking `data_disk_usage_max_disk_size` by moving data directory creation to occur before running this check. 