### PR TITLE
[CASSANDRA-20664][5.0] Improve CommitLogSegmentReader to skip SyncBlocks correctly in case of CRC errors

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentReader.java
@@ -100,53 +100,66 @@ public class CommitLogSegmentReader implements Iterable<CommitLogSegmentReader.S
         {
             while (true)
             {
+                final int currentStart = end;
                 try
                 {
-                    final int currentStart = end;
                     end = readSyncMarker(descriptor, currentStart, reader);
-                    if (end == -1)
-                    {
-                        return endOfData();
-                    }
-                    if (end > reader.length())
-                    {
-                        // the CRC was good (meaning it was good when it was written and still looks legit), but the file is truncated now.
-                        // try to grab and use as much of the file as possible, which might be nothing if the end of the file truly is corrupt
-                        end = (int) reader.length();
-                    }
-                    return segmenter.nextSegment(currentStart + SYNC_MARKER_SIZE, end);
                 }
-                catch(CommitLogSegmentReader.SegmentReadException e)
+                catch (CommitLogSegmentReader.SegmentReadException e)
                 {
-                    try
-                    {
-                        handler.handleUnrecoverableError(new CommitLogReadException(
-                                                    e.getMessage(),
-                                                    CommitLogReadErrorReason.UNRECOVERABLE_DESCRIPTOR_ERROR,
-                                                    !e.invalidCrc && tolerateTruncation));
-                    }
-                    catch (IOException ioe)
-                    {
-                        throw new RuntimeException(ioe);
-                    }
+                    handleUnrecoverableError(e, !e.invalidCrc && tolerateTruncation);
+                    end = -1; // skip the remaining part of the corrupted log segment
                 }
                 catch (IOException e)
                 {
-                    try
-                    {
-                        boolean tolerateErrorsInSection = tolerateTruncation & segmenter.tolerateSegmentErrors(end, reader.length());
-                        // if no exception is thrown, the while loop will continue
-                        handler.handleUnrecoverableError(new CommitLogReadException(
-                                                    e.getMessage(),
-                                                    CommitLogReadErrorReason.UNRECOVERABLE_DESCRIPTOR_ERROR,
-                                                    tolerateErrorsInSection));
-                    }
-                    catch (IOException ioe)
-                    {
-                        throw new RuntimeException(ioe);
-                    }
+                    boolean tolerateErrorsInSection = tolerateTruncation & segmenter.tolerateSegmentErrors(end, reader.length());
+                    handleUnrecoverableError(e, tolerateErrorsInSection);
+                    end = -1; // skip the remaining part of the corrupted log segment
+                }
+
+                if (end == -1)
+                {
+                    return endOfData();
+                }
+                if (end > reader.length())
+                {
+                    // the CRC was good (meaning it was good when it was written and still looks legit), but the file is truncated now.
+                    // try to grab and use as much of the file as possible, which might be nothing if the end of the file truly is corrupt
+                    end = (int) reader.length();
+                }
+
+                try
+                {
+                    return segmenter.nextSegment(currentStart + SYNC_MARKER_SIZE, end);
+                }
+                catch (CommitLogSegmentReader.SegmentReadException e)
+                {
+                    handleUnrecoverableError(e, !e.invalidCrc && tolerateTruncation);
+                    // if no exception is thrown, the while loop will continue
+                }
+                catch (IOException e)
+                {
+                    boolean tolerateErrorsInSection = tolerateTruncation & segmenter.tolerateSegmentErrors(end, reader.length());
+                    handleUnrecoverableError(e, tolerateErrorsInSection);
+                    // if no exception is thrown, the while loop will continue
                 }
             }
+        }
+    }
+
+    private void handleUnrecoverableError(Exception e, boolean permissible)
+    {
+        try
+        {
+            handler.handleUnrecoverableError(new CommitLogReadException(
+                e.getMessage(),
+                CommitLogReadErrorReason.UNRECOVERABLE_DESCRIPTOR_ERROR,
+                permissible)
+            );
+        }
+        catch (IOException ioe)
+        {
+            throw new RuntimeException(ioe);
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/commitlog/CommitLogReaderTest.java
+++ b/test/unit/org/apache/cassandra/db/commitlog/CommitLogReaderTest.java
@@ -17,11 +17,15 @@
  */
 package org.apache.cassandra.db.commitlog;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.security.EncryptionContextGenerator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -40,9 +44,15 @@ import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.KillerForTests;
+import org.assertj.core.api.Assertions;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.COMMITLOG_IGNORE_REPLAY_ERRORS;
 
 public class CommitLogReaderTest extends CQLTester
 {
+    private static final long CORRUPTED_COMMIT_LOG_FILE_ID = 111L;
+    private static final String CORRUPTED_COMMIT_LOG_FILE_NAME = "CommitLog-7-1234567.log";
+
     @BeforeClass
     public static void setUpClass()
     {
@@ -60,6 +70,7 @@ public class CommitLogReaderTest extends CQLTester
     @Before
     public void before() throws IOException
     {
+        clearCorruptedCommitLogFile();
         CommitLog.instance.resetUnsafe(true);
     }
 
@@ -163,6 +174,61 @@ public class CommitLogReaderTest extends CQLTester
             readCount, testHandler.seenMutationCount());
 
         confirmReadOrder(testHandler, samples / 2);
+    }
+
+    @Test
+    public void testSyncMarkerChecksumReadFailed_ignoreReplayErrorsDisabled() throws Throwable
+    {
+        DatabaseDescriptor.setCommitFailurePolicy(Config.CommitFailurePolicy.stop);
+
+        File corruptedSegmentFile = createAndWriteCorruptedCommitLogFile();
+        CommitLogReader reader = new CommitLogReader();
+        // use real CLR handler to test actual behavior
+        CommitLogReadHandler clrHandler =
+                new CommitLogReplayer(new CommitLog(null), null, null, null);
+
+        // ignore.replay.errors disabled, so we expect the exception here
+        Assertions.assertThatThrownBy(() ->
+                                      reader.readCommitLogSegment(clrHandler,
+                                                                  corruptedSegmentFile,
+                                                                  CommitLogPosition.NONE,
+                                                                  CommitLogReader.ALL_MUTATIONS,
+                                                                  false)
+                  ).isInstanceOf(CommitLogReplayer.CommitLogReplayException.class);
+    }
+
+    @Test
+    public void testSyncMarkerChecksumReadFailed_ignoreReplayErrorsEnabled() throws Throwable
+    {
+        try (WithProperties properties = new WithProperties().set(COMMITLOG_IGNORE_REPLAY_ERRORS, "true"))
+        {
+            DatabaseDescriptor.setCommitFailurePolicy(Config.CommitFailurePolicy.stop);
+            File corruptedSegmentFile = createAndWriteCorruptedCommitLogFile();
+
+            CommitLogReader reader = new CommitLogReader();
+            // use real CLR handler to test actual behavior
+            CommitLogReadHandler clrHandler =
+            new CommitLogReplayer(new CommitLog(null), null, null, null);
+
+            // ignore.replay.errors enabled, so we don't expect any errors
+            reader.readCommitLogSegment(clrHandler, corruptedSegmentFile, CommitLogPosition.NONE, CommitLogReader.ALL_MUTATIONS, false);
+        }
+    }
+
+    @Test
+    public void testSyncMarkerChecksumReadFailed_ignoreReplayErrorsDisabled_commitFailurePolicyIgnore() throws Throwable
+    {
+        DatabaseDescriptor.setCommitFailurePolicy(Config.CommitFailurePolicy.ignore);
+
+        File corruptedSegmentFile = createAndWriteCorruptedCommitLogFile();
+
+        CommitLogReader reader = new CommitLogReader();
+        // use real CLR handler to test actual behavior
+        CommitLogReadHandler clrHandler =
+                new CommitLogReplayer(new CommitLog(null), null, null, null);
+
+        // commit.failure.policy=ignore, so we don't expect any errors
+        reader.readCommitLogSegment(clrHandler, corruptedSegmentFile, CommitLogPosition.NONE, CommitLogReader.ALL_MUTATIONS, false);
     }
 
     /**
@@ -273,5 +339,36 @@ public class CommitLogReaderTest extends CQLTester
                 .getColumnFamilyStore(currentTable())
                 .forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
         return result;
+    }
+
+    private static File createAndWriteCorruptedCommitLogFile() throws IOException
+    {
+        final ByteBuffer corruptedSegmentByteBuffer =
+                ByteBuffer.allocate(DatabaseDescriptor.getCommitLogSegmentSize());
+
+        final CommitLogDescriptor commitLogDescriptor =
+                new CommitLogDescriptor(CORRUPTED_COMMIT_LOG_FILE_ID, null, EncryptionContextGenerator.createDisabledContext());
+
+        CommitLogDescriptor.writeHeader(corruptedSegmentByteBuffer, commitLogDescriptor);
+
+        // write corrupted sync marker:
+        // put wrong offset
+        corruptedSegmentByteBuffer.putInt(42);
+        // put wrong CRC
+        corruptedSegmentByteBuffer.putInt(42);
+
+        final File corruptedLogFile = new File(DatabaseDescriptor.getCommitLogLocation(), CORRUPTED_COMMIT_LOG_FILE_NAME);
+        try (FileOutputStream fos = new FileOutputStream(corruptedLogFile.toJavaIOFile()))
+        {
+            fos.write(corruptedSegmentByteBuffer.array());
+            fos.flush();
+        }
+
+        return corruptedLogFile;
+    }
+
+    private static void clearCorruptedCommitLogFile()
+    {
+        new File(DatabaseDescriptor.getCommitLogLocation(), CORRUPTED_COMMIT_LOG_FILE_NAME).deleteIfExists();
     }
 }


### PR DESCRIPTION
Improve CommitLogSegmentReader to skip SyncBlocks correctly in case of CRC errors

Patch by Dmitry Konstantinov; reviewed by Štefan Miklošovič for CASSANDRA-20664