### PR TITLE
CASSANDRA-20823 trunk Update README.asc - 404 not found https://cassandra.apache.org/doc/stable/cassandra/cql/

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -74,7 +74,7 @@ If your session looks similar to what's above, congrats, your single node
 cluster is operational!
 
 For more on what commands are supported by CQL, see
-http://cassandra.apache.org/doc/latest/cql/[the CQL reference]. A
+https://cassandra.apache.org/doc/4.0/cassandra/cql/[the CQL reference]. A
 reasonable way to think of it is as, "SQL minus joins and subqueries, plus collections."
 
 Wondering where to go from here?


### PR DESCRIPTION
404 not found https://cassandra.apache.org/doc/stable/cassandra/cql/ correction in README.asc

<img width="1289" height="435" alt="Screenshot from 2025-08-02 12-47-36" src="https://github.com/user-attachments/assets/d430ca56-63f0-44cb-bad7-89de804c4084" />


The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

