### PR TITLE
[CASSANDRA-20816][trunk] Optimize MessagingService.getVersionOrdinal

### DIFF
--- a/src/java/org/apache/cassandra/net/MessagingService.java
+++ b/src/java/org/apache/cassandra/net/MessagingService.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.net;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -29,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -254,16 +252,6 @@ public class MessagingService extends MessagingServiceMBeanImpl implements Messa
             return Collections.unmodifiableList(versions);
         }
 
-        public List<Version> greaterThanOrEqual()
-        {
-            Version[] all = Version.values();
-            if (ordinal() == all.length - 1)
-                return Collections.singletonList(this);
-            List<Version> values = new ArrayList<>(all.length - ordinal());
-            for (int i = ordinal(); i < all.length; i++)
-                values.add(all[i]);
-            return values;
-        }
     }
     // Maintance Note:
     // Try to keep Version enum in-sync for testing.  By having the versions in the enum tests can get access without forcing this class
@@ -299,22 +287,23 @@ public class MessagingService extends MessagingServiceMBeanImpl implements Messa
             accept_streaming = new AcceptVersions(current_version, current_version);
         }
     }
-    static Map<Integer, Integer> versionOrdinalMap = Arrays.stream(Version.values()).collect(Collectors.toMap(v -> v.value, v -> v.ordinal()));
+    static final int minVersion = Version.values()[0].value;
+    static final int maxVersion = Version.values()[Version.values().length - 1].value;
 
     /**
      * This is an optimisation to speed up the translation of the serialization
      * version to the {@link Version} enum ordinal.
+     * We expect values for new versions to be incremented sequentally
      *
      * @param version the serialization version
      * @return a {@link Version} ordinal value
      */
     public static int getVersionOrdinal(int version)
     {
-        Integer ordinal = versionOrdinalMap.get(version);
-        if (ordinal == null)
+        int result = version - minVersion;
+        if (result < 0 || result > maxVersion)
             throw new IllegalStateException("Unkown serialization version: " + version);
-
-        return ordinal;
+        return result;
     }
 
     private static Version currentVersion()

--- a/test/unit/org/apache/cassandra/net/MessagingServiceOrdinaryVersionTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceOrdinaryVersionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.net;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessagingServiceOrdinaryVersionTest
+{
+    @Test
+    public void checkAllKnownVersions()
+    {
+        for(MessagingService.Version version : MessagingService.Version.values())
+            Assert.assertEquals("Incorrect ordinal version for: " + version,
+                                version.ordinal(), MessagingService.getVersionOrdinal(version.value));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void checkUnknownSmallVersion()
+    {
+        MessagingService.getVersionOrdinal(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void checkUnknownBigVersion()
+    {
+        MessagingService.getVersionOrdinal(Byte.MAX_VALUE + 1);
+    }
+}


### PR DESCRIPTION
The map lookup (with an implicit auto-boxing) can be replaced with a plain arithmetic operation. 
A unit test is used to ensure that the assumption about serialization version incrementing for new versions is still correct. greaterThanOrEqual method is removed as unused.

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-20816