### PR TITLE
CASSANDRA-20819: [5.0] ThreadLocalReadAheadBufferTest fails with FileNotFound exception when -Djava.io.tmpdir set to /tmp

### DIFF
--- a/test/unit/org/apache/cassandra/io/util/ThreadLocalReadAheadBufferTest.java
+++ b/test/unit/org/apache/cassandra/io/util/ThreadLocalReadAheadBufferTest.java
@@ -177,13 +177,13 @@ public class ThreadLocalReadAheadBufferTest implements WithQuickTheories
 
     private static File writeFile(int seed, int length)
     {
-        String fileName = JAVA_IO_TMPDIR.getString() + "data+" + length + ".bin";
+        String fileName = "data+" + length + ".bin";
 
         byte[] dataChunk = new byte[4096 * 8];
         java.util.Random random = new Random(seed);
         int writtenData = 0;
 
-        File file = new File(fileName);
+        File file = new File(JAVA_IO_TMPDIR.getString(), fileName);
         try (FileOutputStream fos = new FileOutputStream(file.toJavaIOFile()))
         {
             while (writtenData < length)


### PR DESCRIPTION
This PR updates ThreadLocalReadAheadBuffer#writeFile to construct the temporary file by using the File(parent, child) constructor. Doing this lets us support with or without a trailing slash when someone sets -Djava.io.tmpdir.

patch by Isaac Reath; reviewed by TBD for CASSANDRA-20819


