### PR TITLE
CASSANDRA-20829 Secondary index implementations do not integrate with IndexGCTransaction when compaction contains fully expired SSTables

### DIFF
--- a/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionTask.java
@@ -18,9 +18,11 @@
 package org.apache.cassandra.db.compaction;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -37,9 +39,16 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Directories;
 import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.db.WriteContext;
 import org.apache.cassandra.db.compaction.writers.CompactionAwareWriter;
 import org.apache.cassandra.db.compaction.writers.DefaultCompactionWriter;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
+import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.db.rows.Unfiltered;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.transactions.IndexTransaction;
+import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.sstable.metadata.MetadataCollector;
 import org.apache.cassandra.service.ActiveRepairService;
@@ -170,6 +179,8 @@ public class CompactionTask extends AbstractCompactionTask
             long estimatedKeys = 0;
             long inputSizeBytes;
             long timeSpentWritingKeys;
+
+            maybeNotifyIndexersAboutRowsInFullyExpiredSSTables(fullyExpiredSSTables);
 
             Set<SSTableReader> actuallyCompact = Sets.difference(transaction.originals(), fullyExpiredSSTables);
             Collection<SSTableReader> newSStables;
@@ -439,5 +450,67 @@ public class CompactionTask extends AbstractCompactionTask
                 max = sstable.maxDataAge;
         }
         return max;
+    }
+
+    private void maybeNotifyIndexersAboutRowsInFullyExpiredSSTables(Set<SSTableReader> fullyExpiredSSTables)
+    {
+        if (fullyExpiredSSTables.isEmpty())
+            return;
+
+        List<Index> indexes = new ArrayList<>();
+        for (Index index : cfs.indexManager.listIndexes())
+        {
+            if (index.notifyIndexerAboutRowsInFullyExpiredSSTables())
+                indexes.add(index);
+        }
+
+        if (indexes.isEmpty())
+            return;
+
+        for (SSTableReader expiredSSTable : fullyExpiredSSTables)
+        {
+            try (ISSTableScanner scanner = expiredSSTable.getScanner())
+            {
+                while (scanner.hasNext())
+                {
+                    UnfilteredRowIterator partition = scanner.next();
+
+                    try (WriteContext ctx = cfs.keyspace.getWriteHandler().createContextForIndexing())
+                    {
+                        List<Index.Indexer> indexers = new ArrayList<>();
+                        for (int i = 0; i < indexes.size(); i++)
+                        {
+                            Index.Indexer indexer = indexes.get(i).indexerFor(partition.partitionKey(),
+                                                                              partition.columns(),
+                                                                              FBUtilities.nowInSeconds(),
+                                                                              ctx,
+                                                                              IndexTransaction.Type.COMPACTION);
+
+                            if (indexer != null)
+                                indexers.add(indexer);
+                        }
+
+                        if (!indexers.isEmpty())
+                        {
+                            for (Index.Indexer indexer : indexers)
+                                indexer.begin();
+
+                            while (partition.hasNext())
+                            {
+                                Unfiltered unfiltered = partition.next();
+                                if (unfiltered instanceof Row)
+                                {
+                                    for (Index.Indexer indexer : indexers)
+                                        indexer.removeRow((Row) unfiltered);
+                                }
+                            }
+
+                            for (Index.Indexer indexer : indexers)
+                                indexer.finish();
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/java/org/apache/cassandra/index/Index.java
+++ b/src/java/org/apache/cassandra/index/Index.java
@@ -422,6 +422,28 @@ public interface Index
      */
     public void validate(PartitionUpdate update) throws InvalidRequestException;
 
+
+    /**
+     * When a secondary index is created on a column for a table with e.g. TWCS strategy,
+     * when this table contains SSTables which are evaluated as fully expired upon compaction,
+     * they are by default filtered out as they can be dropped in their entirety. However, once dropped like that,
+     * the index implementation is not notified about this fact via IndexGCTransaction as compaction on
+     * non-fully expired tables would do. This in turn means that custom index will never know that some data have
+     * been removed hence data custom index implementation is responsible for will grow beyond any limit.
+     *
+     * Override this method and return false in index implementation only in case you do not want to be notified about
+     * dropped fully-expired data. This will eventually mean that {@link Indexer#removeRow(Row)} will not be called
+     * for rows contained in fully expired table. Return true if you do want to be notified about that fact.
+     *
+     * This method returns true by default.
+     *
+     * @return true when fully expired tables should be included in compaction process, false otherwise.
+     */
+    public default boolean notifyIndexerAboutRowsInFullyExpiredSSTables()
+    {
+        return true;
+    }
+
     /*
      * Update processing
      */

--- a/src/java/org/apache/cassandra/index/sasi/SASIIndex.java
+++ b/src/java/org/apache/cassandra/index/sasi/SASIIndex.java
@@ -252,6 +252,12 @@ public class SASIIndex implements Index, INotificationConsumer
         return false;
     }
 
+    @Override
+    public boolean notifyIndexerAboutRowsInFullyExpiredSSTables()
+    {
+        return false;
+    }
+
     public Indexer indexerFor(DecoratedKey key, RegularAndStaticColumns columns, int nowInSec, WriteContext context, IndexTransaction.Type transactionType)
     {
         return new Indexer()


### PR DESCRIPTION
Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

