### PR TITLE
CASSANDRA-20827 Represent complex settings as JSON on system_views.settings table

### DIFF
--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -679,6 +679,8 @@ public enum CassandraRelevantProperties
     /** When enabled, recursive directory deletion will be executed using a unix command `rm -rf` instead of traversing
      * and removing individual files. This is now used only tests, but eventually we will make it true by default.*/
     USE_NIX_RECURSIVE_DELETE("cassandra.use_nix_recursive_delete"),
+    /** Controls output format for Map-type settings in system_views.settings table */
+    VIRTUAL_TABLE_COMPLEX_SETTINGS_FORMAT_JSON("cassandra.virtual_table_complex_settings_format_json", "true"),
     /** Gossiper compute expiration timeout. Default value 3 days. */
     VERY_LONG_TIME_MS("cassandra.very_long_time_ms", "259200000"),
     WAIT_FOR_TRACING_EVENTS_TIMEOUT_SECS("cassandra.wait_for_tracing_events_timeout_secs", "0"),

--- a/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.Redacted;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -126,11 +127,18 @@ final class SettingsTable extends AbstractVirtualTable
 
     private String tryConstructJson(Object o)
     {
-        try
+        if (CassandraRelevantProperties.VIRTUAL_TABLE_COMPLEX_SETTINGS_FORMAT_JSON.getBoolean())
         {
-            return JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(o);
+            try
+            {
+                return JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(o);
+            }
+            catch (Exception e)
+            {
+                return o.toString();
+            }
         }
-        catch (Exception e)
+        else
         {
             return o.toString();
         }

--- a/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
@@ -51,6 +51,7 @@ final class SettingsTable extends AbstractVirtualTable
     protected static final Map<String, Property> PROPERTIES = ImmutableMap.copyOf(getProperties());
 
     private final Config config;
+    private final boolean useJsonFormat;
 
     SettingsTable(String keyspace)
     {
@@ -67,6 +68,7 @@ final class SettingsTable extends AbstractVirtualTable
                            .addRegularColumn(VALUE, UTF8Type.instance)
                            .build());
         this.config = config;
+        this.useJsonFormat = CassandraRelevantProperties.VIRTUAL_TABLE_COMPLEX_SETTINGS_FORMAT_JSON.getBoolean();
     }
 
     @Override
@@ -127,7 +129,7 @@ final class SettingsTable extends AbstractVirtualTable
 
     private String tryConstructJson(Object o)
     {
-        if (CassandraRelevantProperties.VIRTUAL_TABLE_COMPLEX_SETTINGS_FORMAT_JSON.getBoolean())
+        if (useJsonFormat)
         {
             try
             {

--- a/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
@@ -18,6 +18,7 @@
 package org.apache.cassandra.db.virtual;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -36,6 +37,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.LocalPartitioner;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.utils.JsonUtils;
 import org.apache.cassandra.service.ClientWarn;
 import org.yaml.snakeyaml.introspector.Property;
 
@@ -98,8 +100,17 @@ final class SettingsTable extends AbstractVirtualTable
         if (value == null)
             return null;
 
-        if (value.getClass().isArray())
-            return Arrays.asList((Object[]) value).toString();
+        if (value.getClass().isArray() || value instanceof Collection || value instanceof Map)
+        {
+            try {
+                if (value.getClass().isArray())
+                    value = Arrays.asList((Object[]) value);
+            
+                return JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(value);
+            } catch (Exception e) {
+                return value.toString();
+            }
+        }
 
         if (value instanceof Map)
         {

--- a/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/SettingsTable.java
@@ -100,19 +100,11 @@ final class SettingsTable extends AbstractVirtualTable
         if (value == null)
             return null;
 
-        if (value.getClass().isArray() || value instanceof Collection || value instanceof Map)
-        {
-            try {
-                if (value.getClass().isArray())
-                    value = Arrays.asList((Object[]) value);
-            
-                return JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(value);
-            } catch (Exception e) {
-                return value.toString();
-            }
-        }
-
-        if (value instanceof Map)
+        if (value.getClass().isArray())
+            return tryConstructJson(Arrays.asList((Object[]) value));
+        else if (value instanceof Collection)
+            return tryConstructJson(value);
+        else if (value instanceof Map)
         {
             Map<String, Object> map = new HashMap<>();
             for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet())
@@ -126,10 +118,22 @@ final class SettingsTable extends AbstractVirtualTable
                     map.put(entry.getKey(), entry.getValue());
             }
 
-            return map.toString();
+            return tryConstructJson(map);
         }
 
         return value.toString();
+    }
+
+    private String tryConstructJson(Object o)
+    {
+        try
+        {
+            return JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(o);
+        }
+        catch (Exception e)
+        {
+            return o.toString();
+        }
     }
 
     private static Map<String, Property> getProperties()

--- a/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.db.virtual;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,8 @@ import org.apache.cassandra.config.TransparentDataEncryptionOptions;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.security.SSLFactory;
 import org.apache.cassandra.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.introspector.Property;
 
 import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
@@ -51,6 +54,7 @@ import static java.util.stream.Collectors.toMap;
 
 public class SettingsTableTest extends CQLTester
 {
+    private static final Logger logger = LoggerFactory.getLogger(SettingsTableTest.class);
     private static final String KS_NAME = "vts";
 
     private Config config;
@@ -359,5 +363,26 @@ public class SettingsTableTest extends CQLTester
 
         Assert.assertEquals(settingName, name);
         Assert.assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void testMapSerialization() throws Throwable
+    {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("seeds", "127.0.0.1:7000");
+        parameters.put("timeout", "30000");
+        ParameterizedClass seedProvider = new ParameterizedClass("org.apache.cassandra.locator.SimpleSeedProvider", parameters);
+        
+        config.seed_provider = seedProvider;
+        
+        try
+        {
+            String expectedJson = JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(parameters);
+            check("seed_provider.parameters", expectedJson);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to serialize seed provider parameters as JSON", e);
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
+import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.Redacted;
 import org.apache.cassandra.config.DefaultLoader;
@@ -43,6 +44,7 @@ import org.apache.cassandra.config.JMXServerOptions;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.config.TransparentDataEncryptionOptions;
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.security.SSLFactory;
 import org.apache.cassandra.utils.JsonUtils;
 import org.slf4j.Logger;
@@ -383,6 +385,29 @@ public class SettingsTableTest extends CQLTester
         catch (Exception e)
         {
             throw new RuntimeException("Failed to serialize seed provider parameters as JSON", e);
+        }
+    }
+
+    @Test
+    public void testComplexSettingsFormatProperty() throws Throwable
+    {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("seeds", "127.0.0.1:7000");
+        config.seed_provider = new ParameterizedClass("org.apache.cassandra.locator.SimpleSeedProvider", parameters);
+        
+        // Test unset property (default JSON format)
+        check("data_file_directories", "[\"/my/data/directory\",\"/another/data/directory\"]");
+        check("seed_provider.parameters", "{\"seeds\":\"127.0.0.1:7000\"}");
+        
+        // Test set property to false (toString format)
+        try (WithProperties properties = new WithProperties().set(CassandraRelevantProperties.VIRTUAL_TABLE_COMPLEX_SETTINGS_FORMAT_JSON, "false"))
+        {
+            VirtualKeyspaceRegistry.instance.unregister(new VirtualKeyspace(KS_NAME, ImmutableList.of(table)));
+            table = new SettingsTable(KS_NAME, config);
+            VirtualKeyspaceRegistry.instance.register(new VirtualKeyspace(KS_NAME, ImmutableList.of(table)));
+            
+            check("data_file_directories", "[/my/data/directory, /another/data/directory]");
+            check("seed_provider.parameters", "{seeds=127.0.0.1:7000}");
         }
     }
 }

--- a/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
@@ -88,7 +88,7 @@ public class SettingsTableTest extends CQLTester
     public void testArray() throws Throwable
     {
         Row one = executeNet("SELECT value FROM vts.settings WHERE name = 'data_file_directories'").one();
-        Assert.assertEquals("[/my/data/directory, /another/data/directory]", one.getString("value"));
+        Assert.assertEquals("[\"/my/data/directory\", \"/another/data/directory\"]", one.getString("value"));
     }
 
     @Test
@@ -201,23 +201,23 @@ public class SettingsTableTest extends CQLTester
 
         check(pre + "cipher_suites", null);
         config.server_encryption_options = serverEncryptionOptionsBuilder.withCipherSuites("c1", "c2").build();
-        check(pre + "cipher_suites", "[c1, c2]");
+        check(pre + "cipher_suites", "[\"c1\", \"c2\"]");
 
         // name doesn't match yaml
         check(pre + "protocol", null);
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLSv5").build();
-        check(pre + "protocol", "[TLSv5]");
+        check(pre + "protocol", "[\"TLSv5\"]");
 
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLS").build();
         check(pre + "protocol", SSLFactory.tlsInstanceProtocolSubstitution().toString());
 
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLS").build();
         config.server_encryption_options = serverEncryptionOptionsBuilder.withAcceptedProtocols(ImmutableList.of("TLSv1.2","TLSv1.1")).build();
-        check(pre + "protocol", "[TLSv1.2, TLSv1.1]");
+        check(pre + "protocol", "[\"TLSv1.2\", \"TLSv1.1\"]");
 
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLSv2").build();
         config.server_encryption_options = serverEncryptionOptionsBuilder.withAcceptedProtocols(ImmutableList.of("TLSv1.2","TLSv1.1")).build();
-        check(pre + "protocol", "[TLSv1.2, TLSv1.1, TLSv2]"); // protocol goes after the explicit accept list if non-TLS
+        check(pre + "protocol", "[\"TLSv1.2\", \"TLSv1.1\", \"TLSv2\"]"); // protocol goes after the explicit accept list if non-TLS
 
         check(pre + "optional", "false");
         config.server_encryption_options = serverEncryptionOptionsBuilder.withOptional(true).build();

--- a/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.config.TransparentDataEncryptionOptions;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.security.SSLFactory;
+import org.apache.cassandra.utils.JsonUtils;
 import org.yaml.snakeyaml.introspector.Property;
 
 import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
@@ -88,7 +89,7 @@ public class SettingsTableTest extends CQLTester
     public void testArray() throws Throwable
     {
         Row one = executeNet("SELECT value FROM vts.settings WHERE name = 'data_file_directories'").one();
-        Assert.assertEquals("[\"/my/data/directory\", \"/another/data/directory\"]", one.getString("value"));
+        Assert.assertEquals("[\"/my/data/directory\",\"/another/data/directory\"]", one.getString("value"));
     }
 
     @Test
@@ -201,7 +202,7 @@ public class SettingsTableTest extends CQLTester
 
         check(pre + "cipher_suites", null);
         config.server_encryption_options = serverEncryptionOptionsBuilder.withCipherSuites("c1", "c2").build();
-        check(pre + "cipher_suites", "[\"c1\", \"c2\"]");
+        check(pre + "cipher_suites", "[\"c1\",\"c2\"]");
 
         // name doesn't match yaml
         check(pre + "protocol", null);
@@ -209,15 +210,22 @@ public class SettingsTableTest extends CQLTester
         check(pre + "protocol", "[\"TLSv5\"]");
 
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLS").build();
-        check(pre + "protocol", SSLFactory.tlsInstanceProtocolSubstitution().toString());
+        try
+        {
+            check(pre + "protocol", JsonUtils.JSON_OBJECT_MAPPER.writeValueAsString(SSLFactory.tlsInstanceProtocolSubstitution()));
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Failed to serialize TLS protocols as JSON", e);
+        }
 
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLS").build();
         config.server_encryption_options = serverEncryptionOptionsBuilder.withAcceptedProtocols(ImmutableList.of("TLSv1.2","TLSv1.1")).build();
-        check(pre + "protocol", "[\"TLSv1.2\", \"TLSv1.1\"]");
+        check(pre + "protocol", "[\"TLSv1.2\",\"TLSv1.1\"]");
 
         config.server_encryption_options = serverEncryptionOptionsBuilder.withProtocol("TLSv2").build();
         config.server_encryption_options = serverEncryptionOptionsBuilder.withAcceptedProtocols(ImmutableList.of("TLSv1.2","TLSv1.1")).build();
-        check(pre + "protocol", "[\"TLSv1.2\", \"TLSv1.1\", \"TLSv2\"]"); // protocol goes after the explicit accept list if non-TLS
+        check(pre + "protocol", "[\"TLSv1.2\",\"TLSv1.1\",\"TLSv2\"]"); // protocol goes after the explicit accept list if non-TLS
 
         check(pre + "optional", "false");
         config.server_encryption_options = serverEncryptionOptionsBuilder.withOptional(true).build();


### PR DESCRIPTION
**JIRA:** https://issues.apache.org/jira/browse/CASSANDRA-20827

Replace Collections.toString() with JSON serialization for arrays, maps, and collections in SettingsTable.getValue() to improve programmatic access.

Complex configuration values were previously displayed using Collections.toString() format:
```
seed_provider.parameters | {seeds=127.0.0.1:7000}
```

Now output as proper JSON for better programmatic parsing:
```
seed_provider.parameters | {"seeds": "127.0.0.1:7000"}
```

**Changes:**
- Modified SettingsTable.getValue() to use JsonUtils.JSON_OBJECT_MAPPER for complex types
- Added exception handling with fallback to toString() for robustness  
- Updated all affected tests to expect JSON array format: ["item1", "item2"] vs [item1, item2]
- Covers data_file_directories, cipher_suites, and protocol configuration tests

**Testing:**
- All existing tests updated and passing with new JSON format
- Verified proper JSON serialization for arrays, maps, and collections
- Exception handling tested via fallback mechanism

patch by Marko Tsymbaliuk for CASSANDRA-20827