### PR TITLE
Implementing isAuthenticationRequired() in DatabaseDescriptor (CASSAN…

### DIFF
--- a/src/java/org/apache/cassandra/auth/NetworkPermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/NetworkPermissionsCache.java
@@ -36,7 +36,7 @@ public class NetworkPermissionsCache extends AuthCache<RoleResource, DCPermissio
               DatabaseDescriptor::getRolesCacheActiveUpdate,
               authorizer::authorize,
               authorizer.bulkLoader(),
-              () -> DatabaseDescriptor.getAuthenticator().requireAuthentication());
+              DatabaseDescriptor::isAuthenticationRequired);
 
         MBeanWrapper.instance.registerMBean(this, MBEAN_NAME_BASE + DEPRECATED_CACHE_NAME);
     }

--- a/src/java/org/apache/cassandra/auth/Roles.java
+++ b/src/java/org/apache/cassandra/auth/Roles.java
@@ -36,7 +36,7 @@ public class Roles
 
     private static final Role NO_ROLE = new Role("", false, false, Collections.emptyMap(), Collections.emptySet());
 
-    public static final RolesCache cache = new RolesCache(DatabaseDescriptor.getRoleManager(), () -> DatabaseDescriptor.getAuthenticator().requireAuthentication());
+    public static final RolesCache cache = new RolesCache(DatabaseDescriptor.getRoleManager(), DatabaseDescriptor::isAuthenticationRequired);
 
     /** Use {@link AuthCacheService#initializeAndRegisterCaches} rather than calling this directly */
     public static void init()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1969,6 +1969,15 @@ public class DatabaseDescriptor
         DatabaseDescriptor.authenticator = authenticator;
     }
 
+    /**
+     * Indicates if this node uses an authenticator that requires authentication.
+     */
+    public static boolean isAuthenticationRequired()
+    {
+        return DatabaseDescriptor.getAuthenticator().requireAuthentication();
+    }
+
+
     public static IAuthorizer getAuthorizer()
     {
         return authorizer;

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -809,7 +809,7 @@ public class CassandraDaemon
         {
             if (StorageService.instance.isSurveyMode())
             {
-                if (!StorageService.instance.readyToFinishJoiningRing() || DatabaseDescriptor.getAuthenticator().requireAuthentication())
+                if (!StorageService.instance.readyToFinishJoiningRing() || DatabaseDescriptor.isAuthenticationRequired())
                 {
                     throw new IllegalStateException("Not starting client transports in write_survey mode as it's bootstrapping or " +
                                                     "auth is enabled");

--- a/src/java/org/apache/cassandra/service/ClientState.java
+++ b/src/java/org/apache/cassandra/service/ClientState.java
@@ -194,7 +194,7 @@ public class ClientState
     {
         this.isInternal = false;
         this.remoteAddress = remoteAddress;
-        if (!DatabaseDescriptor.getAuthenticator().requireAuthentication())
+        if (!DatabaseDescriptor.isAuthenticationRequired())
             this.user = AuthenticatedUser.ANONYMOUS_USER;
     }
 
@@ -623,7 +623,7 @@ public class ClientState
      */
     public boolean isSuper()
     {
-        return !DatabaseDescriptor.getAuthenticator().requireAuthentication() || (user != null && user.isSuper());
+        return !DatabaseDescriptor.isAuthenticationRequired() || (user != null && user.isSuper());
     }
 
     /**


### PR DESCRIPTION
…DRA-20834)

Implementing DatabaseDescriptor.isAuthenticationRequired() and removing calls made to DatabaseDescriptor.getAuthenticator() from code that needs to know whether the node is enforcing authentication or not. Prerequisite to enabling per-connection authenticator selection (CEP-50).

https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-50%3A+Authentication+Negotiation
https://issues.apache.org/jira/browse/CASSANDRA-20834

Patch by jcshepherd@; reviewed by TBD
