### PR TITLE
CASSANDRA-19829: Update docs to reflect supported query operators in SAI

### DIFF
--- a/doc/modules/cassandra/partials/sai/supported-query-operators-list.adoc
+++ b/doc/modules/cassandra/partials/sai/supported-query-operators-list.adoc
@@ -4,6 +4,6 @@ ifeval::["{evalproduct}" == "dse"]
 * Strings: `=`, `CONTAINS`, `CONTAINS KEY`, `AND`
 endif::[]
 ifeval::["{evalproduct}" != "dse"]
-* Numerics: `=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `IN`
-* Strings: `=`, `CONTAINS`, `CONTAINS KEY`, `AND`, `OR`, `IN`
+* Numerics: `=`, `<`, `>`, `<=`, `>=`, `AND`
+* Strings: `=`, `CONTAINS`, `CONTAINS KEY`, `AND`
 endif::[]


### PR DESCRIPTION
This PR updates the documentation for Storage-Attached Index (SAI) to clarify
which query operators are currently supported in Cassandra 5.0.

Changes:
- Updated supported-query-operators-list.adoc
- Removed misleading implication that `OR` and `IN` are supported
- Ensured consistency between numerics and string operator lists

This improves the getting started guide to avoid confusion for new users
trying out SAI queries.

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19829)

