### PR TITLE
CASSANDRA-20870: Expose StorageService.dropPreparedStatements via JMX (5.0)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.6
+ * Expose StorageService.dropPreparedStatements via JMX (CASSANDRA-20870)
  * Sort SSTable TOC entries for determinism (CASSANDRA-20494)
 Merged from 4.0:
  * Update Jackson to 2.19.2 (CASSANDRA-20848)

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4242,6 +4242,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return statements;
     }
 
+    @Override
     public void dropPreparedStatements(boolean memoryOnly)
     {
         QueryProcessor.instance.clearPreparedStatements(memoryOnly);

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1326,4 +1326,6 @@ public interface StorageServiceMBean extends NotificationEmitter
     void setPaxosRepairRaceWait(boolean paxosRepairCoordinatorWait);
 
     boolean getPaxosRepairRaceWait();
+
+    public void dropPreparedStatements(boolean memoryOnly);
 }


### PR DESCRIPTION
Patch by Paulo Motta; Reviewed by X for CASSANDRA-20870

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

