### PR TITLE
strict_mv_consistency implementation

### DIFF
--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2070,6 +2070,12 @@ materialized_views_enabled: false
 # (losing > quorum # nodes in a replica set), you may have data in your SSTables that never makes it to the Materialized View.
 # materialized_views_on_repair_enabled: true
 
+# Controls whether metrics are collected for base tables when materialized views are present.
+# When enabled, additional metrics will be collected for the base tables that have materialized views.
+# The metrics are used for determine if current MV base table is qualified to move to strict MV consistency.
+# Defaults to false.
+# materialized_view_base_table_metric_collection_enabled: false
+
 # Enables SASI index creation on this node.
 # SASI indexes are considered experimental and are not recommended for production use.
 sasi_indexes_enabled: false

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -659,6 +659,7 @@ public class Config
     // strict_mv_consistency need to be enabled to enable the feature.
     public boolean materialized_view_strict_consistency_enabled = false;
 
+    // When true (and materialized_view_strict_consistency_enabled is true), materialized views can only be created on tables with strict_mv_consistency enabled.
     public boolean materialized_view_strict_consistency_enforced = false;
 
     @Replaces(oldName = "enable_transient_replication", converter = Converters.IDENTITY, deprecated = true)

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -653,6 +653,14 @@ public class Config
     // When false, it behaves the same as normal streaming.
     public volatile boolean materialized_views_on_repair_enabled = true;
 
+    public boolean materialized_view_base_table_metric_collection_enabled = false;
+
+    // node level setting, both materialized_view_strict_consistency_enabled and table level option
+    // strict_mv_consistency need to be enabled to enable the feature.
+    public boolean materialized_view_strict_consistency_enabled = false;
+
+    public boolean materialized_view_strict_consistency_enforced = false;
+
     @Replaces(oldName = "enable_transient_replication", converter = Converters.IDENTITY, deprecated = true)
     public boolean transient_replication_enabled = false;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -4685,6 +4685,36 @@ public class DatabaseDescriptor
         conf.materialized_views_on_repair_enabled = val;
     }
 
+    public static boolean getMaterializedViewStrictConsistencyEnabled()
+    {
+        return conf.materialized_view_strict_consistency_enabled;
+    }
+
+    public static void setMaterializedViewStrictConsistencyEnabled(boolean enabled)
+    {
+        conf.materialized_view_strict_consistency_enabled = enabled;
+    }
+
+    public static boolean getMaterializedViewStrictConsistencyEnforced()
+    {
+        return conf.materialized_view_strict_consistency_enforced;
+    }
+
+    public static void setMaterializedViewStrictConsistencyEnforced(boolean enforced)
+    {
+        conf.materialized_view_strict_consistency_enforced = enforced;
+    }
+
+    public static boolean getMaterializedViewsBasetableMetricCollectionEnabled()
+    {
+        return conf.materialized_view_base_table_metric_collection_enabled;
+    }
+
+    public static void setMaterializedViewsBasetableMetricCollectionEnabled(boolean enabled)
+    {
+        conf.materialized_view_base_table_metric_collection_enabled = enabled;
+    }
+
     public static boolean getSASIIndexesEnabled()
     {
         return conf.sasi_indexes_enabled;

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -235,14 +235,9 @@ public class BatchStatement implements CQLStatement.CompositeCQLStatement
 
         for (ModificationStatement statement : statements)
         {
-            if (DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled())
-            {
-                ColumnFamilyStore cfs = Keyspace.openAndGetStoreIfExists(statement.metadata());
-                if (cfs != null && cfs.viewManager.hasViews())
-                {
-                    cfs.metric.viewBaseTableUsedInBatchStatement.inc();
-                }
-            }
+            statement.collectMaterializedViewBasetableMetricIfEnabled(cfs -> {
+                cfs.metric.viewBaseTableUsedInBatchStatement.inc();
+            });
 
             if (statement.metadata().strictMVEnabled())
             {

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -52,9 +52,11 @@ import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.IMutation;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.ReadCommand.PotentialTxnConflicts;
 import org.apache.cassandra.db.RegularAndStaticColumns;
 import org.apache.cassandra.db.Slice;
@@ -233,6 +235,20 @@ public class BatchStatement implements CQLStatement.CompositeCQLStatement
 
         for (ModificationStatement statement : statements)
         {
+            if (DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled())
+            {
+                ColumnFamilyStore cfs = Keyspace.openAndGetStoreIfExists(statement.metadata());
+                if (cfs != null && cfs.viewManager.hasViews())
+                {
+                    cfs.metric.viewBaseTableUsedInBatchStatement.inc();
+                }
+            }
+
+            if (statement.metadata().strictMVEnabled())
+            {
+                throw new InvalidRequestException("Cannot use batch statement for strict MV enabled table: " + statement.table());
+            }
+
             if (timestampSet && statement.isTimestampSet())
                 throw new InvalidRequestException("Timestamp must be set either on BATCH or individual statements: " + statement.source);
 

--- a/src/java/org/apache/cassandra/cql3/statements/CQL3CasRequest.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CQL3CasRequest.java
@@ -247,15 +247,16 @@ public class CQL3CasRequest implements CASRequest
     {
         assert staticConditions != null || !conditions.isEmpty() || metadata.strictMVEnabled();
 
-        // Fetch all columns, but query only the selected ones
-        ColumnFilter columnFilter = ColumnFilter.selection(columnsToRead());
-
         if (metadata.strictMVEnabled())
         {
             // making sure base table request is only updating one row
-            assert updates.size() == 1;
+            if (updates.size() != 1)
+                throw new IllegalStateException("Only one row update is supported for strict mv consistency enabled table");
             return SinglePartitionReadCommand.create(metadata, nowInSec, key, updates.get(0).clustering);
         }
+
+        // Fetch all columns, but query only the selected ones
+        ColumnFilter columnFilter = ColumnFilter.selection(columnsToRead());
 
         // With only a static condition, we still want to make the distinction between a non-existing partition and one
         // that exists (has some live data) but has not static content. So we query the first live row of the partition.

--- a/src/java/org/apache/cassandra/cql3/statements/CQL3CasRequest.java
+++ b/src/java/org/apache/cassandra/cql3/statements/CQL3CasRequest.java
@@ -229,6 +229,9 @@ public class CQL3CasRequest implements CASRequest
     private RegularAndStaticColumns columnsToRead()
     {
         RegularAndStaticColumns allColumns = metadata.regularAndStaticColumns();
+        // if it is for MV base table, we should read all columns
+        if (metadata.strictMVEnabled())
+            return allColumns;
 
         // If we update static row, we won't have any conditions on regular rows.
         // If we update regular row, we have to fetch all regular rows (which would satisfy column condition) and
@@ -242,10 +245,17 @@ public class CQL3CasRequest implements CASRequest
 
     public SinglePartitionReadCommand readCommand(long nowInSec)
     {
-        assert staticConditions != null || !conditions.isEmpty();
+        assert staticConditions != null || !conditions.isEmpty() || metadata.strictMVEnabled();
 
         // Fetch all columns, but query only the selected ones
         ColumnFilter columnFilter = ColumnFilter.selection(columnsToRead());
+
+        if (metadata.strictMVEnabled())
+        {
+            // making sure base table request is only updating one row
+            assert updates.size() == 1;
+            return SinglePartitionReadCommand.create(metadata, nowInSec, key, updates.get(0).clustering);
+        }
 
         // With only a static condition, we still want to make the distinction between a non-existing partition and one
         // that exists (has some live data) but has not static content. So we query the first live row of the partition.

--- a/src/java/org/apache/cassandra/cql3/statements/DeleteStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/DeleteStatement.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Attributes;
 import org.apache.cassandra.cql3.Operation;
 import org.apache.cassandra.cql3.Operations;
@@ -36,6 +37,8 @@ import org.apache.cassandra.cql3.conditions.ColumnCondition;
 import org.apache.cassandra.cql3.conditions.Conditions;
 import org.apache.cassandra.cql3.restrictions.StatementRestrictions;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Slice;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -190,6 +193,21 @@ public class DeleteStatement extends ModificationStatement
                                                        attrs,
                                                        source);
 
+            if (DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled())
+            {
+                ColumnFamilyStore cfs = Keyspace.openAndGetStoreIfExists(metadata);
+                if (cfs != null && cfs.viewManager.hasViews() && !restrictions.hasAllPrimaryKeyColumnsRestrictedByEqualities())
+                {
+                    cfs.metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.inc();
+                }
+            }
+
+            if (stmt.metadata().strictMVEnabled())
+            {
+                checkTrue(restrictions.hasAllPrimaryKeyColumnsRestrictedByEqualities(),
+                        "DELETE statements must restrict all PRIMARY KEY columns with equality relations for Strict MV consistency enabled table.");
+            }
+            
             if (stmt.hasConditions() && !restrictions.hasAllPrimaryKeyColumnsRestrictedByEqualities())
             {
                 checkFalse(stmt.isVirtual(), "DELETE statements must restrict all PRIMARY KEY columns with equality relations");

--- a/src/java/org/apache/cassandra/cql3/statements/DeleteStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/DeleteStatement.java
@@ -193,14 +193,12 @@ public class DeleteStatement extends ModificationStatement
                                                        attrs,
                                                        source);
 
-            if (DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled())
-            {
-                ColumnFamilyStore cfs = Keyspace.openAndGetStoreIfExists(metadata);
-                if (cfs != null && cfs.viewManager.hasViews() && !restrictions.hasAllPrimaryKeyColumnsRestrictedByEqualities())
+            stmt.collectMaterializedViewBasetableMetricIfEnabled(cfs -> {
+                if (!restrictions.hasAllPrimaryKeyColumnsRestrictedByEqualities())
                 {
                     cfs.metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.inc();
                 }
-            }
+            });
 
             if (stmt.metadata().strictMVEnabled())
             {

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -727,22 +727,12 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
     {
         // Strict MV consistency currently requires Paxos V2. Once additional transaction modes for strict MV are supported, we can relax this restriction.
         assert metadata().params.transactionalMode == TransactionalMode.off && Paxos.useV2();
-        CQL3CasRequest request = makeCasRequest(queryState, options, requestTime);
-
-        try (RowIterator result = StorageProxy.cas(keyspace(),
-                table(),
-                request.key,
-                request,
-                options.getSerialConsistency(),
-                options.getConsistency(),
-                queryState.getClientState(),
-                options.getNowInSeconds(queryState),
-                requestTime))
+        ResultMessage result = executeWithCondition(queryState, options, requestTime);
+        if (hasConditions())
         {
-            if (hasConditions())
-                return new ResultMessage.Rows(buildCasResultSet(result, queryState, options));
-            return null;
+            return result;
         }
+        return null;
     }
 
     private CQL3CasRequest makeCasRequest(QueryState queryState, QueryOptions options, Dispatcher.RequestTime requestTime)

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -36,11 +36,14 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.cassandra.service.consensus.TransactionalMode;
+import org.apache.cassandra.service.paxos.Paxos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import accord.utils.Invariants;
 import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.Attributes;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -69,6 +72,7 @@ import org.apache.cassandra.cql3.terms.Constants;
 import org.apache.cassandra.cql3.transactions.ReferenceOperation;
 import org.apache.cassandra.db.CBuilder;
 import org.apache.cassandra.db.Clustering;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.IMutation;
@@ -396,6 +400,26 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
 
     public void validate(ClientState state) throws InvalidRequestException
     {
+        if (DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled())
+        {
+            ColumnFamilyStore cfs = Keyspace.openAndGetStoreIfExists(metadata);
+            if (cfs != null && cfs.viewManager.hasViews())
+            {
+                if (attrs.isTimestampSet())
+                    cfs.metric.viewBaseTableModificationWithTimestamp.inc();
+
+                if (restrictions.clusteringKeyRestrictionsHasIN() || restrictions.keyIsInRelation())
+                    cfs.metric.viewBaseTableInRestirctionsUsed.inc();
+            }
+        }
+
+        if (metadata().strictMVEnabled())
+        {
+            checkFalse(attrs.isTimestampSet(), "Cannot provide custom timestamp for strict MV consistency enabled table");
+            checkFalse(restrictions.clusteringKeyRestrictionsHasIN() || restrictions.keyIsInRelation(),
+                       "Cannot use IN restritions in statement for strict MV consistency enabled table");
+        }
+
         checkFalse(hasConditions() && attrs.isTimestampSet(), "Cannot provide custom timestamp for conditional updates");
         checkFalse(isCounter() && attrs.isTimestampSet(), "Cannot provide custom timestamp for counter updates");
         checkFalse(isCounter() && attrs.isTimeToLiveSet(), "Cannot provide custom TTL for counter updates");
@@ -624,6 +648,11 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
             Guardrails.writeConsistencyLevels.guard(EnumSet.of(options.getConsistency(), options.getSerialConsistency()),
                                                     queryState.getClientState());
 
+        if (metadata.strictMVEnabled())
+        {
+            return executeWithStrictMVConsistency(queryState, options, requestTime);
+        }
+
         return hasConditions()
              ? executeWithCondition(queryState, options, requestTime)
              : executeWithoutCondition(queryState, options, requestTime);
@@ -678,6 +707,28 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
                                                    requestTime))
         {
             return new ResultMessage.Rows(buildCasResultSet(result, queryState, options));
+        }
+    }
+
+    private ResultMessage executeWithStrictMVConsistency(QueryState queryState, QueryOptions options, Dispatcher.RequestTime requestTime)
+    {
+        // Strict MV consistency currently requires Paxos V2. Once additional transaction modes for strict MV are supported, we can relax this restriction.
+        assert metadata().params.transactionalMode == TransactionalMode.off && Paxos.useV2();
+        CQL3CasRequest request = makeCasRequest(queryState, options, requestTime);
+
+        try (RowIterator result = StorageProxy.cas(keyspace(),
+                table(),
+                request.key,
+                request,
+                options.getSerialConsistency(),
+                options.getConsistency(),
+                queryState.getClientState(),
+                options.getNowInSeconds(queryState),
+                requestTime))
+        {
+            if (hasConditions())
+                return new ResultMessage.Rows(buildCasResultSet(result, queryState, options));
+            return null;
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -398,20 +398,33 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
             state.ensurePermission(Permission.EXECUTE, function);
     }
 
-    public void validate(ClientState state) throws InvalidRequestException
+    /**
+     * Helper method to collect materialized view base table metrics if enabled.
+     * This method encapsulates the common pattern used across multiple statement types.
+     * 
+     * @param metricAction A functional interface that performs the specific metric collection
+     */
+    protected void collectMaterializedViewBasetableMetricIfEnabled(java.util.function.Consumer<ColumnFamilyStore> metricAction)
     {
         if (DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled())
         {
             ColumnFamilyStore cfs = Keyspace.openAndGetStoreIfExists(metadata);
             if (cfs != null && cfs.viewManager.hasViews())
             {
-                if (attrs.isTimestampSet())
-                    cfs.metric.viewBaseTableModificationWithTimestamp.inc();
-
-                if (restrictions.clusteringKeyRestrictionsHasIN() || restrictions.keyIsInRelation())
-                    cfs.metric.viewBaseTableInRestirctionsUsed.inc();
+                metricAction.accept(cfs);
             }
         }
+    }
+
+    public void validate(ClientState state) throws InvalidRequestException
+    {
+        collectMaterializedViewBasetableMetricIfEnabled(cfs -> {
+            if (attrs.isTimestampSet())
+                cfs.metric.viewBaseTableModificationWithTimestamp.inc();
+
+            if (restrictions.clusteringKeyRestrictionsHasIN() || restrictions.keyIsInRelation())
+                cfs.metric.viewBaseTableInRestirctionsUsed.inc();
+        });
 
         if (metadata().strictMVEnabled())
         {

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -46,7 +46,9 @@ import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.QualifiedName;
 import org.apache.cassandra.cql3.constraints.ColumnConstraints;
 import org.apache.cassandra.cql3.functions.masking.ColumnMask;
+import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.UserType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -683,6 +685,13 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
             attrs.validate();
 
             TableParams params = attrs.asAlteredTableParams(table.params);
+
+            // if enabling strict_mv_consistency
+            if (params.strictMVConsistency)
+            {
+                ColumnFamilyStore cfs = Keyspace.openAndGetStore(table);
+                cfs.checkQualifiedForStrictMVConsistency();
+            }
 
             if (table.isCounter() && params.defaultTimeToLive > 0)
                 throw ire("Cannot set default_time_to_live on a table with counters");

--- a/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/CreateViewStatement.java
@@ -185,6 +185,12 @@ public final class CreateViewStatement extends AlterSchemaStatement
                                                    false,
                                                    state);
 
+        if (DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled() && DatabaseDescriptor.getMaterializedViewStrictConsistencyEnforced())
+        {
+            if (!table.strictMVEnabled())
+                throw ire("Materialized views can only be created on table with strict MV consistency enabled.");
+        }
+
         if (table.params.gcGraceSeconds == 0)
         {
             throw ire("Cannot create materialized view '%s' for base table " +

--- a/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/TableAttributes.java
@@ -200,6 +200,9 @@ public final class TableAttributes extends PropertyDefinitions
         if (hasOption(Option.AUTO_REPAIR))
             builder.automatedRepair(AutoRepairParams.fromMap(getMap(Option.AUTO_REPAIR)));
 
+        if (hasOption(Option.STRICT_MV_CONSISTENCY))
+            builder.strictMVConsistency(getBoolean(Option.STRICT_MV_CONSISTENCY.toString(), false));
+
         return builder.build();
     }
 

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2673,8 +2673,8 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
         {
             throw new InvalidRequestException(
             String.format("Not qualified for strict mv consistency because base table has non-LWT compatible queries, " +
-                          "modification with ts: %s, batch statement: %s, delete without full primary key: %s, IN restrictions " +
-                          "used: %s",
+                          "modification with ts: %d, batch statement: %d, delete without full primary key: %d, IN restrictions " +
+                          "used: %d",
                           metric.viewBaseTableModificationWithTimestamp.getCount(),
                           metric.viewBaseTableUsedInBatchStatement.getCount(),
                           metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount(),

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -87,6 +87,7 @@ import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.compression.CompressionDictionaryManager;
 import org.apache.cassandra.db.filter.ClusteringIndexFilter;
 import org.apache.cassandra.db.filter.DataLimits;
+import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.lifecycle.ILifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.lifecycle.SSTableSet;
@@ -2647,6 +2648,39 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
             forceBlockingFlush(ColumnFamilyStore.FlushReason.DROP);
         else
             FBUtilities.waitOnFuture(dumpMemtable());
+    }
+
+    public void checkQualifiedForStrictMVConsistency()
+    {
+        if (!DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled())
+        {
+            throw new InvalidRequestException("Not qualified for strict mv consistency because node level setting materialized_view_strict_consistency_enabled is disabled.");
+        }
+
+        if (Guardrails.instance.getMaterializedViewsPerTableFailThreshold() <= 0)
+        {
+            throw new InvalidRequestException("Not qualified for strict mv consistency because maximum number of MVs per table is not set.");
+        }
+
+        if (viewManager.size() > Guardrails.instance.getMaterializedViewsPerTableFailThreshold())
+        {
+            throw new InvalidRequestException(String.format("Not qualified for strict mv consistency because base table has %s MVs which is more than limit: %s", viewManager.size(), Guardrails.instance.getMaterializedViewsPerTableFailThreshold()));
+        }
+        if (metric.viewBaseTableModificationWithTimestamp.getCount() > 0 ||
+            metric.viewBaseTableUsedInBatchStatement.getCount() > 0 ||
+            metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount() > 0 ||
+            metric.viewBaseTableInRestirctionsUsed.getCount() > 0)
+        {
+            throw new InvalidRequestException(
+            String.format("Not qualified for strict mv consistency because base table has non-LWT compatible queries, " +
+                          "modification with ts: %s, batch statement: %s, delete without full primary key: %s, IN restrictions " +
+                          "used: %s",
+                          metric.viewBaseTableModificationWithTimestamp.getCount(),
+                          metric.viewBaseTableUsedInBatchStatement.getCount(),
+                          metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount(),
+                          metric.viewBaseTableInRestirctionsUsed.getCount()
+                          ));
+        }
     }
 
     public <V> V runWithCompactionsDisabled(Callable<V> callable, OperationType operationType, boolean interruptValidation, boolean interruptViews)

--- a/src/java/org/apache/cassandra/db/Keyspace.java
+++ b/src/java/org/apache/cassandra/db/Keyspace.java
@@ -455,7 +455,17 @@ public class Keyspace
 
         Lock[] locks = null;
 
-        boolean requiresViewUpdate = updateIndexes && viewManager.updatesAffectView(mutation, false);
+        boolean isStrictMVenabled = false;
+        // strict MV with LWT can only touch one table at a time
+        if (mutation.getPartitionUpdates().size() == 1)
+        {
+            for (PartitionUpdate update : mutation.getPartitionUpdates())
+            {
+                isStrictMVenabled = update.metadata().strictMVEnabled();
+            }
+        }
+
+        boolean requiresViewUpdate = updateIndexes && viewManager.updatesAffectView(mutation, false) && !isStrictMVenabled;
 
         if (requiresViewUpdate)
         {

--- a/src/java/org/apache/cassandra/db/partitions/PartitionUpdate.java
+++ b/src/java/org/apache/cassandra/db/partitions/PartitionUpdate.java
@@ -416,6 +416,46 @@ public class PartitionUpdate extends AbstractBTreePartition
              + (deletionInfo.getPartitionDeletion().isLive() ? 0 : 1);
     }
 
+
+    /**
+     * Returns the clustering of the single row contained in this partition update,
+     * specifically for tables with strict Materialized View (MV) consistency enabled.
+     * <p>
+     * Strict MV consistency requires that updates to base tables be single-row operations
+     * to ensure deterministic and consistent view updates. This method extracts the clustering
+     * key of that single row while validating that the update conforms to strict MV constraints.
+     * <p>
+     * The following constraints are enforced via assertions:
+     * <ul>
+     *   <li>Static row updates are not allowed</li>
+     *   <li>Range deletions are not allowed</li>
+     *   <li>Partition deletions are not allowed unless the table has no clustering columns</li>
+     *   <li>The update must contain at most one row</li>
+     * </ul>
+     *
+     * @return the clustering of the single row in this update, or {@link Clustering#EMPTY}
+     *         if this update contains no rows (e.g., partition-level deletion on a table
+     *         without clustering columns)
+     * @throws AssertionError if any of the strict MV consistency constraints are violated
+     */
+    public Clustering<?> getClusteringForSingleRowForStrictMVConsistency()
+    {
+        // Strict MV base table should not have static row
+        assert staticRow().isEmpty() : "Static row updated is not supported for strict MV Consistency enabled table";
+
+        // if this contains range deletion in partition
+        assert deletionInfo.rangeCount() == 0 : "Range deletion is not supported for strict MV Consistency enabled table";
+
+        // if this is partition deletion with clustering key
+        assert !(!deletionInfo.getPartitionDeletion().isLive() && !metadata().clusteringColumns().isEmpty()) :
+        "Partition deletion is not supported unless there is no clustering key for strict MV Consistency enabled table";
+
+        assert rowCount() <= 1 : "Cannot modify multiple rows in one operation for strict MV Consistency enabled table: " + rowCount();
+        if (rowCount() == 0)
+            return Clustering.EMPTY;
+        return lastRow().clustering();
+    }
+
     /**
      * The size of the data contained in this update.
      *

--- a/src/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -171,6 +171,14 @@ public class TableMetrics
     public final TableTimer viewLockAcquireTime;
     /** time taken during the local read of a materialized view update */
     public final TableTimer viewReadTime;
+    /** Number of delete statements without specifying all primary key columns for MV base table */
+    public final Counter viewBaseTableDeleteStatementWithoutFullPrimaryKey;
+    /** Number of batch statements used for MV base table */
+    public final Counter viewBaseTableUsedInBatchStatement;
+    /** Number of modification statements with timestamp used for MV base table */
+    public final Counter viewBaseTableModificationWithTimestamp;
+    /** Number of modification statements has IN restrictions in primary key used for MV base table */
+    public final Counter viewBaseTableInRestirctionsUsed;
     /** Disk space used by snapshot files which */
     public final Gauge<Long> trueSnapshotsSize;
     /** Row cache hits, but result out of range */
@@ -825,6 +833,12 @@ public class TableMetrics
             viewLockAcquireTime = createTableTimer("ViewLockAcquireTime", cfs.keyspace.metric.viewLockAcquireTime);
             viewReadTime = createTableTimer("ViewReadTime", cfs.keyspace.metric.viewReadTime);
         }
+
+        // MV base table metrics used by determine if a base table is qualified to convert to strict_mv_consistency mode
+        viewBaseTableDeleteStatementWithoutFullPrimaryKey = createTableCounter("ViewBaseTableDeleteStatementWithoutFullPrimaryKey");
+        viewBaseTableUsedInBatchStatement = createTableCounter("ViewBaseTableUsedInBatchStatement");
+        viewBaseTableModificationWithTimestamp = createTableCounter("ViewBaseTableModificationWithTimestamp");
+        viewBaseTableInRestirctionsUsed = createTableCounter("ViewBaseTableInRestirctionsUsed");
 
         trueSnapshotsSize = createTableGauge("SnapshotsSize", cfs::trueSnapshotsSize);
         rowCacheHitOutOfRange = createTableCounter("RowCacheHitOutOfRange");

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -629,7 +629,9 @@ public final class SchemaKeyspace
         }
 
         if (DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled() && !forView)
+        {
             builder.add("strict_mv_consistency", params.strictMVConsistency);
+        }
     }
 
     private static void addAlterTableToSchemaMutation(TableMetadata oldTable, TableMetadata newTable, Mutation.SimpleBuilder builder)

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -133,6 +133,7 @@ public final class SchemaKeyspace
               + "read_repair text,"
               + "fast_path frozen<map<text, text>>,"
               + "auto_repair frozen<map<text, text>>,"
+              + "strict_mv_consistency boolean,"
               + "PRIMARY KEY ((keyspace_name), table_name))");
 
     private static final TableMetadata Columns =
@@ -626,6 +627,9 @@ public final class SchemaKeyspace
         {
             builder.add("auto_repair", params.autoRepair.asMap());
         }
+
+        if (DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled() && !forView)
+            builder.add("strict_mv_consistency", params.strictMVConsistency);
     }
 
     private static void addAlterTableToSchemaMutation(TableMetadata oldTable, TableMetadata newTable, Mutation.SimpleBuilder builder)
@@ -1105,6 +1109,11 @@ public final class SchemaKeyspace
         if (row.has("auto_repair"))
         {
             builder.automatedRepair(AutoRepairParams.fromMap(row.getFrozenTextMap("auto_repair")));
+        }
+
+        if (row.has("strict_mv_consistency"))
+        {
+            builder.strictMVConsistency(row.getBoolean("strict_mv_consistency"));
         }
 
         return builder.build();

--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -932,6 +932,11 @@ public class TableMetadata implements SchemaElement
         return differsDeeply ? Optional.of(Difference.DEEP) : Optional.empty();
     }
 
+    public boolean strictMVEnabled()
+    {
+        return DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled() && params.strictMVConsistency;
+    }
+
     @Override
     public int hashCode()
     {

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -101,7 +101,8 @@ public final class TableParams
         TRANSACTIONAL_MODE,
         TRANSACTIONAL_MIGRATION_FROM,
         PENDING_DROP,
-        AUTO_REPAIR;
+        AUTO_REPAIR,
+        STRICT_MV_CONSISTENCY;
 
         @Override
         public String toString()
@@ -136,6 +137,7 @@ public final class TableParams
     public final boolean pendingDrop;
 
     public final AutoRepairParams autoRepair;
+    public final boolean strictMVConsistency;
 
     private TableParams(Builder builder)
     {
@@ -167,6 +169,7 @@ public final class TableParams
         pendingDrop = builder.pendingDrop;
         checkNotNull(transactionalMigrationFrom);
         autoRepair = builder.autoRepair;
+        strictMVConsistency = builder.strictMVConsistency;
     }
 
     public static Builder builder()
@@ -200,7 +203,8 @@ public final class TableParams
                             .transactionalMode(params.transactionalMode)
                             .transactionalMigrationFrom(params.transactionalMigrationFrom)
                             .pendingDrop(params.pendingDrop)
-                            .automatedRepair(params.autoRepair);
+                            .automatedRepair(params.autoRepair)
+                            .strictMVConsistency(params.strictMVConsistency);
     }
 
     public Builder unbuild()
@@ -302,7 +306,8 @@ public final class TableParams
             && transactionalMode == p.transactionalMode
             && transactionalMigrationFrom == p.transactionalMigrationFrom
             && pendingDrop == p.pendingDrop
-            && autoRepair.equals(p.autoRepair);
+            && autoRepair.equals(p.autoRepair)
+            && strictMVConsistency == p.strictMVConsistency;
     }
 
     @Override
@@ -332,7 +337,8 @@ public final class TableParams
                                 transactionalMode,
                                 transactionalMigrationFrom,
                                 pendingDrop,
-                                autoRepair);
+                                autoRepair,
+                                strictMVConsistency);
     }
 
     @Override
@@ -365,6 +371,7 @@ public final class TableParams
                           .add(Option.TRANSACTIONAL_MIGRATION_FROM.toString(), transactionalMigrationFrom)
                           .add(PENDING_DROP.toString(), pendingDrop)
                           .add(Option.AUTO_REPAIR.toString(), autoRepair)
+                          .add(Option.STRICT_MV_CONSISTENCY.toString(), strictMVConsistency)
                           .toString();
     }
 
@@ -434,6 +441,12 @@ public final class TableParams
             builder.newLine()
                 .append("AND auto_repair = ").append(autoRepair.asMap());
         }
+
+        if (!isView && DatabaseDescriptor.getRawConfig() != null && DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled())
+        {
+            builder.newLine();
+            builder.append("AND strict_mv_consistency = ").append(strictMVConsistency);
+        }
     }
 
     public static final class Builder
@@ -464,6 +477,7 @@ public final class TableParams
         public boolean pendingDrop = false;
 
         private AutoRepairParams autoRepair = AutoRepairParams.DEFAULT;
+        private boolean strictMVConsistency = false;
         public Builder()
         {
         }
@@ -620,6 +634,12 @@ public final class TableParams
         public Builder automatedRepair(AutoRepairParams val)
         {
             autoRepair = val;
+            return this;
+        }
+
+        public Builder strictMVConsistency(boolean val)
+        {
+            strictMVConsistency = val;
             return this;
         }
     }

--- a/src/java/org/apache/cassandra/service/StorageProxy.java
+++ b/src/java/org/apache/cassandra/service/StorageProxy.java
@@ -50,6 +50,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.cassandra.db.rows.UnfilteredRowIterator;
+import org.apache.cassandra.db.view.TableViews;
+import org.apache.cassandra.db.view.View;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1091,6 +1094,20 @@ public class StorageProxy implements StorageProxyMBean
 
         return ReplicaLayout.forTokenWriteLiveAndDown(metadata, Keyspace.open(keyspaceName), token)
                 .all().endpoints().contains(local);
+    }
+
+    public static void applyMVMutationsBasedOnBaseTableMutation(PartitionUpdate upd, FilteredPartition exisitings, ConsistencyLevel consistencyLevel, Dispatcher.RequestTime requestTime){
+        List<Mutation> MVmutations = generateMVMutations(upd, exisitings.unfilteredIterator());
+        if (MVmutations.isEmpty())
+            return;
+        StorageProxy.mutateWithTriggers(MVmutations, consistencyLevel, false, requestTime, PreserveTimestamp.no);
+    }
+
+    private static List<Mutation> generateMVMutations(PartitionUpdate upd, UnfilteredRowIterator exisitings){
+        // genenerate mv mutations
+        TableViews tableViews = Keyspace.open(upd.metadata().keyspace).viewManager.forTable(upd.metadata());
+        Collection<View> viewsToUpdate = tableViews.updatedViews(upd, ClusterMetadata.currentNullable());
+        return (List<Mutation>) Iterators.getOnlyElement(tableViews.generateViewUpdates(viewsToUpdate, upd.unfilteredIterator(), exisitings, FBUtilities.nowInSeconds(), false));
     }
 
     /**

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -1104,7 +1104,7 @@ public class Paxos
                         case SUCCESS:
                             if (query.metadata().strictMVEnabled() && !repropose.update.isEmpty())
                             {
-                                getCurrentAndApplyMVMutations(query, repropose.update, inProgress, consistencyForConsensus, requestTime);
+                                resolveCurrentAndApplyMVMutations(query, repropose.update, inProgress, consistencyForConsensus, requestTime);
                             }
                             retry = commitAndPrepare(repropose.agreed(), inProgress.participants, query, isWrite, acceptEarlyReadPermission);
                             break retry;
@@ -1179,11 +1179,11 @@ public class Paxos
         }
     }
 
-    public static void getCurrentAndApplyMVMutations(SinglePartitionReadCommand query,
-                                                      PartitionUpdate update,
-                                                      PaxosPrepare.FoundIncompleteAccepted inProgress,
-                                                      ConsistencyLevel consistencyForConsensus,
-                                                      Dispatcher.RequestTime requestTime)
+    public static void resolveCurrentAndApplyMVMutations(SinglePartitionReadCommand query,
+                                                         PartitionUpdate update,
+                                                         PaxosPrepare.FoundIncompleteAccepted inProgress,
+                                                         ConsistencyLevel consistencyForConsensus,
+                                                         Dispatcher.RequestTime requestTime)
     {
         // process to get current value of base table
         Supplier<Participants> plan = () -> inProgress.participants;

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
+import org.apache.cassandra.service.StorageProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -822,7 +823,13 @@ public class Paxos
                         //   1) reached a majority, in which case it was agreed, had no effect and we can do nothing; or
                         //   2) did not reach a majority, was not agreed, and was not user visible as a result so we can ignore it
                         if (!proposal.update.isEmpty())
+                        {
+                            if (metadata.strictMVEnabled())
+                            {
+                                StorageProxy.applyMVMutationsBasedOnBaseTableMutation(proposal.update, current, consistencyForCommit, requestTime);
+                            }
                             commit = commit(proposal.agreed(), participants, consistencyForConsensus, consistencyForCommit, true);
+                        }
 
                         break done;
                     }
@@ -1095,6 +1102,10 @@ public class Paxos
                             throw proposeResult.maybeFailure().markAndThrowAsTimeoutOrFailure(isWrite, consistencyForConsensus, failedAttemptsDueToContention);
 
                         case SUCCESS:
+                            if (query.metadata().strictMVEnabled() && !repropose.update.isEmpty())
+                            {
+                                getCurrentAndApplyMVMutations(query, repropose.update, inProgress, consistencyForConsensus, requestTime);
+                            }
                             retry = commitAndPrepare(repropose.agreed(), inProgress.participants, query, isWrite, acceptEarlyReadPermission);
                             break retry;
 
@@ -1166,6 +1177,29 @@ public class Paxos
 
             preparing = retry;
         }
+    }
+
+    public static void getCurrentAndApplyMVMutations(SinglePartitionReadCommand query,
+                                                      PartitionUpdate update,
+                                                      PaxosPrepare.FoundIncompleteAccepted inProgress,
+                                                      ConsistencyLevel consistencyForConsensus,
+                                                      Dispatcher.RequestTime requestTime)
+    {
+        // process to get current value of base table
+        Supplier<Participants> plan = () -> inProgress.participants;
+        DataResolver<?, ?> resolver = new DataResolver(ReadCoordinator.DEFAULT, query, plan, NoopReadRepair.instance, requestTime);
+        for (int i = 0 ; i < inProgress.responses.size() ; ++i)
+            resolver.preprocess(inProgress.responses.get(i));
+        PartitionIterator result = resolver.resolve();
+        FilteredPartition current;
+        try (RowIterator iter = PartitionIterators.getOnlyElement(result, query))
+        {
+            current = FilteredPartition.create(iter);
+        }
+        final ConsistencyLevel consistencyLevelForMVMutation = consistencyForConsensus == ConsistencyLevel.LOCAL_SERIAL
+                ? ConsistencyLevel.LOCAL_QUORUM
+                : ConsistencyLevel.QUORUM;
+        StorageProxy.applyMVMutationsBasedOnBaseTableMutation(update, current, consistencyLevelForMVMutation, requestTime);
     }
 
     public static boolean isInRangeAndShouldProcess(InetAddressAndPort from, DecoratedKey key, TableMetadata table, boolean includesRead)

--- a/src/java/org/apache/cassandra/service/paxos/Paxos.java
+++ b/src/java/org/apache/cassandra/service/paxos/Paxos.java
@@ -1189,13 +1189,17 @@ public class Paxos
         Supplier<Participants> plan = () -> inProgress.participants;
         DataResolver<?, ?> resolver = new DataResolver(ReadCoordinator.DEFAULT, query, plan, NoopReadRepair.instance, requestTime);
         for (int i = 0 ; i < inProgress.responses.size() ; ++i)
+        {
             resolver.preprocess(inProgress.responses.get(i));
+        }
         PartitionIterator result = resolver.resolve();
         FilteredPartition current;
         try (RowIterator iter = PartitionIterators.getOnlyElement(result, query))
         {
             current = FilteredPartition.create(iter);
         }
+        // not using user cl is because we want to make sure the MV mutation is applied to local_quorum/quorum nodes
+        // so reading with proper consistency will get read after write consistency
         final ConsistencyLevel consistencyLevelForMVMutation = consistencyForConsensus == ConsistencyLevel.LOCAL_SERIAL
                 ? ConsistencyLevel.LOCAL_QUORUM
                 : ConsistencyLevel.QUORUM;

--- a/src/java/org/apache/cassandra/service/paxos/PaxosPrepare.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosPrepare.java
@@ -252,11 +252,13 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
     static class FoundIncompleteAccepted extends FoundIncomplete
     {
         final Accepted accepted;
+        final List<Message<ReadResponse>> responses;
 
-        private FoundIncompleteAccepted(Ballot promisedBallot, Participants participants, Accepted accepted)
+        private FoundIncompleteAccepted(Ballot promisedBallot, Participants participants, Accepted accepted, List<Message<ReadResponse>> responses)
         {
             super(FOUND_INCOMPLETE_ACCEPTED, participants, promisedBallot);
             this.accepted = accepted;
+            this.responses = responses;
         }
 
         public String toString()
@@ -392,10 +394,11 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
     }
 
     @SuppressWarnings("SameParameterValue")
-    static <T extends Consumer<Status>> T prepareWithBallot(Ballot ballot, Participants participants, DecoratedKey partitionKey, TableMetadata table, boolean isWrite, boolean acceptEarlyReadPermission, T onDone)
+    static <T extends Consumer<Status>> T prepareWithBallot(Ballot ballot, Participants participants, DecoratedKey partitionKey, TableMetadata table, SinglePartitionReadCommand readCommand, boolean isWrite, boolean acceptEarlyReadPermission, T onDone)
     {
         Tracing.trace("Preparing {}", ballot);
-        prepareWithBallotInternal(participants, new Request(ballot, participants.electorate, partitionKey, table, isWrite, true), acceptEarlyReadPermission, onDone);
+        Request request = readCommand == null ? new Request(ballot, participants.electorate, partitionKey, table, isWrite, true) : new Request(ballot, participants.electorate, readCommand, isWrite, true);
+        prepareWithBallotInternal(participants, request, acceptEarlyReadPermission, onDone);
         return onDone;
     }
 
@@ -896,7 +899,7 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
             case SUPERSEDED:
                 return new Superseded(supersededBy, participants);
             case FOUND_INCOMPLETE_ACCEPTED:
-                return new FoundIncompleteAccepted(request.ballot, participants, latestAccepted);
+                return new FoundIncompleteAccepted(request.ballot, participants, latestAccepted, readResponses);
             case FOUND_INCOMPLETE_COMMITTED:
                 return new FoundIncompleteCommitted(request.ballot, participants, latestCommitted);
             case PROMISED:
@@ -996,7 +999,7 @@ public class PaxosPrepare extends PaxosRequestCallback<PaxosPrepare.Response> im
         }
     }
 
-    static class Request extends AbstractRequest<Request>
+    public static class Request extends AbstractRequest<Request>
     {
         Request(Ballot ballot, Electorate electorate, SinglePartitionReadCommand read, boolean isWrite, boolean isForRecovery)
         {

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ScheduledExecutorPlus;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.Clustering;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
@@ -302,8 +303,8 @@ public class PaxosRepair extends AbstractPaxosRepair
                 SinglePartitionReadCommand readCommand = null;
                 if (isAcceptedButNotCommitted && table.strictMVEnabled() && !latestAccepted.update.isEmpty())
                 {
-                    assert latestAccepted.update.rowCount() == 1 : "latest accepted with multiple rows: " + latestAccepted.update.rowCount();
-                    readCommand = SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), latestAccepted.update.partitionKey(), latestAccepted.update.lastRow().clustering());
+                    Clustering<?> clustering = latestAccepted.update.getClusteringForSingleRowForStrictMVConsistency();
+                    readCommand = SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), latestAccepted.update.partitionKey(), clustering);
                 }
 
                 return prepareWithBallot(ballot, participants, partitionKey(), table, readCommand, false, false,
@@ -414,10 +415,15 @@ public class PaxosRepair extends AbstractPaxosRepair
 
                     if (proposal.update.metadata().strictMVEnabled())
                     {
+                        // it is possible that the prepare phase is sent with no read command but the replica responded
+                        // with an acceptted uncommitted proposal. In this case, the read responses could be empty.
+                        // We need to retry in this case because for strict MV base table, we need to read the current status
+                        // of the row.
+                        if (incompleteAccepted == null || incompleteAccepted.responses.isEmpty())
+                            return retry(this);
                         // apply MV muatation before commit
-                        assert incompleteAccepted != null && !incompleteAccepted.responses.isEmpty();
                         Paxos.resolveCurrentAndApplyMVMutations(
-                        SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), proposal.update.partitionKey(), proposal.update.lastRow().clustering()),
+                        SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), proposal.update.partitionKey(), proposal.update.getClusteringForSingleRowForStrictMVConsistency()),
                         proposal.update, incompleteAccepted, paxosConsistency, Dispatcher.RequestTime.forImmediateExecution());
                     }
 

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import org.apache.cassandra.transport.Dispatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.RequestFailure;
@@ -269,7 +271,7 @@ public class PaxosRepair extends AbstractPaxosRepair
                         : PaxosCommit.commit(latestCommitted, participants, paxosConsistency, commitConsistency(), true,
                                              new CommittingRepair());
             }
-            else if (isAcceptedButNotCommitted && !isPromisedButNotAccepted && !reproposalMayBeRejected)
+            else if (isAcceptedButNotCommitted && !isPromisedButNotAccepted && !reproposalMayBeRejected && !table.strictMVEnabled())
             {
                 if (logger.isTraceEnabled())
                     logger.trace("PaxosRepair of {} completing {}", partitionKey(), latestAccepted);
@@ -282,8 +284,11 @@ public class PaxosRepair extends AbstractPaxosRepair
                 // If ballots with same timestamp have been both accepted and rejected by different nodes,
                 // to avoid a livelock we simply try to poison, knowing we will fail but use a new ballot
                 // (note there are alternative approaches but this is conservative)
+
+                // for strict MV consistency enabled table, we cannot apply mutation directly, need to re-prepare and propose
+                // so we use the PoisonProposals in the next block
                 return PaxosPropose.propose(latestAccepted, participants, false,
-                        new ProposingRepair(latestAccepted));
+                        new ProposingRepair(latestAccepted, null));
             }
             else if (isAcceptedButNotCommitted || isPromisedButNotAccepted || latestWitnessed.compareTo(latestPreviouslyWitnessed) < 0)
             {
@@ -294,8 +299,14 @@ public class PaxosRepair extends AbstractPaxosRepair
                 // Since this operation is not urgent, and we can piggy-back on other paxos operations
                 if (logger.isTraceEnabled())
                     logger.trace("PaxosRepair of {} found incomplete promise or proposal; preparing stale ballot {}", partitionKey(), Ballot.toString(ballot));
+                SinglePartitionReadCommand readCommand = null;
+                if (isAcceptedButNotCommitted && table.strictMVEnabled() && !latestAccepted.update.isEmpty())
+                {
+                    assert latestAccepted.update.rowCount() == 1 : "latest accepted with multiple rows: " + latestAccepted.update.rowCount();
+                    readCommand = SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), latestAccepted.update.partitionKey(), latestAccepted.update.lastRow().clustering());
+                }
 
-                return prepareWithBallot(ballot, participants, partitionKey(), table, false, false,
+                return prepareWithBallot(ballot, participants, partitionKey(), table, readCommand, false, false,
                         new PoisonProposals());
             }
             else
@@ -344,7 +355,7 @@ public class PaxosRepair extends AbstractPaxosRepair
                     Proposal propose = new Proposal(incomplete.ballot, incomplete.accepted.update);
                     logger.trace("PaxosRepair of {} found incomplete {}", partitionKey(), incomplete.accepted);
                     return PaxosPropose.propose(propose, participants, false,
-                            new ProposingRepair(propose)); // we don't know if we're done, so we must restart
+                            new ProposingRepair(propose, incomplete)); // we don't know if we're done, so we must restart
                 }
 
                 case FOUND_INCOMPLETE_COMMITTED:
@@ -362,7 +373,7 @@ public class PaxosRepair extends AbstractPaxosRepair
                     logger.trace("PaxosRepair of {} submitting empty proposal", partitionKey());
                     Proposal proposal = Proposal.empty(input.success().ballot, partitionKey(), table);
                     return PaxosPropose.propose(proposal, participants, false,
-                            new ProposingRepair(proposal));
+                            new ProposingRepair(proposal, null));
                 }
 
                 default:
@@ -374,9 +385,11 @@ public class PaxosRepair extends AbstractPaxosRepair
     private class ProposingRepair extends ConsumerState<PaxosPropose.Status>
     {
         final Proposal proposal;
-        private ProposingRepair(Proposal proposal)
+        final FoundIncompleteAccepted incompleteAccepted;
+        private ProposingRepair(Proposal proposal, FoundIncompleteAccepted incompleteAccepted)
         {
             this.proposal = proposal;
+            this.incompleteAccepted = incompleteAccepted;
         }
 
         @Override
@@ -397,6 +410,15 @@ public class PaxosRepair extends AbstractPaxosRepair
                     {
                         logger.trace("PaxosRepair of {} complete after successful empty proposal", partitionKey());
                         return DONE;
+                    }
+
+                    if (proposal.update.metadata().strictMVEnabled())
+                    {
+                        // apply MV muatation before commit
+                        assert incompleteAccepted != null && !incompleteAccepted.responses.isEmpty();
+                        Paxos.getCurrentAndApplyMVMutations(
+                        SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), proposal.update.partitionKey(), proposal.update.lastRow().clustering()),
+                        proposal.update, incompleteAccepted, paxosConsistency, Dispatcher.RequestTime.forImmediateExecution());
                     }
 
                     logger.trace("PaxosRepair of {} committing successful proposal {}", partitionKey(), proposal);

--- a/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
+++ b/src/java/org/apache/cassandra/service/paxos/PaxosRepair.java
@@ -416,7 +416,7 @@ public class PaxosRepair extends AbstractPaxosRepair
                     {
                         // apply MV muatation before commit
                         assert incompleteAccepted != null && !incompleteAccepted.responses.isEmpty();
-                        Paxos.getCurrentAndApplyMVMutations(
+                        Paxos.resolveCurrentAndApplyMVMutations(
                         SinglePartitionReadCommand.create(table, FBUtilities.nowInSeconds(), proposal.update.partitionKey(), proposal.update.lastRow().clustering()),
                         proposal.update, incompleteAccepted, paxosConsistency, Dispatcher.RequestTime.forImmediateExecution());
                     }

--- a/test/distributed/org/apache/cassandra/distributed/test/PaxosRepair2Test.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/PaxosRepair2Test.java
@@ -131,7 +131,7 @@ public class PaxosRepair2Test extends TestBaseImpl
         return uncommitted;
     }
 
-    private static void assertUncommitted(IInvokableInstance instance, String ks, String table, int expected)
+    public static void assertUncommitted(IInvokableInstance instance, String ks, String table, int expected)
     {
         Assert.assertEquals(expected, getUncommitted(instance, ks, table));
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/StrictMVConsistencyTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/StrictMVConsistencyTest.java
@@ -1,0 +1,503 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.IMessageFilters;
+import org.apache.cassandra.distributed.api.Row;
+import org.apache.cassandra.distributed.api.SimpleQueryResult;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.net.Message;
+import org.apache.cassandra.net.NoPayload;
+import org.apache.cassandra.net.Verb;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableId;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.paxos.Commit;
+import org.apache.cassandra.service.paxos.PaxosCommit;
+import org.apache.cassandra.service.paxos.PaxosPrepare;
+import org.apache.cassandra.service.paxos.PaxosPropose;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.apache.cassandra.distributed.api.TokenSupplier.evenlyDistributedTokens;
+import static org.apache.cassandra.distributed.shared.NetworkTopology.singleDcNetworkTopology;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class StrictMVConsistencyTest extends TestBaseImpl
+{
+    private static final Logger logger = LoggerFactory.getLogger(StrictMVConsistencyTest.class);
+    static String baseTableName = "base_tbl";
+    static String MVName = "mv";
+
+    @Test
+    public void happyPathTest() throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(3)
+                                        .withTokenSupplier(evenlyDistributedTokens(3, 1))
+                                        .withNodeIdTopology(singleDcNetworkTopology(3, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK).set("materialized_views_enabled", "true")
+                                                                    .set("materialized_view_strict_consistency_enabled", "true")
+                                                                    .set("paxos_variant", "v2"))
+                                        .start())
+        {
+            cluster.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc0': 3}"));
+            cluster.schemaChange(String.format("CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH strict_mv_consistency = true;", KEYSPACE, baseTableName));
+            cluster.schemaChange(String.format("CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE pk IS NOT NULL AND ck IS NOT NULL " +
+                                               "AND v IS NOT NULL PRIMARY KEY (v, ck,pk)", KEYSPACE, MVName, KEYSPACE, baseTableName));
+
+            populateRandomData(cluster, 10, 0, 0, false);
+            verifyBaseTableAndMVInSync(cluster, 10);
+
+            // test LWT is still working
+            populateRandomData(cluster, 10, 20, 20, false, true);
+            verifyBaseTableAndMVInSync(cluster, 20);
+        }
+    }
+
+    @Test
+    public void preparePhaseFailedTest() throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(3)
+                                        .withTokenSupplier(evenlyDistributedTokens(3, 1))
+                                        .withNodeIdTopology(singleDcNetworkTopology(3, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK).set("materialized_views_enabled", "true")
+                                                                    .set("materialized_view_strict_consistency_enabled", "true")
+                                                                    .set("paxos_variant", "v2"))
+                                        .withInstanceInitializer(BBPaxosPrepareRequestHandler::install)
+                                        .start())
+        {
+            cluster.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc0': 3}"));
+            cluster.schemaChange(String.format("CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH strict_mv_consistency = true;", KEYSPACE, baseTableName));
+            cluster.schemaChange(String.format("CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE pk IS NOT NULL AND ck IS NOT NULL " +
+                                               "AND v IS NOT NULL PRIMARY KEY (v, ck,pk)", KEYSPACE, MVName, KEYSPACE, baseTableName));
+            // blocking prepare, we will get timeout for base table update, making sure base table and MV is in sync
+            // block prepare phase on 3 nodes
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosPrepareRequestHandler.disableHandlingPrepare.set(true);
+                }
+                );
+            }
+
+            populateRandomData(cluster, 10, 0, 0, true);
+            verifyBaseTableAndMVInSync(cluster, 0);
+            // unblock prepare
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosPrepareRequestHandler.disableHandlingPrepare.set(false);
+                }
+                );
+            }
+
+            // read with serial consistency will not add new rows because no proposal is accepted
+            readBaseTableWithSerialConsistency(cluster, 10, 0, 0);
+            verifyBaseTableAndMVInSync(cluster, 0);
+
+            populateRandomData(cluster, 10, 0, 0, false);
+            verifyBaseTableAndMVInSync(cluster, 10);
+
+
+        }
+    }
+
+    @Test
+    public void proposePhaseFailedTest() throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(3)
+                                        .withTokenSupplier(evenlyDistributedTokens(3, 1))
+                                        .withNodeIdTopology(singleDcNetworkTopology(3, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK).set("materialized_views_enabled", "true")
+                                                                    .set("materialized_view_strict_consistency_enabled", "true")
+                                                                    .set("paxos_variant", "v2"))
+                                        .withInstanceInitializer(BBPaxosProposeRequestHandler::install)
+                                        .start())
+        {
+            cluster.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc0': 3}"));
+            cluster.schemaChange(String.format("CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH strict_mv_consistency = true;", KEYSPACE, baseTableName));
+            cluster.schemaChange(String.format("CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE pk IS NOT NULL AND ck IS NOT NULL " +
+                                               "AND v IS NOT NULL PRIMARY KEY (v, ck,pk)", KEYSPACE, MVName, KEYSPACE, baseTableName));
+            // blocking propose, we will get timeout for base table update, making sure base table and MV is in sync
+            // block propose phase on 3 nodes
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosProposeRequestHandler.disableHandlingPropose.set(true);
+                }
+                );
+            }
+
+            populateRandomData(cluster, 10, 0, 0, true);
+            verifyBaseTableAndMVInSync(cluster, 0);
+            // unblock propose, making change to exact key/row, we hanve only 10 rows
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosProposeRequestHandler.disableHandlingPropose.set(false);
+                }
+                );
+            }
+            populateRandomData(cluster, 10, 0, 0, false);
+            verifyBaseTableAndMVInSync(cluster, 10);
+
+            // block propose phase on 3 nodes
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosProposeRequestHandler.disableHandlingPropose.set(true);
+                }
+                );
+            }
+
+            populateRandomData(cluster, 10, 100, 0, true);
+            verifyBaseTableAndMVInSync(cluster, 10);
+
+            // unblock propose
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosProposeRequestHandler.disableHandlingPropose.set(false);
+                }
+                );
+            }
+            readBaseTableWithSerialConsistency(cluster, 10, 100, 0);
+            // reading with serial consistency will replay the failed proposal, we are expecting 20 rows now.
+            verifyBaseTableAndMVInSync(cluster, 20);
+        }
+    }
+
+    @Test
+    public void paxosRepairAlwaysBringMVInConsistentWithBaseTableTest() throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(3)
+                                        .withTokenSupplier(evenlyDistributedTokens(3, 1))
+                                        .withNodeIdTopology(singleDcNetworkTopology(3, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK).set("materialized_views_enabled", "true")
+                                                                    .set("materialized_view_strict_consistency_enabled", "true")
+                                                                    .set("paxos_variant", "v2"))
+                                        .withInstanceInitializer(BBPaxosCommitExecuteHandler::install)
+                                        .start())
+        {
+            cluster.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc0': 3}"));
+            cluster.schemaChange(String.format("CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH strict_mv_consistency = true;", KEYSPACE, baseTableName));
+            cluster.schemaChange(String.format("CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE pk IS NOT NULL AND ck IS NOT NULL " +
+                                               "AND v IS NOT NULL PRIMARY KEY (v, ck,pk)", KEYSPACE, MVName, KEYSPACE, baseTableName));
+
+
+            // verify block prepare so that prepare will fail and both MV and base table get 0 row
+            IMessageFilters.Filter filter = cluster.filters().verbs(Verb.PAXOS2_PREPARE_REQ.id).from(1).to(2, 3).drop();
+            populateRandomData(cluster, 5, 0, 0, true);
+            verifyBaseTableAndMVInSync(cluster, 0);
+            // resume message, run paxos repair, verify we still get 0 row
+            filter.off();
+            runPaxosRepairInCluster(cluster);
+            verifyBaseTableAndMVInSync(cluster, 0);
+            // verify there is no uncommitted data ie nothing to be repaired
+            assertClusterNoUncommitted(cluster);
+            // verify block propose so that propose will fail and both MV and base table get 0 row
+            filter = cluster.filters().verbs(Verb.PAXOS2_PROPOSE_REQ.id).from(1).to(2, 3).drop();
+            populateRandomData(cluster, 5, 0, 0, true);
+            verifyBaseTableAndMVInSync(cluster, 0);
+            // resume message, run paxos repair, verify we still get same rows
+            filter.off();
+            runPaxosRepairInCluster(cluster);
+            int rowCount = verifyBaseTableAndMVInSync(cluster, -1);
+            // verify there is no uncommitted data ie nothing to be repaired
+            assertClusterNoUncommitted(cluster);
+            // drop mutation request to node 2 and node 3 so the MV apply will not get quorum
+            // This will cause base table and MV mismatch because MV may have the change but base table has not
+            // committed the update yet.
+            filter = cluster.filters().verbs(Verb.MUTATION_REQ.id).from(1).to(2, 3).drop();
+            populateRandomData(cluster, 5, 10, 0, true);
+            Set<RowData> baseTableResultSet = getTableData("SELECT * FROM " + KEYSPACE + "." + baseTableName, cluster);
+            Set<RowData> MVResultSet = getTableData("SELECT * FROM " + KEYSPACE + "." + MVName, cluster);
+            assertEquals(rowCount, baseTableResultSet.size());
+            assertTrue(MVResultSet.size() > rowCount);
+            filter.off();
+            // verify run paxos repair will bring MV and base table in sync
+            runPaxosRepairInCluster(cluster);
+            rowCount = verifyBaseTableAndMVInSync(cluster, -1);
+            // verify there is no uncommitted data ie nothing to be repaired
+            assertClusterNoUncommitted(cluster);
+            // disable commit message execution on all nodes
+            // This will cause base table and MV mismatch because MV may have the change but base table has not
+            // committed the update yet.
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosCommitExecuteHandler.disableHandlingCommit.set(true);
+                }
+                );
+            }
+            populateRandomData(cluster, 5, 20, 0, true);
+            baseTableResultSet = getTableData("SELECT * FROM " + KEYSPACE + "." + baseTableName, cluster);
+            MVResultSet = getTableData("SELECT * FROM " + KEYSPACE + "." + MVName, cluster);
+            assertEquals(rowCount, baseTableResultSet.size());
+            assertTrue(MVResultSet.size() > rowCount);
+            // resume commit message, run repair MV and base table get back in sync
+            for (int i = 1; i <= 3; i++)
+            {
+                cluster.get(i).runOnInstance(
+                () -> {
+                    BBPaxosCommitExecuteHandler.disableHandlingCommit.set(false);
+                }
+                );
+            }
+            // verify run paxos repair will bring MV and base table in sync
+            runPaxosRepairInCluster(cluster);
+            verifyBaseTableAndMVInSync(cluster, -1);
+            // verify there is no uncommitted data ie nothing to be repaired
+            assertClusterNoUncommitted(cluster);
+        }
+    }
+
+    private void assertClusterNoUncommitted(Cluster cluster)
+    {
+        for (int i = 1; i <= 3; i++)
+            PaxosRepair2Test.assertUncommitted(cluster.get(i), KEYSPACE, baseTableName, 0);
+    }
+
+    private void runPaxosRepairInCluster(Cluster cluster)
+    {
+        // run paxos repari on all three nodes
+        for (int i = 1; i <= 3; i++)
+        {
+            cluster.get(i).runOnInstance(
+            () -> {
+                try
+                {
+                    TableId tableid = Schema.instance.getTableMetadata(KEYSPACE, baseTableName).id;
+                    StorageService.instance.autoRepairPaxos(tableid).get();
+                    return;
+                }
+                catch (Exception e)
+                {
+                    e.printStackTrace();
+
+                }
+                fail("Paxos repair failed");
+            }
+            );
+        }
+    }
+
+    private void populateRandomData(Cluster cluster, int rowCount, int pkFrom, int ckFrom, boolean expectExceptions)
+    {
+        populateRandomData(cluster, rowCount, pkFrom, ckFrom, expectExceptions, false);
+    }
+
+    private void populateRandomData(Cluster cluster, int rowCount, int pkFrom, int ckFrom, boolean expectExceptions, boolean withCondition)
+    {
+        Random random = new Random();
+        for (int i = 0; i < rowCount; i++)
+        {
+            int pk = pkFrom + i;
+            int ck = ckFrom + i;
+            int v = random.nextInt();
+            try
+            {
+                if (withCondition)
+                {
+                    cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + "." + baseTableName + " (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS;",
+                                                   ConsistencyLevel.LOCAL_QUORUM,
+                                                   pk, ck, v);
+                }
+                else
+                {
+                    cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + "." + baseTableName + " (pk, ck, v) VALUES (?, ?, ?)",
+                                                   ConsistencyLevel.LOCAL_QUORUM,
+                                                   pk, ck, v);
+                }
+            } catch (Exception e)
+            {
+                if (!expectExceptions)
+                {
+                    throw e;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            if (expectExceptions)
+            {
+                fail(String.format("Expecting exceptions but got nothing, i: %s", i));
+            }
+        }
+
+    }
+
+    private void readBaseTableWithSerialConsistency(Cluster cluster, int rowCount, int pkFrom, int ckFrom)
+    {
+        for (int i = 0; i < rowCount; i++)
+        {
+            int pk = pkFrom + i;
+            int ck = ckFrom + i;
+            String query = String.format("Select * from " + KEYSPACE + "." + baseTableName + " where pk=" + pk + " and ck=" + ck);
+            cluster.coordinator(1).executeWithResult(query, ConsistencyLevel.LOCAL_SERIAL);
+        }
+
+    }
+
+    private int verifyBaseTableAndMVInSync(Cluster cluster, int expectedRows)
+    {
+        Set<RowData> baseTableResultSet = getTableData("SELECT * FROM " + KEYSPACE + "." + baseTableName, cluster);
+        Set<RowData> MVResultSet = getTableData("SELECT * FROM " + KEYSPACE + "." + MVName, cluster);
+        // disable size check if expected rows < 0
+        if (expectedRows >= 0)
+            Assert.assertEquals(expectedRows, baseTableResultSet.size());
+        Assert.assertEquals(baseTableResultSet, MVResultSet);
+        return baseTableResultSet.size();
+    }
+
+    private Set<RowData> getTableData(String query, Cluster cluster)
+    {
+        SimpleQueryResult tableResult = cluster.coordinator(1).executeWithResult(
+        query, ConsistencyLevel.LOCAL_QUORUM);
+        Set<RowData> rst = new HashSet<>();
+        while (tableResult.hasNext())
+        {
+            Row row = tableResult.next();
+            rst.add(new RowData(row.getInteger("pk"), row.getInteger("ck"), row.getInteger("v")));
+        }
+        return rst;
+    }
+
+    public static class BBPaxosPrepareRequestHandler
+    {
+        public static final AtomicBoolean disableHandlingPrepare = new AtomicBoolean();
+        public static void install(ClassLoader cl, Integer i)
+        {
+            new ByteBuddy().rebase(PaxosPrepare.RequestHandler.class)
+                           .method(named("doVerb"))
+                           .intercept(MethodDelegation.to(StrictMVConsistencyTest.BBPaxosPrepareRequestHandler.class))
+                           .make()
+                           .load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
+        public static void doVerb(Message<PaxosPrepare.Request> message, @SuperCall Callable<Void> zuper) throws Exception
+        {
+            if (disableHandlingPrepare.get())
+            {
+                logger.info("Paxos Prepare request handling is disabled");
+                return;
+            }
+            zuper.call();
+        }
+    }
+
+    public static class BBPaxosProposeRequestHandler
+    {
+        public static final AtomicBoolean disableHandlingPropose = new AtomicBoolean();
+        public static void install(ClassLoader cl, Integer i)
+        {
+            new ByteBuddy().rebase(PaxosPropose.RequestHandler.class)
+                           .method(named("doVerb"))
+                           .intercept(MethodDelegation.to(StrictMVConsistencyTest.BBPaxosProposeRequestHandler.class))
+                           .make()
+                           .load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
+        public static void doVerb(Message<PaxosPrepare.Request> message, @SuperCall Callable<Void> zuper) throws Exception
+        {
+            if (disableHandlingPropose.get())
+            {
+                logger.info("Paxos Propose request handling is disabled");
+                return;
+            }
+            zuper.call();
+        }
+    }
+
+    public static class BBPaxosCommitExecuteHandler
+    {
+        public static final AtomicBoolean disableHandlingCommit = new AtomicBoolean();
+        public static void install(ClassLoader cl, Integer i)
+        {
+            new ByteBuddy().rebase(PaxosCommit.RequestHandler.class)
+                           .method(named("execute"))
+                           .intercept(MethodDelegation.to(StrictMVConsistencyTest.BBPaxosCommitExecuteHandler.class))
+                           .make()
+                           .load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
+        public static NoPayload execute(Commit.Agreed agreed, InetAddressAndPort from, @SuperCall Callable<NoPayload> zuper) throws Exception
+        {
+            if (disableHandlingCommit.get())
+            {
+                logger.info("Paxos commit handling is disabled");
+                return null;
+            }
+            return zuper.call();
+        }
+    }
+
+    private class RowData
+    {
+        int pk, ck, v;
+        RowData(int pk, int ck, int v)
+        {
+            this.pk = pk;
+            this.ck = ck;
+            this.v = v;
+        }
+
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            RowData other = (RowData) o;
+            return this.pk == other.pk && this.ck == other.ck && this.v == other.v;
+        }
+
+        public int hashCode()
+        {
+            return Objects.hash(pk, ck, v);
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/StrictMVConsistencyTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/StrictMVConsistencyTest.java
@@ -51,6 +51,8 @@ import org.apache.cassandra.service.paxos.Commit;
 import org.apache.cassandra.service.paxos.PaxosCommit;
 import org.apache.cassandra.service.paxos.PaxosPrepare;
 import org.apache.cassandra.service.paxos.PaxosPropose;
+import org.apache.cassandra.service.paxos.cleanup.PaxosCleanupResponse;
+import org.apache.cassandra.utils.concurrent.Future;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
@@ -182,28 +184,17 @@ public class StrictMVConsistencyTest extends TestBaseImpl
             populateRandomData(cluster, 10, 0, 0, false);
             verifyBaseTableAndMVInSync(cluster, 10);
 
-            // block propose phase on 3 nodes
-            for (int i = 1; i <= 3; i++)
-            {
-                cluster.get(i).runOnInstance(
-                () -> {
-                    BBPaxosProposeRequestHandler.disableHandlingPropose.set(true);
-                }
-                );
-            }
+            // Use message filter to drop propose requests from coordinator to other nodes.
+            // This allows node 1 to accept the proposal locally, but the coordinator won't get quorum
+            // and will timeout. Later, serial read will discover and replay the accepted proposal.
+            IMessageFilters.Filter filter = cluster.filters().verbs(Verb.PAXOS2_PROPOSE_REQ.id).from(1).to(2, 3).drop();
 
             populateRandomData(cluster, 10, 100, 0, true);
             verifyBaseTableAndMVInSync(cluster, 10);
 
-            // unblock propose
-            for (int i = 1; i <= 3; i++)
-            {
-                cluster.get(i).runOnInstance(
-                () -> {
-                    BBPaxosProposeRequestHandler.disableHandlingPropose.set(false);
-                }
-                );
-            }
+            // remove filter
+            filter.off();
+
             readBaseTableWithSerialConsistency(cluster, 10, 100, 0);
             // reading with serial consistency will replay the failed proposal, we are expecting 20 rows now.
             verifyBaseTableAndMVInSync(cluster, 20);
@@ -296,6 +287,53 @@ public class StrictMVConsistencyTest extends TestBaseImpl
         }
     }
 
+    @Test
+    public void paxosRepairForDeletionForSingleColumnPrimaryKeyBaseTableTest() throws Throwable
+    {
+        try (Cluster cluster = builder().withNodes(3)
+                                        .withTokenSupplier(evenlyDistributedTokens(3, 1))
+                                        .withNodeIdTopology(singleDcNetworkTopology(3, "dc0", "rack0"))
+                                        .withConfig(config -> config.with(NETWORK).set("materialized_views_enabled", "true")
+                                                                    .set("materialized_view_strict_consistency_enabled", "true")
+                                                                    .set("paxos_variant", "v2"))
+                                        .start())
+        {
+            cluster.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc0': 3}"));
+            cluster.schemaChange(String.format("CREATE TABLE %s.%s (pk int PRIMARY KEY, ck int, v int) WITH strict_mv_consistency = true;", KEYSPACE, baseTableName));
+            cluster.schemaChange(String.format("CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE pk IS NOT NULL " +
+                                               "AND v IS NOT NULL PRIMARY KEY (v, pk)", KEYSPACE, MVName, KEYSPACE, baseTableName));
+
+
+            cluster.coordinator(1).execute("INSERT INTO " + KEYSPACE + "." + baseTableName + " (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS;",
+                                           ConsistencyLevel.LOCAL_QUORUM,
+                                           1, 1, 1);
+            verifyBaseTableAndMVInSync(cluster, 1);
+            // verify block propose response so that all nodes accept the propose but the coordinator will not proceed to commit because
+            // all nodes cannot reply the propose request
+            IMessageFilters.Filter filter = cluster.filters().verbs(Verb.PAXOS2_PROPOSE_RSP.id).drop();
+
+            try
+            {
+                cluster.coordinator(1).execute("DELETE FROM " + KEYSPACE + "." + baseTableName + " WHERE pk = ?;",
+                                               ConsistencyLevel.LOCAL_QUORUM,
+                                               1);
+                fail("Should have thrown an exception");
+            } catch (Exception ignored)
+            {
+                // this is expected as this will timeout
+            }
+
+
+            filter.off();
+
+            // verify run paxos repair will bring MV and base table in sync
+            runPaxosRepairInCluster(cluster);
+            verifyBaseTableAndMVInSync(cluster, 0);
+            // verify there is no uncommitted data ie nothing to be repaired
+            assertClusterNoUncommitted(cluster);
+        }
+    }
+
     private void assertClusterNoUncommitted(Cluster cluster)
     {
         for (int i = 1; i <= 3; i++)
@@ -312,13 +350,13 @@ public class StrictMVConsistencyTest extends TestBaseImpl
                 try
                 {
                     TableId tableid = Schema.instance.getTableMetadata(KEYSPACE, baseTableName).id;
-                    StorageService.instance.autoRepairPaxos(tableid).get();
+                    PaxosCleanupResponse response = (PaxosCleanupResponse) StorageService.instance.autoRepairPaxos(tableid).get();
+                    Assert.assertTrue(response.wasSuccessful);
                     return;
                 }
                 catch (Exception e)
                 {
                     e.printStackTrace();
-
                 }
                 fail("Paxos repair failed");
             }

--- a/test/unit/org/apache/cassandra/cql3/StrictMVConsistencyTest.java
+++ b/test/unit/org/apache/cassandra/cql3/StrictMVConsistencyTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.service.EmbeddedCassandraService;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.service.paxos.Paxos;
+
+import java.io.IOException;
+
+public class StrictMVConsistencyTest
+{
+    private static final String KEYSPACE = "cql_test_keyspace";
+    private static Session session;
+    private static EmbeddedCassandraService cassandra;
+    private static Cluster cluster;
+    private static final String BASE_TABLE = "basetablemetricstest";
+
+    private static final String MV1 = "mv1metricstest";
+
+    @BeforeClass
+    public static void setUpClass() {
+        try {
+            cassandra = ServerTestUtils.startEmbeddedCassandraService();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Paxos.setPaxosVariant(Config.PaxosVariant.v2);
+        DatabaseDescriptor.setMaterializedViewStrictConsistencyEnabled(true);
+
+        cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(DatabaseDescriptor.getNativeTransportPort()).build();
+        session = cluster.connect();
+
+        session.execute(String.format("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };", KEYSPACE));
+        session.execute(String.format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEYSPACE, MV1));
+        session.execute(String.format("DROP TABLE IF EXISTS %s.%s", KEYSPACE, BASE_TABLE));
+        session.execute(String.format("CREATE TABLE IF NOT EXISTS %s.%s (id int, val1 text, val2 text, PRIMARY KEY(id, val1)) WITH strict_mv_consistency = true;", KEYSPACE, BASE_TABLE));
+        session.execute(String.format("CREATE MATERIAlIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE id IS NOT NULL AND val1 IS NOT NULL AND val2 IS NOT NULL PRIMARY KEY(val2, id, val1);", KEYSPACE, MV1, KEYSPACE, BASE_TABLE));
+    }
+
+    @Test
+    public void testStrictMVConsistencyEnforced()
+    {
+        DatabaseDescriptor.setMaterializedViewStrictConsistencyEnforced(true);
+        String tableNmae = "test_base_table_strict_mv_enforced";
+        String mvName = "test_base_table_strict_mv_enforced_mv1";
+        session.execute(String.format("CREATE TABLE IF NOT EXISTS %s.%s (id int, val1 text, val2 text, PRIMARY KEY(id, val1)) WITH strict_mv_consistency = false;", KEYSPACE, tableNmae));
+        invalidQueryExceptionTestHelper(String.format("CREATE MATERIAlIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE id IS NOT NULL AND val1 IS NOT NULL AND val2 IS NOT NULL PRIMARY KEY(val2, id, val1);", KEYSPACE, mvName, KEYSPACE, tableNmae),
+                                        "Materialized views can only be created on table with strict MV consistency enabled.");
+        // test strict MV consistency enabled on base table, MV can be created
+        tableNmae = "test_base_table_strict_mv_enforced1";
+        session.execute(String.format("CREATE TABLE IF NOT EXISTS %s.%s (id int, val1 text, val2 text, PRIMARY KEY(id, val1)) WITH strict_mv_consistency = true;", KEYSPACE, tableNmae));
+        session.execute(String.format("CREATE MATERIAlIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE id IS NOT NULL AND val1 IS NOT NULL AND val2 IS NOT NULL PRIMARY KEY(val2, id, val1);", KEYSPACE, mvName, KEYSPACE, tableNmae));
+    }
+
+    @Test
+    public void testUnqualifiedQueriesShouldFail() throws Throwable
+    {
+        String partitionDelete = "DELETE FROM %s.%s WHERE id = %d";
+        invalidQueryExceptionTestHelper(String.format(partitionDelete, KEYSPACE, BASE_TABLE, 1),
+                                        "DELETE statements must restrict all PRIMARY KEY columns with equality relations for Strict MV consistency enabled table.");
+
+
+        String batch = "BEGIN BATCH\n" +
+                       "INSERT INTO %s.%s (id, val1, val2) VALUES (1, '1', '11');\n" +
+                       "INSERT INTO %s.%s (id, val1, val2) VALUES (2, '1', '11');\n" +
+                       "APPLY BATCH";
+        invalidQueryExceptionTestHelper(String.format(batch, KEYSPACE, BASE_TABLE, KEYSPACE, BASE_TABLE),
+                                        "Cannot use batch statement for strict MV enabled table: " + BASE_TABLE);
+
+        String insert = "INSERT INTO %s.%s (id, val1, val2) VALUES (1, '1', '11') USING TIMESTAMP 12345;";
+        invalidQueryExceptionTestHelper(String.format(insert, KEYSPACE, BASE_TABLE),
+                                        "Cannot provide custom timestamp for strict MV consistency enabled table");
+
+        // insert without timestamp should work
+        insert = "INSERT INTO %s.%s (id, val1, val2) VALUES (1, '1', '11')";
+        session.execute(String.format(insert, KEYSPACE, BASE_TABLE));
+
+        // update with IN partition key
+        String update = "UPDATE %s.%s SET val2 = '2' WHERE id IN (1, 2) AND val1='1';";
+        invalidQueryExceptionTestHelper(String.format(update, KEYSPACE, BASE_TABLE),
+                                        "Cannot use IN restritions in statement for strict MV consistency enabled table");
+
+        // update with IN clustering key
+        update = "UPDATE %s.%s SET val2 = '2' WHERE id=1 AND val1 IN ('1', '2');";
+        invalidQueryExceptionTestHelper(String.format(update, KEYSPACE, BASE_TABLE),
+                                        "Cannot use IN restritions in statement for strict MV consistency enabled table");
+
+        // update with IN both partition key and clustering key
+        update = "UPDATE %s.%s SET val2 = '2' WHERE id IN (1, 2) AND val1 IN ('1', '2');";
+        invalidQueryExceptionTestHelper(String.format(update, KEYSPACE, BASE_TABLE),
+                                        "Cannot use IN restritions in statement for strict MV consistency enabled table");
+
+    }
+
+    private void invalidQueryExceptionTestHelper(String query, String errorMessage)
+    {
+        try
+        {
+            session.execute(query);
+        } catch (InvalidQueryException e)
+        {
+            Assert.assertEquals(e.getMessage(), errorMessage);
+            return;
+        }
+        Assert.fail("Expecting InvalidRequestException but didn't get it.");
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        if (cluster != null)
+            cluster.close();
+        if (cassandra != null)
+            cassandra.stop();
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/DescribeStatementTest.java
@@ -274,6 +274,7 @@ public class DescribeStatementTest extends CQLTester
     public void testDescribe() throws Throwable
     {
         DatabaseDescriptor.getAutoRepairConfig().setAutoRepairSchedulingEnabled(false);
+        DatabaseDescriptor.setMaterializedViewStrictConsistencyEnabled(false);
         helperTestDescribe();
     }
 
@@ -281,6 +282,13 @@ public class DescribeStatementTest extends CQLTester
     public void testDescribeWithAutoRepair() throws Throwable
     {
         DatabaseDescriptor.getAutoRepairConfig().setAutoRepairSchedulingEnabled(true);
+        helperTestDescribe();
+    }
+
+    @Test
+    public void testDescribeWithMaterializedViewStrictConsistency() throws Throwable
+    {
+        DatabaseDescriptor.setMaterializedViewStrictConsistencyEnabled(true);
         helperTestDescribe();
     }
 
@@ -1310,57 +1318,42 @@ public class DescribeStatementTest extends CQLTester
 
     private static String tableParametersCql(String comment)
     {
-        if (!DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
+        String tableParametersCqlString = "additional_write_policy = '99p'\n" +
+                                          "    AND allow_auto_snapshot = true\n" +
+                                          "    AND bloom_filter_fp_chance = 0.01\n" +
+                                          "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n" +
+                                          "    AND cdc = false\n" +
+                                          "    AND comment = '" + comment + "'\n" +
+                                          "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
+                                          "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
+                                          "    AND memtable = 'default'\n" +
+                                          "    AND crc_check_chance = 1.0\n" +
+                                          "    AND fast_path = 'keyspace'\n" +
+                                          "    AND default_time_to_live = 0\n" +
+                                          "    AND extensions = {}\n" +
+                                          "    AND gc_grace_seconds = 864000\n" +
+                                          "    AND incremental_backups = true\n" +
+                                          "    AND max_index_interval = 2048\n" +
+                                          "    AND memtable_flush_period_in_ms = 0\n" +
+                                          "    AND min_index_interval = 128\n" +
+                                          "    AND read_repair = 'BLOCKING'\n" +
+                                          "    AND transactional_mode = 'off'\n" +
+                                          "    AND transactional_migration_from = 'none'\n" +
+                                          "    AND speculative_retry = '99p'";
+
+
+        if (DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
         {
-            return "additional_write_policy = '99p'\n" +
-                   "    AND allow_auto_snapshot = true\n" +
-                   "    AND bloom_filter_fp_chance = 0.01\n" +
-                   "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n" +
-                   "    AND cdc = false\n" +
-                   "    AND comment = '" + comment + "'\n" +
-                   "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-                   "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
-                   "    AND memtable = 'default'\n" +
-                   "    AND crc_check_chance = 1.0\n" +
-                   "    AND fast_path = 'keyspace'\n" +
-                   "    AND default_time_to_live = 0\n" +
-                   "    AND extensions = {}\n" +
-                   "    AND gc_grace_seconds = 864000\n" +
-                   "    AND incremental_backups = true\n" +
-                   "    AND max_index_interval = 2048\n" +
-                   "    AND memtable_flush_period_in_ms = 0\n" +
-                   "    AND min_index_interval = 128\n" +
-                   "    AND read_repair = 'BLOCKING'\n" +
-                   "    AND transactional_mode = 'off'\n" +
-                   "    AND transactional_migration_from = 'none'\n" +
-                   "    AND speculative_retry = '99p';";
+            tableParametersCqlString += "\n    AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'}";
         }
-        else
+        if (DatabaseDescriptor.getMaterializedViewStrictConsistencyEnabled())
         {
-            return "additional_write_policy = '99p'\n" +
-                   "    AND allow_auto_snapshot = true\n" +
-                   "    AND bloom_filter_fp_chance = 0.01\n" +
-                   "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}\n" +
-                   "    AND cdc = false\n" +
-                   "    AND comment = ''\n" +
-                   "    AND compaction = " + cqlQuoted(CompactionParams.DEFAULT.asMap()) + "\n" +
-                   "    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n" +
-                   "    AND memtable = 'default'\n" +
-                   "    AND crc_check_chance = 1.0\n" +
-                   "    AND fast_path = 'keyspace'\n" +
-                   "    AND default_time_to_live = 0\n" +
-                   "    AND extensions = {}\n" +
-                   "    AND gc_grace_seconds = 864000\n" +
-                   "    AND incremental_backups = true\n" +
-                   "    AND max_index_interval = 2048\n" +
-                   "    AND memtable_flush_period_in_ms = 0\n" +
-                   "    AND min_index_interval = 128\n" +
-                   "    AND read_repair = 'BLOCKING'\n" +
-                   "    AND transactional_mode = 'off'\n" +
-                   "    AND transactional_migration_from = 'none'\n" +
-                   "    AND speculative_retry = '99p'\n" +
-                   "    AND auto_repair = {'full_enabled': 'true', 'incremental_enabled': 'true', 'preview_repaired_enabled': 'true', 'priority': '0'};";
+            tableParametersCqlString += "\n    AND strict_mv_consistency = false";
         }
+
+        tableParametersCqlString += ";";
+
+        return tableParametersCqlString;
     }
 
     private static String cqlQuoted(Map<String, String> map)

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.memtable.Memtable;
 import org.apache.cassandra.db.memtable.SkipListMemtable;
 import org.apache.cassandra.db.memtable.TestMemtable;
@@ -960,5 +961,53 @@ public class AlterTest extends CQLTester
                                         row(ks1, true, map("class", "org.apache.cassandra.locator.SimpleStrategy", "replication_factor", "1")));
 
         assertInvalidThrow(InvalidRequestException.class, "ALTER KEYSPACE ks1 WITH replication= { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
+    }
+
+    @Test
+    public void testAlterTableWithStrictMVConsistency() throws Throwable
+    {
+        // setup config, enable MV creation and enable metric collection
+        DatabaseDescriptor.setMaterializedViewsEnabled(true);
+        DatabaseDescriptor.setMaterializedViewsBasetableMetricCollectionEnabled(true);
+        requireNetwork();
+
+        createTable("CREATE TABLE %s (a int, b int, c int, d int, PRIMARY KEY (a, b)); ");
+        assertAlterTableThrowsException(InvalidRequestException.class,
+                                        "Not qualified for strict mv consistency because node level setting materialized_view_strict_consistency_enabled is disabled.",
+                                        "ALTER TABLE %s WITH strict_mv_consistency = true");
+        DatabaseDescriptor.setMaterializedViewStrictConsistencyEnabled(true);
+        assertAlterTableThrowsException(InvalidRequestException.class,
+                                        "Not qualified for strict mv consistency because maximum number of MVs per table is not set.",
+                                        "ALTER TABLE %s WITH strict_mv_consistency = true");
+        // set max number of MVs per table to 2
+        Guardrails.instance.setMaterializedViewsPerTableThreshold(-1, 2);
+        // alter table to enable strict mv consistency worked
+        alterTable("ALTER TABLE %s WITH strict_mv_consistency = true");
+        // alter table to disable strict mv consistency worked
+        alterTable("ALTER TABLE %s WITH strict_mv_consistency = false");
+
+        String mv1 = createView("CREATE MATERIALIZED VIEW %s AS SELECT * FROM %s " +
+                                "WHERE a IS NOT NULL AND b IS NOT NULL and c IS NOT NULL PRIMARY KEY (c, a, b)");
+        String mv2 = createView("CREATE MATERIALIZED VIEW %s AS SELECT * FROM %s " +
+                                "WHERE a IS NOT NULL AND b IS NOT NULL and d IS NOT NULL PRIMARY KEY (d, a, b)");
+
+        // set max number of MVs per table to 1 and we have 2 MVs now, enable strict mv consistency should fail
+        Guardrails.instance.setMaterializedViewsPerTableThreshold(-1, 1);
+        assertAlterTableThrowsException(InvalidRequestException.class,
+                                        "Not qualified for strict mv consistency because base table has 2 MVs which is more than limit: 1",
+                                        "ALTER TABLE %s WITH strict_mv_consistency = true");
+
+        // set threshold to 2
+        Guardrails.instance.setMaterializedViewsPerTableThreshold(-1, 2);
+        alterTable("ALTER TABLE %s WITH strict_mv_consistency = true");
+        alterTable("ALTER TABLE %s WITH strict_mv_consistency = false");
+
+        // send non-LWT compatible queries
+        execute("DELETE from %s WHERE a = 3");
+        assertAlterTableThrowsException(InvalidRequestException.class,
+                                        "Not qualified for strict mv consistency because base table has non-LWT compatible queries, modification with ts: 0, batch statement: 0, delete without full primary key: 1, IN restrictions used: 0",
+                                        "ALTER TABLE %s WITH strict_mv_consistency = true");
+
+
     }
 }

--- a/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
+++ b/test/unit/org/apache/cassandra/metrics/TableMetricsTest.java
@@ -53,6 +53,8 @@ public class TableMetricsTest
     private static final String TABLE = "tablemetricstest";
     private static final String COUNTER_TABLE = "tablemetricscountertest";
     private static final String TWCS_TABLE = "tablemetricstesttwcs";
+    private static final String BASE_TABLE = "basetablemetricstest";
+    private static final String MV1 = "mv1metricstest";
 
     private static EmbeddedCassandraService cassandra;
     private static Cluster cluster;
@@ -88,6 +90,15 @@ public class TableMetricsTest
         session.execute(String.format("DROP TABLE IF EXISTS %s.%s", KEYSPACE, table));
         session.execute(String.format("CREATE TABLE IF NOT EXISTS %s.%s (id int, val1 text, val2 text, PRIMARY KEY(id, val1));", KEYSPACE, table));
         return ColumnFamilyStore.getIfExists(KEYSPACE, table);
+    }
+
+    private ColumnFamilyStore recreateMVAndBaseTable()
+    {
+        session.execute(String.format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEYSPACE, MV1));
+        session.execute(String.format("DROP TABLE IF EXISTS %s.%s", KEYSPACE, BASE_TABLE));
+        session.execute(String.format("CREATE TABLE IF NOT EXISTS %s.%s (id int, val1 text, val2 text, PRIMARY KEY(id, val1));", KEYSPACE, BASE_TABLE));
+        session.execute(String.format("CREATE MATERIAlIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE id IS NOT NULL AND val1 IS NOT NULL AND val2 IS NOT NULL PRIMARY KEY(val2, id, val1);", KEYSPACE, MV1, KEYSPACE, BASE_TABLE));
+        return ColumnFamilyStore.getIfExists(KEYSPACE, BASE_TABLE);
     }
 
     private void executeBatch(boolean isLogged, int distinctPartitions, int statementsPerPartition, String... tables)
@@ -192,6 +203,74 @@ public class TableMetricsTest
         assertRowsContains(cluster, session.execute("SELECT * FROM system_metrics.column_family_group"),
                 row("org.apache.cassandra.metrics.ColumnFamily.MaxSSTableDuration.junit.tablemetricstesttwcs", "junit.tablemetricstesttwcs", "gauge",
                         String.valueOf(cfs.metric.maxSSTableDuration.getValue())));
+    }
+
+    @Test
+    public void testStrictMVConsistencyQualificationMetrics()
+    {
+        Boolean originalConfig = DatabaseDescriptor.getMaterializedViewsBasetableMetricCollectionEnabled();
+        DatabaseDescriptor.setMaterializedViewsBasetableMetricCollectionEnabled(true);
+        ColumnFamilyStore base = recreateMVAndBaseTable();
+        ColumnFamilyStore withoutMV = recreateTable();
+        // delete statement not providing all primary key columns
+        // test all PK columns are provided
+        // for MV base table and normal table without MV, counter will not change
+        String fullParimarykeyDelete = "DELETE FROM %s.%s WHERE id = %d AND val1 = '%s'";
+        session.execute(String.format(fullParimarykeyDelete, KEYSPACE, BASE_TABLE, 1, "2"));
+        assertEquals(0, base.metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount());
+        session.execute(String.format(fullParimarykeyDelete, KEYSPACE, TABLE, 1, "2"));
+        assertEquals(0, withoutMV.metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount());
+        // test not all PK columns are provided
+        // for MV base table, the counter should increase, for normal table without MV, counter will not change
+        String partitionDelete = "DELETE FROM %s.%s WHERE id = %d";
+        session.execute(String.format(partitionDelete, KEYSPACE, BASE_TABLE, 1));
+        assertEquals(1, base.metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount());
+        session.execute(String.format(partitionDelete, KEYSPACE, TABLE, 1));
+        assertEquals(0, withoutMV.metric.viewBaseTableDeleteStatementWithoutFullPrimaryKey.getCount());
+
+        // batch statement
+        // test base table involved in batch statement
+        String batch = "BEGIN BATCH\n" +
+                       "INSERT INTO %s.%s (id, val1, val2) VALUES (1, '1', '11');\n" +
+                       "INSERT INTO %s.%s (id, val1, val2) VALUES (2, '1', '11');\n" +
+                       "APPLY BATCH";
+        session.execute(String.format(batch, KEYSPACE, BASE_TABLE, KEYSPACE, BASE_TABLE));
+        assertEquals(2, base.metric.viewBaseTableUsedInBatchStatement.getCount());
+        session.execute(String.format(batch, KEYSPACE, TABLE, KEYSPACE, TABLE));
+        assertEquals(0, withoutMV.metric.viewBaseTableUsedInBatchStatement.getCount());
+
+        // insert with timestamp
+        String insert = "INSERT INTO %s.%s (id, val1, val2) VALUES (1, '1', '11') USING TIMESTAMP 12345;";
+        session.execute(String.format(insert, KEYSPACE, BASE_TABLE));
+        assertEquals(1, base.metric.viewBaseTableModificationWithTimestamp.getCount());
+        session.execute(String.format(insert, KEYSPACE, TABLE));
+        assertEquals(0, withoutMV.metric.viewBaseTableModificationWithTimestamp.getCount());
+        // update with timestamp
+        String update = "UPDATE %s.%s USING TIMESTAMP 12345 SET val2 = '2' WHERE id=1 AND val1='1';";
+        session.execute(String.format(update, KEYSPACE, BASE_TABLE));
+        assertEquals(2, base.metric.viewBaseTableModificationWithTimestamp.getCount());
+        session.execute(String.format(update, KEYSPACE, TABLE));
+        assertEquals(0, withoutMV.metric.viewBaseTableModificationWithTimestamp.getCount());
+        // update with IN partition key
+        update = "UPDATE %s.%s SET val2 = '2' WHERE id IN (1, 2) AND val1='1';";
+        session.execute(String.format(update, KEYSPACE, BASE_TABLE));
+        assertEquals(1, base.metric.viewBaseTableInRestirctionsUsed.getCount());
+        session.execute(String.format(update, KEYSPACE, TABLE));
+        assertEquals(0, withoutMV.metric.viewBaseTableInRestirctionsUsed.getCount());
+        // update with IN clustering key
+        update = "UPDATE %s.%s SET val2 = '2' WHERE id=1 AND val1 IN ('1', '2');";
+        session.execute(String.format(update, KEYSPACE, BASE_TABLE));
+        assertEquals(2, base.metric.viewBaseTableInRestirctionsUsed.getCount());
+        session.execute(String.format(update, KEYSPACE, TABLE));
+        assertEquals(0, withoutMV.metric.viewBaseTableInRestirctionsUsed.getCount());
+        // update with IN both partition key and clustering key
+        update = "UPDATE %s.%s SET val2 = '2' WHERE id IN (1, 2) AND val1 IN ('1', '2');";
+        session.execute(String.format(update, KEYSPACE, BASE_TABLE));
+        assertEquals(3, base.metric.viewBaseTableInRestirctionsUsed.getCount());
+        session.execute(String.format(update, KEYSPACE, TABLE));
+        assertEquals(0, withoutMV.metric.viewBaseTableInRestirctionsUsed.getCount());
+
+        DatabaseDescriptor.setMaterializedViewsBasetableMetricCollectionEnabled(originalConfig);
     }
 
     @Test


### PR DESCRIPTION
This PR is for strict_mv_consistency that move MV base table update backed by LWT (Paxos V2).
It contains following changes:
1. Add metrics for MV base table to determine if base table is qualified to be migrated to LWT backed use case (Those metrics are added for migration purpose if users want to migrate from non strict MV consistency to this new design, users need to make sure the metrics are good)
2. Add table options to change the MV behavior to use strict MV consistency (strict_mv_consistency is introduced as a new table params for base table so it can be turned on and off)
3. strict_mv_consistency enabled table will be updated with Paxos V2
4. Paxos repair for strict_mv_consistency enabled table will replay MV mutations

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20880)

