### PR TITLE
CASSANDRA-20881: make LogbackMetrics work as a virtual table

### DIFF
--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -158,6 +158,7 @@ public class CassandraMetricsRegistry extends MetricRegistry
                                    .add(TrieMemtableMetricsView.TYPE_NAME)
                                    .add(UnweightedCacheMetrics.TYPE_NAME)
                                    .add(AutoRepairMetrics.TYPE_NAME)
+                                   .add(LogbackMetrics.TYPE_NAME)
                                    .build();
     }
 

--- a/src/java/org/apache/cassandra/metrics/LogbackMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/LogbackMetrics.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.metrics;
+
+public class LogbackMetrics
+{
+    /**
+     * Corresponding to the appender named LogbackMetrics in logback.xml, this configuration enables the tracking and reporting of log event statistics,
+     * such as counts for different log levels (e.g., INFO, WARN, ERROR) as metrics.
+     */
+    public static final String TYPE_NAME = "LogbackMetrics";
+}

--- a/test/conf/logback-dtest_with_logback_metric_appender.xml
+++ b/test/conf/logback-dtest_with_logback_metric_appender.xml
@@ -1,0 +1,61 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration debug="false" scan="true" scanPeriod="60 seconds">
+    <define name="cluster_id" class="org.apache.cassandra.distributed.impl.ClusterIDDefiner" />
+    <define name="instance_id" class="org.apache.cassandra.distributed.impl.InstanceIDDefiner" />
+
+    <!-- Shutdown hook ensures that async appender flushes -->
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
+
+    <appender name="INSTANCEFILE" class="ch.qos.logback.core.FileAppender">
+        <file>./build/test/logs/${cassandra.testtag}/${suitename}/${cluster_id}/${instance_id}/system.log</file>
+        <encoder>
+            <pattern>%-5level [%thread] ${instance_id} %date{"yyyy-MM-dd'T'HH:mm:ss,SSS", UTC} %msg%n</pattern>
+        </encoder>
+        <immediateFlush>true</immediateFlush>
+    </appender>
+
+    <appender name="INSTANCESTDERR" target="System.err" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level %date{"yyyy-MM-dd'T'HH:mm:ss,SSS", UTC} %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <appender name="INSTANCESTDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level [%thread] ${instance_id} %date{"yyyy-MM-dd'T'HH:mm:ss,SSS", UTC} %F:%L - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+    </appender>
+
+    <!--enable this for testing-->
+    <appender name="LogbackMetrics" class="com.codahale.metrics.logback.InstrumentedAppender" />
+
+    <root level="DEBUG">
+        <appender-ref ref="INSTANCEFILE" /> <!-- use blocking to avoid race conditions with appending and searching -->
+        <appender-ref ref="INSTANCESTDERR" />
+        <appender-ref ref="INSTANCESTDOUT" />
+        <appender-ref ref="LogbackMetrics" />
+    </root>
+</configuration>

--- a/test/distributed/org/apache/cassandra/distributed/test/VirtualTableLogbackMetricTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/VirtualTableLogbackMetricTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.Feature;
+import org.apache.cassandra.distributed.api.SimpleQueryResult;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.schema.SchemaConstants;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.config.CassandraRelevantProperties.LOGBACK_CONFIGURATION_FILE;
+import static org.apache.cassandra.distributed.api.ConsistencyLevel.ONE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VirtualTableLogbackMetricTest extends AbstractVirtualLogsTableTest
+{
+    @Override
+    public String getTableName()
+    {
+        return format("%s.%s", SchemaConstants.VIRTUAL_METRICS, "logback_metrics_group");
+    }
+
+    @Test
+    public void testVTableOutputWhenDisable() throws Throwable
+    {
+        // logback-dtest.xml does not configure LogbackMetrics; reuse it to avoid creating another file.
+        try (WithProperties properties = new WithProperties().set(LOGBACK_CONFIGURATION_FILE, "test/conf/logback-dtest.xml");
+             Cluster cluster = Cluster.build(1)
+                                      .withConfig(c -> c.with(Feature.values()))
+                                      .start();
+        )
+        {
+            SimpleQueryResult simpleQueryResult = cluster.coordinator(1).executeWithResult(query("select * from %s"), ONE);
+            Object[][] rows = simpleQueryResult.toObjectArrays();
+            assertEquals(0, rows.length);
+        }
+    }
+
+    @Test
+    public void testVTableOutputWhenEnable() throws Throwable
+    {
+        try (WithProperties properties = new WithProperties().set(LOGBACK_CONFIGURATION_FILE, "test/conf/logback-dtest_with_logback_metric_appender.xml");
+             Cluster cluster = Cluster.build(1)
+                                      .withConfig(c -> c.with(Feature.values()))
+                                      .start();
+        )
+        {
+            SimpleQueryResult simpleQueryResult = cluster.coordinator(1).executeWithResult(query("select * from %s"), ONE);
+            Object[][] rows = simpleQueryResult.toObjectArrays();
+            assertEquals(6, rows.length);
+
+            simpleQueryResult.forEachRemaining(row -> {
+                String name = row.getString("name");
+                String scope = row.getString("scope");
+                String type = row.getString("type");
+                String value = row.getString("value");
+
+                assertTrue(name.startsWith("org.apache.cassandra.metrics.LogbackMetrics."));
+                String suffix = name.substring("org.apache.cassandra.metrics.LogbackMetrics.".length());
+                assertTrue(Sets.newHashSet("all", "debug", "error", "info", "trace", "warn").contains(suffix));
+                assertEquals("undefined", scope);
+                assertEquals("meter", type);
+                assertThat(Integer.parseInt(value)).isGreaterThanOrEqualTo(0);
+            });
+        }
+    }
+}


### PR DESCRIPTION
- more details in the [CASSANDRA-20881](https://issues.apache.org/jira/browse/CASSANDRA-20881)