### PR TITLE
Stop repair scheduler if two major versions are detected

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -220,6 +220,7 @@
  * Add ELAPSED command to cqlsh (CASSANDRA-18861)
  * Add the ability to disable bulk loading of SSTables (CASSANDRA-18781)
  * Clean up obsolete functions and simplify cql_version handling in cqlsh (CASSANDRA-18787)
+ * Stop repair scheduler if two major versions are detected (CASSANDRA-20048)
 Merged from 5.0:
  * Sort SSTable TOC entries for determinism (CASSANDRA-20494)
  * Do not source cassandra-env.sh unnecessarily in nodetool and other tooling (CASSANDRA-20745)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2782,6 +2782,9 @@ storage_compatibility_mode: NONE
 #   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
 #   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
 #   history_clear_delete_hosts_buffer_interval: 2h
+#   # By default repair is disabled if there are mixed major versions detected - which would happen
+#   # if a major version upgrade is being performed on the cluster, but a user can enable it using this flag
+#   mixed_major_version_repair_enabled: false
 #   # NOTE: Each of the below settings can be overridden per repair type under repair_type_overrides
 #   global_settings:
 #     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2467,6 +2467,9 @@ storage_compatibility_mode: NONE
 #   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
 #   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
 #   history_clear_delete_hosts_buffer_interval: 2h
+#   # By default repair is disabled if there are mixed major versions detected - which would happen
+#   # if a major version upgrade is being performed on the cluster, but a user can enable it using this flag
+#   mixed_major_version_repair_enabled: false
 #   # NOTE: Each of the below settings can be overridden per repair type under repair_type_overrides
 #   global_settings:
 #     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired

--- a/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
@@ -167,6 +167,10 @@ is time to schedule repairs.
 | history_clear_delete_hosts_buffer_interval | 2h | The scheduler needs to adjust its order when nodes leave the ring.
 Deleted hosts are tracked in metadata for a specified duration to ensure they are indeed removed before adjustments
 are made to the schedule.
+| mixed_major_version_repair_enabled | false | Enable/Disable running repairs on the cluster when there are mixed
+major versions detected, which usually occurs when the cluster is being upgraded. Repairs between nodes of
+different major versions is not something that is tested, so this may lead to data compatibility issues.
+It is strongly discouraged to set this to true without doing extensive testing beforehand.
 |===
 
 

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -165,6 +165,11 @@ public class AutoRepair
             logger.debug("Auto-repair is disabled for repair type {}", repairType);
             return;
         }
+        if (!config.isMixedMajorVersionRepairEnabled() && AutoRepairUtils.hasMultipleLiveMajorVersions())
+        {
+            logger.info("Auto-repair is disabled when nodes in the cluster have different major versions");
+            return;
+        }
         AutoRepairService.instance.checkCanRun(repairType);
         AutoRepairState repairState = repairStates.get(repairType);
         try

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -59,6 +59,8 @@ public class AutoRepairConfig implements Serializable
     // Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
     // the node by scheduling too many repair tasks in a short period of time.
     public volatile DurationSpec.LongSecondsBound repair_task_min_duration = new DurationSpec.LongSecondsBound("5s");
+    // by default repair is disabled if there are mixed major versions detected, but you can enable it using this flag
+    public volatile boolean mixed_major_version_repair_enabled = false;
 
     // global_settings overides Options.defaultOptions for all repair types
     public volatile Options global_settings;
@@ -147,6 +149,11 @@ public class AutoRepairConfig implements Serializable
     public void setAutoRepairSchedulingEnabled(boolean enabled)
     {
         this.enabled = enabled;
+    }
+
+    public boolean isMixedMajorVersionRepairEnabled()
+    {
+        return mixed_major_version_repair_enabled;
     }
 
     public DurationSpec.IntSecondsBound getAutoRepairHistoryClearDeleteHostsBufferInterval()
@@ -364,6 +371,16 @@ public class AutoRepairConfig implements Serializable
     public void setRepairRetryBackoff(RepairType repairType, String interval)
     {
         getOptions(repairType).repair_retry_backoff = new DurationSpec.LongSecondsBound(interval);
+    }
+
+    public boolean getMixedMajorVersionRepairEnabled()
+    {
+        return this.mixed_major_version_repair_enabled;
+    }
+
+    public void setMixedMajorVersionRepairEnabled(boolean enabled)
+    {
+        this.mixed_major_version_repair_enabled = enabled;
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -425,6 +425,21 @@ public class AutoRepairUtils
         return null;
     }
 
+    /**
+     * Checks whether the cluster has multiple major versions
+     * @return
+     *  true if more than one major versions are detected
+     *  false if only one major version is detected
+     *
+     */
+    public static boolean hasMultipleLiveMajorVersions()
+    {
+        ClusterMetadata metadata = ClusterMetadata.current();
+        int maxMajorVersion = ClusterMetadata.current().directory.clusterMaxVersion.cassandraVersion.major;
+        int minMajorVersion = ClusterMetadata.current().directory.clusterMinVersion.cassandraVersion.major;
+        return maxMajorVersion != minMajorVersion;
+    }
+
     @VisibleForTesting
     protected static TreeSet<UUID> getHostIdsInCurrentRing(RepairType repairType, Collection<NodeAddresses> allNodesInRing)
     {

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -102,6 +102,7 @@ public class AutoRepairService implements AutoRepairServiceMBean
         appendConfig(sb, "repair_check_interval", config.getRepairCheckInterval());
         appendConfig(sb, "repair_task_min_duration", config.getRepairTaskMinDuration());
         appendConfig(sb, "history_clear_delete_hosts_buffer_interval", config.getAutoRepairHistoryClearDeleteHostsBufferInterval());
+        appendConfig(sb, "mixed_major_version_repair_enabled", config.getMixedMajorVersionRepairEnabled());
         for (RepairType repairType : RepairType.values())
         {
             sb.append(formatRepairTypeConfig(repairType, config));
@@ -269,6 +270,12 @@ public class AutoRepairService implements AutoRepairServiceMBean
     public void setAutoRepairRetryBackoff(String repairType, String interval)
     {
         config.setRepairRetryBackoff(RepairType.parse(repairType), interval);
+    }
+
+    @Override
+    public void setMixedMajorVersionRepairEnabled(boolean enabled)
+    {
+        config.setMixedMajorVersionRepairEnabled(enabled);
     }
 
     private String formatRepairTypeConfig(RepairType repairType, AutoRepairConfig config)

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -74,4 +74,6 @@ public interface AutoRepairServiceMBean
     public void setAutoRepairMaxRetriesCount(String repairType, int retries);
 
     public void setAutoRepairRetryBackoff(String repairType, String interval);
+
+    public void setMixedMajorVersionRepairEnabled(boolean enabled);
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2677,6 +2677,11 @@ public class NodeProbe implements AutoCloseable
     {
         return grProxy;
     }
+
+    public void setMixedMajorVersionRepairEnabled(boolean enabled)
+    {
+        autoRepairProxy.setMixedMajorVersionRepairEnabled(enabled);
+    }
 }
 
 class ColumnFamilyStoreMBeanIterator implements Iterator<Map.Entry<String, ColumnFamilyStoreMBean>>

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -53,7 +53,7 @@ public class SetAutoRepairConfig extends AbstractCommand
                                                           "|allow_parallel_replica_repair|allow_parallel_repair_across_schedules" +
                                                           "|materialized_view_repair_enabled|repair_max_retries" +
                                                           "|repair_retry_backoff|repair_session_timeout|min_repair_task_duration" +
-                                                          "|repair_by_keyspace|token_range_splitter.<property>]" })
+                                                          "|repair_by_keyspace|mixed_major_version_repair_enabled|token_range_splitter.<property>]" })
     public String autorepairParamType;
 
     @Parameters(index = "1", description = "Autorepair param value", arity = "0..1")
@@ -96,6 +96,9 @@ public class SetAutoRepairConfig extends AbstractCommand
                 return;
             case "min_repair_task_duration":
                 probe.setAutoRepairMinRepairTaskDuration(paramVal);
+                return;
+            case "mixed_major_version_repair_enabled":
+                probe.setMixedMajorVersionRepairEnabled(Boolean.parseBoolean(paramVal));
                 return;
             default:
                 // proceed to options that require --repair-type option

--- a/test/distributed/org/apache/cassandra/distributed/test/log/ClusterMetadataTestHelper.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/log/ClusterMetadataTestHelper.java
@@ -798,9 +798,14 @@ public class ClusterMetadataTestHelper
 
     public static void addEndpoint(int i)
     {
+        addEndpoint(i, NodeVersion.CURRENT);
+    }
+
+    public static void addEndpoint(int i, NodeVersion nodeVersion)
+    {
         try
         {
-            addEndpoint(InetAddressAndPort.getByName("127.0.0." + i), new Murmur3Partitioner.LongToken(i));
+            addEndpoint(InetAddressAndPort.getByName("127.0.0." + i), new Murmur3Partitioner.LongToken(i), nodeVersion);
         }
         catch (UnknownHostException e)
         {
@@ -810,7 +815,12 @@ public class ClusterMetadataTestHelper
 
     public static void addEndpoint(InetAddressAndPort endpoint, Token t)
     {
-        addEndpoint(endpoint, t, "dc1", "rack1");
+        addEndpoint(endpoint, t, NodeVersion.CURRENT);
+    }
+
+    public static void addEndpoint(InetAddressAndPort endpoint, Token t, NodeVersion nodeVersion)
+    {
+        addEndpoint(endpoint, t, "dc1", "rack1", nodeVersion);
     }
 
     public static void addEndpoint(InetAddressAndPort endpoint, Collection<Token> tokens)
@@ -830,15 +840,26 @@ public class ClusterMetadataTestHelper
 
     public static void addEndpoint(InetAddressAndPort endpoint, Token t, String dc, String rack)
     {
-        addEndpoint(endpoint, Collections.singleton(t), dc, rack);
+        addEndpoint(endpoint, Collections.singleton(t), dc, rack, NodeVersion.CURRENT);
+    }
+
+    public static void addEndpoint(InetAddressAndPort endpoint, Token t, String dc, String rack, NodeVersion nodeVersion)
+    {
+        addEndpoint(endpoint, Collections.singleton(t), dc, rack, nodeVersion);
     }
 
     public static void addEndpoint(InetAddressAndPort endpoint, Collection<Token> t, String dc, String rack)
     {
+        addEndpoint(endpoint, t, dc, rack, NodeVersion.CURRENT);
+    }
+
+    public static void addEndpoint(InetAddressAndPort endpoint, Collection<Token> t, String dc, String rack,
+                                   NodeVersion nodeVersion)
+    {
         try
         {
             Location l = new Location(dc, rack);
-            commit(new Register(addr(endpoint), l, NodeVersion.CURRENT));
+            commit(new Register(addr(endpoint), l, nodeVersion));
             if (endpoint.equals(FBUtilities.getBroadcastAddressAndPort()))
                 RegistrationStatus.instance.onRegistration();
             lazyJoin(endpoint, new HashSet<>(t)).prepareJoin()

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -24,6 +24,8 @@ import java.util.TreeSet;
 import java.util.UUID;
 
 import com.google.common.collect.ImmutableSet;
+
+import org.apache.cassandra.distributed.test.log.ClusterMetadataTestHelper;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -44,6 +46,8 @@ import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.membership.NodeAddresses;
+import org.apache.cassandra.tcm.membership.NodeVersion;
+import org.apache.cassandra.utils.CassandraVersion;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.Util.setAutoRepairEnabled;
@@ -230,6 +234,52 @@ public class AutoRepairUtilsTest extends CQLTester
         assertNotNull(hosts);
         assertEquals(1, hosts.size());
         assertTrue(hosts.contains(hostId));
+    }
+
+    @Test
+    public void testHasMultipleLiveMajorVersionsWithSingleNode()
+    {
+        boolean result = AutoRepairUtils.hasMultipleLiveMajorVersions();
+        assertFalse(result);
+    }
+
+    @Test
+    public void testHasMultipleLiveMajorVersionsWithMultipleNodesOfSameVersion()
+    {
+        ClusterMetadataTestHelper.addEndpoint(2);
+        // Test the current behavior with the existing cluster setup
+        // In a single-node test environment, this should return false
+        boolean result = AutoRepairUtils.hasMultipleLiveMajorVersions();
+        assertFalse(result);
+    }
+
+    @Test
+    public void testHasMultipleLiveMajorVersionsWithMultipleNodesOfSameMajorVersionDifferentMinorVersions()
+    {
+        // add two nodes with the current cassandra major version, but different minor version
+        CassandraVersion differentCassandraVersion = new CassandraVersion(
+            String.format("%d.%d",
+                          NodeVersion.CURRENT.cassandraVersion.major,
+                          NodeVersion.CURRENT.cassandraVersion.minor+1));
+        ClusterMetadataTestHelper.addEndpoint(2, new NodeVersion(
+             differentCassandraVersion,
+             NodeVersion.CURRENT_METADATA_VERSION));
+        // With the same major versions, but different minor versions, we should still see this function return true
+        boolean result = AutoRepairUtils.hasMultipleLiveMajorVersions();
+        assertFalse(result);
+    }
+
+    @Test
+    public void testHasMultipleLiveMajorVersionsWithMultipleNodesOfDifferentMajorVersions()
+    {
+        // add two nodes with different cassandra major versions
+        CassandraVersion differentCassandraVersion = new CassandraVersion(
+            String.format("%d.%d", NodeVersion.CURRENT.cassandraVersion.major - 1, 0));
+        ClusterMetadataTestHelper.addEndpoint(2, new NodeVersion(differentCassandraVersion,
+                                                                 NodeVersion.CURRENT_METADATA_VERSION));
+        // With different major versions, we should see this function return true
+        boolean result = AutoRepairUtils.hasMultipleLiveMajorVersions();
+        assertTrue(result);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
@@ -268,7 +268,8 @@ public class SetAutoRepairConfigTest
             forEachRepairType("ignore_dcs", "dc1,dc2", (type) -> verify(probe, times(1)).setAutoRepairIgnoreDCs(type.name(), ImmutableSet.of("dc1", "dc2"))),
             forEachRepairType("token_range_splitter.max_bytes_per_schedule", "500GiB", (type) -> verify(probe, times(1)).setAutoRepairTokenRangeSplitterParameter(type.name(), "max_bytes_per_schedule", "500GiB")),
             forEachRepairType("repair_max_retries", "3", (type) -> verify(probe, times(1)).setAutoRepairMaxRetriesCount(type.name(), 3)),
-            forEachRepairType("repair_retry_backoff", "60s", (type) -> verify(probe, times(1)).setAutoRepairRetryBackoff(type.name(), "60s"))
+            forEachRepairType("repair_retry_backoff", "60s", (type) -> verify(probe, times(1)).setAutoRepairRetryBackoff(type.name(), "60s")),
+            forEachRepairType("mixed_major_version_repair_enabled", "false", (type) -> verify(probe, times(1)).setMixedMajorVersionRepairEnabled(false))
             ).flatMap(Function.identity()).collect(Collectors.toList());
         }
 


### PR DESCRIPTION
Do not allow repair scheduler to run repair if two major versions are detected. This can happen during major version upgrade, and we don't want repair to run since the streaming data for repair can be incompatible across major versions.

Users can override this using a cassandra yaml config if they want to.

Also, this does not affect minor version upgrades, or repair jobs run manually.

https://issues.apache.org/jira/browse/CASSANDRA-20048
https://github.com/apache/cassandra/pull/4304

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

