### PR TITLE
docs: add cqlsh section for setting and verifying consistency

### DIFF
--- a/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
+++ b/doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
@@ -145,6 +145,40 @@ include:
 * `SERIAL`
 * `LOCAL_SERIAL`
 
+=== Set and verify consistency in cqlsh
+
+You can view or change the consistency level that `cqlsh` uses for subsequent statements in the current session.
+
+[source,sql]
+----
+CONSISTENCY;
+----
+
+The command above prints the current consistency level. To set it:
+
+[source,sql]
+----
+CONSISTENCY QUORUM;
+----
+
+You can also set the *serial* consistency level used by conditional updates (LWT):
+
+[source,sql]
+----
+CONSISTENCY SERIAL;
+CONSISTENCY LOCAL_SERIAL;
+----
+
+To restore a simple default:
+
+[source,sql]
+----
+CONSISTENCY ONE;
+----
+
+TIP: Choose read/write levels that meet your application goals. As a rule of thumb, pick levels so that reads and writes overlap (for example, QUORUM reads with QUORUM writes) to ensure acknowledged writes are visible to subsequent reads. See “Picking Consistency Levels” in the Architecture → Dynamo docs for more background.
+
+
 === `SERIAL CONSISTENCY`
 
 `Usage`: `SERIAL CONSISTENCY <consistency level>`


### PR DESCRIPTION
This PR adds a concise, task-focused subsection to the cqlsh docs showing how to:
- Display the current consistency with `CONSISTENCY;`
- Set common levels such as QUORUM/ONE
- Set SERIAL/LOCAL_SERIAL for LWT
- Understand why pairing read/write levels matters (link to Dynamo/consistency guidance)

File: doc/modules/cassandra/pages/managing/tools/cqlsh.adoc
Rationale: cqlsh newcomers often ask how to verify and change session consistency. Putting the examples in one place improves discoverability and complements the existing consistency docs.

