### PR TITLE
drivers.adoc: Replace Rust CQL with Scylla Rust Driver

### DIFF
--- a/doc/modules/cassandra/pages/getting-started/drivers.adoc
+++ b/doc/modules/cassandra/pages/getting-started/drivers.adoc
@@ -60,7 +60,7 @@ connector]
 
 == Rust
 
-* https://github.com/neich/rust-cql[Rust CQL]
+* https://github.com/scylladb/scylla-rust-driver[Scylla Rust Driver]
 
 == Perl
 


### PR DESCRIPTION
Rust CQL did not have any commits in 9 years. It doesn't even support protocol V4, and most of the features that a user could expect from the driver - like load balancing or pagination. No reasonable app would use it in production.

This PR replaces it with Scylla Rust Driver on the page with recommended drivers.
Scylla Rust Driver is actively developed and feature-rich. Even though it is primarily developed for Scylla, we do always make sure it is also compatible with Cassandra and tested with it.


