### PR TITLE
CASSANDRA-20951 - Documentation/Storage Engine - Markdown Render Misformat Fix

### DIFF
--- a/doc/modules/cassandra/pages/architecture/storage-engine.adoc
+++ b/doc/modules/cassandra/pages/architecture/storage-engine.adoc
@@ -18,10 +18,10 @@ The sequence of the steps in the write path:
 [[commit-log]]
 == Logging writes to commit logs
 
-When a write operation takes place, Cassandra records the data in a local append-only https://cassandra.apache.org/_/glossary.html#commit-log[commit log] on disk.
+When a write operation takes place, Cassandra records the data in a local append-only https://cassandra.apache.org/\_/glossary.html#commit-log[commit log] on disk.
 This action provides xref:cassandra:managing/configuration/cass_yaml_file.adoc[configurable durability] by logging every write made to a Cassandra node.
 If an unexpected shutdown occurs, the commit log provides permanent durable writes of the data.
-On startup, any mutations in the commit log will be applied to https://cassandra.apache.org/_/glossary.html#memtable[memtables].
+On startup, any mutations in the commit log will be applied to https://cassandra.apache.org/\_/glossary.html#memtable[memtables].
 The commit log is shared among tables.
 
 All mutations are write-optimized on storage in commit log segments, reducing the number of seeks needed to write to disk. 


### PR DESCRIPTION
patch by Matthias Doepmann; reviewed by TBD for [CASSANDRA-20951](https://issues.apache.org/jira/browse/CASSANDRA-20951)

* Fix formatting on Storage Engine Documentation

<img width="1122" height="340" alt="image" src="https://github.com/user-attachments/assets/dde63e68-e13e-4d6a-83cf-b418f2e71cd5" />
