### PR TITLE
docs: adding async python cassandra driver client to driver docs

### DIFF
--- a/doc/modules/cassandra/pages/getting-started/drivers.adoc
+++ b/doc/modules/cassandra/pages/getting-started/drivers.adoc
@@ -11,6 +11,7 @@ functionality supported by a specific driver.
 == Python
 
 * https://github.com/datastax/python-driver[Datastax Python driver]
+* https://github.com/axonops/async-python-cassandra-client[Async Python Cassandra Client]
 
 == Ruby
 


### PR DESCRIPTION
This PR adds a reference link to the async Python Cassandra driver project in the driver documentation. The goal is to help users discover async solutions for Python when working with Cassandra.

No existing content was modified, only a new link added. Let me know if there are suggestions for clearer placement or better wording.