### PR TITLE
CASSANDRA-20147: Semaphore permit overflow in batch commit mode

### DIFF
--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogService.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogService.java
@@ -203,6 +203,7 @@ public abstract class AbstractCommitLogService
                 if (markerIntervalNanos <= 0)
                 {
                     haveWork.acquire(1);
+                    haveWork.drain();
                 }
                 else
                 {
@@ -213,6 +214,7 @@ public abstract class AbstractCommitLogService
                     long wakeUpAt = pollStarted + markerIntervalNanos;
                     if (wakeUpAt > now)
                         haveWork.tryAcquireUntil(1, wakeUpAt);
+                        haveWork.drain();
                 }
             }
             catch (Throwable t)
@@ -221,6 +223,7 @@ public abstract class AbstractCommitLogService
                     throw new TerminateException();
                 else // sleep for full poll-interval after an error, so we don't spam the log file
                     haveWork.tryAcquire(1, markerIntervalNanos, NANOSECONDS);
+                    haveWork.drain();
             }
         }
 


### PR DESCRIPTION
In Batch commit mode, if multiple writes arrive during a single commitlog flush it will release the haveWork semaphore more times than it's acquired.  If this happens often enough without an idle period, it will eventually overflow (several weeks, in our case). So, every time we acquire() the permit count should be reset to 0. This is similar to how it worked in 3.0, but with more places it's acquired. In theory this leaves a potential race, but only if 2 billion writes arrive within a single commitlog flush interval.
Without this change, I believe the flusher loop would also run without waiting for a while during idle periods after sustained high load.


[junit-timeout] OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
[junit-timeout] Testsuite: org.apache.cassandra.db.commitlog.BatchCommitLogTest-_jdk11
[junit-timeout] Testsuite: org.apache.cassandra.db.commitlog.BatchCommitLogTest-_jdk11 Tests run: 198, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.254 sec

patch by Elliott Sims (elliott@backblaze.com); reviewed by TBD for CASSANDRA-20147

https://issues.apache.org/jira/browse/CASSANDRA-20147
 
