### PR TITLE
CASSANDRA-20982: Restrict BytesType value compatibility to scalar types, exclude collections and UDTs

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,13 @@
+Restrict BytesType compatibility to scalar types only
+
+BytesType.isValueCompatibleWith() previously accepted all types,
+including frozen collections and UDTs. This was incorrect because
+converting collections or UDTs to raw bytes is nonsensical - it
+allows reading raw serialized bytes which have no meaningful
+interpretation.
+
+This patch restricts BytesType to only accept simple scalar types
+by checking !isCollection() && !isUDT() in isValueCompatibleWithInternal().
+
+patch by Dekrate for CASSANDRA-20982
+

--- a/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/schema/AlterTableStatement.java
@@ -362,9 +362,10 @@ public abstract class AlterTableStatement extends AlterSchemaStatement
                 // columns is pushed deeper down the line. The latter would still be problematic in cases of schema races.
                 if (!type.isSerializationCompatibleWith(droppedColumn.type))
                 {
-                    throw ire("Cannot re-add previously dropped column '%s' of type %s, incompatible with previous type %s",
+                    throw ire("Cannot add a column '%s' of type %s, incompatible with previously dropped column '%s' of type %s",
                               name,
                               type.asCQL3Type(),
+                              name,
                               droppedColumn.type.asCQL3Type());
                 }
 

--- a/src/java/org/apache/cassandra/db/marshal/BytesType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BytesType.java
@@ -92,7 +92,7 @@ public class BytesType extends AbstractType<ByteBuffer>
     {
         // BytesType should only be compatible with simple scalar types, not with collections or UDTs
         // because converting a collection or UDT to raw bytes is nonsensical
-        return !otherType.isCollection() && !otherType.isUDT();
+        return !otherType.isMultiCell();
     }
 
     public CQL3Type asCQL3Type()

--- a/src/java/org/apache/cassandra/db/marshal/BytesType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BytesType.java
@@ -90,9 +90,16 @@ public class BytesType extends AbstractType<ByteBuffer>
     @Override
     public boolean isValueCompatibleWithInternal(AbstractType<?> otherType)
     {
+        // BytesType can read anything
+        return true;
+    }
+
+    @Override
+    public boolean isSerializationCompatibleWith(AbstractType<?> previous)
+    {
         // BytesType should only be compatible with simple scalar types, not with collections or UDTs
         // because converting a collection or UDT to raw bytes is nonsensical
-        return !otherType.isMultiCell();
+        return !previous.isCollection() && !previous.isUDT() && super.isSerializationCompatibleWith(previous);
     }
 
     public CQL3Type asCQL3Type()

--- a/src/java/org/apache/cassandra/db/marshal/BytesType.java
+++ b/src/java/org/apache/cassandra/db/marshal/BytesType.java
@@ -90,8 +90,9 @@ public class BytesType extends AbstractType<ByteBuffer>
     @Override
     public boolean isValueCompatibleWithInternal(AbstractType<?> otherType)
     {
-        // BytesType can read anything
-        return true;
+        // BytesType should only be compatible with simple scalar types, not with collections or UDTs
+        // because converting a collection or UDT to raw bytes is nonsensical
+        return !otherType.isCollection() && !otherType.isUDT();
     }
 
     public CQL3Type asCQL3Type()

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -68,7 +68,7 @@ public class AlterTest extends CQLTester
     }
 
     @Test
-    public void testFrozenCollectionsAreCompatibleWithBlob()
+    public void testFrozenCollectionsAreNotCompatibleWithBlob()
     {
         String[] collectionTypes = new String[] {"frozen<map<int, int>>", "frozen<set<int>>", "frozen<list<int>>"};
 
@@ -76,7 +76,8 @@ public class AlterTest extends CQLTester
         {
             createTable("CREATE TABLE %s (a int, b " + type + ", PRIMARY KEY (a));");
             alterTable("ALTER TABLE %s DROP b;");
-            alterTable("ALTER TABLE %s ADD b blob;");
+            assertInvalidMessage("Cannot re-add previously dropped column 'b' of type blob, incompatible with previous type " + type,
+                                 "ALTER TABLE %s ADD b blob;");
         }
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -54,7 +54,7 @@ public class AlterTest extends CQLTester
         {
             createTable("CREATE TABLE %s (a int, b " + type + ", PRIMARY KEY (a));");
             alterTable("ALTER TABLE %s DROP b;");
-            assertInvalidMessage("Cannot re-add previously dropped column 'b' of type blob, incompatible with previous type " + type,
+            assertInvalidMessage("Cannot add a column 'b' of type blob, incompatible with previously dropped column 'b' of type " + type,
                                  "ALTER TABLE %s ADD b blob;");
         }
 
@@ -62,7 +62,7 @@ public class AlterTest extends CQLTester
         {
             createTable("CREATE TABLE %s (a int, b blob, PRIMARY KEY (a));");
             alterTable("ALTER TABLE %s DROP b;");
-            assertInvalidMessage("Cannot re-add previously dropped column 'b' of type " + type + ", incompatible with previous type blob",
+            assertInvalidMessage("Cannot add a column 'b' of type " + type + ", incompatible with previously dropped column 'b' of type blob",
                                  "ALTER TABLE %s ADD b " + type + ';');
         }
     }
@@ -76,7 +76,7 @@ public class AlterTest extends CQLTester
         {
             createTable("CREATE TABLE %s (a int, b " + type + ", PRIMARY KEY (a));");
             alterTable("ALTER TABLE %s DROP b;");
-            assertInvalidMessage("Cannot re-add previously dropped column 'b' of type blob, incompatible with previous type " + type,
+            assertInvalidMessage("Cannot add a column 'b' of type blob, incompatible with previously dropped column 'b' of type " + type,
                                  "ALTER TABLE %s ADD b blob;");
         }
     }

--- a/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/operations/AlterTest.java
@@ -576,8 +576,8 @@ public class AlterTest extends CQLTester
         {
             createTable("create table %s (k int, c int, v " + typePair[0] + ", PRIMARY KEY (k, c))");
             execute("alter table %s drop v");
-            assertInvalidMessage("Cannot re-add previously dropped column 'v' of type "
-                                 + typePair[1] + ", incompatible with previous type " + typePair[0],
+            assertInvalidMessage("Cannot add a column 'v' of type "
+                                 + typePair[1] + ", incompatible with previously dropped column 'v' of type " + typePair[0],
                                  "alter table %s add v " + typePair[1]);
         }
     }

--- a/test/unit/org/apache/cassandra/db/marshal/BytesTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/BytesTypeTest.java
@@ -19,8 +19,15 @@
  */
 package org.apache.cassandra.db.marshal;
 
+import java.util.Arrays;
+
+import org.apache.cassandra.cql3.FieldIdentifier;
 import org.apache.cassandra.serializers.MarshalException;
+import org.apache.cassandra.utils.ByteBufferUtil;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BytesTypeTest
 {
@@ -37,5 +44,69 @@ public class BytesTypeTest
     public void testFromStringWithValidString()
     {
         BytesType.instance.fromString(VALID_HEX);
+    }
+
+    @Test
+    public void testValueCompatibilityWithScalarTypes()
+    {
+        // BytesType should be compatible with simple scalar types
+        assertTrue("BytesType should be compatible with AsciiType",
+                   BytesType.instance.isValueCompatibleWith(AsciiType.instance));
+        assertTrue("BytesType should be compatible with UTF8Type",
+                   BytesType.instance.isValueCompatibleWith(UTF8Type.instance));
+        assertTrue("BytesType should be compatible with Int32Type",
+                   BytesType.instance.isValueCompatibleWith(Int32Type.instance));
+        assertTrue("BytesType should be compatible with LongType",
+                   BytesType.instance.isValueCompatibleWith(LongType.instance));
+        assertTrue("BytesType should be compatible with UUIDType",
+                   BytesType.instance.isValueCompatibleWith(UUIDType.instance));
+        assertTrue("BytesType should be compatible with BooleanType",
+                   BytesType.instance.isValueCompatibleWith(BooleanType.instance));
+        assertTrue("BytesType should be compatible with itself",
+                   BytesType.instance.isValueCompatibleWith(BytesType.instance));
+    }
+
+    @Test
+    public void testValueIncompatibilityWithCollections()
+    {
+        // BytesType should NOT be compatible with collections (even frozen ones)
+        // because converting a collection to raw bytes is nonsensical
+        ListType<?> frozenList = ListType.getInstance(Int32Type.instance, false);
+        SetType<?> frozenSet = SetType.getInstance(Int32Type.instance, false);
+        MapType<?, ?> frozenMap = MapType.getInstance(Int32Type.instance, UTF8Type.instance, false);
+
+        assertFalse("BytesType should NOT be compatible with frozen<list>",
+                    BytesType.instance.isValueCompatibleWith(frozenList));
+        assertFalse("BytesType should NOT be compatible with frozen<set>",
+                    BytesType.instance.isValueCompatibleWith(frozenSet));
+        assertFalse("BytesType should NOT be compatible with frozen<map>",
+                    BytesType.instance.isValueCompatibleWith(frozenMap));
+
+        // Also test with multi-cell collections
+        ListType<?> multiCellList = ListType.getInstance(Int32Type.instance, true);
+        SetType<?> multiCellSet = SetType.getInstance(Int32Type.instance, true);
+        MapType<?, ?> multiCellMap = MapType.getInstance(Int32Type.instance, UTF8Type.instance, true);
+
+        assertFalse("BytesType should NOT be compatible with list",
+                    BytesType.instance.isValueCompatibleWith(multiCellList));
+        assertFalse("BytesType should NOT be compatible with set",
+                    BytesType.instance.isValueCompatibleWith(multiCellSet));
+        assertFalse("BytesType should NOT be compatible with map",
+                    BytesType.instance.isValueCompatibleWith(multiCellMap));
+    }
+
+    @Test
+    public void testValueIncompatibilityWithUDT()
+    {
+        // BytesType should NOT be compatible with User Defined Types
+        // because converting a UDT to raw bytes is nonsensical
+        UserType udt = new UserType("ks",
+                                     ByteBufferUtil.bytes("myType"),
+                                     Arrays.asList(FieldIdentifier.forQuoted("field1"), FieldIdentifier.forQuoted("field2")),
+                                     Arrays.asList(Int32Type.instance, UTF8Type.instance),
+                                     true);
+
+        assertFalse("BytesType should NOT be compatible with UDT",
+                    BytesType.instance.isValueCompatibleWith(udt));
     }
 }

--- a/test/unit/org/apache/cassandra/db/marshal/BytesTypeTest.java
+++ b/test/unit/org/apache/cassandra/db/marshal/BytesTypeTest.java
@@ -49,64 +49,64 @@ public class BytesTypeTest
     @Test
     public void testValueCompatibilityWithScalarTypes()
     {
-        // BytesType should be compatible with simple scalar types
-        assertTrue("BytesType should be compatible with AsciiType",
+        // BytesType should be value-compatible with simple scalar types
+        assertTrue("BytesType should be value-compatible with AsciiType",
                    BytesType.instance.isValueCompatibleWith(AsciiType.instance));
-        assertTrue("BytesType should be compatible with UTF8Type",
+        assertTrue("BytesType should be value-compatible with UTF8Type",
                    BytesType.instance.isValueCompatibleWith(UTF8Type.instance));
-        assertTrue("BytesType should be compatible with Int32Type",
+        assertTrue("BytesType should be value-compatible with Int32Type",
                    BytesType.instance.isValueCompatibleWith(Int32Type.instance));
-        assertTrue("BytesType should be compatible with LongType",
+        assertTrue("BytesType should be value-compatible with LongType",
                    BytesType.instance.isValueCompatibleWith(LongType.instance));
-        assertTrue("BytesType should be compatible with UUIDType",
+        assertTrue("BytesType should be value-compatible with UUIDType",
                    BytesType.instance.isValueCompatibleWith(UUIDType.instance));
-        assertTrue("BytesType should be compatible with BooleanType",
+        assertTrue("BytesType should be value-compatible with BooleanType",
                    BytesType.instance.isValueCompatibleWith(BooleanType.instance));
-        assertTrue("BytesType should be compatible with itself",
+        assertTrue("BytesType should be value-compatible with itself",
                    BytesType.instance.isValueCompatibleWith(BytesType.instance));
     }
 
     @Test
-    public void testValueIncompatibilityWithCollections()
+    public void testSerializationIncompatibilityWithCollections()
     {
-        // BytesType should NOT be compatible with collections (even frozen ones)
-        // because converting a collection to raw bytes is nonsensical
+        // BytesType should NOT be serialization-compatible with collections (even frozen ones)
+        // because converting a collection to raw bytes for schema changes is nonsensical
         ListType<?> frozenList = ListType.getInstance(Int32Type.instance, false);
         SetType<?> frozenSet = SetType.getInstance(Int32Type.instance, false);
         MapType<?, ?> frozenMap = MapType.getInstance(Int32Type.instance, UTF8Type.instance, false);
 
-        assertFalse("BytesType should NOT be compatible with frozen<list>",
-                    BytesType.instance.isValueCompatibleWith(frozenList));
-        assertFalse("BytesType should NOT be compatible with frozen<set>",
-                    BytesType.instance.isValueCompatibleWith(frozenSet));
-        assertFalse("BytesType should NOT be compatible with frozen<map>",
-                    BytesType.instance.isValueCompatibleWith(frozenMap));
+        assertFalse("BytesType should NOT be serialization-compatible with frozen<list>",
+                    BytesType.instance.isSerializationCompatibleWith(frozenList));
+        assertFalse("BytesType should NOT be serialization-compatible with frozen<set>",
+                    BytesType.instance.isSerializationCompatibleWith(frozenSet));
+        assertFalse("BytesType should NOT be serialization-compatible with frozen<map>",
+                    BytesType.instance.isSerializationCompatibleWith(frozenMap));
 
         // Also test with multi-cell collections
         ListType<?> multiCellList = ListType.getInstance(Int32Type.instance, true);
         SetType<?> multiCellSet = SetType.getInstance(Int32Type.instance, true);
         MapType<?, ?> multiCellMap = MapType.getInstance(Int32Type.instance, UTF8Type.instance, true);
 
-        assertFalse("BytesType should NOT be compatible with list",
-                    BytesType.instance.isValueCompatibleWith(multiCellList));
-        assertFalse("BytesType should NOT be compatible with set",
-                    BytesType.instance.isValueCompatibleWith(multiCellSet));
-        assertFalse("BytesType should NOT be compatible with map",
-                    BytesType.instance.isValueCompatibleWith(multiCellMap));
+        assertFalse("BytesType should NOT be serialization-compatible with list",
+                    BytesType.instance.isSerializationCompatibleWith(multiCellList));
+        assertFalse("BytesType should NOT be serialization-compatible with set",
+                    BytesType.instance.isSerializationCompatibleWith(multiCellSet));
+        assertFalse("BytesType should NOT be serialization-compatible with map",
+                    BytesType.instance.isSerializationCompatibleWith(multiCellMap));
     }
 
     @Test
-    public void testValueIncompatibilityWithUDT()
+    public void testSerializationIncompatibilityWithUDT()
     {
-        // BytesType should NOT be compatible with User Defined Types
-        // because converting a UDT to raw bytes is nonsensical
+        // BytesType should NOT be serialization-compatible with User Defined Types
+        // because converting a UDT to raw bytes for schema changes is nonsensical
         UserType udt = new UserType("ks",
                                      ByteBufferUtil.bytes("myType"),
                                      Arrays.asList(FieldIdentifier.forQuoted("field1"), FieldIdentifier.forQuoted("field2")),
                                      Arrays.asList(Int32Type.instance, UTF8Type.instance),
                                      true);
 
-        assertFalse("BytesType should NOT be compatible with UDT",
-                    BytesType.instance.isValueCompatibleWith(udt));
+        assertFalse("BytesType should NOT be serialization-compatible with UDT",
+                    BytesType.instance.isSerializationCompatibleWith(udt));
     }
 }


### PR DESCRIPTION
Restrict BytesType compatibility to scalar types only

BytesType.isValueCompatibleWith() previously accepted all types,
including frozen collections and UDTs. This was incorrect because
converting collections or UDTs to raw bytes is nonsensical - it
allows reading raw serialized bytes which have no meaningful
interpretation.

This patch restricts BytesType to only accept simple scalar types
by checking !isCollection() && !isUDT() in isValueCompatibleWithInternal().

@driftx <- it was your task, I was happy to help!
