### PR TITLE
Fix Eclipse Code Analysis error which got added as part of CASSANDRA-19564 commit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.1.12
+ * Fix Eclipse Code Analysis error which got added as part of CASSANDRA-19564 commit (CASSANDRA-19564)
  * ReadCommandController should close fast to avoid deadlock when building secondary index (CASSANDRA-19564)
 Merged from 4.0
  * Updated dtest-api to 0.0.18 and removed JMX-related classes that now live in the dtest-api (CASSANDRA-20884)

--- a/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
+++ b/src/java/org/apache/cassandra/index/SecondaryIndexManager.java
@@ -919,6 +919,7 @@ public class SecondaryIndexManager implements IndexRegistry, INotificationConsum
             SinglePartitionPager pager = new SinglePartitionPager(cmd, null, ProtocolVersion.CURRENT);
             while (!pager.isExhausted())
             {
+                @SuppressWarnings("resource")
                 UnfilteredRowIterator partition;
                 try (ReadExecutionController controller = cmd.executionController();
                      UnfilteredPartitionIterator page = pager.fetchPageUnfiltered(baseCfs.metadata(), pageSize, controller))


### PR DESCRIPTION
1. I helped commit an original 4.1 patch https://github.com/apache/cassandra/commit/59574a86a3a829d904ce3964e36ec71f5b62b961
2. But that commit generated a CI error. https://ci-cassandra.apache.org/job/Cassandra-4.1-artifacts/728/jdk=jdk_1.8_latest,label=cassandra/console 
```
00:53:47      [java] ----------
00:53:47      [java] 1. ERROR in /home/jenkins/jenkins-slave/workspace/Cassandra-4.1-artifacts/jdk/jdk_1.8_latest/label/cassandra/src/java/org/apache/cassandra/index/SecondaryIndexManager.java (at line 931)
00:53:47      [java] 	partition = ImmutableBTreePartition.create(onePartition).unfilteredIterator();
00:53:47      [java] 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
00:53:47      [java] Resource 'partition' should be managed by try-with-resource
```
3. This PR addresses the error
 
The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-19564)

