### PR TITLE
CASSANDRA-20914: document new table name length limit (4.0)

### DIFF
--- a/doc/modules/cassandra/pages/cql/ddl.adoc
+++ b/doc/modules/cassandra/pages/cql/ddl.adoc
@@ -22,8 +22,10 @@ include::example$BNF/ks_table.bnf[]
 ----
 
 Both keyspace and table name should be comprised of only alphanumeric
-characters, cannot be empty and are limited in size to 48 characters
-(that limit exists mostly to avoid filenames (which may include the
+or underscore characters and cannot be empty. 
+Keyspace name is limited in size to 48 characters, while
+table name is limited in size to 222 characters
+(those limits exist mostly to avoid filenames (which may include the
 keyspace and table name) to go over the limits of certain file systems).
 By default, keyspace and table names are case-insensitive (`myTable` is
 equivalent to `mytable`) but case sensitivity can be forced by using

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -40,6 +40,7 @@ import static org.apache.cassandra.schema.SchemaConstants.NAME_LENGTH;
 import static org.apache.cassandra.schema.SchemaConstants.TABLE_NAME_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -169,6 +170,9 @@ public class CreateTableValidationTest extends CQLTester
         String keyspaceName = StringUtils.repeat("k", NAME_LENGTH);
         String tableName = StringUtils.repeat("t", FILENAME_LENGTH - tableIdSuffix);
         String tooLongTableName = StringUtils.repeat("l", FILENAME_LENGTH - tableIdSuffix + 1);
+
+        // Assert that the documented value of 222 corresponds to the actual constant.
+        assertEquals(222, TABLE_NAME_LENGTH);
 
         execute(String.format("CREATE KEYSPACE %s with replication = " +
                               "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",


### PR DESCRIPTION
CASSANDRA-20389 (6c29686ea7d1a6ca2d9f9723c7fed7aac940a6ed) implemented limit on table name length of 222 characters. This commit updates the documentation to reflect this.

It also adds an assert in CreateTableValidationTest to ensure that the documented limit matches the actual constant.

patch by Ruslan Fomkin; reviewed by Dmitry Konstantinov and Brad Schoening for CASSANDRA-20914
