### PR TITLE
CASSANDRA-20914: document new table name length limit

### DIFF
--- a/doc/modules/cassandra/pages/developing/cql/ddl.adoc
+++ b/doc/modules/cassandra/pages/developing/cql/ddl.adoc
@@ -23,8 +23,10 @@ include::cassandra:example$BNF/ks_table.bnf[]
 ----
 
 Both keyspace and table name should be comprised of only alphanumeric
-characters, cannot be empty and are limited in size to 48 characters
-(that limit exists mostly to avoid filenames (which may include the
+or underscore characters and cannot be empty. 
+Keyspace name is limited in size to 48 characters, while
+table name is limited in size to 222 characters
+(those limits exist mostly to avoid filenames (which may include the
 keyspace and table name) to go over the limits of certain file systems).
 By default, keyspace and table names are case-insensitive (`myTable` is
 equivalent to `mytable`) but case sensitivity can be forced by using

--- a/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
+++ b/test/unit/org/apache/cassandra/schema/CreateTableValidationTest.java
@@ -103,6 +103,9 @@ public class CreateTableValidationTest extends CQLTester
         String tableName = "t".repeat(FILENAME_LENGTH - tableIdSuffix);
         String tooLongTableName = "l".repeat(FILENAME_LENGTH - tableIdSuffix + 1);
 
+        // Assert that the documented value of 222 corresponds to the actual constant.
+        assertThat(TABLE_NAME_LENGTH).isEqualTo(222);
+
         execute(String.format("CREATE KEYSPACE %s with replication = " +
                               "{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }",
                               keyspaceName));


### PR DESCRIPTION
CASSANDRA-20389 implemented limit on table name length of 222 characters. This commit updates the documentation to reflect this.

It also adds an assert in CreateTableValidationTest to ensure that the documented limit matches the actual constant.

patch by Ruslan Fomkin; reviewed by Dmitry Konstantinov and Brad Schoening for CASSANDRA-20914