### PR TITLE
CASSANDRA-20996 Use LWTs for all auto-repair history mutations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Use LWTs for all auto-repair history mutations (CASSANDRA-20996)
  * Change the eager reference counting of compression dictionaries to lazy (CASSANDRA-21074)
  * Add cursor based optimized compaction path (CASSANDRA-20918)
  * Ensure peers with LEFT status are expired from gossip state (CASSANDRA-21035)

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -133,10 +133,10 @@ public class AutoRepairUtils
     "SELECT * FROM %s.%s WHERE %s = ?", SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
     SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY, COL_REPAIR_TYPE);
     final static String DEL_REPAIR_PRIORITY = String.format(
-    "DELETE %s[?] FROM %s.%s WHERE %s = ? IF EXISTS", COL_REPAIR_PRIORITY, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
+    "DELETE %s[?] FROM %s.%s WHERE %s = ?", COL_REPAIR_PRIORITY, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
     SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY, COL_REPAIR_TYPE);
     final static String ADD_PRIORITY_HOST = String.format(
-    "UPDATE %s.%s SET %s = %s + ?  WHERE %s = ? IF EXISTS", SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
+    "UPDATE %s.%s SET %s = %s + ?  WHERE %s = ?", SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
     SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY, COL_REPAIR_PRIORITY, COL_REPAIR_PRIORITY, COL_REPAIR_TYPE);
 
     final static String INSERT_NEW_REPAIR_HISTORY = String.format(

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -133,10 +133,10 @@ public class AutoRepairUtils
     "SELECT * FROM %s.%s WHERE %s = ?", SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
     SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY, COL_REPAIR_TYPE);
     final static String DEL_REPAIR_PRIORITY = String.format(
-    "DELETE %s[?] FROM %s.%s WHERE %s = ?", COL_REPAIR_PRIORITY, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
+    "DELETE %s[?] FROM %s.%s WHERE %s = ? IF EXISTS", COL_REPAIR_PRIORITY, SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
     SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY, COL_REPAIR_TYPE);
     final static String ADD_PRIORITY_HOST = String.format(
-    "UPDATE %s.%s SET %s = %s + ?  WHERE %s = ?", SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
+    "UPDATE %s.%s SET %s = %s + ?  WHERE %s = ? IF EXISTS", SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
     SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY, COL_REPAIR_PRIORITY, COL_REPAIR_PRIORITY, COL_REPAIR_TYPE);
 
     final static String INSERT_NEW_REPAIR_HISTORY = String.format(
@@ -150,27 +150,27 @@ public class AutoRepairUtils
     COL_DELETE_HOSTS, COL_DELETE_HOSTS_UPDATE_TIME, COL_REPAIR_TYPE, COL_HOST_ID);
 
     final static String DEL_AUTO_REPAIR_HISTORY = String.format(
-    "DELETE FROM %s.%s WHERE %s = ? AND %s = ?"
+    "DELETE FROM %s.%s WHERE %s = ? AND %s = ? IF EXISTS"
     , SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY, COL_REPAIR_TYPE,
     COL_HOST_ID);
 
     final static String RECORD_START_REPAIR_HISTORY = String.format(
-    "UPDATE %s.%s SET %s= ?, repair_turn = ? WHERE %s = ? AND %s = ?"
+    "UPDATE %s.%s SET %s= ?, repair_turn = ? WHERE %s = ? AND %s = ? IF EXISTS"
     , SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY, COL_REPAIR_START_TS,
     COL_REPAIR_TYPE, COL_HOST_ID);
 
     final static String RECORD_FINISH_REPAIR_HISTORY = String.format(
-    "UPDATE %s.%s SET %s= ?, %s=false WHERE %s = ? AND %s = ?"
+    "UPDATE %s.%s SET %s= ?, %s=false WHERE %s = ? AND %s = ? IF EXISTS"
     , SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY, COL_REPAIR_FINISH_TS,
     COL_FORCE_REPAIR, COL_REPAIR_TYPE, COL_HOST_ID);
 
     final static String CLEAR_DELETE_HOSTS = String.format(
-    "UPDATE %s.%s SET %s= {} WHERE %s = ? AND %s = ?"
+    "UPDATE %s.%s SET %s= {} WHERE %s = ? AND %s = ? IF EXISTS"
     , SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY, COL_DELETE_HOSTS,
     COL_REPAIR_TYPE, COL_HOST_ID);
 
     final static String SET_FORCE_REPAIR = String.format(
-    "UPDATE %s.%s SET %s=true  WHERE %s = ? AND %s = ?"
+    "UPDATE %s.%s SET %s=true  WHERE %s = ? AND %s = ? IF EXISTS"
     , SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY, COL_FORCE_REPAIR,
     COL_REPAIR_TYPE, COL_HOST_ID);
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -567,9 +567,9 @@ public class AutoRepairUtilsTest extends CQLTester
         // 2. Then, a vote to delete arrives after the row has already been deleted
         AutoRepairUtils.addHostIdToDeleteHosts(repairType, votingNode, nodeToDelete);
 
-        // 3. This should not happen under normal circumstances but let's also simulate another node trying to clear
-        // the delete hosts list for the deleted node
+        // 3. Simulate other operations that can be called by other nodes in the cluster for the deleted node
         AutoRepairUtils.clearDeleteHosts(repairType, nodeToDelete);
+        AutoRepairUtils.setForceRepair(repairType, nodeToDelete);
         
         // Verify that the row is still deleted despite the out-of-order operations
         UntypedResultSet afterRace = QueryProcessor.executeInternal(String.format(

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -538,4 +538,42 @@ public class AutoRepairUtilsTest extends CQLTester
     {
         assertFalse(AutoRepairUtils.shouldConsiderKeyspace(Keyspace.open(SchemaConstants.TRACE_KEYSPACE_NAME)));
     }
+
+    @Test
+    public void testAutoRepairHistoryOutOfOrderDeleteRaceCondition()
+    {
+        // Setup: Create a node that will be deleted
+        UUID nodeToDelete = UUID.randomUUID();
+        UUID votingNode = UUID.randomUUID();
+        
+        // Insert an initial row for the node to be deleted
+        QueryProcessor.executeInternal(String.format(
+        "INSERT INTO %s.%s (repair_type, host_id, repair_start_ts, repair_finish_ts) VALUES ('%s', %s, 100, 200)",
+        SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY,
+        repairType, nodeToDelete));
+        
+        // Verify the row exists
+        UntypedResultSet beforeDelete = QueryProcessor.executeInternal(String.format(
+        "SELECT * FROM %s.%s WHERE repair_type = '%s' AND host_id = %s",
+        SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY,
+        repairType, nodeToDelete));
+        assertNotNull(beforeDelete);
+        assertEquals(1, beforeDelete.size());
+        
+        // Simulate the race condition:
+        // 1. First, the delete is executed (this should create a tombstone)
+        AutoRepairUtils.deleteAutoRepairHistory(repairType, nodeToDelete);
+        
+        // 2. Then, a vote to delete arrives after the row has already been deleted
+        AutoRepairUtils.addHostIdToDeleteHosts(repairType, votingNode, nodeToDelete);
+        
+        // Verify that the row is still deleted despite the out-of-order vote
+        UntypedResultSet afterRace = QueryProcessor.executeInternal(String.format(
+        "SELECT * FROM %s.%s WHERE repair_type = '%s' AND host_id = %s",
+        SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY,
+        repairType, nodeToDelete));
+        assertNotNull(afterRace);
+        // The row should not exist - the delete should win despite the vote arriving later
+        assertEquals("Row should remain deleted despite out-of-order vote", 0, afterRace.size());
+    }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -566,8 +566,12 @@ public class AutoRepairUtilsTest extends CQLTester
         
         // 2. Then, a vote to delete arrives after the row has already been deleted
         AutoRepairUtils.addHostIdToDeleteHosts(repairType, votingNode, nodeToDelete);
+
+        // 3. This should not happen under normal circumstances but let's also simulate another node trying to clear
+        // the delete hosts list for the deleted node
+        AutoRepairUtils.clearDeleteHosts(repairType, nodeToDelete);
         
-        // Verify that the row is still deleted despite the out-of-order vote
+        // Verify that the row is still deleted despite the out-of-order operations
         UntypedResultSet afterRace = QueryProcessor.executeInternal(String.format(
         "SELECT * FROM %s.%s WHERE repair_type = '%s' AND host_id = %s",
         SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY,

--- a/test/unit/org/apache/cassandra/service/AutoRepairServiceSetterTest.java
+++ b/test/unit/org/apache/cassandra/service/AutoRepairServiceSetterTest.java
@@ -132,6 +132,10 @@ public class AutoRepairServiceSetterTest<T> extends CQLTester
         QueryProcessor.executeInternal(String.format(
         "TRUNCATE %s.%s",
         SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY));
+        QueryProcessor.executeInternal(String.format(
+        "INSERT INTO %s.%s (host_id, repair_type) VALUES (%s, '%s')",
+        SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY,
+        StorageService.instance.getHostIdForEndpoint(InetAddressAndPort.getLocalHost()), repairTypeStr));
     }
 
     @Test


### PR DESCRIPTION
For issue https://issues.apache.org/jira/browse/CASSANDRA-20996

The auto-repair history management mechanism does not use LWTs for all of its history table queries. As a result, it is possible to run into a few edge cases where a deleted node's repair history gets resurrected. For example:
This can lead to the following race condition:
1. Node A sends out a query to vote for Node D to be removed from auto-repair history
2. Whereas node B sends out a query clear the node D's delete hosts list (or to set force repair to true for node D)
3. Node A's vote is carried out, it is now present in the auto-repair history table
4. Node C sees that enough nodes have voted to remove Node D and sends out a query to delete the auto-repair history for Node D.
5. The delete query is executed, a tombstone is inserted for Node D's auto-repair history
6. Finally, Node B's query to modify Node D's entry in the repair history is carried out, this mutation has a higher timestamp than the tombstone inserted by Node C. As a result, Node D's auto-repair history gets resurrected.

This PR introduces a unit test to simulate these out-of-order deletions/upserts and updates the auto-repair history mutations to use LWTs in order to prevent the race conditions from happening.

