### PR TITLE
doc(managing): Add snitch to operating module index

### DIFF
--- a/doc/modules/cassandra/pages/managing/operating/index.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/index.adoc
@@ -15,6 +15,7 @@
 * xref:cassandra:managing/operating/repair.adoc[Repair]
 * xref:cassandra:managing/operating/read_repair.adoc[Read repair]
 * xref:cassandra:managing/operating/security.adoc[Security]
+* xref:cassandra:managing/operating/snitch.adoc[Snitches]
 * xref:cassandra:managing/operating/topo_changes.adoc[Topology changes]
 * xref:cassandra:managing/operating/transientreplication.adoc[Transient replication]
 * xref:cassandra:managing/operating/virtualtables.adoc[Virtual tables]


### PR DESCRIPTION
## Description

This PR adds the missing Snitches reference to the Operating Cassandra module index.

## Changes

* Add `Snitches` to the operating module index in alphabetical order

## Motivation

Snitches determine datacenter and rack placement, which is an operational concern.
The snitch.adoc file exists but is not referenced in the operating/index.adoc file.

## Files Changed

- `doc/modules/cassandra/pages/managing/operating/index.adoc`

## Checklist

- [x] I have updated documentation accordingly
- [x] I have followed Cassandra's contributor guidelines
