### PR TITLE
Fix typo in NoOpAuditLogger description

### DIFF
--- a/doc/modules/cassandra/pages/managing/operating/auditlogging.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/auditlogging.adoc
@@ -157,7 +157,7 @@ Supported values are:
 
 `BinAuditLogger` logs events to a file in binary format.
 `FileAuditLogger` uses the standard logging mechanism, `slf4j` to log events to the `audit/audit.log` file. It is a synchronous, file-based audit logger. The roll_cycle will be set in the `logback.xml` file.
-`NoOpAuditLogger` is a no-op implementation of the audit logger that shoudl be specified when audit logging is disabled.
+`NoOpAuditLogger` is a no-op implementation of the audit logger that should be specified when audit logging is disabled.
 
 For example:
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the audit logger documentation where "should" was incorrectly written as "shoudl".

## Changes

- Corrected spelling of "should" in the logger section of auditlogging.adoc.

## Motivation

Proper spelling and grammar improve documentation quality and readability.

## Files Changed

- `doc/modules/cassandra/pages/managing/operating/auditlogging.adoc`
