### PR TITLE
CASSANDRA-20820 Include Level information for UnifiedCompactionStrategy in nodetool tablestats output

### DIFF
--- a/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -2995,6 +2995,42 @@ public class ColumnFamilyStore implements ColumnFamilyStoreMBean, Memtable.Owner
     }
 
     @Override
+    public double[] getPerLevelAvgTokenSpace()
+    {
+        return compactionStrategyManager.getPerLevelAvgTokenSpace();
+    }
+
+    @Override
+    public double[] getPerLevelMaxDensityThreshold()
+    {
+        return compactionStrategyManager.getPerLevelMaxDensityThreshold();
+    }
+
+    @Override
+    public double[] getPerLevelAvgSize()
+    {
+        return compactionStrategyManager.getPerLevelAvgSize();
+    }
+
+    @Override
+    public double[] getPerLevelAvgDensity()
+    {
+        return compactionStrategyManager.getPerLevelAvgDensity();
+    }
+
+    @Override
+    public double[] getPerLevelAvgDensityMaxDensityThresholdRatio()
+    {
+        return compactionStrategyManager.getPerLevelAvgDensityMaxDensityThresholdRatio();
+    }
+
+    @Override
+    public double[] getPerLevelMaxDensityMaxDensityThresholdRatio()
+    {
+        return compactionStrategyManager.getPerLevelMaxDensityMaxDensityThresholdRatio();
+    }
+
+    @Override
     public boolean isLeveledCompaction()
     {
         return compactionStrategyManager.isLeveledCompaction();

--- a/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
+++ b/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
@@ -278,6 +278,48 @@ public interface ColumnFamilyStoreMBean
     public long[] getPerLevelSizeBytes();
 
     /**
+     * @return average of sstable covered token spaces in each level.
+     *         null unless unified compaction strategy is used.
+     *         array index corresponds to level(int[0] is for level 0, ...).
+     */
+    public double[] getPerLevelAvgTokenSpace();
+
+    /**
+     * @return the maximum density each level is allowed to hold.
+     *         null unless unified compaction strategy is used.
+     *         array index corresponds to level(int[0] is for level 0, ...).
+     */
+    public double[] getPerLevelMaxDensityThreshold();
+
+    /**
+     * @return the average size of sstables in each level.
+     *         null unless unified compaction strategy is used.
+     *         array index corresponds to level(int[0] is for level 0, ...).
+     */
+    public double[] getPerLevelAvgSize();
+
+    /**
+     * @return the average density of sstables in each level.
+     *         null unless unified compaction strategy is used.
+     *         array index corresponds to level(int[0] is for level 0, ...).
+     */
+    public double[] getPerLevelAvgDensity();
+
+    /**
+     * @return the ratio of avg density to the maximum density threshold of that level
+     *         in each level. null unless unified compaction strategy is used.
+     *         array index corresponds to level(int[0] is for level 0, ...).
+     */
+    public double[] getPerLevelAvgDensityMaxDensityThresholdRatio();
+
+    /**
+     * @return the ratio of maximum density to the maximum density threshold of that level
+     *         in each level. null unless unified compaction strategy is used.
+     *         array index corresponds to level(int[0] is for level 0, ...).
+     */
+    public double[] getPerLevelMaxDensityMaxDensityThresholdRatio();
+
+    /**
      * @return true if the table is using LeveledCompactionStrategy. false otherwise.
      */
     public boolean isLeveledCompaction();

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -700,7 +700,7 @@ public class CompactionStrategyManager implements INotificationConsumer
                     data.sum[data.levelIndex] += data.sstable.tokenSpaceCoverage();
                     data.count[data.levelIndex]++;
                 },
-                CompactionStrategyManager::averageFinalizer
+                CompactionStrategyManager::averageArrayFinalizer
         );
     }
 
@@ -721,7 +721,7 @@ public class CompactionStrategyManager implements INotificationConsumer
                     data.sum[data.levelIndex] += data.sstable.onDiskLength();
                     data.count[data.levelIndex]++;
                 },
-                CompactionStrategyManager::averageFinalizer
+                CompactionStrategyManager::averageArrayFinalizer
         );
     }
 
@@ -732,7 +732,7 @@ public class CompactionStrategyManager implements INotificationConsumer
                     data.sum[data.levelIndex] += data.strategy.getDensity(data.sstable);
                     data.count[data.levelIndex]++;
                 },
-                CompactionStrategyManager::averageFinalizer
+                CompactionStrategyManager::averageArrayFinalizer
         );
     }
 
@@ -837,7 +837,7 @@ public class CompactionStrategyManager implements INotificationConsumer
     }
 
     @VisibleForTesting
-    static double[] averageFinalizer(CompactionStatsMetricsData data)
+    static double[] averageArrayFinalizer(CompactionStatsMetricsData data)
     {
         double[] res = new double[data.numberOfLevels];
         for (int i = 0; i < data.numberOfLevels; i++)

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -776,7 +776,8 @@ public class CompactionStrategyManager implements INotificationConsumer
      * Data class for accumulating UCS metrics computation state.
      * Holds intermediate values during metric calculation across all strategies and levels.
      */
-    private static class CompactionStatsMetricsData
+    @VisibleForTesting
+    static class CompactionStatsMetricsData
     {
         final double[] sum = new double[UnifiedCompactionStrategy.MAX_LEVELS];
         final int[] count = new int[UnifiedCompactionStrategy.MAX_LEVELS];
@@ -835,7 +836,8 @@ public class CompactionStrategyManager implements INotificationConsumer
         }
     }
 
-    private static double[] averageFinalizer(CompactionStatsMetricsData data)
+    @VisibleForTesting
+    static double[] averageFinalizer(CompactionStatsMetricsData data)
     {
         double[] res = new double[data.numberOfLevels];
         for (int i = 0; i < data.numberOfLevels; i++)
@@ -843,12 +845,14 @@ public class CompactionStrategyManager implements INotificationConsumer
         return res;
     }
 
-    private static double[] maxArrayFinalizer(CompactionStatsMetricsData data)
+    @VisibleForTesting
+    static double[] maxArrayFinalizer(CompactionStatsMetricsData data)
     {
         return Arrays.copyOf(data.max, data.numberOfLevels);
     }
 
-    private static double[] ratioArrayFinalizer(CompactionStatsMetricsData data) {
+    @VisibleForTesting
+    static double[] ratioArrayFinalizer(CompactionStatsMetricsData data) {
         double[] res = new double[data.numberOfLevels];
         for (int i = 0; i < data.numberOfLevels; i++)
             res[i] = data.sum[i] / data.max[i];

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -32,7 +32,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -81,7 +82,6 @@ import org.apache.cassandra.repair.consistent.admin.CleanupSummary;
 import org.apache.cassandra.schema.CompactionParams;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.TimeUUID;
-import org.apache.cassandra.utils.TriFunction;
 import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.Level;
 
 import static org.apache.cassandra.db.compaction.AbstractStrategyHolder.GroupedSSTableContainer;
@@ -695,90 +695,69 @@ public class CompactionStrategyManager implements INotificationConsumer
 
     public double[] getPerLevelAvgTokenSpace()
     {
-        return avgUCSHelper((ucs, sstable) ->
-                sstable.tokenSpaceCoverage());
+        return computeUCSMetric(
+                data -> {
+                    data.sum[data.levelIndex] += data.sstable.tokenSpaceCoverage();
+                    data.count[data.levelIndex]++;
+                },
+                CompactionStrategyManager::averageFinalizer
+        );
     }
 
     public double[] getPerLevelMaxDensityThreshold()
     {
-        return perLevelUCSHelper((level, sstable, acc) -> Math.max(acc, level.max));
+        return computeUCSMetric(
+                data -> {
+                    data.max[data.levelIndex] = Math.max(data.max[data.levelIndex], data.level.max);
+                },
+                CompactionStrategyManager::maxArrayFinalizer
+        );
     }
 
     public double[] getPerLevelAvgSize()
     {
-        return avgUCSHelper((ucs, sstable) -> (double) sstable.onDiskLength());
+        return computeUCSMetric(
+                data -> {
+                    data.sum[data.levelIndex] += data.sstable.onDiskLength();
+                    data.count[data.levelIndex]++;
+                },
+                CompactionStrategyManager::averageFinalizer
+        );
     }
 
     public double[] getPerLevelAvgDensity()
     {
-        return avgUCSHelper(UnifiedCompactionStrategy::getDensity);
+        return computeUCSMetric(
+                data -> {
+                    data.sum[data.levelIndex] += data.strategy.getDensity(data.sstable);
+                    data.count[data.levelIndex]++;
+                },
+                CompactionStrategyManager::averageFinalizer
+        );
     }
 
     public double[] getPerLevelAvgDensityMaxDensityThresholdRatio()
     {
-        readLock.lock();
-        try
-        {
-            if (repaired.first() instanceof UnifiedCompactionStrategy)
-            {
-                double[] avgDensityPerLevel = getPerLevelAvgDensity();
-                double[] maxDensityThresholdPerLevel = getPerLevelMaxDensityThreshold();
-
-                double[] res = new double[avgDensityPerLevel.length];
-
-                for (int i = 0; i < avgDensityPerLevel.length; i++)
-                {
-                    res[i] = avgDensityPerLevel[i] / maxDensityThresholdPerLevel[i];
-                }
-
-                return res;
-            }
+        double[] avgDensity = getPerLevelAvgDensity();
+        if (avgDensity == null)
             return null;
-        }
-        finally
-        {
-            readLock.unlock();
-        }
+
+        double[] maxThreshold = getPerLevelMaxDensityThreshold();
+        double[] res = new double[avgDensity.length];
+        for (int i = 0; i < avgDensity.length; i++)
+            res[i] = avgDensity[i] / maxThreshold[i];
+        return res;
     }
 
     public double[] getPerLevelMaxDensityMaxDensityThresholdRatio()
     {
-        readLock.lock();
-        try
-        {
-            if (repaired.first() instanceof UnifiedCompactionStrategy)
-            {
-
-                double[] maxDensityThresholdPerLevel = getPerLevelMaxDensityThreshold();
-                double[] maxDensityPerLevel = new double[maxDensityThresholdPerLevel.length];
-                double[] res = new double[maxDensityThresholdPerLevel.length];
-
-                for (AbstractCompactionStrategy strategy : getAllStrategies())
-                {
-                    UnifiedCompactionStrategy ucsStrategy = (UnifiedCompactionStrategy) strategy;
-                    List<Level> levels = ucsStrategy.getLevelsSnapshot();
-                    for (int i = 0; i < levels.size(); i++)
-                    {
-                        for (SSTableReader sstable : levels.get(i).getSSTables())
-                        {
-                            maxDensityPerLevel[i] = Math.max(maxDensityPerLevel[i], ucsStrategy.getDensity(sstable));
-                        }
-                    }
-                }
-
-                for (int i = 0; i < maxDensityThresholdPerLevel.length; i++)
-                {
-                    res[i] = maxDensityPerLevel[i] / maxDensityThresholdPerLevel[i];
-                }
-
-                return res;
-            }
-            return null;
-        }
-        finally
-        {
-            readLock.unlock();
-        }
+        return computeUCSMetric(
+                data -> {
+                    data.sum[data.levelIndex] = Math.max(data.sum[data.levelIndex], data.strategy.getDensity(data.sstable));
+                    data.max[data.levelIndex] = Math.max(data.max[data.levelIndex], data.level.max);
+                },
+                CompactionStrategyManager::ratioArrayFinalizer
+        );
     }
 
     public boolean isLeveledCompaction()
@@ -793,83 +772,87 @@ public class CompactionStrategyManager implements INotificationConsumer
         }
     }
 
-    double[] avgUCSHelper(BiFunction<UnifiedCompactionStrategy, SSTableReader, Double> fn)
+    /**
+     * Data class for accumulating UCS metrics computation state.
+     * Holds intermediate values during metric calculation across all strategies and levels.
+     */
+    private static class CompactionStatsMetricsData
+    {
+        final double[] sum = new double[UnifiedCompactionStrategy.MAX_LEVELS];
+        final int[] count = new int[UnifiedCompactionStrategy.MAX_LEVELS];
+        final double[] max = new double[UnifiedCompactionStrategy.MAX_LEVELS];
+        int numberOfLevels = 0;
+
+        int levelIndex;
+        Level level;
+        SSTableReader sstable;
+        UnifiedCompactionStrategy strategy;
+    }
+
+    /**
+     * Generic helper to compute UCS metrics across all strategies and levels.
+     * Reduces code duplication for per-level metric calculations.
+     *
+     * @param accumulator processes each sstable and updates the metrics data state
+     * @param finalizer computes the final result array from the accumulated metrics data
+     * @return computed metric array, one value per level, or null if not using UCS
+     */
+    private double[] computeUCSMetric(Consumer<CompactionStatsMetricsData> accumulator, Function<CompactionStatsMetricsData, double[]> finalizer)
     {
         readLock.lock();
         try
         {
             if (repaired.first() instanceof UnifiedCompactionStrategy)
             {
-                int numberOfLevels = 0;
-
-                double[] sum = new double[UnifiedCompactionStrategy.MAX_LEVELS];
-                int[] count = new int[UnifiedCompactionStrategy.MAX_LEVELS];
+                CompactionStatsMetricsData data = new CompactionStatsMetricsData();
 
                 for (AbstractCompactionStrategy strategy : getAllStrategies())
                 {
                     UnifiedCompactionStrategy ucsStrategy = (UnifiedCompactionStrategy) strategy;
                     List<Level> levels = ucsStrategy.getLevelsSnapshot();
-                    numberOfLevels = Math.max(numberOfLevels, levels.size());
+
+                    data.numberOfLevels = Math.max(data.numberOfLevels, levels.size());
+                    data.strategy = ucsStrategy;
+
                     for (int i = 0; i < levels.size(); i++)
                     {
+                        data.levelIndex = i;
+                        data.level = levels.get(i);
                         for (SSTableReader sstable : levels.get(i).getSSTables())
                         {
-                            sum[i] += fn.apply(ucsStrategy, sstable);
-                            count[i] += 1;
+                            data.sstable = sstable;
+                            accumulator.accept(data);
                         }
                     }
                 }
 
-                double[] res = new double[numberOfLevels];
-                for (int i = 0; i < numberOfLevels; i++)
-                    res[i] = count[i] == 0 ? 0 : sum[i] / count[i];
-
-                return res;
+                return finalizer.apply(data);
             }
             return null;
         }
-        finally
-        {
+        finally {
             readLock.unlock();
         }
     }
 
-    double[] perLevelUCSHelper(TriFunction<Level, SSTableReader, Double, Double> fn)
+    private static double[] averageFinalizer(CompactionStatsMetricsData data)
     {
-        readLock.lock();
-        try
-        {
-            if (repaired.first() instanceof UnifiedCompactionStrategy)
-            {
-                int numberOfLevels = 0;
+        double[] res = new double[data.numberOfLevels];
+        for (int i = 0; i < data.numberOfLevels; i++)
+            res[i] = data.count[i] == 0 ? 0 : data.sum[i] / data.numberOfLevels;
+        return res;
+    }
 
-                double[] tmp = new double[UnifiedCompactionStrategy.MAX_LEVELS];
+    private static double[] maxArrayFinalizer(CompactionStatsMetricsData data)
+    {
+        return Arrays.copyOf(data.max, data.numberOfLevels);
+    }
 
-                for (AbstractCompactionStrategy strategy : getAllStrategies())
-                {
-                    UnifiedCompactionStrategy ucsStrategy = (UnifiedCompactionStrategy) strategy;
-                    List<Level> levels = ucsStrategy.getLevelsSnapshot();
-                    numberOfLevels = Math.max(numberOfLevels, levels.size());
-                    for (int i = 0; i < levels.size(); i++)
-                    {
-                        for (SSTableReader sstable : levels.get(i).getSSTables())
-                        {
-                            tmp[i] = fn.apply(levels.get(i), sstable, tmp[i]);
-                        }
-                    }
-                }
-
-                double[] res = new double[numberOfLevels];
-                System.arraycopy(tmp, 0, res, 0, numberOfLevels);
-
-                return res;
-            }
-            return null;
-        }
-        finally
-        {
-            readLock.unlock();
-        }
+    private static double[] ratioArrayFinalizer(CompactionStatsMetricsData data) {
+        double[] res = new double[data.numberOfLevels];
+        for (int i = 0; i < data.numberOfLevels; i++)
+            res[i] = data.sum[i] / data.max[i];
+        return res;
     }
 
     public int[] getSSTableCountPerTWCSBucket()

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -80,6 +81,8 @@ import org.apache.cassandra.repair.consistent.admin.CleanupSummary;
 import org.apache.cassandra.schema.CompactionParams;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.TimeUUID;
+import org.apache.cassandra.utils.TriFunction;
+import org.apache.cassandra.db.compaction.UnifiedCompactionStrategy.Level;
 
 import static org.apache.cassandra.db.compaction.AbstractStrategyHolder.GroupedSSTableContainer;
 
@@ -690,6 +693,94 @@ public class CompactionStrategyManager implements INotificationConsumer
         }
     }
 
+    public double[] getPerLevelAvgTokenSpace()
+    {
+        return avgUCSHelper((ucs, sstable) ->
+                sstable.tokenSpaceCoverage());
+    }
+
+    public double[] getPerLevelMaxDensityThreshold()
+    {
+        return perLevelUCSHelper((level, sstable, acc) -> Math.max(acc, level.max));
+    }
+
+    public double[] getPerLevelAvgSize()
+    {
+        return avgUCSHelper((ucs, sstable) -> (double) sstable.onDiskLength());
+    }
+
+    public double[] getPerLevelAvgDensity()
+    {
+        return avgUCSHelper(UnifiedCompactionStrategy::getDensity);
+    }
+
+    public double[] getPerLevelAvgDensityMaxDensityThresholdRatio()
+    {
+        readLock.lock();
+        try
+        {
+            if (repaired.first() instanceof UnifiedCompactionStrategy)
+            {
+                double[] avgDensityPerLevel = getPerLevelAvgDensity();
+                double[] maxDensityThresholdPerLevel = getPerLevelMaxDensityThreshold();
+
+                double[] res = new double[avgDensityPerLevel.length];
+
+                for (int i = 0; i < avgDensityPerLevel.length; i++)
+                {
+                    res[i] = avgDensityPerLevel[i] / maxDensityThresholdPerLevel[i];
+                }
+
+                return res;
+            }
+            return null;
+        }
+        finally
+        {
+            readLock.unlock();
+        }
+    }
+
+    public double[] getPerLevelMaxDensityMaxDensityThresholdRatio()
+    {
+        readLock.lock();
+        try
+        {
+            if (repaired.first() instanceof UnifiedCompactionStrategy)
+            {
+
+                double[] maxDensityThresholdPerLevel = getPerLevelMaxDensityThreshold();
+                double[] maxDensityPerLevel = new double[maxDensityThresholdPerLevel.length];
+                double[] res = new double[maxDensityThresholdPerLevel.length];
+
+                for (AbstractCompactionStrategy strategy : getAllStrategies())
+                {
+                    UnifiedCompactionStrategy ucsStrategy = (UnifiedCompactionStrategy) strategy;
+                    List<Level> levels = ucsStrategy.getLevelsSnapshot();
+                    for (int i = 0; i < levels.size(); i++)
+                    {
+                        for (SSTableReader sstable : levels.get(i).getSSTables())
+                        {
+                            maxDensityPerLevel[i] = Math.max(maxDensityPerLevel[i], ucsStrategy.getDensity(sstable));
+                        }
+                    }
+                }
+
+                for (int i = 0; i < maxDensityThresholdPerLevel.length; i++)
+                {
+                    res[i] = maxDensityPerLevel[i] / maxDensityThresholdPerLevel[i];
+                }
+
+                return res;
+            }
+            return null;
+        }
+        finally
+        {
+            readLock.unlock();
+        }
+    }
+
     public boolean isLeveledCompaction()
     {
         readLock.lock();
@@ -697,6 +788,85 @@ public class CompactionStrategyManager implements INotificationConsumer
         {
             return repaired.first() instanceof LeveledCompactionStrategy;
         } finally
+        {
+            readLock.unlock();
+        }
+    }
+
+    double[] avgUCSHelper(BiFunction<UnifiedCompactionStrategy, SSTableReader, Double> fn)
+    {
+        readLock.lock();
+        try
+        {
+            if (repaired.first() instanceof UnifiedCompactionStrategy)
+            {
+                int numberOfLevels = 0;
+
+                double[] sum = new double[UnifiedCompactionStrategy.MAX_LEVELS];
+                int[] count = new int[UnifiedCompactionStrategy.MAX_LEVELS];
+
+                for (AbstractCompactionStrategy strategy : getAllStrategies())
+                {
+                    UnifiedCompactionStrategy ucsStrategy = (UnifiedCompactionStrategy) strategy;
+                    List<Level> levels = ucsStrategy.getLevelsSnapshot();
+                    numberOfLevels = Math.max(numberOfLevels, levels.size());
+                    for (int i = 0; i < levels.size(); i++)
+                    {
+                        for (SSTableReader sstable : levels.get(i).getSSTables())
+                        {
+                            sum[i] += fn.apply(ucsStrategy, sstable);
+                            count[i] += 1;
+                        }
+                    }
+                }
+
+                double[] res = new double[numberOfLevels];
+                for (int i = 0; i < numberOfLevels; i++)
+                    res[i] = count[i] == 0 ? 0 : sum[i] / count[i];
+
+                return res;
+            }
+            return null;
+        }
+        finally
+        {
+            readLock.unlock();
+        }
+    }
+
+    double[] perLevelUCSHelper(TriFunction<Level, SSTableReader, Double, Double> fn)
+    {
+        readLock.lock();
+        try
+        {
+            if (repaired.first() instanceof UnifiedCompactionStrategy)
+            {
+                int numberOfLevels = 0;
+
+                double[] tmp = new double[UnifiedCompactionStrategy.MAX_LEVELS];
+
+                for (AbstractCompactionStrategy strategy : getAllStrategies())
+                {
+                    UnifiedCompactionStrategy ucsStrategy = (UnifiedCompactionStrategy) strategy;
+                    List<Level> levels = ucsStrategy.getLevelsSnapshot();
+                    numberOfLevels = Math.max(numberOfLevels, levels.size());
+                    for (int i = 0; i < levels.size(); i++)
+                    {
+                        for (SSTableReader sstable : levels.get(i).getSSTables())
+                        {
+                            tmp[i] = fn.apply(levels.get(i), sstable, tmp[i]);
+                        }
+                    }
+                }
+
+                double[] res = new double[numberOfLevels];
+                System.arraycopy(tmp, 0, res, 0, numberOfLevels);
+
+                return res;
+            }
+            return null;
+        }
+        finally
         {
             readLock.unlock();
         }

--- a/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
+++ b/src/java/org/apache/cassandra/db/compaction/CompactionStrategyManager.java
@@ -839,7 +839,7 @@ public class CompactionStrategyManager implements INotificationConsumer
     {
         double[] res = new double[data.numberOfLevels];
         for (int i = 0; i < data.numberOfLevels; i++)
-            res[i] = data.count[i] == 0 ? 0 : data.sum[i] / data.numberOfLevels;
+            res[i] = data.count[i] == 0 ? 0 : data.sum[i] / data.count[i];
         return res;
     }
 

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -534,7 +534,6 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
      * are currently undergoing compaction. This is used only for table stats so we can have a consistent
      * snapshot of the levels.
      */
-    @VisibleForTesting
     List<Level> getLevelsSnapshot()
     {
         Set<SSTableReader> sstables = getSSTables();
@@ -565,6 +564,9 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         return formLevels(suitable);
     }
 
+    /**
+     * Returns the density of the SSTable
+     */
     public double getDensity(SSTableReader sstable)
     {
         return shardManager.density(sstable);

--- a/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
+++ b/src/java/org/apache/cassandra/db/compaction/UnifiedCompactionStrategy.java
@@ -530,6 +530,25 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
     }
 
     /**
+     * @return a list of the levels in the compaction hierarchy, that also includes SSTables that
+     * are currently undergoing compaction. This is used only for table stats so we can have a consistent
+     * snapshot of the levels.
+     */
+    @VisibleForTesting
+    List<Level> getLevelsSnapshot()
+    {
+        Set<SSTableReader> sstables = getSSTables();
+        List<SSTableReader> suitable = new ArrayList<>(sstables.size());
+        for (SSTableReader rdr : sstables)
+        {
+            if (isSuitableForCompaction(rdr))
+                suitable.add(rdr);
+        }
+
+        return formLevels(suitable);
+    }
+
+    /**
      * Groups the sstables passed in into levels. This is used by the strategy to determine
      * new compactions, and by external tools to analyze the strategy decisions.
      *
@@ -546,6 +565,11 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         return formLevels(suitable);
     }
 
+    public double getDensity(SSTableReader sstable)
+    {
+        return shardManager.density(sstable);
+    }
+
     private List<Level> formLevels(List<SSTableReader> suitable)
     {
         maybeUpdateShardManager();
@@ -557,7 +581,7 @@ public class UnifiedCompactionStrategy extends AbstractCompactionStrategy
         Level level = new Level(controller, index, 0, maxDensity);
         for (SSTableReader candidate : suitable)
         {
-            final double density = shardManager.density(candidate);
+            final double density = getDensity(candidate);
             if (density < level.max)
             {
                 level.add(candidate);

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/StatsTable.java
@@ -29,6 +29,7 @@ public class StatsTable
     public String tableName;
     public boolean isIndex;
     public boolean isLeveledSstable = false;
+    public boolean isUCSSstable = false;
     public Object sstableCount;
     public Object oldSSTableCount;
     public Long maxSSTableSize;
@@ -72,6 +73,12 @@ public class StatsTable
     public long maximumTombstonesPerSliceLastFiveMinutes;
     public List<String> sstablesInEachLevel = new ArrayList<>();
     public List<String> sstableBytesInEachLevel = new ArrayList<>();
+    public List<String> sstableAvgTokenSpaceInEachLevel = new ArrayList<>();
+    public List<String> sstableMaxDensityThresholdInEachLevel = new ArrayList<>();
+    public List<String> sstableAvgSizeInEachLevel = new ArrayList<>();
+    public List<String> sstableAvgDensityInEachLevel = new ArrayList<>();
+    public List<String> sstableAvgDensityMaxDensityThresholdRatioInEachLevel = new ArrayList<>();
+    public List<String> sstableMaxDensityMaxDensityThresholdRatioInEachLevel = new ArrayList<>();
     public int[] sstableCountPerTWCSBucket = null;
     public Boolean isInCorrectLocation = null; // null: option not active
     public double droppableTombstoneRatio;

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -304,13 +304,13 @@ public class TableStatsHolder implements StatsHolder
                     }
                 }
 
-                double[] ucsSsTableAvgSize = table.getPerLevelAvgSize();
-                if (ucsSsTableAvgSize != null)
+                double[] ucsSSTableAvgSize = table.getPerLevelAvgSize();
+                if (ucsSSTableAvgSize != null)
                 {
                     statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsSsTableAvgSize.length; level++)
+                    for (int level = 0; level < ucsSSTableAvgSize.length; level++)
                     {
-                        statsTable.sstableAvgSizeInEachLevel.add(String.format("%.03f", ucsSsTableAvgSize[level]));
+                        statsTable.sstableAvgSizeInEachLevel.add(String.format("%.03f", ucsSSTableAvgSize[level]));
                     }
                 }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -284,65 +284,17 @@ public class TableStatsHolder implements StatsHolder
                     }
                 }
 
-                double[] ucsSSTableTokenSpace = table.getPerLevelAvgTokenSpace();
-                if (ucsSSTableTokenSpace != null)
-                {
-                    statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsSSTableTokenSpace.length; level++)
-                    {
-                        statsTable.sstableAvgTokenSpaceInEachLevel.add(String.format("%.03f", ucsSSTableTokenSpace[level]));
-                    }
-                }
+                addUCSMetric(statsTable, statsTable.sstableAvgTokenSpaceInEachLevel, table.getPerLevelAvgTokenSpace());
 
-                double[] ucsMaxDensityThreshold = table.getPerLevelMaxDensityThreshold();
-                if (ucsMaxDensityThreshold != null)
-                {
-                    statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsMaxDensityThreshold.length; level++)
-                    {
-                        statsTable.sstableMaxDensityThresholdInEachLevel.add(String.format("%.03f", ucsMaxDensityThreshold[level]));
-                    }
-                }
+                addUCSMetric(statsTable, statsTable.sstableMaxDensityThresholdInEachLevel, table.getPerLevelMaxDensityThreshold());
 
-                double[] ucsSSTableAvgSize = table.getPerLevelAvgSize();
-                if (ucsSSTableAvgSize != null)
-                {
-                    statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsSSTableAvgSize.length; level++)
-                    {
-                        statsTable.sstableAvgSizeInEachLevel.add(String.format("%.03f", ucsSSTableAvgSize[level]));
-                    }
-                }
+                addUCSMetric(statsTable, statsTable.sstableAvgSizeInEachLevel, table.getPerLevelAvgSize());
 
-                double[] ucsSStableAvgDensity = table.getPerLevelAvgDensity();
-                if (ucsSStableAvgDensity != null)
-                {
-                    statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsSStableAvgDensity.length; level++)
-                    {
-                        statsTable.sstableAvgDensityInEachLevel.add(String.format("%.03f", ucsSStableAvgDensity[level]));
-                    }
-                }
+                addUCSMetric(statsTable, statsTable.sstableAvgDensityInEachLevel, table.getPerLevelAvgDensity());
 
-                double[] ucsSStableAvgDensityMaxDensityThresholdRatio = table.getPerLevelAvgDensityMaxDensityThresholdRatio();
-                if (ucsSStableAvgDensityMaxDensityThresholdRatio != null)
-                {
-                    statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsSStableAvgDensityMaxDensityThresholdRatio.length; level++)
-                    {
-                        statsTable.sstableAvgDensityMaxDensityThresholdRatioInEachLevel.add(String.format("%.03f", ucsSStableAvgDensityMaxDensityThresholdRatio[level]));
-                    }
-                }
+                addUCSMetric(statsTable, statsTable.sstableAvgDensityMaxDensityThresholdRatioInEachLevel, table.getPerLevelAvgDensityMaxDensityThresholdRatio());
 
-                double[] ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel = table.getPerLevelMaxDensityMaxDensityThresholdRatio();
-                if (ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel != null)
-                {
-                    statsTable.isUCSSstable = true;
-                    for (int level = 0; level < ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel.length; level++)
-                    {
-                        statsTable.sstableMaxDensityMaxDensityThresholdRatioInEachLevel.add(String.format("%.03f", ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel[level]));
-                    }
-                }
+                addUCSMetric(statsTable, statsTable.sstableMaxDensityMaxDensityThresholdRatioInEachLevel, table.getPerLevelMaxDensityMaxDensityThresholdRatio());
 
                 if (locationCheck)
                     statsTable.isInCorrectLocation = !table.hasMisplacedSSTables();
@@ -513,6 +465,18 @@ public class TableStatsHolder implements StatsHolder
                 statsKeyspace.tables.add(statsTable);
             }
             keyspaces.add(statsKeyspace);
+        }
+    }
+
+    private void addUCSMetric(StatsTable statsTable, List<String> acc, double[] values)
+    {
+        if (values != null)
+        {
+            statsTable.isUCSSstable = true;
+            for (int level = 0; level < values.length; level++)
+            {
+                acc.add(String.format("%.03f", values[level]));
+            }
         }
     }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -124,6 +124,15 @@ public class TableStatsHolder implements StatsHolder
         mpTable.put("old_sstable_count", table.oldSSTableCount);
         mpTable.put("sstables_in_each_level", table.sstablesInEachLevel);
         mpTable.put("sstable_bytes_in_each_level", table.sstableBytesInEachLevel);
+        if (table.isUCSSstable)
+        {
+            mpTable.put("sstable_avg_token_space_in_each_level", table.sstableAvgTokenSpaceInEachLevel);
+            mpTable.put("sstable_max_density_threshold_in_each_level", table.sstableMaxDensityThresholdInEachLevel);
+            mpTable.put("sstable_avg_size_in_each_level", table.sstableAvgSizeInEachLevel);
+            mpTable.put("sstable_avg_density_in_each_level", table.sstableAvgDensityInEachLevel);
+            mpTable.put("sstable_avg_density_max_density_threshold_ratio_in_each_level", table.sstableAvgDensityMaxDensityThresholdRatioInEachLevel);
+            mpTable.put("sstable_max_density_max_density_threshold_ratio_in_each_level", table.sstableMaxDensityMaxDensityThresholdRatioInEachLevel);
+        }
         mpTable.put("max_sstable_size", table.maxSSTableSize);
         mpTable.put("twcs", table.twcs);
         mpTable.put("space_used_live", table.spaceUsedLive);
@@ -272,6 +281,66 @@ public class TableStatsHolder implements StatsHolder
                     {
                         long size = leveledSSTablesBytes[level];
                         statsTable.sstableBytesInEachLevel.add(FileUtils.stringifyFileSize(size, humanReadable));
+                    }
+                }
+
+                double[] ucsSSTableTokenSpace = table.getPerLevelAvgTokenSpace();
+                if (ucsSSTableTokenSpace != null)
+                {
+                    statsTable.isUCSSstable = true;
+                    for (int level = 0; level < ucsSSTableTokenSpace.length; level++)
+                    {
+                        statsTable.sstableAvgTokenSpaceInEachLevel.add(String.format("%.03f", ucsSSTableTokenSpace[level]));
+                    }
+                }
+
+                double[] ucsMaxDensityThreshold = table.getPerLevelMaxDensityThreshold();
+                if (ucsMaxDensityThreshold != null)
+                {
+                    statsTable.isUCSSstable = true;
+                    for (int level = 0; level < ucsMaxDensityThreshold.length; level++)
+                    {
+                        statsTable.sstableMaxDensityThresholdInEachLevel.add(String.format("%.03f", ucsMaxDensityThreshold[level]));
+                    }
+                }
+
+                double[] ucsSsTableAvgSize = table.getPerLevelAvgSize();
+                if (ucsSsTableAvgSize != null)
+                {
+                    statsTable.isUCSSstable = true;
+                    for (int level = 0; level < ucsSsTableAvgSize.length; level++)
+                    {
+                        statsTable.sstableAvgSizeInEachLevel.add(String.format("%.03f", ucsSsTableAvgSize[level]));
+                    }
+                }
+
+                double[] ucsSStableAvgDensity = table.getPerLevelAvgDensity();
+                if (ucsSStableAvgDensity != null)
+                {
+                    statsTable.isUCSSstable = true;
+                    for (int level = 0; level < ucsSStableAvgDensity.length; level++)
+                    {
+                        statsTable.sstableAvgDensityInEachLevel.add(String.format("%.03f", ucsSStableAvgDensity[level]));
+                    }
+                }
+
+                double[] ucsSStableAvgDensityMaxDensityThresholdRatio = table.getPerLevelAvgDensityMaxDensityThresholdRatio();
+                if (ucsSStableAvgDensityMaxDensityThresholdRatio != null)
+                {
+                    statsTable.isUCSSstable = true;
+                    for (int level = 0; level < ucsSStableAvgDensityMaxDensityThresholdRatio.length; level++)
+                    {
+                        statsTable.sstableAvgDensityMaxDensityThresholdRatioInEachLevel.add(String.format("%.03f", ucsSStableAvgDensityMaxDensityThresholdRatio[level]));
+                    }
+                }
+
+                double[] ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel = table.getPerLevelMaxDensityMaxDensityThresholdRatio();
+                if (ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel != null)
+                {
+                    statsTable.isUCSSstable = true;
+                    for (int level = 0; level < ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel.length; level++)
+                    {
+                        statsTable.sstableMaxDensityMaxDensityThresholdRatioInEachLevel.add(String.format("%.03f", ucsSStableMaxDensityMaxDensityThresholdRatioInEachLevel[level]));
                     }
                 }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -104,15 +104,15 @@ public class TableStatsPrinter<T extends StatsHolder>
             {
                 out.println(indent + "Average token space for SSTables in each level: [" + String.join(", ",
                         table.sstableAvgTokenSpaceInEachLevel) + "]");
-                out.println(indent + "Maximum density for SSTables in each level: [" + String.join(", ",
+                out.println(indent + "Maximum density threshold for SSTables in each level: [" + String.join(", ",
                         table.sstableMaxDensityThresholdInEachLevel) + "]");
                 out.println(indent + "Average SSTable size in each level: [" + String.join(", ",
                         table.sstableAvgSizeInEachLevel) + "]");
                 out.println(indent + "Average SSTable density in each level: [" + String.join(", ",
                         table.sstableAvgDensityInEachLevel) + "]");
-                out.println(indent + "Ratio of average SSTable density and maximum density threshold in each level: [" + String.join(", ",
+                out.println(indent + "Average SSTable density to max threshold ratio in each level: [" + String.join(", ",
                         table.sstableAvgDensityMaxDensityThresholdRatioInEachLevel) + "]");
-                out.println(indent + "Ratio of maximum SSTable density and maximum density threshold in each level: [" + String.join(", ",
+                out.println(indent + "Maximum SSTable density to max threshold ratio in each level: [" + String.join(", ",
                         table.sstableMaxDensityMaxDensityThresholdRatioInEachLevel) + "]");
             }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsPrinter.java
@@ -100,6 +100,22 @@ public class TableStatsPrinter<T extends StatsHolder>
                                                                                     table.sstableBytesInEachLevel) + "]");
             }
 
+            if (table.isUCSSstable)
+            {
+                out.println(indent + "Average token space for SSTables in each level: [" + String.join(", ",
+                        table.sstableAvgTokenSpaceInEachLevel) + "]");
+                out.println(indent + "Maximum density for SSTables in each level: [" + String.join(", ",
+                        table.sstableMaxDensityThresholdInEachLevel) + "]");
+                out.println(indent + "Average SSTable size in each level: [" + String.join(", ",
+                        table.sstableAvgSizeInEachLevel) + "]");
+                out.println(indent + "Average SSTable density in each level: [" + String.join(", ",
+                        table.sstableAvgDensityInEachLevel) + "]");
+                out.println(indent + "Ratio of average SSTable density and maximum density threshold in each level: [" + String.join(", ",
+                        table.sstableAvgDensityMaxDensityThresholdRatioInEachLevel) + "]");
+                out.println(indent + "Ratio of maximum SSTable density and maximum density threshold in each level: [" + String.join(", ",
+                        table.sstableMaxDensityMaxDensityThresholdRatioInEachLevel) + "]");
+            }
+
             out.println(indent + "Space used (live): " + table.spaceUsedLive);
             out.println(indent + "Space used (total): " + table.spaceUsedTotal);
             out.println(indent + "Space used by snapshots (total): " + table.spaceUsedBySnapshotsTotal);

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
@@ -25,9 +25,6 @@ import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.distributed.Cluster;
 
 import java.io.IOException;
-
-import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
-import static org.apache.cassandra.distributed.api.Feature.NETWORK;
 import static org.junit.Assert.assertTrue;
 
 public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
@@ -37,9 +34,8 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
     @BeforeClass
     public static void setup() throws IOException
     {
-        CLUSTER = init(Cluster.build(1).withConfig(c ->
-                        c.with(GOSSIP, NETWORK))
-                .start());
+        CLUSTER = init(Cluster.build(1)
+                              .start());
 
         CLUSTER.schemaChange(withKeyspace("DROP KEYSPACE %s"));
         CLUSTER.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"));

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 
 import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
 import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.Assert.assertTrue;
 
 public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
 {
@@ -56,9 +57,9 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
         CLUSTER.get(1).runOnInstance(() -> {
             ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
             double[] perLevelAvgTokenSpace = cfs.getPerLevelAvgTokenSpace();
-            assert(perLevelAvgTokenSpace.length > 0);
+            assertTrue(perLevelAvgTokenSpace.length > 0);
             for (int i = 0; i < perLevelAvgTokenSpace.length; i++)
-                Assert.assertTrue(perLevelAvgTokenSpace[i] > 0);
+                assertTrue(perLevelAvgTokenSpace[i] > 0);
         });
     }
 
@@ -67,7 +68,7 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
     {
         CLUSTER.get(1).runOnInstance(() -> {
             ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
-            Assert.assertTrue(cfs.getPerLevelMaxDensityThreshold().length > 0);
+            assertTrue(cfs.getPerLevelMaxDensityThreshold().length > 0);
         });
     }
 
@@ -77,9 +78,9 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
         CLUSTER.get(1).runOnInstance(() -> {
             ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
             double[] perLevelAvgSize = cfs.getPerLevelAvgSize();
-            assert(perLevelAvgSize.length > 0);
+            assertTrue(perLevelAvgSize.length > 0);
             for (int i = 0; i < perLevelAvgSize.length; i++)
-                Assert.assertTrue(perLevelAvgSize[i] > 0);
+                assertTrue(perLevelAvgSize[i] > 0);
         });
     }
 
@@ -89,9 +90,9 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
         CLUSTER.get(1).runOnInstance(() -> {
             ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
             double[] perLevelAvgDensity = cfs.getPerLevelAvgDensity();
-            assert(perLevelAvgDensity.length > 0);
+            assertTrue(perLevelAvgDensity.length > 0);
             for (int i = 0; i < perLevelAvgDensity.length; i++)
-                Assert.assertTrue(perLevelAvgDensity[i] > 0);
+                assertTrue(perLevelAvgDensity[i] > 0);
         });
     }
 
@@ -101,11 +102,11 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
         CLUSTER.get(1).runOnInstance(() -> {
             ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
             double[] perLevelAvgDensityMaxDensityThresholdRatio = cfs.getPerLevelAvgDensityMaxDensityThresholdRatio();
-            assert(perLevelAvgDensityMaxDensityThresholdRatio.length > 0);
+            assertTrue(perLevelAvgDensityMaxDensityThresholdRatio.length > 0);
             for (int i = 0; i < perLevelAvgDensityMaxDensityThresholdRatio.length; i++)
             {
-                Assert.assertTrue(0 <= perLevelAvgDensityMaxDensityThresholdRatio[i]);
-                Assert.assertTrue(perLevelAvgDensityMaxDensityThresholdRatio[i] < 1);
+                assertTrue(0 <= perLevelAvgDensityMaxDensityThresholdRatio[i]);
+                assertTrue(perLevelAvgDensityMaxDensityThresholdRatio[i] < 1);
             }
         });
     }
@@ -116,10 +117,10 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
         CLUSTER.get(1).runOnInstance(() -> {
             ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
             double[] perLevelMaxDensityMaxDensityThresholdRatio = cfs.getPerLevelMaxDensityMaxDensityThresholdRatio();
-            assert(perLevelMaxDensityMaxDensityThresholdRatio.length > 0);
+            assertTrue(perLevelMaxDensityMaxDensityThresholdRatio.length > 0);
             for (int i = 0; i < perLevelMaxDensityMaxDensityThresholdRatio.length; i++) {
-                Assert.assertTrue(0 <= perLevelMaxDensityMaxDensityThresholdRatio[i]);
-                Assert.assertTrue(perLevelMaxDensityMaxDensityThresholdRatio[i] < 1);
+                assertTrue(0 <= perLevelMaxDensityMaxDensityThresholdRatio[i]);
+                assertTrue(perLevelMaxDensityMaxDensityThresholdRatio[i] < 1);
             }
         });
     }

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import org.junit.*;
+
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.distributed.Cluster;
+
+import java.io.IOException;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+
+public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
+{
+    private static Cluster CLUSTER;
+
+    @BeforeClass
+    public static void setup() throws IOException
+    {
+        CLUSTER = init(Cluster.build(1).withConfig(c ->
+                        c.with(GOSSIP, NETWORK))
+                .start());
+
+        CLUSTER.schemaChange(withKeyspace("DROP KEYSPACE %s"));
+        CLUSTER.schemaChange(withKeyspace("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"));
+        CLUSTER.schemaChange(withKeyspace("CREATE TABLE %s.cf (k text, c1 text, c2 text, PRIMARY KEY (k)) WITH compaction = {'class': 'UnifiedCompactionStrategy', 'scaling_parameters': 'L10'}"));
+
+        for (int i = 0; i < 10000; i++)
+            CLUSTER.get(1).executeInternal(withKeyspace("INSERT INTO %s.cf (k, c1, c2) VALUES (?, 'value1', 'value2');"), Integer.toString(i));
+
+        CLUSTER.get(1).nodetool("flush");
+    }
+
+    @Test
+    public void testPerLevelAverageTokenSpace() throws Throwable
+    {
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
+            double[] perLevelAvgTokenSpace = cfs.getPerLevelAvgTokenSpace();
+            assert(perLevelAvgTokenSpace.length > 0);
+            for (int i = 0; i < perLevelAvgTokenSpace.length; i++)
+                Assert.assertTrue(perLevelAvgTokenSpace[i] > 0);
+        });
+    }
+
+    @Test
+    public void testGetPerLevelMaxDensityThreshold() throws Throwable
+    {
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
+            Assert.assertTrue(cfs.getPerLevelMaxDensityThreshold().length > 0);
+        });
+    }
+
+    @Test
+    public void testGetPerLevelAvgSize() throws Throwable
+    {
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
+            double[] perLevelAvgSize = cfs.getPerLevelAvgSize();
+            assert(perLevelAvgSize.length > 0);
+            for (int i = 0; i < perLevelAvgSize.length; i++)
+                Assert.assertTrue(perLevelAvgSize[i] > 0);
+        });
+    }
+
+    @Test
+    public void testGetPerLevelAvgDensity() throws Throwable
+    {
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
+            double[] perLevelAvgDensity = cfs.getPerLevelAvgDensity();
+            assert(perLevelAvgDensity.length > 0);
+            for (int i = 0; i < perLevelAvgDensity.length; i++)
+                Assert.assertTrue(perLevelAvgDensity[i] > 0);
+        });
+    }
+
+    @Test
+    public void testGetPerLevelAvgDensityMaxDensityThresholdRatio() throws Throwable
+    {
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
+            double[] perLevelAvgDensityMaxDensityThresholdRatio = cfs.getPerLevelAvgDensityMaxDensityThresholdRatio();
+            assert(perLevelAvgDensityMaxDensityThresholdRatio.length > 0);
+            for (int i = 0; i < perLevelAvgDensityMaxDensityThresholdRatio.length; i++)
+            {
+                Assert.assertTrue(0 <= perLevelAvgDensityMaxDensityThresholdRatio[i]);
+                Assert.assertTrue(perLevelAvgDensityMaxDensityThresholdRatio[i] < 1);
+            }
+        });
+    }
+
+    @Test
+    public void testGetPerLevelMaxDensityMaxDensityThresholdRatio() throws Throwable
+    {
+        CLUSTER.get(1).runOnInstance(() -> {
+            ColumnFamilyStore cfs = Keyspace.open(KEYSPACE).getColumnFamilyStore("cf");
+            double[] perLevelMaxDensityMaxDensityThresholdRatio = cfs.getPerLevelMaxDensityMaxDensityThresholdRatio();
+            assert(perLevelMaxDensityMaxDensityThresholdRatio.length > 0);
+            for (int i = 0; i < perLevelMaxDensityMaxDensityThresholdRatio.length; i++) {
+                Assert.assertTrue(0 <= perLevelMaxDensityMaxDensityThresholdRatio[i]);
+                Assert.assertTrue(perLevelMaxDensityMaxDensityThresholdRatio[i] < 1);
+            }
+        });
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ColumnFamilyStoreMBeansTest.java
@@ -51,6 +51,13 @@ public class ColumnFamilyStoreMBeansTest extends TestBaseImpl
         CLUSTER.get(1).nodetool("flush");
     }
 
+    @AfterClass
+    public static void teardownCluster() throws Exception
+    {
+        if (CLUSTER != null)
+            CLUSTER.close();
+    }
+
     @Test
     public void testPerLevelAverageTokenSpace() throws Throwable
     {

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
@@ -457,9 +457,8 @@ public class CompactionStrategyManagerTest extends CassandraTestBase
         Random random = new Random();
         data.numberOfLevels = random.nextInt(32);
 
-        for (int i = 0; i < data.numberOfLevels; i++) {
+        for (int i = 0; i < data.numberOfLevels; i++)
             data.max[i] = random.nextInt(250);
-        }
 
         double[] res = CompactionStrategyManager.maxArrayFinalizer(data);
         assertEquals(res.length, data.numberOfLevels);

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
@@ -430,7 +430,7 @@ public class CompactionStrategyManagerTest extends CassandraTestBase
     }
 
     @Test
-    public void testAverageFinalizer()
+    public void testAverageArrayFinalizer()
     {
         CompactionStrategyManager.CompactionStatsMetricsData data = new CompactionStrategyManager.CompactionStatsMetricsData();
         Random random = new Random();

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
@@ -19,11 +19,7 @@
 package org.apache.cassandra.db.compaction;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -431,6 +427,62 @@ public class CompactionStrategyManagerTest extends CassandraTestBase
             CompactionStrategyManager.sumCountsByBucket(ImmutableList.of(
                 Collections.emptyMap(),
                 Collections.emptyMap()), CompactionStrategyManager.TWCS_BUCKET_COUNT_MAX));
+    }
+
+    @Test
+    public void testAverageFinalizer()
+    {
+        CompactionStrategyManager.CompactionStatsMetricsData data = new CompactionStrategyManager.CompactionStatsMetricsData();
+        Random random = new Random();
+        data.numberOfLevels = random.nextInt(32);
+
+        for (int i = 0; i < data.numberOfLevels; i++) {
+            data.sum[i] = random.nextInt(250);
+            data.count[i] = random.nextInt(10);
+        }
+
+        double[] res = CompactionStrategyManager.averageFinalizer(data);
+        assertEquals(res.length, data.numberOfLevels);
+        for (int i = 0; i < data.numberOfLevels; i++)
+            if (data.count[i] == 0)
+                assertEquals(0, res[i], 0.0);
+            else
+                assertEquals(data.sum[i] / data.count[i], res[i], 0.1);
+    }
+
+    @Test
+    public void testMaxArrayFinalizer()
+    {
+        CompactionStrategyManager.CompactionStatsMetricsData data = new CompactionStrategyManager.CompactionStatsMetricsData();
+        Random random = new Random();
+        data.numberOfLevels = random.nextInt(32);
+
+        for (int i = 0; i < data.numberOfLevels; i++) {
+            data.max[i] = random.nextInt(250);
+        }
+
+        double[] res = CompactionStrategyManager.maxArrayFinalizer(data);
+        assertEquals(res.length, data.numberOfLevels);
+        for (int i = 0; i < data.numberOfLevels; i++)
+            assertEquals(data.max[i], res[i], 0.0);
+    }
+
+    @Test
+    public void testRatioArrayFinalizer()
+    {
+        CompactionStrategyManager.CompactionStatsMetricsData data = new CompactionStrategyManager.CompactionStatsMetricsData();
+        Random random = new Random();
+        data.numberOfLevels = random.nextInt(32);
+
+        for (int i = 0; i < data.numberOfLevels; i++) {
+            data.sum[i] = random.nextInt(250);
+            data.max[i] = 250 + random.nextInt(500);
+        }
+
+        double[] res = CompactionStrategyManager.ratioArrayFinalizer(data);
+        assertEquals(res.length, data.numberOfLevels);
+        for (int i = 0; i < data.numberOfLevels; i++)
+            assertEquals(data.sum[i] / data.max[i], res[i], 0.1);
     }
 
     private MockCFS createJBODMockCFS(int disks)

--- a/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compaction/CompactionStrategyManagerTest.java
@@ -441,7 +441,7 @@ public class CompactionStrategyManagerTest extends CassandraTestBase
             data.count[i] = random.nextInt(10);
         }
 
-        double[] res = CompactionStrategyManager.averageFinalizer(data);
+        double[] res = CompactionStrategyManager.averageArrayFinalizer(data);
         assertEquals(res.length, data.numberOfLevels);
         for (int i = 0; i < data.numberOfLevels; i++)
             if (data.count[i] == 0)


### PR DESCRIPTION
Added additional level information to table stats for UCS. 
- perLevelAvgTokenSpace
- perLevelMaxDensityThreshold
- perLevelAvgSize
- perLevelAvgDensity
- perLevelAvgDensityMaxDensityThresholdRatio
- perLevelMaxDensityMaxDensityThresholdRatio

patch by Alan Wang;

reviewed by for [CASSANDRA-20820](https://issues.apache.org/jira/browse/CASSANDRA-20820)

Co-authored-by: Name1
Co-authored-by: Name2