### PR TITLE
 Update cassandra-stress default cipher suites to support tls 1.3

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -88,6 +88,7 @@ public class SettingsTransport implements Serializable
                                                                 TRANSPORT_KEYSTORE_PASSWORD_PROPERTY_KEY), false);
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", null, "SSL: algorithm", false);
+        // Default is to auto-negotiate
         final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*",
                                                       "",
                                                       "SSL: comma delimited list of encryption suites to use", false);

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -89,7 +89,7 @@ public class SettingsTransport implements Serializable
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", null, "SSL: algorithm", false);
         final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*",
-                                                      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                                                      "",
                                                       "SSL: comma delimited list of encryption suites to use", false);
 
         @Override

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -89,7 +89,7 @@ public class SettingsTransport implements Serializable
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", null, "SSL: algorithm", false);
         final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*",
-                                                      "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA",
+                                                      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                                                       "SSL: comma delimited list of encryption suites to use", false);
 
         @Override

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -54,8 +54,10 @@ public class SettingsTransport implements Serializable
                                         .withTrustStore(options.trustStore.value())
                                         .withTrustStorePassword(options.trustStorePw.setByUser() ? options.trustStorePw.value() : credentials.transportTruststorePassword)
                                         .withAlgorithm(options.alg.value())
-                                        .withProtocol(options.protocol.value())
-                                        .withCipherSuites(options.ciphers.value().split(","));
+                                        .withProtocol(options.protocol.value());
+
+			if (options.ciphers.value() != null)
+				encOptionsBuilder.withCipherSuites(options.ciphers.value().split(","));
 
             if (options.keyStore.present())
             {

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -88,9 +88,9 @@ public class SettingsTransport implements Serializable
                                                                 TRANSPORT_KEYSTORE_PASSWORD_PROPERTY_KEY), false);
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", null, "SSL: algorithm", false);
-        // Default is to auto-negotiate
+        // Null is to auto-negotiate
         final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*",
-                                                      "",
+                                                      null,
                                                       "SSL: comma delimited list of encryption suites to use", false);
 
         @Override

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -89,7 +89,7 @@ public class SettingsTransport implements Serializable
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", null, "SSL: algorithm", false);
         final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*",
-                                                      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                                                      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
                                                       "SSL: comma delimited list of encryption suites to use", false);
 
         @Override

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -56,8 +56,8 @@ public class SettingsTransport implements Serializable
                                         .withAlgorithm(options.alg.value())
                                         .withProtocol(options.protocol.value());
 
-			if (options.ciphers.value() != null)
-				encOptionsBuilder.withCipherSuites(options.ciphers.value().split(","));
+            if (options.ciphers.value() != null)
+                encOptionsBuilder.withCipherSuites(options.ciphers.value().split(","));
 
             if (options.keyStore.present())
             {


### PR DESCRIPTION
Fixes: [CASSANDRA-21007](https://issues.apache.org/jira/browse/CASSANDRA-21007)

## Problem
`cassandra-stress` can not connect to tls 1.3 servers with the current default cipher suites (TLS_RSA_WITH_AES_128_CBC_SHA and TLS_RSA_WITH_AES_256_CBC_SHA) because they don't have perfect forward secrecy, which tls 1.3 needs.

## What i changed
I updated the default cipher suites in the ssl-ciphers option to use modern ones that support PFS:
Old ciphers:
- `TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA`
New ciphers:
- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`

## Why This Helps
* Fixes the tls 1.3 connection issue
* Adds perfect forward secrecy using ecdhe
* Switches from cbc to gcm which is more secure
* Still works with tls 1.2 servers

This is my first open source contribution, kindly let me know if i need to change anything or if there is any issue with my approach.