### PR TITLE
[ CASSANDRA-21056][trunk] Fix flaky ThreadLocalMeterTest by disabling background triggering of ThreadLocalMeter#tickAll within the test case

### DIFF
--- a/src/java/org/apache/cassandra/metrics/ThreadLocalMeter.java
+++ b/src/java/org/apache/cassandra/metrics/ThreadLocalMeter.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -92,9 +93,21 @@ public class ThreadLocalMeter extends com.codahale.metrics.Meter implements Mete
         maxTicks = m3Ticks;
     }
 
+    private static final ScheduledFuture<?> backgroundTickingJob;
+
+    /**
+     * the method is provided for test purposes only,
+     * to disable background activities and make tests more deterministic
+     */
+    @VisibleForTesting
+    static void disableBackgroundTicking()
+    {
+        backgroundTickingJob.cancel(true);
+    }
+
     static
     {
-        ScheduledExecutors.scheduledTasks.scheduleWithFixedDelay(ThreadLocalMeter::tickAll,
+        backgroundTickingJob = ScheduledExecutors.scheduledTasks.scheduleWithFixedDelay(ThreadLocalMeter::tickAll,
                                                                  BACKGROUND_TICK_INTERVAL_SEC,
                                                                  BACKGROUND_TICK_INTERVAL_SEC,
                                                                  TimeUnit.SECONDS);

--- a/test/unit/org/apache/cassandra/metrics/ThreadLocalMeterTest.java
+++ b/test/unit/org/apache/cassandra/metrics/ThreadLocalMeterTest.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.codahale.metrics.Clock;
@@ -37,6 +38,13 @@ import static org.junit.Assert.assertEquals;
 
 public class ThreadLocalMeterTest
 {
+
+    @Before
+    public void before()
+    {
+        ThreadLocalMeter.disableBackgroundTicking();
+    }
+
     @Test
     public void checkNoMark()
     {


### PR DESCRIPTION
Fix flaky ThreadLocalMeterTest by disabling background triggering of ThreadLocalMeter#tickAll within the test case

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-21056

