### PR TITLE
Update Cassandra doc link to 4.1

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -31,7 +31,7 @@ Getting started
 ---------------
 
 This short guide will walk you through getting a basic one node cluster up
-and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/latest/cassandra/getting_started/index.html[Getting Started Guide].
+and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/4.1/cassandra/getting_started/index.html[Getting Started Guide].
 
 First, we'll unpack our archive:
 

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -89,7 +89,7 @@ public class SettingsTransport implements Serializable
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", null, "SSL: algorithm", false);
         final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*",
-                                                      "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA",
+                                                      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                                                       "SSL: comma delimited list of encryption suites to use", false);
 
         @Override


### PR DESCRIPTION
Updates the Getting Started guide link to point to version 4.1. The previous link was returning a "Not Found" error.
Previous link
<img width="932" height="237" alt="image" src="https://github.com/user-attachments/assets/6cbe7a14-4897-4f73-878d-b574b2187e6e" />

New link
<img width="1564" height="925" alt="image" src="https://github.com/user-attachments/assets/55e0809c-4b62-4ebc-b6d5-ed3566e57799" />

