### PR TITLE
[ CASSANDRA-21088][trunk] Minor perf optimizations around memtable put logic

### DIFF
--- a/src/java/org/apache/cassandra/db/memtable/AbstractMemtable.java
+++ b/src/java/org/apache/cassandra/db/memtable/AbstractMemtable.java
@@ -196,10 +196,9 @@ public abstract class AbstractMemtable implements Memtable
 
         public void update(RegularAndStaticColumns columns)
         {
-            for (ColumnMetadata s : columns.statics)
-                update(s);
-            for (ColumnMetadata r : columns.regulars)
-                update(r);
+            if (!columns.statics.isEmpty())
+                columns.statics.apply(this::update);
+            columns.regulars.apply(this::update);
         }
 
         public void update(ColumnsCollector other)
@@ -253,6 +252,8 @@ public abstract class AbstractMemtable implements Memtable
             {
                 EncodingStats current = stats.get();
                 EncodingStats updated = current.mergeWith(newStats);
+                if (current == updated)
+                    return;
                 if (stats.compareAndSet(current, updated))
                     return;
             }

--- a/src/java/org/apache/cassandra/db/rows/AbstractCell.java
+++ b/src/java/org/apache/cassandra/db/rows/AbstractCell.java
@@ -149,9 +149,10 @@ public abstract class AbstractCell<V> extends Cell<V>
     public int dataSize()
     {
         CellPath path = path();
-        return TypeSizes.sizeof(timestamp())
-               + TypeSizes.sizeof(ttl())
-               + TypeSizes.sizeof(localDeletionTime())
+        // NOTE: TypeSizes.sizeof(localDeletionTime()) - method call like this is not eliminated by JIT in case of a megamorphic call
+        return TypeSizes.LONG_SIZE // timestamp()
+               + TypeSizes.INT_SIZE // ttl()
+               + TypeSizes.LONG_SIZE // localDeletionTime()
                + valueSize()
                + (path == null ? 0 : path.dataSize());
     }

--- a/src/java/org/apache/cassandra/db/rows/BTreeRow.java
+++ b/src/java/org/apache/cassandra/db/rows/BTreeRow.java
@@ -527,8 +527,8 @@ public class BTreeRow extends AbstractRow
     @Override
     public Row clone(Cloner cloner)
     {
-        Object[] tree = BTree.<ColumnData, ColumnData>transform(btree, c -> c.clone(cloner));
-        return BTreeRow.create(cloner.clone(clustering), primaryKeyLivenessInfo, deletion, tree);
+        Object[] tree = BTree.<ColumnData, Cloner,ColumnData>transform(btree, ColumnData::clone, cloner);
+        return BTreeRow.create(cloner.clone(clustering), primaryKeyLivenessInfo, deletion, tree, minLocalDeletionTime);
     }
 
     public int dataSize()

--- a/src/java/org/apache/cassandra/db/rows/ComplexColumnData.java
+++ b/src/java/org/apache/cassandra/db/rows/ComplexColumnData.java
@@ -257,7 +257,7 @@ public class ComplexColumnData extends ColumnData implements Iterable<Cell<?>>
     @Override
     public ColumnData clone(Cloner cloner)
     {
-        return transform(c -> cloner.clone(c));
+        return transform(cloner::clone);
     }
 
     public int estimateCloneSize(Cloner cloner)

--- a/src/java/org/apache/cassandra/db/rows/NativeCell.java
+++ b/src/java/org/apache/cassandra/db/rows/NativeCell.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db.rows;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.db.marshal.AddressBasedNativeData;
 import org.apache.cassandra.db.marshal.ByteArrayAccessor;
 import org.apache.cassandra.db.marshal.NativeAccessor;
@@ -198,6 +199,16 @@ public class NativeCell extends AbstractCell<NativeData> implements NativeData
         return NativeEndianMemoryUtil.getInt(peer + LENGTH);
     }
 
+    public int dataSize()
+    {
+        // NOTE: TypeSizes.sizeof(localDeletionTime()) - method calls like these are not eliminated by JIT in case of a megamorphic call
+        return TypeSizes.LONG_SIZE   // timestamp()
+               + TypeSizes.INT_SIZE  // ttl()
+               + TypeSizes.LONG_SIZE // localDeletionTime()
+               + valueSize()
+               + (hasPath() ? pathDataSize() : 0);
+    }
+
     public CellPath path()
     {
         if (!hasPath())
@@ -206,6 +217,12 @@ public class NativeCell extends AbstractCell<NativeData> implements NativeData
         long offset = getAddress() + valueSize();
         int size = NativeEndianMemoryUtil.getInt(offset);
         return CellPath.create(MemoryUtil.getByteBuffer(offset + 4, size, ByteOrder.BIG_ENDIAN));
+    }
+
+    private int pathDataSize()
+    {
+        long offset = getAddress() + valueSize();
+        return NativeEndianMemoryUtil.getInt(offset);
     }
 
     public Cell<?> withUpdatedValue(ByteBuffer newValue)

--- a/src/java/org/apache/cassandra/utils/btree/BTree.java
+++ b/src/java/org/apache/cassandra/utils/btree/BTree.java
@@ -1273,6 +1273,7 @@ public class BTree
      * The result of any transformation must sort identically as their originals, wrt other results.
      * <p>
      * If no modifications are made, the original is returned.
+     * NOTE: codewise *identical* to {@link #transform(Object[], BiFunction, Object)}
      */
     public static <I, O> Object[] transform(Object[] tree, Function<? super I, ? extends O> function)
     {
@@ -1316,6 +1317,55 @@ public class BTree
         return result;
     }
 
+    /**
+     * Takes a tree and transforms it using the provided function.
+     * The result of any transformation must sort identically as their originals, wrt other results.
+     * <p>
+     * If no modifications are made, the original is returned.
+     * NOTE: codewise *identical* to {@link #transform(Object[], Function)}
+     */
+    public static <I, I2, O> Object[] transform(Object[] tree, BiFunction<? super I, ? super I2, ? extends O> function, I2 param)
+    {
+        if (isEmpty(tree)) // isEmpty determined by identity; must return input
+            return tree;
+
+        if (isLeaf(tree)) // escape hatch for fast leaf transformation
+            return transformLeaf(tree, function, param);
+
+        Object[] result = tree; // optimistically assume we'll return our input unmodified
+        int keyCount = shallowSizeOfBranch(tree);
+        for (int i = 0; i < keyCount; ++i)
+        {
+            // operate on a pair of (child,key) each loop
+            Object[] curChild = (Object[]) tree[keyCount + i];
+            Object[] updChild = transform(curChild, function, param);
+            Object curKey = tree[i];
+            Object updKey = function.apply((I) curKey, param);
+            if (result == tree)
+            {
+                if (curChild == updChild && curKey == updKey)
+                    continue; // if output still same as input, loop
+
+                // otherwise initialise output to a copy of input up to this point
+                result = transformCopyBranchHelper(tree, keyCount, i, i);
+            }
+            result[keyCount + i] = updChild;
+            result[i] = updKey;
+        }
+        // final unrolled copy of loop for last child only (unbalanced with keys)
+        Object[] curChild = (Object[]) tree[2 * keyCount];
+        Object[] updChild = transform(curChild, function, param);
+        if (result == tree)
+        {
+            if (curChild == updChild)
+                return tree;
+            result = transformCopyBranchHelper(tree, keyCount, keyCount, keyCount);
+        }
+        result[2 * keyCount] = updChild;
+        result[2 * keyCount + 1] = tree[2 * keyCount + 1]; // take the original sizeMap, as we are exactly the same shape
+        return result;
+    }
+
     // create a copy of a branch, with the exact same size, copying the specified number of keys and children
     private static Object[] transformCopyBranchHelper(Object[] branch, int keyCount, int copyKeyCount, int copyChildCount)
     {
@@ -1326,6 +1376,7 @@ public class BTree
     }
 
     // an efficient transformAndFilter implementation suitable for a tree consisting of a single leaf root
+    // NOTE: codewise *identical* to {@link #transformLeaf(Object[], BiFunction, Object)}
     private static <I, O> Object[] transformLeaf(Object[] leaf, Function<? super I, ? extends O> apply)
     {
         Object[] result = leaf; // optimistically assume we'll return our input unmodified
@@ -1334,6 +1385,30 @@ public class BTree
         {
             Object current = leaf[i];
             Object updated = apply.apply((I) current);
+            if (result == leaf)
+            {
+                if (current == updated)
+                    continue; // if output still same as input, loop
+
+                // otherwise initialise output to a copy of input up to this point
+                result = new Object[leaf.length];
+                System.arraycopy(leaf, 0, result, 0, i);
+            }
+            result[i] = updated;
+        }
+        return result;
+    }
+
+    // an efficient transformAndFilter implementation suitable for a tree consisting of a single leaf root
+    // NOTE: codewise *identical* to {@link #transformLeaf(Object[], Function)}
+    private static <I, I2, O> Object[] transformLeaf(Object[] leaf, BiFunction<? super I, ? super I2, ? extends O> apply, I2 param)
+    {
+        Object[] result = leaf; // optimistically assume we'll return our input unmodified
+        int size = sizeOfLeaf(leaf);
+        for (int i = 0; i < size; ++i)
+        {
+            Object current = leaf[i];
+            Object updated = apply.apply((I) current, param);
             if (result == leaf)
             {
                 if (current == updated)


### PR DESCRIPTION
Avoid BTree iterators allocation in ColumnsCollector.update 
reduce amount of virtual calls for Cell.dataSize
avoid capturing lambda allocation in BTreeRow.clone 
do not recalculate minLocalDeletionTime when BTreeRow is cloned

Patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-21088