### PR TITLE
CASSANDRA-20446: Removed parsing of string for MBean creation

### DIFF
--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -1308,7 +1308,8 @@ public class CassandraMetricsRegistry extends MetricRegistry
             try
             {
                 Hashtable<String, String> props = new Hashtable<>(4);
-                props.put("type", type);
+                if (type != null)
+                    props.put("type", type);
                 if (scope != null)
                     props.put("scope", ObjectName.quote(scope));
 

--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1144,6 +1145,7 @@ public class CassandraMetricsRegistry extends MetricRegistry
         private final String name;
         private final String scope;
         private final String mBeanName;
+        private volatile ObjectName objectName;
         private final String systemViewName;
 
         /**
@@ -1299,25 +1301,26 @@ public class CassandraMetricsRegistry extends MetricRegistry
          */
         public ObjectName getMBeanName()
         {
-
-            String mname = mBeanName;
-
-            if (mname == null)
-                mname = getMetricName();
+            ObjectName local = objectName;
+            if (local != null)
+                return local;
 
             try
             {
+                Hashtable<String, String> props = new Hashtable<>(4);
+                if (scope != null)
+                    props.put("scope", scope);
 
-                return new ObjectName(mname);
-            } catch (MalformedObjectNameException e)
+                if (!name.isEmpty())
+                    props.put("name", name);
+
+                local = new ObjectName(group, props);
+                objectName = local;
+                return local;
+            }
+            catch (MalformedObjectNameException e)
             {
-                try
-                {
-                    return new ObjectName(ObjectName.quote(mname));
-                } catch (MalformedObjectNameException e1)
-                {
-                    throw new RuntimeException(e1);
-                }
+                throw new RuntimeException("Invalid JMX ObjectName for metric", e);
             }
         }
 

--- a/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
+++ b/src/java/org/apache/cassandra/metrics/CassandraMetricsRegistry.java
@@ -1308,11 +1308,12 @@ public class CassandraMetricsRegistry extends MetricRegistry
             try
             {
                 Hashtable<String, String> props = new Hashtable<>(4);
+                props.put("type", type);
                 if (scope != null)
-                    props.put("scope", scope);
+                    props.put("scope", ObjectName.quote(scope));
 
                 if (!name.isEmpty())
-                    props.put("name", name);
+                    props.put("name", ObjectName.quote(name));
 
                 local = new ObjectName(group, props);
                 objectName = local;


### PR DESCRIPTION

[JIRA Ticket](https://issues.apache.org/jira/browse/CASSANDRA-20446)

**Issue:**
For MBean creation, cassandra uses `javax.management.ObjectName(String name)` constructor. Due to this, string has to be parsed to extract properties.

**My Proposed Solution:**
Use `javax.management.ObjectName(String name, Hashtable<String, String> table)` constructor. Using this we skip parsing. 

**Validation**
All the [`CassandraMetricsRegistryTest.java`](https://github.com/apache/cassandra/blob/trunk/test/unit/org/apache/cassandra/metrics/CassandraMetricsRegistryTest.java) pass
<img width="1884" height="360" alt="image" src="https://github.com/user-attachments/assets/2d92202e-fb60-462e-bc51-007f1031b386" />

jmap before patch
<img width="1022" height="243" alt="image" src="https://github.com/user-attachments/assets/49ccea53-68e2-466d-b9ef-8a1d263b52ff" />

jmap after patch
<img width="918" height="166" alt="image" src="https://github.com/user-attachments/assets/de87fb80-e25b-4b38-aed6-edbc0aa86c97" />

**Before patch**
1. ObjectName$Property: 56,206 instances (~1.35 MB)
2. ObjectName$Property[]: 29,383 instances (~0.93 MB)
3. String: 107,906 instances

**After patch**
1. ObjectName$Property: 18,763 instances (~0.45 MB)
2. ObjectName$Property[]: 19,023 instances (~0.46 MB)
3. String: 96,639 instances
4. ObjectName: 9,512 instances (~0.30 MB)

This represents ~66% reduction in `ObjectName$Property` instances and a decrease in overall JMX's heap usage, and no changes to the externally visible JMX names or behavior.