### PR TITLE
Fix Getting Started documentation link in README

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -31,7 +31,7 @@ Getting started
 ---------------
 
 This short guide will walk you through getting a basic one node cluster up
-and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/4.1/cassandra/getting_started/index.html[Getting Started Guide].
+and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/5.0/cassandra/getting-started/index.html[Getting Started Guide].
 
 First, we'll unpack our archive:
 

--- a/README.asc
+++ b/README.asc
@@ -31,7 +31,7 @@ Getting started
 ---------------
 
 This short guide will walk you through getting a basic one node cluster up
-and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/5.0/cassandra/getting-started/index.html[Getting Started Guide].
+and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/latest/cassandra/getting-started/index.html[Getting Started Guide].
 
 First, we'll unpack our archive:
 

--- a/README.asc
+++ b/README.asc
@@ -31,7 +31,7 @@ Getting started
 ---------------
 
 This short guide will walk you through getting a basic one node cluster up
-and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/latest/cassandra/getting_started/index.html[Getting Started Guide].
+and running, and demonstrate some simple reads and writes. For a more-complete guide, please see the Apache Cassandra website's https://cassandra.apache.org/doc/4.1/cassandra/getting_started/index.html[Getting Started Guide].
 
 First, we'll unpack our archive:
 


### PR DESCRIPTION
Updates the Getting Started guide URL from `/doc/latest/` to `/doc/5.0/` to point to the correct documentation version.

The `/doc/latest/` URL returns a 404 error, while `/doc/5.0/` works correctly.