### PR TITLE
CASSANDRA-21111 Fix overflowing of SSTable generation id by moving to long instead of integer

### DIFF
--- a/src/java/org/apache/cassandra/db/SystemKeyspace.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspace.java
@@ -1688,19 +1688,27 @@ public final class SystemKeyspace
         executeInternal(format(cql, SSTABLE_ACTIVITY_V2),
                         keyspace,
                         table,
-                        id.toString(),
+                        id.toString(), // this is on text type, so we do not care if we save "integer" or "long" in there
                         meter.fifteenMinuteRate(),
                         meter.twoHourRate());
 
         if (!DatabaseDescriptor.isUUIDSSTableIdentifiersEnabled() && id instanceof SequenceBasedSSTableId)
         {
+            SequenceBasedSSTableId sequenceBasedSSTableId = (SequenceBasedSSTableId) id;
+            // We can not put a value bigger than max int to legacy sstable_activity where generation column is still on int.
+            // The probablity of that happening is quite low, we would need to use all generations from Integer.MAX_VALUE
+            // to hit this problem.
+            if (Integer.MAX_VALUE < sequenceBasedSSTableId.generation)
+                return;
+
             // we do this in order to make it possible to downgrade until we switch in cassandra.yaml to UUID based ids
             // see the discussion on CASSANDRA-17048
             cql = "INSERT INTO system.%s (keyspace_name, columnfamily_name, generation, rate_15m, rate_120m) VALUES (?, ?, ?, ?, ?) USING TTL 864000";
             executeInternal(format(cql, LEGACY_SSTABLE_ACTIVITY),
                             keyspace,
                             table,
-                            ((SequenceBasedSSTableId) id).generation,
+                            // safe to cast generation to int as it always fits to that, based on the above condition
+                            (int) sequenceBasedSSTableId.generation,
                             meter.fifteenMinuteRate(),
                             meter.twoHourRate());
         }
@@ -1717,8 +1725,17 @@ public final class SystemKeyspace
         {
             // we do this in order to make it possible to downgrade until we switch in cassandra.yaml to UUID based ids
             // see the discussion on CASSANDRA-17048
+
+            SequenceBasedSSTableId sequenceBasedSSTableId = (SequenceBasedSSTableId) id;
+
+            // legacy sstable activity table does not contain generation id's bigger than this, so we return,
+            // we would be otherwise trying to pass a long into generation column which is int which would fail.
+            if (Integer.MAX_VALUE < sequenceBasedSSTableId.generation)
+                return;
+
             cql = "DELETE FROM system.%s WHERE keyspace_name=? AND columnfamily_name=? and generation=?";
-            executeInternal(format(cql, LEGACY_SSTABLE_ACTIVITY), keyspace, table, ((SequenceBasedSSTableId) id).generation);
+            // safe to cast generation to int as it always fits to that, based on the above condition
+            executeInternal(format(cql, LEGACY_SSTABLE_ACTIVITY), keyspace, table, (int) sequenceBasedSSTableId.generation);
         }
     }
 

--- a/src/java/org/apache/cassandra/db/SystemKeyspaceMigrator41.java
+++ b/src/java/org/apache/cassandra/db/SystemKeyspaceMigrator41.java
@@ -157,6 +157,10 @@ public class SystemKeyspaceMigrator41
                      row ->
                      Collections.singletonList(new Object[]{ row.getString("keyspace_name"),
                                                              row.getString("columnfamily_name"),
+                                                             // here SequenceBasedSSTableId is based on generation ids which are longs,
+                                                             // but we might technically use a number which is also an integer.
+                                                             // This is fine, because the generation column is of type 'text'
+                                                             // so we do not risk that types would be incompatible or similar.
                                                              new SequenceBasedSSTableId(row.getInt("generation")).toString(),
                                                              row.has("rate_120m") ? row.getDouble("rate_120m") : null,
                                                              row.has("rate_15m") ? row.getDouble("rate_15m") : null

--- a/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
+++ b/src/java/org/apache/cassandra/io/sstable/AbstractSSTableSimpleWriter.java
@@ -53,7 +53,7 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
     protected final TableMetadataRef metadata;
     protected final RegularAndStaticColumns columns;
     protected SSTableFormat<?, ?> format = DatabaseDescriptor.getSelectedSSTableFormat();
-    protected static final AtomicReference<SSTableId> id = new AtomicReference<>(SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
+    protected final AtomicReference<SSTableId> id = new AtomicReference<>(SSTableIdFactory.instance.defaultBuilder().generator(Stream.empty()).get());
     protected boolean makeRangeAware = false;
     protected final Collection<Index.Group> indexGroups;
     protected Consumer<Collection<SSTableReader>> sstableProducedListener;
@@ -147,13 +147,13 @@ public abstract class AbstractSSTableSimpleWriter implements Closeable
                                        effectiveOwner);
     }
 
-    private static Descriptor createDescriptor(File directory, final String keyspace, final String columnFamily, final SSTableFormat<?, ?> fmt) throws IOException
+    private Descriptor createDescriptor(File directory, final String keyspace, final String columnFamily, final SSTableFormat<?, ?> fmt) throws IOException
     {
         SSTableId nextGen = getNextId(directory, columnFamily);
         return new Descriptor(directory, keyspace, columnFamily, nextGen, fmt);
     }
 
-    private static SSTableId getNextId(File directory, final String columnFamily) throws IOException
+    private SSTableId getNextId(File directory, final String columnFamily) throws IOException
     {
         while (true)
         {

--- a/src/java/org/apache/cassandra/io/sstable/SequenceBasedSSTableId.java
+++ b/src/java/org/apache/cassandra/io/sstable/SequenceBasedSSTableId.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.io.sstable;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -33,9 +33,9 @@ import com.google.common.base.Preconditions;
  */
 public class SequenceBasedSSTableId implements SSTableId, Comparable<SequenceBasedSSTableId>
 {
-    public final int generation;
+    public final long generation;
 
-    public SequenceBasedSSTableId(final int generation)
+    public SequenceBasedSSTableId(final long generation)
     {
         assert generation >= 0;
 
@@ -50,7 +50,7 @@ public class SequenceBasedSSTableId implements SSTableId, Comparable<SequenceBas
         else if (o == this)
             return 0;
 
-        return Integer.compare(this.generation, o.generation);
+        return Long.compare(this.generation, o.generation);
     }
 
     @Override
@@ -72,8 +72,8 @@ public class SequenceBasedSSTableId implements SSTableId, Comparable<SequenceBas
     @Override
     public ByteBuffer asBytes()
     {
-        ByteBuffer bytes = ByteBuffer.allocate(Integer.BYTES);
-        bytes.putInt(0, generation);
+        ByteBuffer bytes = ByteBuffer.allocate(Long.BYTES);
+        bytes.putLong(0, generation);
         return bytes;
     }
 
@@ -96,13 +96,13 @@ public class SequenceBasedSSTableId implements SSTableId, Comparable<SequenceBas
         @Override
         public Supplier<SequenceBasedSSTableId> generator(Stream<SSTableId> existingIdentifiers)
         {
-            int value = existingIdentifiers.filter(SequenceBasedSSTableId.class::isInstance)
-                                           .map(SequenceBasedSSTableId.class::cast)
-                                           .mapToInt(id -> id.generation)
-                                           .max()
-                                           .orElse(0);
+            long value = existingIdentifiers.filter(SequenceBasedSSTableId.class::isInstance)
+                                            .map(SequenceBasedSSTableId.class::cast)
+                                            .mapToLong(id -> id.generation)
+                                            .max()
+                                            .orElse(0);
 
-            AtomicInteger fileIndexGenerator = new AtomicInteger(value);
+            AtomicLong fileIndexGenerator = new AtomicLong(value);
             return () -> new SequenceBasedSSTableId(fileIndexGenerator.incrementAndGet());
         }
 
@@ -115,20 +115,20 @@ public class SequenceBasedSSTableId implements SSTableId, Comparable<SequenceBas
         @Override
         public boolean isUniqueIdentifier(ByteBuffer bytes)
         {
-            return bytes != null && bytes.remaining() == Integer.BYTES && bytes.getInt(0) >= 0;
+            return bytes != null && bytes.remaining() == Long.BYTES && bytes.getLong(0) >= 0;
         }
 
         @Override
         public SequenceBasedSSTableId fromString(String token) throws IllegalArgumentException
         {
-            return new SequenceBasedSSTableId(Integer.parseInt(token));
+            return new SequenceBasedSSTableId(Long.parseLong(token));
         }
 
         @Override
         public SequenceBasedSSTableId fromBytes(ByteBuffer bytes) throws IllegalArgumentException
         {
-            Preconditions.checkArgument(bytes.remaining() == Integer.BYTES, "Buffer does not have a valid number of bytes remaining. Expecting: %s but was: %s", Integer.BYTES, bytes.remaining());
-            return new SequenceBasedSSTableId(bytes.getInt(0));
+            Preconditions.checkArgument(bytes.remaining() == Long.BYTES, "Buffer does not have a valid number of bytes remaining. Expecting: %s but was: %s", Long.BYTES, bytes.remaining());
+            return new SequenceBasedSSTableId(bytes.getLong(0));
         }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/SSTableIdGenerationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/SSTableIdGenerationTest.java
@@ -530,7 +530,12 @@ public class SSTableIdGenerationTest extends TestBaseImpl
         String tableColName = SSTABLE_ACTIVITY_V2.equals(table) ? "table_name" : "columnfamily_name";
         String idColName = SSTABLE_ACTIVITY_V2.equals(table) ? "id" : "generation";
         String cql = "SELECT rate_15m, rate_120m FROM system.%s WHERE keyspace_name=? and %s=? and %s=?";
-        UntypedResultSet results = executeInternal(format(cql, table, tableColName, idColName), "ks", "tab", genId);
+
+        Object id = genId;
+        if (LEGACY_SSTABLE_ACTIVITY.equals(table) && genId instanceof Long)
+            id = Integer.valueOf(Long.toString((Long) genId));
+
+        UntypedResultSet results = executeInternal(format(cql, table, tableColName, idColName), "ks", "tab", id);
         assertThat(results).isNotNull();
 
         if (expectExists)


### PR DESCRIPTION
… integer.

patch by Stefan Miklosovic; reviewed by TBD for CASSANDRA-21111

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

