### PR TITLE
CASSANDRA-21121 - Changed readme http links to https

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -17,7 +17,7 @@ https://cwiki.apache.org/confluence/display/CASSANDRA2/Partitioners[Partitioning
 
 https://cwiki.apache.org/confluence/display/CASSANDRA2/DataModel[Row store] means that like relational databases, Cassandra organizes data by rows and columns. The Cassandra Query Language (CQL) is a close relative of SQL.
 
-For more information, see http://cassandra.apache.org/[the Apache Cassandra web site].
+For more information, see https://cassandra.apache.org/[the Apache Cassandra web site].
 
 Issues should be reported on https://issues.apache.org/jira/projects/CASSANDRA/issues/[The Cassandra Jira].
 
@@ -94,5 +94,5 @@ Wondering where to go from here?
     user-subscribe@cassandra.apache.org.
   * Subscribe to the Developer mailing list by sending a mail to
     dev-subscribe@cassandra.apache.org.
-  * Visit the http://cassandra.apache.org/community/[community section] of the Cassandra website for more information on getting involved.
-  * Visit the http://cassandra.apache.org/doc/latest/development/index.html[development section] of the Cassandra website for more information on how to contribute.
+  * Visit the https://cassandra.apache.org/community/[community section] of the Cassandra website for more information on getting involved.
+  * Visit the https://cassandra.apache.org/doc/latest/development/index.html[development section] of the Cassandra website for more information on how to contribute.


### PR DESCRIPTION

Changed readme http links to https.
All the http links were previous returned `301 Moved Permanently` and `Location` pointing towards their https alternatives.