### PR TITLE
CASSANDRA-21122 Fix dead link in Accord doc

### DIFF
--- a/doc/modules/cassandra/pages/architecture/accord.adoc
+++ b/doc/modules/cassandra/pages/architecture/accord.adoc
@@ -3,5 +3,5 @@
 Accord is one of the transaction protocols supported by Apache Cassandra. Accord is a separate sub-project that
 is implemented as a library that is Cassandra agnostic.
 
-* xref:architecture/accord-architecture.adoc[]
-* xref:architecture/cql-on-accord.adoc[]
+* xref:accord-architecture.adoc[]
+* xref:cql-on-accord.adoc[]


### PR DESCRIPTION
Fixed dead link in Accord doc https://github.com/apache/cassandra/blob/trunk/doc/modules/cassandra/pages/architecture/accord.adoc.

patch by Alan Wang;

reviewed by for [CASSANDRA-21122](https://issues.apache.org/jira/browse/CASSANDRA-21122)