### PR TITLE
CASSANDRA-21123: Send a ClientWarning when the server-side default (serial) consistency level is used

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2348,6 +2348,10 @@ drop_compact_storage_enabled: false
 # write_consistency_levels_warned: []
 # write_consistency_levels_disallowed: []
 #
+# Guardrail to warn or fail if no serial consistency level is provided for CAS operations. By default, this is turned off.
+# warn_if_no_serial_consistency_level_provided_for_cas_enabled: false
+# fail_if_no_serial_consistency_level_provided_for_cas_enabled: false
+#
 # Guardrail to warn or fail when writing partitions larger than threshold, expressed as 100MiB, 1GiB, etc.
 # The guardrail is only checked when writing sstables (flush and compaction), and exceeding the fail threshold on that
 # moment will only log an error message, without interrupting the operation.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -934,6 +934,8 @@ public class Config
     public volatile Set<ConsistencyLevel> read_consistency_levels_disallowed = Collections.emptySet();
     public volatile Set<ConsistencyLevel> write_consistency_levels_warned = Collections.emptySet();
     public volatile Set<ConsistencyLevel> write_consistency_levels_disallowed = Collections.emptySet();
+    public volatile boolean warn_if_no_serial_consistency_level_provided_for_cas_enabled = false;
+    public volatile boolean fail_if_no_serial_consistency_level_provided_for_cas_enabled = false;
     public volatile boolean user_timestamps_enabled = true;
     public volatile boolean alter_table_enabled = true;
     public volatile boolean group_by_enabled = true;

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -623,6 +623,34 @@ public class GuardrailsOptions implements GuardrailsConfig
     }
 
     @Override
+    public boolean getWarnIfNoSerialConsistencyLevelProvidedForCASEnabled()
+    {
+        return config.warn_if_no_serial_consistency_level_provided_for_cas_enabled;
+    }
+
+    public void setWarnIfNoSerialConsistencyLevelProvidedForCASEnabled(boolean enabled)
+    {
+        updatePropertyWithLogging("warn_if_no_serial_consistency_level_provided_for_cas_enabled",
+                                  enabled,
+                                  () -> config.warn_if_no_serial_consistency_level_provided_for_cas_enabled,
+                                  x -> config.warn_if_no_serial_consistency_level_provided_for_cas_enabled = x);
+    }
+
+    @Override
+    public boolean getFailIfNoSerialConsistencyLevelProvidedForCASEnabled()
+    {
+        return config.fail_if_no_serial_consistency_level_provided_for_cas_enabled;
+    }
+
+    public void setFailIfNoSerialConsistencyLevelProvidedForCASEnabled(boolean enabled)
+    {
+        updatePropertyWithLogging("fail_if_no_serial_consistency_level_provided_for_cas_enabled",
+                                  enabled,
+                                  () -> config.fail_if_no_serial_consistency_level_provided_for_cas_enabled,
+                                  x -> config.fail_if_no_serial_consistency_level_provided_for_cas_enabled = x);
+    }
+
+    @Override
     @Nullable
     public DataStorageSpec.LongBytesBound getPartitionSizeWarnThreshold()
     {

--- a/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/BatchQueryOptions.java
@@ -78,6 +78,11 @@ public abstract class BatchQueryOptions
         return wrapped.getSerialConsistency();
     }
 
+    public boolean serialConsistencyNotProvided()
+    {
+        return wrapped.serialConsistencyNotProvided();
+    }
+
     public List<Object> getQueryOrIdList()
     {
         return queryOrIdList;

--- a/src/java/org/apache/cassandra/cql3/QueryOptions.java
+++ b/src/java/org/apache/cassandra/cql3/QueryOptions.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -71,17 +73,20 @@ public abstract class QueryOptions
 
     public static QueryOptions forInternalCalls(ConsistencyLevel consistency, List<ByteBuffer> values)
     {
-        return new DefaultQueryOptions(consistency, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, SpecificOptions.DEFAULT, ProtocolVersion.V3);
+        SpecificOptions specificOptions = new SpecificOptions(-1, null, ConsistencyLevel.SERIAL, Long.MIN_VALUE, null, UNSET_NOWINSEC);
+        return new DefaultQueryOptions(consistency, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, specificOptions, ProtocolVersion.V3);
     }
 
     public static QueryOptions forInternalCallsWithNowInSec(long nowInSec, ConsistencyLevel consistency, List<ByteBuffer> values)
     {
-        return new DefaultQueryOptions(consistency, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, SpecificOptions.DEFAULT.withNowInSec(nowInSec), ProtocolVersion.CURRENT);
+        SpecificOptions specificOptions = new SpecificOptions(-1, null, ConsistencyLevel.SERIAL, Long.MIN_VALUE, null, nowInSec);
+        return new DefaultQueryOptions(consistency, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, specificOptions, ProtocolVersion.CURRENT);
     }
 
     public static QueryOptions forInternalCalls(List<ByteBuffer> values)
     {
-        return new DefaultQueryOptions(ConsistencyLevel.ONE, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, SpecificOptions.DEFAULT, ProtocolVersion.V3);
+        SpecificOptions specificOptions = new SpecificOptions(-1, null, ConsistencyLevel.SERIAL, Long.MIN_VALUE, null, UNSET_NOWINSEC);
+        return new DefaultQueryOptions(ConsistencyLevel.ONE, values, ByteArrayUtil.EMPTY_ARRAY_OF_BYTE_ARRAYS, false, specificOptions, ProtocolVersion.V3);
     }
 
     public static QueryOptions forProtocolVersion(ProtocolVersion protocolVersion)
@@ -249,7 +254,12 @@ public abstract class QueryOptions
     /**  Serial consistency for conditional updates. */
     public ConsistencyLevel getSerialConsistency()
     {
-        return getSpecificOptions().serialConsistency;
+        return getSpecificOptions().serialConsistency == null ? ConsistencyLevel.SERIAL : getSpecificOptions().serialConsistency;
+    }
+
+    public boolean serialConsistencyNotProvided()
+    {
+        return getSpecificOptions().serialConsistency == null;
     }
 
     public long getTimestamp(QueryState state)
@@ -642,14 +652,14 @@ public abstract class QueryOptions
 
         private SpecificOptions(int pageSize,
                                 PagingState state,
-                                ConsistencyLevel serialConsistency,
+                                @Nullable ConsistencyLevel serialConsistency,
                                 long timestamp,
                                 String keyspace,
                                 long nowInSeconds)
         {
             this.pageSize = pageSize;
             this.state = state;
-            this.serialConsistency = serialConsistency == null ? ConsistencyLevel.SERIAL : serialConsistency;
+            this.serialConsistency = serialConsistency;
             this.timestamp = timestamp;
             this.keyspace = keyspace;
             this.nowInSeconds = nowInSeconds;
@@ -743,7 +753,7 @@ public abstract class QueryOptions
             {
                 int pageSize = Flag.contains(flags, Flag.PAGE_SIZE) ? body.readInt() : -1;
                 PagingState pagingState = Flag.contains(flags, Flag.PAGING_STATE) ? PagingState.deserialize(CBUtil.readValueNoCopy(body), version) : null;
-                ConsistencyLevel serialConsistency = Flag.contains(flags, Flag.SERIAL_CONSISTENCY) ? CBUtil.readConsistencyLevel(body) : ConsistencyLevel.SERIAL;
+                ConsistencyLevel serialConsistency = Flag.contains(flags, Flag.SERIAL_CONSISTENCY) ? CBUtil.readConsistencyLevel(body) : null;
                 long timestamp = Long.MIN_VALUE;
                 if (Flag.contains(flags, Flag.TIMESTAMP))
                 {
@@ -830,7 +840,7 @@ public abstract class QueryOptions
                 flags = Flag.add(flags, Flag.PAGE_SIZE);
             if (options.getPagingState() != null)
                 flags = Flag.add(flags, Flag.PAGING_STATE);
-            if (options.getSerialConsistency() != ConsistencyLevel.SERIAL)
+            if (options.getSpecificOptions().serialConsistency != null)
                 flags = Flag.add(flags, Flag.SERIAL_CONSISTENCY);
             if (options.getSpecificOptions().timestamp != Long.MIN_VALUE)
                 flags = Flag.add(flags, Flag.TIMESTAMP);

--- a/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/BatchStatement.java
@@ -524,6 +524,8 @@ public class BatchStatement implements CQLStatement.CompositeCQLStatement
 
     private ResultMessage executeWithConditions(BatchQueryOptions options, QueryState state, Dispatcher.RequestTime requestTime)
     {
+        Guardrails.serialConsistency.guard(options.serialConsistencyNotProvided(), state.getClientState());
+
         Pair<CQL3CasRequest, Set<ColumnMetadata>> p = makeCasRequest(options, state, requestTime);
         CQL3CasRequest casRequest = p.left;
         Set<ColumnMetadata> columnsWithConditions = p.right;

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -667,6 +667,8 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
 
     private ResultMessage executeWithCondition(QueryState queryState, QueryOptions options, Dispatcher.RequestTime requestTime)
     {
+        Guardrails.serialConsistency.guard(options.serialConsistencyNotProvided(), queryState.getClientState());
+
         CQL3CasRequest request = makeCasRequest(queryState, options, requestTime);
 
         try (RowIterator result = StorageProxy.cas(keyspace(),

--- a/src/java/org/apache/cassandra/db/guardrails/Guardrails.java
+++ b/src/java/org/apache/cassandra/db/guardrails/Guardrails.java
@@ -351,6 +351,16 @@ public final class Guardrails implements GuardrailsMBean
                  "write consistency levels");
 
     /**
+     * Guardrail on if a client specifies a serial consistency level for CAS operations.
+     */
+    public static final Predicates<Boolean> serialConsistency =
+    new Predicates<>("warn_when_using_default_serial_consistency_on_cas",
+                     null,
+                     state -> x -> x && CONFIG_PROVIDER.getOrCreate(state).getWarnIfNoSerialConsistencyLevelProvidedForCASEnabled(),
+                     state -> x -> x && CONFIG_PROVIDER.getOrCreate(state).getFailIfNoSerialConsistencyLevelProvidedForCASEnabled(),
+                     (isWarning, value) -> "Query did not provide a serial consistency level.");
+
+    /**
      * Guardrail on the size of a partition.
      */
     public static final MaxThreshold partitionSize =
@@ -1446,6 +1456,30 @@ public final class Guardrails implements GuardrailsMBean
     public void setWriteConsistencyLevelsDisallowedCSV(String consistencyLevels)
     {
         DEFAULT_CONFIG.setWriteConsistencyLevelsDisallowed(fromCSV(consistencyLevels, ConsistencyLevel::fromString));
+    }
+
+    @Override
+    public boolean getWarnIfNoSerialConsistencyLevelProvidedForCASEnabled()
+    {
+        return DEFAULT_CONFIG.getWarnIfNoSerialConsistencyLevelProvidedForCASEnabled();
+    }
+
+    @Override
+    public void setWarnIfNoSerialConsistencyLevelProvidedForCASEnabled(boolean enabled)
+    {
+        DEFAULT_CONFIG.setWarnIfNoSerialConsistencyLevelProvidedForCASEnabled(enabled);
+    }
+
+    @Override
+    public boolean getFailIfNoSerialConsistencyLevelProvidedForCASEnabled()
+    {
+        return DEFAULT_CONFIG.getFailIfNoSerialConsistencyLevelProvidedForCASEnabled();
+    }
+
+    @Override
+    public void setFailIfNoSerialConsistencyLevelProvidedForCASEnabled(boolean enabled)
+    {
+        DEFAULT_CONFIG.setFailIfNoSerialConsistencyLevelProvidedForCASEnabled(enabled);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsConfig.java
@@ -261,6 +261,18 @@ public interface GuardrailsConfig
     Set<ConsistencyLevel> getWriteConsistencyLevelsDisallowed();
 
     /**
+     * @return {@code true} warn if no serial consistency level is provided for CAS operations.
+     * {@code false} does not warn when no serial consistency is used on CAS operations.
+     */
+    boolean getWarnIfNoSerialConsistencyLevelProvidedForCASEnabled();
+
+    /**
+     * @return {@code true} fail if no serial consistency level is provided for CAS operations.
+     * {@code false} does not fail when no serial consistency is used on CAS operations.
+     */
+    boolean getFailIfNoSerialConsistencyLevelProvidedForCASEnabled();
+
+    /**
      * @return The threshold to warn when writing partitions larger than threshold.
      */
     @Nullable

--- a/src/java/org/apache/cassandra/db/guardrails/GuardrailsMBean.java
+++ b/src/java/org/apache/cassandra/db/guardrails/GuardrailsMBean.java
@@ -542,6 +542,28 @@ public interface GuardrailsMBean
     void setWriteConsistencyLevelsDisallowedCSV(String consistencyLevels);
 
     /**
+     * @return {@code true} warn if no serial consistency level is provided for CAS operations.
+     * {@code false} does not warn when no serial consistency is used on CAS operations.
+     */
+    boolean getWarnIfNoSerialConsistencyLevelProvidedForCASEnabled();
+
+    /**
+     * @param enabled {@code true} if when no serial consistency is provided a client warning is produced.
+     */
+    void setWarnIfNoSerialConsistencyLevelProvidedForCASEnabled(boolean enabled);
+
+    /**
+     * @return {@code true} fail if no serial consistency level is provided for CAS operations.
+     * {@code false} does not fail when no serial consistency is used on CAS operations.
+     */
+    boolean getFailIfNoSerialConsistencyLevelProvidedForCASEnabled();
+
+    /**
+     * @param enabled {@code true} if when no serial consistency is provided the query fails.
+     */
+    void setFailIfNoSerialConsistencyLevelProvidedForCASEnabled(boolean enabled);
+
+    /**
      * @return The threshold to warn when encountering partitions larger than threshold, as a string formatted as in,
      * for example, {@code 10GiB}, {@code 20MiB}, {@code 30KiB} or {@code 40B}. A {@code null} value means disabled.
      */

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailWhenSerialConsistencyNotProvidedTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailWhenSerialConsistencyNotProvidedTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.guardrails;
+
+import org.junit.Before;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+
+import static org.apache.cassandra.db.ConsistencyLevel.ALL;
+import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE;
+import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM;
+import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_SERIAL;
+import static org.apache.cassandra.db.ConsistencyLevel.ONE;
+import static org.apache.cassandra.db.ConsistencyLevel.QUORUM;
+import static org.apache.cassandra.db.ConsistencyLevel.SERIAL;
+
+public class GuardrailWhenSerialConsistencyNotProvidedTest extends GuardrailTester
+{
+    public GuardrailWhenSerialConsistencyNotProvidedTest()
+    {
+        super(Guardrails.serialConsistency);
+    }
+
+    @Before
+    public void before()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+    }
+
+    @Test
+    public void testWarnsWhenNoSerialConsistencyLevelProvided() throws Throwable
+    {
+        guardrails().setWarnIfNoSerialConsistencyLevelProvidedForCASEnabled(true);
+        testLWTQuery(String.format("INSERT INTO %s.%s (k, v) VALUES (1, 1) IF NOT EXISTS;",
+                                   KEYSPACE,
+                                   currentTable()), true);
+        testLWTQuery(String.format("BEGIN BATCH \n" +
+                                   "INSERT INTO %s.%s \n" +
+                                   "(k, v) VALUES (1, 1) IF NOT EXISTS\n;" +
+                                   "INSERT INTO cql_test_keyspace.%s \n" +
+                                   "(k, v) VALUES (1, 2) \n;" +
+                                   "APPLY BATCH;",
+                                   KEYSPACE,
+                                   currentTable(), currentTable()), true);
+        testNotUsingLWT(String.format("INSERT INTO %s.%s (k, v) VALUES (1, 1);",
+                                      KEYSPACE,
+                                      currentTable()));
+    }
+
+    @Test
+    public void testFailWhenNoSerialConsistencyLevelProvided() throws Throwable
+    {
+        guardrails().setFailIfNoSerialConsistencyLevelProvidedForCASEnabled(true);
+        testLWTQuery(String.format("INSERT INTO %s.%s (k, v) VALUES (1, 1) IF NOT EXISTS;",
+                                   KEYSPACE,
+                                   currentTable()), false);
+        testLWTQuery(String.format("BEGIN BATCH \n" +
+                                   "INSERT INTO %s.%s \n" +
+                                   "(k, v) VALUES (1, 1) IF NOT EXISTS\n;" +
+                                   "INSERT INTO cql_test_keyspace.%s \n" +
+                                   "(k, v) VALUES (1, 2) \n;" +
+                                   "APPLY BATCH;",
+                                   KEYSPACE,
+                                   currentTable(), currentTable()), false);
+        testNotUsingLWT(String.format("INSERT INTO %s.%s (k, v) VALUES (1, 1);",
+                                      KEYSPACE,
+                                      currentTable()));
+    }
+
+    private void testNotUsingLWT(String query) throws Throwable
+    {
+        testNotUsingLWT(query, ONE);
+        testNotUsingLWT(query, ALL);
+        testNotUsingLWT(query, QUORUM);
+        testNotUsingLWT(query, LOCAL_ONE);
+        testNotUsingLWT(query, LOCAL_QUORUM);
+    }
+
+    private void testNotUsingLWT(String query, ConsistencyLevel cl) throws Throwable
+    {
+        assertValid(query, cl, SERIAL);
+        assertValid(query, cl, LOCAL_SERIAL);
+        assertValid(query, cl, null);
+    }
+
+    private void testLWTQuery(String query, boolean shouldWarn) throws Throwable
+    {
+        testLWTQuery(query, ONE, shouldWarn);
+        testLWTQuery(query, ALL, shouldWarn);
+        testLWTQuery(query, QUORUM, shouldWarn);
+        testLWTQuery(query, LOCAL_ONE, shouldWarn);
+        testLWTQuery(query, LOCAL_QUORUM, shouldWarn);
+    }
+
+    private void testLWTQuery(String query, ConsistencyLevel cl, boolean shouldWarn) throws Throwable
+    {
+        assertValid(query, cl, SERIAL);
+        assertValid(query, cl, LOCAL_SERIAL);
+        if (shouldWarn) {
+            assertWarns(query, cl, null);
+        } else {
+            assertFails(query, cl, null);
+        }
+    }
+
+    private void assertValid(String query, ConsistencyLevel cl, ConsistencyLevel serialCl) throws Throwable
+    {
+        assertValid(() -> execute(userClientState, query, cl, serialCl));
+    }
+
+    private void assertWarns(String query, ConsistencyLevel cl, ConsistencyLevel serialCl) throws Throwable
+    {
+        assertWarns(() -> execute(userClientState, query, cl, serialCl), "Query did not provide a serial consistency level.");
+    }
+
+    private void assertFails(String query, ConsistencyLevel cl, ConsistencyLevel serialCl) throws Throwable
+    {
+        assertFails(() -> execute(userClientState, query, cl, serialCl), "Query did not provide a serial consistency level.");
+    }
+}

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailWhenSerialConsistencyNotProvidedTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailWhenSerialConsistencyNotProvidedTest.java
@@ -136,4 +136,3 @@ public class GuardrailWhenSerialConsistencyNotProvidedTest extends GuardrailTest
         assertFails(() -> execute(userClientState, query, cl, serialCl), "Query did not provide a serial consistency level.");
     }
 }
-

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailWhenSerialConsistencyNotProvidedTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailWhenSerialConsistencyNotProvidedTest.java
@@ -136,3 +136,4 @@ public class GuardrailWhenSerialConsistencyNotProvidedTest extends GuardrailTest
         assertFails(() -> execute(userClientState, query, cl, serialCl), "Query did not provide a serial consistency level.");
     }
 }
+


### PR DESCRIPTION
Added a client warning for when no serial consistency level is specified by the user. This is turned off by default

patch by Alan Wang;

reviewed by for [CASSANDRA-21123](https://issues.apache.org/jira/browse/CASSANDRA-21123)

Co-authored-by: Name1
Co-authored-by: Name2