### PR TITLE
CASSANDRA-21096: queryNames might cause NPE

### DIFF
--- a/test/distributed/org/apache/cassandra/distributed/test/metric/TableMetricTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/metric/TableMetricTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.distributed.test.metric;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -285,7 +286,7 @@ public class TableMetricTest extends TestBaseImpl
         @Override
         public Set<ObjectName> queryNames(ObjectName name, QueryExp query)
         {
-            return null;
+            return Collections.emptySet();
         }
 
         @Override


### PR DESCRIPTION
This PR fix [CASSANDRA-21096](https://issues.apache.org/jira/browse/CASSANDRA-21096)


### Issue

  MapMBeanWrapper.queryNames() returned null instead of an empty Set, violating the MBeanWrapper interface contract. This caused NullPointerException when GCInspector iterates over the result during nodetool operations.

### Fix Applied
```javan
   @Override
   public Set<ObjectName> queryNames(ObjectName name, QueryExp query)
   {
  -    return null;
  +    return Collections.emptySet();
   }
```
