### PR TITLE
CEP-38: Management API MVP Implementation [CASSANDRA-19476]

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -43,30 +43,51 @@ if [ -z "$CASSANDRA_CONF" -o -z "$CLASSPATH" ]; then
     exit 1
 fi
 
-JMX_PORT=""
-
-# Try to parse port from configure_jmx method call, when not commented out
-if [ -f "$CASSANDRA_CONF/cassandra-env.sh" ]; then
-    jmx_method_call=$(grep "^configure_jmx \+[0-9]\+$" "$CASSANDRA_CONF/cassandra-env.sh")
-    if [ ! "x${jmx_method_call}" = "x" ]; then
-        JMX_PORT=$(echo "${jmx_method_call}" | tr -s " " | cut -d " " -f2)
+# Check if protocol is cql (from environment variable)
+PROTOCOL_IS_CQL=""
+if [ "x$CASSANDRA_CLI_EXECUTION_PROTOCOL" != "x" ]; then
+    protocol_lower=$(echo "$CASSANDRA_CLI_EXECUTION_PROTOCOL" | tr '[:upper:]' '[:lower:]')
+    if [ "$protocol_lower" = "cql" ]; then
+        PROTOCOL_IS_CQL="true"
     fi
 fi
 
-# In case JMX_PORT is not set (when configure_jmx in cassandra-env.sh is commented out),
-# try to parse it from cassandra.yaml.
-if [ "x$JMX_PORT" = "x" ]; then
+# Check for cql protocol in system properties to determine if we should parse CQL or JMX port
+for arg in "$@"; do
+    case "$arg" in
+        -Dcassandra.cli.execution.protocol=cql|-Dcassandra.cli.execution.protocol=CQL)
+            PROTOCOL_IS_CQL="true"
+            break
+            ;;
+    esac
+done
+
+# Parse port from config files based on protocol
+CONNECTION_PORT=""
+if [ "$PROTOCOL_IS_CQL" = "true" ]; then
+    # For CQL, parse native_transport_management_port from cassandra.yaml
     if [ -f "$CASSANDRA_CONF/cassandra.yaml" ]; then
-        JMX_PORT=$(grep jmx_port "$CASSANDRA_CONF/cassandra.yaml" | cut -d ':' -f 2 | tr -d '[[:space:]]')
+        CONNECTION_PORT=$(grep native_transport_management_port "$CASSANDRA_CONF/cassandra.yaml" | cut -d ':' -f 2 | tr -d '[[:space:]]')
+    fi
+else
+    # For JMX, parse port from configure_jmx method call, when not commented out
+    if [ -f "$CASSANDRA_CONF/cassandra-env.sh" ]; then
+        jmx_method_call=$(grep "^configure_jmx \+[0-9]\+$" "$CASSANDRA_CONF/cassandra-env.sh")
+        if [ ! "x${jmx_method_call}" = "x" ]; then
+            CONNECTION_PORT=$(echo "${jmx_method_call}" | tr -s " " | cut -d " " -f2)
+        fi
+    fi
+
+    # In case CONNECTION_PORT is not set (when configure_jmx in cassandra-env.sh is commented out),
+    # try to parse it from cassandra.yaml.
+    if [ "x$CONNECTION_PORT" = "x" ]; then
+        if [ -f "$CASSANDRA_CONF/cassandra.yaml" ]; then
+            CONNECTION_PORT=$(grep jmx_port "$CASSANDRA_CONF/cassandra.yaml" | cut -d ':' -f 2 | tr -d '[[:space:]]')
+        fi
     fi
 fi
 
-# If, by any chance, it is not there either, set it to default.
-if [ "x$JMX_PORT" = "x" ]; then
-    JMX_PORT=7199
-fi
-
-# JMX Port passed via cmd line args (-p 9999 / --port 9999 / --port=9999)
+# Connection Port passed via cmd line args (-p 9999 / --port 9999 / --port=9999)
 # should override the value from cassandra-env.sh
 ARGS=""
 JVM_ARGS=""
@@ -76,19 +97,19 @@ do
   if [ ! $1 ]; then break; fi
   case $1 in
     -p)
-      JMX_PORT=$2
+      CONNECTION_PORT=$2
       shift
       ;;
     --port=*)
-      JMX_PORT=$(echo $1 | cut -d '=' -f 2)
+      CONNECTION_PORT=$(echo $1 | cut -d '=' -f 2)
       ;;
     --port)
-      JMX_PORT=$2
+      CONNECTION_PORT=$2
       shift
       ;;
     --ssl)
       if [ -f $SSL_FILE ]
-      then 
+      then
           SSL_ARGS=$(cat $SSL_FILE | tr '\n' ' ')
       fi
       JVM_ARGS="$JVM_ARGS -Dssl.enable=true $SSL_ARGS"
@@ -108,6 +129,14 @@ do
   shift
 done
 
+if [ "x$CONNECTION_PORT" = "x" ]; then
+    if [ "$PROTOCOL_IS_CQL" = "true" ]; then
+        CONNECTION_PORT=11211
+    else
+        CONNECTION_PORT=7199
+    fi
+fi
+
 if [ "x$MAX_HEAP_SIZE" = "x" ]; then
     MAX_HEAP_SIZE="128m"
 fi
@@ -123,7 +152,7 @@ CMD=$(echo "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE
             -Dcassandra.logdir="$CASSANDRA_LOG_DIR" \
             -Dlogback.configurationFile=logback-tools.xml \
             $JVM_ARGS \
-            org.apache.cassandra.tools.NodeTool -p $JMX_PORT $ARGS)
+            org.apache.cassandra.tools.NodeTool -p $CONNECTION_PORT $ARGS)
 
 if [ "x$ARCHIVE_COMMAND" != "x" ]
 then

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -65,9 +65,17 @@ done
 # Parse port from config files based on protocol
 CONNECTION_PORT=""
 if [ "$PROTOCOL_IS_CQL" = "true" ]; then
-    # For CQL, parse native_transport_management_port from cassandra.yaml
-    if [ -f "$CASSANDRA_CONF/cassandra.yaml" ]; then
-        CONNECTION_PORT=$(grep native_transport_management_port "$CASSANDRA_CONF/cassandra.yaml" | cut -d ':' -f 2 | tr -d '[[:space:]]')
+    if [ -f "$CASSANDRA_CONF/jvm-server.options" ]; then
+        sysprop_override=$(grep "^-Dcassandra\.native_transport_management_port=" "$CASSANDRA_CONF/jvm-server.options")
+        if [ ! "x${sysprop_override}" = "x" ]; then
+            CONNECTION_PORT=$(echo "${sysprop_override}" | cut -d '=' -f 2 | tr -d '[[:space:]]')
+        fi
+    fi
+
+    if [ "x$CONNECTION_PORT" = "x" ]; then
+        if [ -f "$CASSANDRA_CONF/cassandra.yaml" ]; then
+            CONNECTION_PORT=$(grep native_transport_management_port "$CASSANDRA_CONF/cassandra.yaml" | cut -d ':' -f 2 | tr -d '[[:space:]]')
+        fi
     fi
 else
     # For JMX, parse port from configure_jmx method call, when not commented out

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1163,6 +1163,57 @@ rpc_address: localhost
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
 
+# Whether to start the native management transport server.
+# The address on which the native management transport is bound can be configured
+# using rpc_management_address or rpc_management_interface. If neither is set,
+# it defaults to rpc_address (or rpc_interface if that was used).
+start_native_transport_management: false
+
+# The address or interface to bind the native management transport server to.
+# This allows you to bind management operations to a different network interface
+# than regular client connections, providing better security isolation.
+#
+# Set rpc_management_address OR rpc_management_interface, not both.
+#
+# If neither rpc_management_address nor rpc_management_interface is set,
+# the management transport will use the same address as the regular native
+# transport (rpc_address or rpc_interface).
+#
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed. Consider binding to a management network interface
+# that is not accessible from public networks.
+# rpc_management_address: localhost
+
+# Set rpc_management_address OR rpc_management_interface, not both. Interfaces
+# must correspond to a single address, IP aliasing is not supported.
+#
+# This allows you to bind the management transport to a specific network
+# interface by name (e.g., eth1, eth0). The IP address will be automatically
+# resolved from the interface. This is useful when the interface IP may change
+# (e.g., DHCP) or when you want to bind to a specific interface without
+# hardcoding the IP address.
+# rpc_management_interface: eth1
+
+# If you choose to specify the management interface by name and the interface
+# has both an ipv4 and an ipv6 address, you can specify which should be chosen
+# using rpc_management_interface_prefer_ipv6. If false the first ipv4 address
+# will be used. If true the first ipv6 address will be used. Defaults to false
+# preferring ipv4. If there is only one address it will be selected regardless
+# of ipv4/ipv6.
+# rpc_management_interface_prefer_ipv6: false
+
+# Port for the management CQL native transport to listen for clients on.
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed.
+native_transport_management_port: 11211
+
+# The maximum threads for handling management requests are set
+# separately from regular requests to allow better isolation and
+# prioritization of management operations. This is important to
+# ensure that management operations can proceed even under a high
+# load of regular client requests. Defaults to 2.
+# native_transport_management_max_threads: 2
+
 # Uncomment to set socket buffer size for internode communication
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1136,6 +1136,57 @@ rpc_address: localhost
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
 
+# Whether to start the native management transport server.
+# The address on which the native management transport is bound can be configured
+# using rpc_management_address or rpc_management_interface. If neither is set,
+# it defaults to rpc_address (or rpc_interface if that was used).
+start_native_transport_management: false
+
+# The address or interface to bind the native management transport server to.
+# This allows you to bind management operations to a different network interface
+# than regular client connections, providing better security isolation.
+#
+# Set rpc_management_address OR rpc_management_interface, not both.
+#
+# If neither rpc_management_address nor rpc_management_interface is set,
+# the management transport will use the same address as the regular native
+# transport (rpc_address or rpc_interface).
+#
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed. Consider binding to a management network interface
+# that is not accessible from public networks.
+# rpc_management_address: localhost
+
+# Set rpc_management_address OR rpc_management_interface, not both. Interfaces
+# must correspond to a single address, IP aliasing is not supported.
+#
+# This allows you to bind the management transport to a specific network
+# interface by name (e.g., eth1, eth0). The IP address will be automatically
+# resolved from the interface. This is useful when the interface IP may change
+# (e.g., DHCP) or when you want to bind to a specific interface without
+# hardcoding the IP address.
+# rpc_management_interface: eth1
+
+# If you choose to specify the management interface by name and the interface
+# has both an ipv4 and an ipv6 address, you can specify which should be chosen
+# using rpc_management_interface_prefer_ipv6. If false the first ipv4 address
+# will be used. If true the first ipv6 address will be used. Defaults to false
+# preferring ipv4. If there is only one address it will be selected regardless
+# of ipv4/ipv6.
+# rpc_management_interface_prefer_ipv6: false
+
+# Port for the management CQL native transport to listen for clients on.
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed.
+native_transport_management_port: 11211
+
+# The maximum threads for handling management requests are set
+# separately from regular requests to allow better isolation and
+# prioritization of management operations. This is important to
+# ensure that management operations can proceed even under a high
+# load of regular client requests. Defaults to 2.
+# native_transport_management_max_threads: 2
+
 # Uncomment to set socket buffer size for internode communication
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1115,6 +1115,57 @@ rpc_address: localhost
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
 
+# Whether to start the native management transport server.
+# The address on which the native management transport is bound can be configured
+# using rpc_management_address or rpc_management_interface. If neither is set,
+# it defaults to rpc_address (or rpc_interface if that was used).
+start_native_transport_management: false
+
+# The address or interface to bind the native management transport server to.
+# This allows you to bind management operations to a different network interface
+# than regular client connections, providing better security isolation.
+#
+# Set rpc_management_address OR rpc_management_interface, not both.
+#
+# If neither rpc_management_address nor rpc_management_interface is set,
+# the management transport will use the same address as the regular native
+# transport (rpc_address or rpc_interface).
+#
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed. Consider binding to a management network interface
+# that is not accessible from public networks.
+# rpc_management_address: localhost
+
+# Set rpc_management_address OR rpc_management_interface, not both. Interfaces
+# must correspond to a single address, IP aliasing is not supported.
+#
+# This allows you to bind the management transport to a specific network
+# interface by name (e.g., eth1, eth0). The IP address will be automatically
+# resolved from the interface. This is useful when the interface IP may change
+# (e.g., DHCP) or when you want to bind to a specific interface without
+# hardcoding the IP address.
+# rpc_management_interface: eth1
+
+# If you choose to specify the management interface by name and the interface
+# has both an ipv4 and an ipv6 address, you can specify which should be chosen
+# using rpc_management_interface_prefer_ipv6. If false the first ipv4 address
+# will be used. If true the first ipv6 address will be used. Defaults to false
+# preferring ipv4. If there is only one address it will be selected regardless
+# of ipv4/ipv6.
+# rpc_management_interface_prefer_ipv6: false
+
+# Port for the management CQL native transport to listen for clients on.
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed.
+native_transport_management_port: 11211
+
+# The maximum threads for handling management requests are set
+# separately from regular requests to allow better isolation and
+# prioritization of management operations. This is important to
+# ensure that management operations can proceed even under a high
+# load of regular client requests. Defaults to 2.
+# native_transport_management_max_threads: 2
+
 # Uncomment to set socket buffer size for internode communication
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -1148,6 +1148,57 @@ rpc_address: localhost
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
 
+# Whether to start the native management transport server.
+# The address on which the native management transport is bound can be configured
+# using rpc_management_address or rpc_management_interface. If neither is set,
+# it defaults to rpc_address (or rpc_interface if that was used).
+start_native_transport_management: false
+
+# The address or interface to bind the native management transport server to.
+# This allows you to bind management operations to a different network interface
+# than regular client connections, providing better security isolation.
+#
+# Set rpc_management_address OR rpc_management_interface, not both.
+#
+# If neither rpc_management_address nor rpc_management_interface is set,
+# the management transport will use the same address as the regular native
+# transport (rpc_address or rpc_interface).
+#
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed. Consider binding to a management network interface
+# that is not accessible from public networks.
+# rpc_management_address: localhost
+
+# Set rpc_management_address OR rpc_management_interface, not both. Interfaces
+# must correspond to a single address, IP aliasing is not supported.
+#
+# This allows you to bind the management transport to a specific network
+# interface by name (e.g., eth1, eth0). The IP address will be automatically
+# resolved from the interface. This is useful when the interface IP may change
+# (e.g., DHCP) or when you want to bind to a specific interface without
+# hardcoding the IP address.
+# rpc_management_interface: eth1
+
+# If you choose to specify the management interface by name and the interface
+# has both an ipv4 and an ipv6 address, you can specify which should be chosen
+# using rpc_management_interface_prefer_ipv6. If false the first ipv4 address
+# will be used. If true the first ipv6 address will be used. Defaults to false
+# preferring ipv4. If there is only one address it will be selected regardless
+# of ipv4/ipv6.
+# rpc_management_interface_prefer_ipv6: false
+
+# Port for the management CQL native transport to listen for clients on.
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed.
+native_transport_management_port: 11211
+
+# The maximum threads for handling management requests are set
+# separately from regular requests to allow better isolation and
+# prioritization of management operations. This is important to
+# ensure that management operations can proceed even under a high
+# load of regular client requests. Defaults to 2.
+# native_transport_management_max_threads: 2
+
 # Uncomment to set socket buffer size for internode communication
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -1104,6 +1104,57 @@ rpc_address: localhost
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
 
+# Whether to start the native management transport server.
+# The address on which the native management transport is bound can be configured
+# using rpc_management_address or rpc_management_interface. If neither is set,
+# it defaults to rpc_address (or rpc_interface if that was used).
+start_native_transport_management: false
+
+# The address or interface to bind the native management transport server to.
+# This allows you to bind management operations to a different network interface
+# than regular client connections, providing better security isolation.
+#
+# Set rpc_management_address OR rpc_management_interface, not both.
+#
+# If neither rpc_management_address nor rpc_management_interface is set,
+# the management transport will use the same address as the regular native
+# transport (rpc_address or rpc_interface).
+#
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed. Consider binding to a management network interface
+# that is not accessible from public networks.
+# rpc_management_address: localhost
+
+# Set rpc_management_address OR rpc_management_interface, not both. Interfaces
+# must correspond to a single address, IP aliasing is not supported.
+#
+# This allows you to bind the management transport to a specific network
+# interface by name (e.g., eth1, eth0). The IP address will be automatically
+# resolved from the interface. This is useful when the interface IP may change
+# (e.g., DHCP) or when you want to bind to a specific interface without
+# hardcoding the IP address.
+# rpc_management_interface: eth1
+
+# If you choose to specify the management interface by name and the interface
+# has both an ipv4 and an ipv6 address, you can specify which should be chosen
+# using rpc_management_interface_prefer_ipv6. If false the first ipv4 address
+# will be used. If true the first ipv6 address will be used. Defaults to false
+# preferring ipv4. If there is only one address it will be selected regardless
+# of ipv4/ipv6.
+# rpc_management_interface_prefer_ipv6: false
+
+# Port for the management CQL native transport to listen for clients on.
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed.
+native_transport_management_port: 11211
+
+# The maximum threads for handling management requests are set
+# separately from regular requests to allow better isolation and
+# prioritization of management operations. This is important to
+# ensure that management operations can proceed even under a high
+# load of regular client requests. Defaults to 2.
+# native_transport_management_max_threads: 2
+
 # Uncomment to set socket buffer size for internode communication
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -1119,6 +1119,57 @@ rpc_address: localhost
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true
 
+# Whether to start the native management transport server.
+# The address on which the native management transport is bound can be configured
+# using rpc_management_address or rpc_management_interface. If neither is set,
+# it defaults to rpc_address (or rpc_interface if that was used).
+start_native_transport_management: false
+
+# The address or interface to bind the native management transport server to.
+# This allows you to bind management operations to a different network interface
+# than regular client connections, providing better security isolation.
+#
+# Set rpc_management_address OR rpc_management_interface, not both.
+#
+# If neither rpc_management_address nor rpc_management_interface is set,
+# the management transport will use the same address as the regular native
+# transport (rpc_address or rpc_interface).
+#
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed. Consider binding to a management network interface
+# that is not accessible from public networks.
+# rpc_management_address: localhost
+
+# Set rpc_management_address OR rpc_management_interface, not both. Interfaces
+# must correspond to a single address, IP aliasing is not supported.
+#
+# This allows you to bind the management transport to a specific network
+# interface by name (e.g., eth1, eth0). The IP address will be automatically
+# resolved from the interface. This is useful when the interface IP may change
+# (e.g., DHCP) or when you want to bind to a specific interface without
+# hardcoding the IP address.
+# rpc_management_interface: eth1
+
+# If you choose to specify the management interface by name and the interface
+# has both an ipv4 and an ipv6 address, you can specify which should be chosen
+# using rpc_management_interface_prefer_ipv6. If false the first ipv4 address
+# will be used. If true the first ipv6 address will be used. Defaults to false
+# preferring ipv4. If there is only one address it will be selected regardless
+# of ipv4/ipv6.
+# rpc_management_interface_prefer_ipv6: false
+
+# Port for the management CQL native transport to listen for clients on.
+# For security reasons, you should not expose this port to the internet.
+# Firewall it if needed.
+native_transport_management_port: 11211
+
+# The maximum threads for handling management requests are set
+# separately from regular requests to allow better isolation and
+# prioritization of management operations. This is important to
+# ensure that management operations can proceed even under a high
+# load of regular client requests. Defaults to 2.
+# native_transport_management_max_threads: 2
+
 # Uncomment to set socket buffer size for internode communication
 # Note that when setting this, the buffer size is limited by net.core.wmem_max
 # and when not setting it it is defined by net.ipv4.tcp_wmem

--- a/doc/native_protocol_v5.spec
+++ b/doc/native_protocol_v5.spec
@@ -1498,6 +1498,15 @@ Table of Contents
                            acknowledged the request.
                 <blockfor> is an [int] representing the number of replicas whose
                            acknowledgement is required to achieve <cl>.
+    0x1800    COMMAND_FAILED: An exception occurred during command execution. This error is returned
+              when a command executed via the native management interface fails during execution.
+              The exception may or may not include more detail in the accompanying error message.
+              The rest of the ERROR message body will be
+                <execution_id>
+              where:
+                <execution_id> is a [uuid] representing the unique identifier for the command
+                              execution that failed. This identifier can be used to correlate the
+                              error with command execution logs on the server.
 
     0x2000    Syntax_error: The submitted query has a syntax error.
     0x2100    Unauthorized: The logged user doesn't have the right to perform

--- a/doc/native_protocol_v5.spec
+++ b/doc/native_protocol_v5.spec
@@ -1419,6 +1419,15 @@ Table of Contents
                            acknowledged the request.
                 <blockfor> is an [int] representing the number of replicas whose
                            acknowledgement is required to achieve <cl>.
+    0x1800    COMMAND_FAILED: An exception occurred during command execution. This error is returned
+              when a command executed via the native management interface fails during execution.
+              The exception may or may not include more detail in the accompanying error message.
+              The rest of the ERROR message body will be
+                <execution_id>
+              where:
+                <execution_id> is a [uuid] representing the unique identifier for the command
+                              execution that failed. This identifier can be used to correlate the
+                              error with command execution logs on the server.
 
     0x2000    Syntax_error: The submitted query has a syntax error.
     0x2100    Unauthorized: The logged user doesn't have the right to perform

--- a/src/antlr/Lexer.g
+++ b/src/antlr/Lexer.g
@@ -148,6 +148,8 @@ K_MODIFY:      M O D I F Y;
 K_AUTHORIZE:   A U T H O R I Z E;
 K_DESCRIBE:    D E S C R I B E;
 K_EXECUTE:     E X E C U T E;
+K_COMMAND:     C O M M A N D;
+K_INVOKE:      I N V O K E;
 K_NORECURSIVE: N O R E C U R S I V E;
 K_MBEAN:       M B E A N;
 K_MBEANS:      M B E A N S;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -294,6 +294,7 @@ cqlStatement returns [CQLStatement.Raw stmt]
     | st55=securityLabelOnUserTypeStatement    { $stmt = st55; }
     | st56=commentOnUserTypeFieldStatement     { $stmt = st56; }
     | st57=securityLabelOnUserTypeFieldStatement   { $stmt = st57; }
+    | st58=executeCommandStatement             { $stmt = st58; }
     ;
 
 /*
@@ -1371,6 +1372,53 @@ securityLabelOnUserTypeFieldStatement returns [SecurityLabelOnUserTypeFieldState
     ;
 
 /**
+ * INVOKE COMMAND <commandName> [WITH key1 = value1 AND key2 = value2];
+ */
+executeCommandStatement returns [ExecuteCommandStatement.Raw stmt]
+    @init {
+        stmtBegins();
+        java.util.Map<String, Object> args = new java.util.LinkedHashMap<>();
+    }
+    : K_INVOKE K_COMMAND cmdName=noncol_ident 
+      (K_WITH commandProperties[args])?
+      {
+          $stmt = new ExecuteCommandStatement.Raw(cmdName.toString(), args);
+      }
+    ;
+
+commandProperties[java.util.Map<String, Object> args]
+    : commandProperty[args] (K_AND commandProperty[args])*
+    ;
+
+commandProperty[java.util.Map<String, Object> args]
+    : k=noncol_ident '=' v=commandPropertyValue
+      {
+          String key = k.toString();
+          Object value = v;
+          if (args.put(key, value) != null)
+          {
+              addRecognitionError("Duplicate argument: " + key);
+          }
+      }
+    ;
+
+commandPropertyValue returns [Object value]
+    : s=STRING_LITERAL { $value = $s.text; }
+    | i=INTEGER { $value = $i.text; }
+    | f=FLOAT { $value = $f.text; }
+    | b=BOOLEAN { $value = $b.text; }
+    | l=commandListValue { $value = l; }
+    ;
+
+commandListValue returns [java.util.List<String> value]
+    @init { java.util.List<String> l = new java.util.ArrayList<>(); }
+    : '[' ( s1=STRING_LITERAL { l.add($s1.text); }
+            ( ',' sn=STRING_LITERAL { l.add($sn.text); } )*
+          )? ']'
+      { $value = l; }
+    ;
+
+/**
  * DROP TABLE [IF EXISTS] <table>;
  */
 dropTableStatement returns [DropTableStatement.Raw stmt]
@@ -1980,7 +2028,7 @@ collectionLiteral returns [Term.Raw value]
 
 listLiteral returns [Term.Raw value]
     @init {List<Term.Raw> l = new ArrayList<Term.Raw>();}
-    @after {$value = new ArrayLiteral(l);}
+@after {$value = new ArrayLiteral(l);}
     : '[' ( t1=term { l.add(t1); } ( ',' tn=term { l.add(tn); } )* )? ']' { $value = new ArrayLiteral(l); }
     ;
 
@@ -2483,5 +2531,7 @@ basic_unreserved_keyword returns [String str]
         | K_LABELS
         | K_FIELD
         | K_COLUMN
+        | K_COMMAND
+        | K_INVOKE
         ) { $str = $k.text; }
     ;

--- a/src/antlr/Parser.g
+++ b/src/antlr/Parser.g
@@ -294,6 +294,7 @@ cqlStatement returns [CQLStatement.Raw stmt]
     | st55=securityLabelOnUserTypeStatement    { $stmt = st55; }
     | st56=commentOnUserTypeFieldStatement     { $stmt = st56; }
     | st57=securityLabelOnUserTypeFieldStatement   { $stmt = st57; }
+    | st58=executeCommandStatement             { $stmt = st58; }
     ;
 
 /*
@@ -1371,6 +1372,52 @@ securityLabelOnUserTypeFieldStatement returns [SecurityLabelOnUserTypeFieldState
     ;
 
 /**
+ * INVOKE COMMAND <commandName> [WITH key1 = value1 AND key2 = value2];
+ */
+executeCommandStatement returns [ExecuteCommandStatement.Raw stmt]
+    @init {
+        stmtBegins();
+        java.util.Map<String, Object> args = new java.util.LinkedHashMap<>();
+    }
+    : K_INVOKE K_COMMAND cmdName=noncol_ident 
+      (K_WITH commandProperties[args])?
+      {
+          $stmt = new ExecuteCommandStatement.Raw(cmdName.toString(), args);
+      }
+    ;
+
+commandProperties[java.util.Map<String, Object> args]
+    : commandProperty[args] (K_AND commandProperty[args])*
+    ;
+
+commandProperty[java.util.Map<String, Object> args]
+    : k=noncol_ident '=' v=commandPropertyValue
+      {
+          String key = k.toString();
+          Object value = v;
+          if (args.put(key, value) != null)
+          {
+              addRecognitionError("Duplicate argument: " + key);
+          }
+      }
+    ;
+
+commandPropertyValue returns [Object value]
+    : s=STRING_LITERAL { $value = $s.text; }
+    | i=INTEGER { $value = $i.text; }
+    | b=BOOLEAN { $value = $b.text; }
+    | l=commandListValue { $value = l; }
+    ;
+
+commandListValue returns [java.util.List<String> value]
+    @init { java.util.List<String> l = new java.util.ArrayList<>(); }
+    : '[' ( s1=STRING_LITERAL { l.add($s1.text); }
+            ( ',' sn=STRING_LITERAL { l.add($sn.text); } )*
+          )? ']'
+      { $value = l; }
+    ;
+
+/**
  * DROP TABLE [IF EXISTS] <table>;
  */
 dropTableStatement returns [DropTableStatement.Raw stmt]
@@ -1980,7 +2027,7 @@ collectionLiteral returns [Term.Raw value]
 
 listLiteral returns [Term.Raw value]
     @init {List<Term.Raw> l = new ArrayList<Term.Raw>();}
-    @after {$value = new ArrayLiteral(l);}
+@after {$value = new ArrayLiteral(l);}
     : '[' ( t1=term { l.add(t1); } ( ',' tn=term { l.add(tn); } )* )? ']' { $value = new ArrayLiteral(l); }
     ;
 
@@ -2481,5 +2528,7 @@ basic_unreserved_keyword returns [String str]
         | K_LABELS
         | K_FIELD
         | K_COLUMN
+        | K_COMMAND
+        | K_INVOKE
         ) { $str = $k.text; }
     ;

--- a/src/java/org/apache/cassandra/audit/AuditLogEntryType.java
+++ b/src/java/org/apache/cassandra/audit/AuditLogEntryType.java
@@ -82,7 +82,8 @@ public enum AuditLogEntryType
     UNAUTHORIZED_ATTEMPT(AuditLogEntryCategory.AUTH),
     LOGIN_SUCCESS(AuditLogEntryCategory.AUTH),
     LIST_SUPERUSERS(AuditLogEntryCategory.DCL),
-    JMX(AuditLogEntryCategory.JMX);
+    JMX(AuditLogEntryCategory.JMX),
+    EXECUTE_COMMAND(AuditLogEntryCategory.OTHER);
 
     private final AuditLogEntryCategory category;
 

--- a/src/java/org/apache/cassandra/auth/AbstractCIDRAuthorizer.java
+++ b/src/java/org/apache/cassandra/auth/AbstractCIDRAuthorizer.java
@@ -28,8 +28,8 @@ import org.apache.cassandra.metrics.CIDRAuthorizerMetrics;
  */
 public abstract class AbstractCIDRAuthorizer implements ICIDRAuthorizer
 {
-    protected static CIDRPermissionsManager cidrPermissionsManager;
-    protected static CIDRGroupsMappingManager cidrGroupsMappingManager;
+    public static CIDRPermissionsManager cidrPermissionsManager;
+    public static CIDRGroupsMappingManager cidrGroupsMappingManager;
 
     protected static CIDRAuthorizerMetrics cidrAuthorizerMetrics;
 

--- a/src/java/org/apache/cassandra/auth/AuthCache.java
+++ b/src/java/org/apache/cassandra/auth/AuthCache.java
@@ -45,6 +45,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
 import org.apache.cassandra.cache.UnweightedCacheSize;
 import org.apache.cassandra.concurrent.ExecutorPlus;
 import org.apache.cassandra.concurrent.ScheduledExecutors;
@@ -466,6 +467,36 @@ public class AuthCache<K, V> implements AuthCacheMBean, UnweightedCacheSize, Shu
     public int entries()
     {
         return Ints.checkedCast(getEstimatedSize());
+    }
+
+    /**
+     * Accepts a visitor for this cache instance. Subclasses should override this method to dispatch
+     * to the appropriate visitor method based on the specific MBean interface they implement.
+     * @param visitor the visitor to accept
+     */
+    public void accept(MBeanVisitor visitor)
+    {
+        visitor.visit(this);
+    }
+
+    /**
+     * Visitor interface for processing auth cache MBeans.
+     * Allows type-safe iteration over different cache types without instanceof checks.
+     */
+    public interface MBeanVisitor
+    {
+        /** Visits a credentials cache MBean. */
+        default void visitCredentials(PasswordAuthenticator.CredentialsCacheMBean cache) {}
+        /** Visits a JMX permissions cache MBean. */
+        default void visitJmxPermissions(AuthorizationProxy.JmxPermissionsCacheMBean cache) {}
+        /** Visits a permissions cache MBean. */
+        default void visitPermissions(PermissionsCacheMBean cache) {}
+        /** Visits a network permissions cache MBean. */
+        default void visitNetwork(NetworkPermissionsCacheMBean cache) {}
+        /** Visits a roles cache MBean. */
+        default void visitRoles(RolesCacheMBean cache) {}
+        /** Visits a generic auth cache (fallback for caches that don't implement specific MBean interfaces).*/
+        default void visit(AuthCacheMBean cache) {}
     }
 
     private class MetricsUpdater implements StatsCounter

--- a/src/java/org/apache/cassandra/auth/AuthCache.java
+++ b/src/java/org/apache/cassandra/auth/AuthCache.java
@@ -495,7 +495,7 @@ public class AuthCache<K, V> implements AuthCacheMBean, UnweightedCacheSize, Shu
         default void visitNetwork(NetworkPermissionsCacheMBean cache) {}
         /** Visits a roles cache MBean. */
         default void visitRoles(RolesCacheMBean cache) {}
-        /** Visits a generic auth cache (fallback for caches that don't implement specific MBean interfaces).*/
+        /** Visits a generic auth cache (fallback for caches that don't implement specific MBean interfaces). */
         default void visit(AuthCacheMBean cache) {}
     }
 

--- a/src/java/org/apache/cassandra/auth/AuthCacheService.java
+++ b/src/java/org/apache/cassandra/auth/AuthCacheService.java
@@ -26,6 +26,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,11 @@ public class AuthCacheService
         {
             cache.warm();
         }
+    }
+
+    public synchronized Set<AuthCache<?, ?>> getCaches()
+    {
+        return Sets.newHashSet(caches);
     }
 
     /**

--- a/src/java/org/apache/cassandra/auth/CommandResource.java
+++ b/src/java/org/apache/cassandra/auth/CommandResource.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.auth;
+
+import java.util.Set;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+
+/**
+ * Resource representing a management command invoked via CQL ({@code INVOKE COMMAND}).
+ * <p>
+ * This is a placeholder: there is no CQL grammar to {@code GRANT}/{@code REVOKE}
+ * permissions on it yet, so no role can currently be granted {@link Permission#EXECUTE} here.
+ */
+public class CommandResource implements IResource
+{
+    enum Level
+    {
+        ROOT, COMMAND
+    }
+
+    private static final String ROOT_NAME = "command";
+    private static final CommandResource ROOT_RESOURCE = new CommandResource();
+    private static final Set<Permission> COMMAND_PERMISSIONS = Sets.immutableEnumSet(Permission.EXECUTE);
+
+    private final Level level;
+    private final String name;
+
+    private CommandResource()
+    {
+        level = Level.ROOT;
+        name = null;
+    }
+
+    private CommandResource(String name)
+    {
+        this.name = name;
+        level = Level.COMMAND;
+    }
+
+    public static CommandResource root()
+    {
+        return ROOT_RESOURCE;
+    }
+
+    public static CommandResource command(String commandName)
+    {
+        return new CommandResource(commandName);
+    }
+
+    @Override
+    public String getName()
+    {
+        return level == Level.ROOT ? ROOT_NAME : String.format("%s/%s", ROOT_NAME, name);
+    }
+
+    @Override
+    public IResource getParent()
+    {
+        if (level == Level.COMMAND)
+            return root();
+        throw new IllegalStateException("Root-level resource can't have a parent");
+    }
+
+    @Override
+    public boolean hasParent()
+    {
+        return level != Level.ROOT;
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return true;
+    }
+
+    @Override
+    public Set<Permission> applicablePermissions()
+    {
+        return COMMAND_PERMISSIONS;
+    }
+
+    @Override
+    public String toString()
+    {
+        return level == Level.ROOT ? "<all commands>" : String.format("<command %s>", name);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+
+        if (!(o instanceof CommandResource))
+            return false;
+
+        CommandResource c = (CommandResource) o;
+        return level == c.level && Objects.equal(name, c.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(level, name);
+    }
+}

--- a/src/java/org/apache/cassandra/auth/NetworkPermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/NetworkPermissionsCache.java
@@ -52,4 +52,10 @@ public class NetworkPermissionsCache extends AuthCache<RoleResource, DCPermissio
         super.unregisterMBean();
         MBeanWrapper.instance.unregisterMBean(MBEAN_NAME_BASE + DEPRECATED_CACHE_NAME, MBeanWrapper.OnException.LOG);
     }
+
+    @Override
+    public void accept(MBeanVisitor visitor)
+    {
+        visitor.visitNetwork(this);
+    }
 }

--- a/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
@@ -384,6 +384,12 @@ public class PasswordAuthenticator implements IAuthenticator, AuthCache.BulkLoad
         {
             invalidate(roleName);
         }
+
+        @Override
+        public void accept(MBeanVisitor visitor)
+        {
+            visitor.visitCredentials(this);
+        }
     }
 
     public static interface CredentialsCacheMBean extends AuthCacheMBean

--- a/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/PasswordAuthenticator.java
@@ -351,6 +351,12 @@ public class PasswordAuthenticator implements IAuthenticator, AuthCache.BulkLoad
         {
             invalidate(roleName);
         }
+
+        @Override
+        public void accept(MBeanVisitor visitor)
+        {
+            visitor.visitCredentials(this);
+        }
     }
 
     public static interface CredentialsCacheMBean extends AuthCacheMBean

--- a/src/java/org/apache/cassandra/auth/PermissionsCache.java
+++ b/src/java/org/apache/cassandra/auth/PermissionsCache.java
@@ -50,4 +50,10 @@ public class PermissionsCache extends AuthCache<Pair<AuthenticatedUser, IResourc
     {
         invalidate(Pair.create(new AuthenticatedUser(roleName), Resources.fromName(resourceName)));
     }
+
+    @Override
+    public void accept(MBeanVisitor visitor)
+    {
+        visitor.visitPermissions(this);
+    }
 }

--- a/src/java/org/apache/cassandra/auth/RolesCache.java
+++ b/src/java/org/apache/cassandra/auth/RolesCache.java
@@ -119,4 +119,10 @@ public class RolesCache extends AuthCache<RoleResource, Set<Role>> implements Ro
         super.setUpdateInterval(updateInterval);
         generation.incrementAndGet();
     }
+
+    @Override
+    public void accept(MBeanVisitor visitor)
+    {
+        visitor.visitRoles(this);
+    }
 }

--- a/src/java/org/apache/cassandra/auth/RolesCache.java
+++ b/src/java/org/apache/cassandra/auth/RolesCache.java
@@ -82,4 +82,10 @@ public class RolesCache extends AuthCache<RoleResource, Set<Role>> implements Ro
     {
         invalidate(RoleResource.role(roleName));
     }
+
+    @Override
+    public void accept(MBeanVisitor visitor)
+    {
+        visitor.visitRoles(this);
+    }
 }

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.audit.AuditLogManager;
 import org.apache.cassandra.auth.AuthCache;
 import org.apache.cassandra.auth.AuthCacheMBean;
+import org.apache.cassandra.auth.AuthCacheService;
 import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.auth.JMXResource;
 import org.apache.cassandra.auth.Permission;
@@ -596,6 +597,8 @@ public class AuthorizationProxy implements InvocationHandler
                   () -> true);
 
             MBeanWrapper.instance.registerMBean(this, MBEAN_NAME_BASE + DEPRECATED_CACHE_NAME);
+            // Registration makes this cache discovearble by the management transport MBean accessor
+            AuthCacheService.instance.register(this);
         }
 
         public void invalidatePermissions(String roleName)
@@ -608,6 +611,12 @@ public class AuthorizationProxy implements InvocationHandler
         {
             super.unregisterMBean();
             MBeanWrapper.instance.unregisterMBean(MBEAN_NAME_BASE + DEPRECATED_CACHE_NAME, MBeanWrapper.OnException.LOG);
+        }
+
+        @Override
+        public void accept(MBeanVisitor visitor)
+        {
+            visitor.visitJmxPermissions(this);
         }
     }
 

--- a/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
+++ b/src/java/org/apache/cassandra/auth/jmx/AuthorizationProxy.java
@@ -609,6 +609,12 @@ public class AuthorizationProxy implements InvocationHandler
             super.unregisterMBean();
             MBeanWrapper.instance.unregisterMBean(MBEAN_NAME_BASE + DEPRECATED_CACHE_NAME, MBeanWrapper.OnException.LOG);
         }
+
+        @Override
+        public void accept(MBeanVisitor visitor)
+        {
+            visitor.visitJmxPermissions(this);
+        }
     }
 
     public static interface JmxPermissionsCacheMBean extends AuthCacheMBean

--- a/src/java/org/apache/cassandra/config/CassandraRelevantEnv.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantEnv.java
@@ -36,6 +36,16 @@ public enum CassandraRelevantEnv
     JAVA_HOME ("JAVA_HOME"),
     CIRCLECI("CIRCLECI"),
     CASSANDRA_SKIP_SYNC("CASSANDRA_SKIP_SYNC"),
+    /**
+     * Defines the protocol used by the Cassandra CLI to connect to Cassandra nodes.
+     * Possible values are {@code "static_mbeans"}, {@code "command_mbeans"} or {@code cql}.
+     * By default, the Cassandra CLI uses the JMX protocol via static MBeans.
+     */
+    CASSANDRA_CLI_EXECUTION_PROTOCOL("CASSANDRA_CLI_EXECUTION_PROTOCOL"),
+    /** Whether to show the execution id for cli command output, useful for correlating commands with logs and tracing. */
+    CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID("CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID"),
+    /** How long the Cassandra CLI waits for a server response when executing a command over CQL, in seconds. */
+    CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS("CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS"),
     /** By default, the standard Cassandra CLI layout is used for backward compatibility, however,
      * the new Picocli layout can be enabled by setting this property to the {@code "picocli"}. */
     CASSANDRA_CLI_LAYOUT("CASSANDRA_CLI_LAYOUT"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantEnv.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantEnv.java
@@ -36,6 +36,14 @@ public enum CassandraRelevantEnv
     JAVA_HOME ("JAVA_HOME"),
     CIRCLECI("CIRCLECI"),
     CASSANDRA_SKIP_SYNC("CASSANDRA_SKIP_SYNC"),
+    /**
+     * Defines the protocol used by the Cassandra CLI to connect to Cassandra nodes.
+     * Possible values are {@code "static_mbeans"}, {@code "command_mbeans"} or {@code cql}.
+     * By default, the Cassandra CLI uses the JMX protocol via static MBeans.
+     */
+    CASSANDRA_CLI_EXECUTION_PROTOCOL("CASSANDRA_CLI_EXECUTION_PROTOCOL"),
+    /** Whether to show the execution id for cli command output, useful for correlating commands with logs and tracing. */
+    CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID("CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID"),
     /** By default, the standard Cassandra CLI layout is used for backward compatibility, however,
      * the new Picocli layout can be enabled by setting this property to the {@code "picocli"}. */
     CASSANDRA_CLI_LAYOUT("CASSANDRA_CLI_LAYOUT"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -97,6 +97,16 @@ public enum CassandraRelevantProperties
     CACHEABLE_MUTATION_SIZE_LIMIT("cassandra.cacheable_mutation_size_limit_bytes", convertToString(1_000_000)),
     CASSANDRA_ALLOW_SIMPLE_STRATEGY("cassandra.allow_simplestrategy"),
     CASSANDRA_AVAILABLE_PROCESSORS("cassandra.available_processors"),
+    /**
+     * Defines the protocol used by the Cassandra CLI to connect to Cassandra nodes.
+     * Possible values are {@code "static_mbean"}, {@code "command_mbean"} or {@code cql}.
+     * By default, the Cassandra CLI uses the JMX protocol via static MBeans.
+     */
+    CASSANDRA_CLI_EXECUTION_PROTOCOL("cassandra.cli.execution.protocol", "static_mbean"),
+    /** Whether to show the execution id for cli command output, useful for correlating commands with logs and tracing. */
+    CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID("cassandra.cli.execution.show_execution_id", "false"),
+    /** How long the Cassandra CLI waits for a server response when executing a command over CQL, in seconds. */
+    CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS("cassandra.cli.execution.timeout_seconds", "0"),
     /** By default, the standard Cassandra CLI layout is used for backward compatibility, however,
      * the new Picocli layout can be enabled by setting this property to the {@code "picocli"}. */
     CASSANDRA_CLI_LAYOUT("cassandra.cli.layout", "airline"),
@@ -422,6 +432,8 @@ public enum CassandraRelevantProperties
     MX4JPORT("mx4jport"),
     NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL("cassandra.NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL", "10000"),
     NATIVE_EPOLL_ENABLED("cassandra.native.epoll.enabled", "true"),
+    /** This is the port used with RPC address for the management native protocol to communicate with clients that manage the node. */
+    NATIVE_TRANSPORT_MANAGEMENT_PORT("cassandra.native_transport_management_port"),
     /** This is the port used with RPC address for the native protocol to communicate with clients. Now that thrift RPC is no longer in use there is no RPC port. */
     NATIVE_TRANSPORT_PORT("cassandra.native_transport_port"),
     NEVER_PURGE_TOMBSTONES("cassandra.never_purge_tombstones"),
@@ -588,6 +600,7 @@ public enum CassandraRelevantProperties
     SSL_ENABLE("ssl.enable"),
     SSL_STORAGE_PORT("cassandra.ssl_storage_port"),
     START_GOSSIP("cassandra.start_gossip", "true"),
+    START_NATIVE_MANAGEMENT_TRANSPORT("cassandra.start_native_management_transport"),
     START_NATIVE_TRANSPORT("cassandra.start_native_transport"),
     STORAGE_DIR("cassandra.storagedir"),
     STORAGE_HOOK("cassandra.storage_hook"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -97,6 +97,16 @@ public enum CassandraRelevantProperties
     CACHEABLE_MUTATION_SIZE_LIMIT("cassandra.cacheable_mutation_size_limit_bytes", convertToString(1_000_000)),
     CASSANDRA_ALLOW_SIMPLE_STRATEGY("cassandra.allow_simplestrategy"),
     CASSANDRA_AVAILABLE_PROCESSORS("cassandra.available_processors"),
+    /**
+     * Defines the protocol used by the Cassandra CLI to connect to Cassandra nodes.
+     * Possible values are {@code "static_mbean"}, {@code "command_mbean"} or {@code cql}.
+     * By default, the Cassandra CLI uses the JMX protocol via static MBeans.
+     */
+    CASSANDRA_CLI_EXECUTION_PROTOCOL("cassandra.cli.execution.protocol", "static_mbean"),
+    /** Whether to show the execution id for cli command output, useful for correlating commands with logs and tracing. */
+    CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID("cassandra.cli.execution.show_execution_id", "false"),
+    /** How long the Cassandra CLI waits for a server response when executing a command over CQL, in seconds. */
+    CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS("cassandra.cli.execution.timeout_seconds", "0"),
     /** By default, the standard Cassandra CLI layout is used for backward compatibility, however,
      * the new Picocli layout can be enabled by setting this property to the {@code "picocli"}. */
     CASSANDRA_CLI_LAYOUT("cassandra.cli.layout", "airline"),
@@ -419,6 +429,8 @@ public enum CassandraRelevantProperties
     MX4JPORT("mx4jport"),
     NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL("cassandra.NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL", "10000"),
     NATIVE_EPOLL_ENABLED("cassandra.native.epoll.enabled", "true"),
+    /** This is the port used with RPC address for the management native protocol to communicate with clients that manage the node. */
+    NATIVE_TRANSPORT_MANAGEMENT_PORT("cassandra.native_transport_management_port"),
     /** This is the port used with RPC address for the native protocol to communicate with clients. Now that thrift RPC is no longer in use there is no RPC port. */
     NATIVE_TRANSPORT_PORT("cassandra.native_transport_port"),
     NEVER_PURGE_TOMBSTONES("cassandra.never_purge_tombstones"),
@@ -580,6 +592,7 @@ public enum CassandraRelevantProperties
     SSL_ENABLE("ssl.enable"),
     SSL_STORAGE_PORT("cassandra.ssl_storage_port"),
     START_GOSSIP("cassandra.start_gossip", "true"),
+    START_NATIVE_MANAGEMENT_TRANSPORT("cassandra.start_native_management_transport"),
     START_NATIVE_TRANSPORT("cassandra.start_native_transport"),
     STORAGE_DIR("cassandra.storagedir"),
     STORAGE_HOOK("cassandra.storage_hook"),

--- a/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
+++ b/src/java/org/apache/cassandra/config/CassandraRelevantProperties.java
@@ -92,6 +92,14 @@ public enum CassandraRelevantProperties
     CACHEABLE_MUTATION_SIZE_LIMIT("cassandra.cacheable_mutation_size_limit_bytes", convertToString(1_000_000)),
     CASSANDRA_ALLOW_SIMPLE_STRATEGY("cassandra.allow_simplestrategy"),
     CASSANDRA_AVAILABLE_PROCESSORS("cassandra.available_processors"),
+    /**
+     * Defines the protocol used by the Cassandra CLI to connect to Cassandra nodes.
+     * Possible values are {@code "static_mbean"}, {@code "command_mbean"} or {@code cql}.
+     * By default, the Cassandra CLI uses the JMX protocol via static MBeans.
+     */
+    CASSANDRA_CLI_EXECUTION_PROTOCOL("cassandra.cli.execution.protocol", "static_mbean"),
+    /** Whether to show the execution id for cli command output, useful for correlating commands with logs and tracing. */
+    CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID("cassandra.cli.execution.show_execution_id", "false"),
     /** By default, the standard Cassandra CLI layout is used for backward compatibility, however,
      * the new Picocli layout can be enabled by setting this property to the {@code "picocli"}. */
     CASSANDRA_CLI_LAYOUT("cassandra.cli.layout", "airline"),
@@ -412,6 +420,8 @@ public enum CassandraRelevantProperties
     MX4JPORT("mx4jport"),
     NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL("cassandra.NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL", "10000"),
     NATIVE_EPOLL_ENABLED("cassandra.native.epoll.enabled", "true"),
+    /** This is the port used with RPC address for the management native protocol to communicate with clients that manage the node. */
+    NATIVE_TRANSPORT_MANAGEMENT_PORT("cassandra.native_transport_management_port"),
     /** This is the port used with RPC address for the native protocol to communicate with clients. Now that thrift RPC is no longer in use there is no RPC port. */
     NATIVE_TRANSPORT_PORT("cassandra.native_transport_port"),
     NEVER_PURGE_TOMBSTONES("cassandra.never_purge_tombstones"),
@@ -567,6 +577,7 @@ public enum CassandraRelevantProperties
     SSL_ENABLE("ssl.enable"),
     SSL_STORAGE_PORT("cassandra.ssl_storage_port"),
     START_GOSSIP("cassandra.start_gossip", "true"),
+    START_NATIVE_MANAGEMENT_TRANSPORT("cassandra.start_native_management_transport", "false"),
     START_NATIVE_TRANSPORT("cassandra.start_native_transport"),
     STORAGE_DIR("cassandra.storagedir"),
     STORAGE_HOOK("cassandra.storage_hook"),

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -372,6 +372,20 @@ public class Config
     public DataStorageSpec.IntBytesBound native_transport_receive_queue_capacity = new DataStorageSpec.IntBytesBound("1MiB");
 
     /**
+     * Management RPC address and interface refer to the address/interface used for the native management protocol
+     * to communicate with management clients. If not explicitly configured, these default to the regular RPC address
+     * configuration (rpc_address or rpc_interface).
+     * <p>
+     * native_transport_management_port is the port paired with the management RPC address to bind on.
+     */
+    public String rpc_management_address;
+    public String rpc_management_interface;
+    public boolean rpc_management_interface_prefer_ipv6 = false;
+    public boolean start_native_transport_management = false;
+    public int native_transport_management_port = 11211;
+    public int native_transport_management_max_threads = 2;
+
+    /**
      * Max size of values in SSTables, in MebiBytes.
      * Default is the same as the native protocol frame limit: 256MiB.
      * See AbstractType for how it is used.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -327,6 +327,20 @@ public class Config
     public DataStorageSpec.IntBytesBound native_transport_receive_queue_capacity = new DataStorageSpec.IntBytesBound("1MiB");
 
     /**
+     * Management RPC address and interface refer to the address/interface used for the native management protocol
+     * to communicate with management clients. If not explicitly configured, these default to the regular RPC address
+     * configuration (rpc_address or rpc_interface).
+     * <p>
+     * native_transport_management_port is the port paired with the management RPC address to bind on.
+     */
+    public String rpc_management_address;
+    public String rpc_management_interface;
+    public boolean rpc_management_interface_prefer_ipv6 = false;
+    public boolean start_native_transport_management = false;
+    public int native_transport_management_port = 11211;
+    public int native_transport_management_max_threads = 2;
+
+    /**
      * Max size of values in SSTables, in MebiBytes.
      * Default is the same as the native protocol frame limit: 256MiB.
      * See AbstractType for how it is used.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -371,6 +371,20 @@ public class Config
     public DataStorageSpec.IntBytesBound native_transport_receive_queue_capacity = new DataStorageSpec.IntBytesBound("1MiB");
 
     /**
+     * Management RPC address and interface refer to the address/interface used for the native management protocol
+     * to communicate with management clients. If not explicitly configured, these default to the regular RPC address
+     * configuration (rpc_address or rpc_interface).
+     * <p>
+     * native_transport_management_port is the port paired with the management RPC address to bind on.
+     */
+    public String rpc_management_address;
+    public String rpc_management_interface;
+    public boolean rpc_management_interface_prefer_ipv6 = false;
+    public boolean start_native_transport_management = false;
+    public int native_transport_management_port = 11211;
+    public int native_transport_management_max_threads = 2;
+
+    /**
      * Max size of values in SSTables, in MebiBytes.
      * Default is the same as the native protocol frame limit: 256MiB.
      * See AbstractType for how it is used.

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -149,6 +149,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.CONFIG_LOA
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_STCS_IN_L0;
 import static org.apache.cassandra.config.CassandraRelevantProperties.INITIAL_TOKEN;
 import static org.apache.cassandra.config.CassandraRelevantProperties.IO_NETTY_TRANSPORT_ESTIMATE_SIZE_ON_SUBMIT;
+import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_TRANSPORT_MANAGEMENT_PORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_TRANSPORT_PORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.OS_ARCH;
 import static org.apache.cassandra.config.CassandraRelevantProperties.PARTITIONER;
@@ -217,6 +218,7 @@ public class DatabaseDescriptor
     private static InetAddress broadcastAddress;
     private static InetAddress rpcAddress;
     private static InetAddress broadcastRpcAddress;
+    private static InetAddress rpcManagementAddress;
     private static SeedProvider seedProvider;
     private static IInternodeAuthenticator internodeAuthenticator = new AllowAllInternodeAuthenticator();
 
@@ -1500,6 +1502,7 @@ public class DatabaseDescriptor
         rpcAddress = null;
         broadcastAddress = null;
         broadcastRpcAddress = null;
+        rpcManagementAddress = null;
 
         /* Local IP, hostname or interface to bind services to */
         if (config.listen_address != null && config.listen_interface != null)
@@ -1586,6 +1589,32 @@ public class DatabaseDescriptor
             if (rpcAddress.isAnyLocalAddress())
                 throw new ConfigurationException("If rpc_address is set to a wildcard address (" + config.rpc_address + "), then " +
                                                  "you must set broadcast_rpc_address to a value other than " + config.rpc_address, false);
+        }
+
+        /* Local IP, hostname or interface to bind Management RPC server to */
+        if (config.rpc_management_address != null && config.rpc_management_interface != null)
+        {
+            throw new ConfigurationException("Set rpc_management_address OR rpc_management_interface, not both", false);
+        }
+        else if (config.rpc_management_address != null)
+        {
+            try
+            {
+                rpcManagementAddress = InetAddress.getByName(config.rpc_management_address);
+            }
+            catch (UnknownHostException e)
+            {
+                throw new ConfigurationException("Unknown host in rpc_management_address " + config.rpc_management_address, false);
+            }
+        }
+        else if (config.rpc_management_interface != null)
+        {
+            rpcManagementAddress = getNetworkInterfaceAddress(config.rpc_management_interface, "rpc_management_interface", config.rpc_management_interface_prefer_ipv6);
+        }
+        else
+        {
+            // Default to regular rpc_address if not specified
+            rpcManagementAddress = rpcAddress;
         }
     }
 
@@ -3636,6 +3665,18 @@ public class DatabaseDescriptor
         return rpcAddress;
     }
 
+    /**
+     * This is the address used to bind for the native management protocol to communicate with management clients.
+     * If not explicitly configured via rpc_management_address or rpc_management_interface, defaults to the regular
+     * rpc_address. The address alone is not enough to uniquely identify this instance because multiple instances
+     * might use the same interface with different ports.
+     */
+    public static InetAddress getRpcManagementAddress()
+    {
+        assert rpcManagementAddress != null;
+        return rpcManagementAddress;
+    }
+
     public static void setBroadcastRpcAddress(InetAddress broadcastRPCAddr)
     {
         broadcastRpcAddress = broadcastRPCAddr;
@@ -3878,6 +3919,38 @@ public class DatabaseDescriptor
                    conf.native_transport_max_request_data_in_flight_per_ip.toBytes()
                    )
         );
+    }
+
+    public static boolean startNativeTransportManagement()
+    {
+        return conf.start_native_transport_management;
+    }
+
+    @VisibleForTesting
+    public static void setStartNativeTransportManagement(boolean start)
+    {
+        conf.start_native_transport_management = start;
+    }
+
+    public static int getNativeTransportManagementPort()
+    {
+        return NATIVE_TRANSPORT_MANAGEMENT_PORT.getInt(conf.native_transport_management_port);
+    }
+
+    @VisibleForTesting
+    public static void setNativeTransportPortManagement(int port)
+    {
+        conf.native_transport_management_port = port;
+    }
+
+    public static int getNativeTransportManagementMaxThreads()
+    {
+        return conf.native_transport_management_max_threads;
+    }
+
+    public static void setNativeTransportManagementMaxThreads(int max_threads)
+    {
+        conf.native_transport_management_max_threads = max_threads;
     }
 
     public static Config.PaxosVariant getPaxosVariant()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -148,6 +148,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.CONFIG_LOA
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_STCS_IN_L0;
 import static org.apache.cassandra.config.CassandraRelevantProperties.INITIAL_TOKEN;
 import static org.apache.cassandra.config.CassandraRelevantProperties.IO_NETTY_TRANSPORT_ESTIMATE_SIZE_ON_SUBMIT;
+import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_TRANSPORT_MANAGEMENT_PORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_TRANSPORT_PORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.OS_ARCH;
 import static org.apache.cassandra.config.CassandraRelevantProperties.PARTITIONER;
@@ -216,6 +217,7 @@ public class DatabaseDescriptor
     private static InetAddress broadcastAddress;
     private static InetAddress rpcAddress;
     private static InetAddress broadcastRpcAddress;
+    private static InetAddress rpcManagementAddress;
     private static SeedProvider seedProvider;
     private static IInternodeAuthenticator internodeAuthenticator = new AllowAllInternodeAuthenticator();
 
@@ -1494,6 +1496,7 @@ public class DatabaseDescriptor
         rpcAddress = null;
         broadcastAddress = null;
         broadcastRpcAddress = null;
+        rpcManagementAddress = null;
 
         /* Local IP, hostname or interface to bind services to */
         if (config.listen_address != null && config.listen_interface != null)
@@ -1580,6 +1583,32 @@ public class DatabaseDescriptor
             if (rpcAddress.isAnyLocalAddress())
                 throw new ConfigurationException("If rpc_address is set to a wildcard address (" + config.rpc_address + "), then " +
                                                  "you must set broadcast_rpc_address to a value other than " + config.rpc_address, false);
+        }
+
+        /* Local IP, hostname or interface to bind Management RPC server to */
+        if (config.rpc_management_address != null && config.rpc_management_interface != null)
+        {
+            throw new ConfigurationException("Set rpc_management_address OR rpc_management_interface, not both", false);
+        }
+        else if (config.rpc_management_address != null)
+        {
+            try
+            {
+                rpcManagementAddress = InetAddress.getByName(config.rpc_management_address);
+            }
+            catch (UnknownHostException e)
+            {
+                throw new ConfigurationException("Unknown host in rpc_management_address " + config.rpc_management_address, false);
+            }
+        }
+        else if (config.rpc_management_interface != null)
+        {
+            rpcManagementAddress = getNetworkInterfaceAddress(config.rpc_management_interface, "rpc_management_interface", config.rpc_management_interface_prefer_ipv6);
+        }
+        else
+        {
+            // Default to regular rpc_address if not specified
+            rpcManagementAddress = rpcAddress;
         }
     }
 
@@ -3606,6 +3635,18 @@ public class DatabaseDescriptor
         return rpcAddress;
     }
 
+    /**
+     * This is the address used to bind for the native management protocol to communicate with management clients.
+     * If not explicitly configured via rpc_management_address or rpc_management_interface, defaults to the regular
+     * rpc_address. The address alone is not enough to uniquely identify this instance because multiple instances
+     * might use the same interface with different ports.
+     */
+    public static InetAddress getRpcManagementAddress()
+    {
+        assert rpcManagementAddress != null;
+        return rpcManagementAddress;
+    }
+
     public static void setBroadcastRpcAddress(InetAddress broadcastRPCAddr)
     {
         broadcastRpcAddress = broadcastRPCAddr;
@@ -3848,6 +3889,38 @@ public class DatabaseDescriptor
                    conf.native_transport_max_request_data_in_flight_per_ip.toBytes()
                    )
         );
+    }
+
+    public static boolean startNativeTransportManagement()
+    {
+        return conf.start_native_transport_management;
+    }
+
+    @VisibleForTesting
+    public static void setStartNativeTransportManagement(boolean start)
+    {
+        conf.start_native_transport_management = start;
+    }
+
+    public static int getNativeTransportManagementPort()
+    {
+        return NATIVE_TRANSPORT_MANAGEMENT_PORT.getInt(conf.native_transport_management_port);
+    }
+
+    @VisibleForTesting
+    public static void setNativeTransportPortManagement(int port)
+    {
+        conf.native_transport_management_port = port;
+    }
+
+    public static int getNativeTransportManagementMaxThreads()
+    {
+        return conf.native_transport_management_max_threads;
+    }
+
+    public static void setNativeTransportManagementMaxThreads(int max_threads)
+    {
+        conf.native_transport_management_max_threads = max_threads;
     }
 
     public static Config.PaxosVariant getPaxosVariant()

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -143,6 +143,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.CONFIG_LOA
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_STCS_IN_L0;
 import static org.apache.cassandra.config.CassandraRelevantProperties.INITIAL_TOKEN;
 import static org.apache.cassandra.config.CassandraRelevantProperties.IO_NETTY_TRANSPORT_ESTIMATE_SIZE_ON_SUBMIT;
+import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_TRANSPORT_MANAGEMENT_PORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_TRANSPORT_PORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.OS_ARCH;
 import static org.apache.cassandra.config.CassandraRelevantProperties.PARTITIONER;
@@ -210,6 +211,7 @@ public class DatabaseDescriptor
     private static InetAddress broadcastAddress;
     private static InetAddress rpcAddress;
     private static InetAddress broadcastRpcAddress;
+    private static InetAddress rpcManagementAddress;
     private static SeedProvider seedProvider;
     private static IInternodeAuthenticator internodeAuthenticator = new AllowAllInternodeAuthenticator();
 
@@ -1443,6 +1445,7 @@ public class DatabaseDescriptor
         rpcAddress = null;
         broadcastAddress = null;
         broadcastRpcAddress = null;
+        rpcManagementAddress = null;
 
         /* Local IP, hostname or interface to bind services to */
         if (config.listen_address != null && config.listen_interface != null)
@@ -1529,6 +1532,32 @@ public class DatabaseDescriptor
             if (rpcAddress.isAnyLocalAddress())
                 throw new ConfigurationException("If rpc_address is set to a wildcard address (" + config.rpc_address + "), then " +
                                                  "you must set broadcast_rpc_address to a value other than " + config.rpc_address, false);
+        }
+
+        /* Local IP, hostname or interface to bind Management RPC server to */
+        if (config.rpc_management_address != null && config.rpc_management_interface != null)
+        {
+            throw new ConfigurationException("Set rpc_management_address OR rpc_management_interface, not both", false);
+        }
+        else if (config.rpc_management_address != null)
+        {
+            try
+            {
+                rpcManagementAddress = InetAddress.getByName(config.rpc_management_address);
+            }
+            catch (UnknownHostException e)
+            {
+                throw new ConfigurationException("Unknown host in rpc_management_address " + config.rpc_management_address, false);
+            }
+        }
+        else if (config.rpc_management_interface != null)
+        {
+            rpcManagementAddress = getNetworkInterfaceAddress(config.rpc_management_interface, "rpc_management_interface", config.rpc_management_interface_prefer_ipv6);
+        }
+        else
+        {
+            // Default to regular rpc_address if not specified
+            rpcManagementAddress = rpcAddress;
         }
     }
 
@@ -3454,6 +3483,18 @@ public class DatabaseDescriptor
         return rpcAddress;
     }
 
+    /**
+     * This is the address used to bind for the native management protocol to communicate with management clients.
+     * If not explicitly configured via rpc_management_address or rpc_management_interface, defaults to the regular
+     * rpc_address. The address alone is not enough to uniquely identify this instance because multiple instances
+     * might use the same interface with different ports.
+     */
+    public static InetAddress getRpcManagementAddress()
+    {
+        assert rpcManagementAddress != null;
+        return rpcManagementAddress;
+    }
+
     public static void setBroadcastRpcAddress(InetAddress broadcastRPCAddr)
     {
         broadcastRpcAddress = broadcastRPCAddr;
@@ -3696,6 +3737,38 @@ public class DatabaseDescriptor
                    conf.native_transport_max_request_data_in_flight_per_ip.toBytes()
                    )
         );
+    }
+
+    public static boolean startNativeTransportManagement()
+    {
+        return conf.start_native_transport_management;
+    }
+
+    @VisibleForTesting
+    public static void setStartNativeTransportManagement(boolean start)
+    {
+        conf.start_native_transport_management = start;
+    }
+
+    public static int getNativeTransportManagementPort()
+    {
+        return NATIVE_TRANSPORT_MANAGEMENT_PORT.getInt(conf.native_transport_management_port);
+    }
+
+    @VisibleForTesting
+    public static void setNativeTransportPortManagement(int port)
+    {
+        conf.native_transport_management_port = port;
+    }
+
+    public static int getNativeTransportManagementMaxThreads()
+    {
+        return conf.native_transport_management_max_threads;
+    }
+
+    public static void setNativeTransportManagementMaxThreads(int max_threads)
+    {
+        conf.native_transport_management_max_threads = max_threads;
     }
 
     public static Config.PaxosVariant getPaxosVariant()

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -20,12 +20,14 @@ package org.apache.cassandra.config;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -49,7 +51,6 @@ import org.apache.cassandra.service.disk.usage.DiskUsageMonitor;
 import org.apache.cassandra.utils.LocalizeString;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Configuration settings for guardrails populated from the Yaml file.
@@ -1617,12 +1618,24 @@ public class GuardrailsOptions implements GuardrailsConfig
                                                       "than the fail threshold %s", warn, name, fail));
     }
 
+    /**
+     * See {@code GuardrailsConfigCommandTest}, that relies on the fact that the error messages for invalid properties
+     * are deterministic and contain the list of invalid properties in the same order as they were provided in the command.
+     *
+     * @param properties set of properties to validate.
+     * @param name name of the property for error messages.
+     * @return set of properties converted to lower case.
+     */
     private static Set<String> validateTableProperties(Set<String> properties, String name)
     {
         if (properties == null)
             throw new IllegalArgumentException(format("Invalid value for %s: null is not allowed", name));
 
-        Set<String> lowerCaseProperties = properties.stream().map(String::toLowerCase).collect(toSet());
+        // We use LinkedHashSet to preserve the order of properties in error messages. This is
+        // used to avoid confusion in an error message when the CQL/nodetool commands are invoked
+        // with properties in a specific order.
+        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized)
+                                                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<String> diff = Sets.difference(lowerCaseProperties, TableAttributes.allKeywords());
 
@@ -1637,7 +1650,11 @@ public class GuardrailsOptions implements GuardrailsConfig
         if (properties == null)
             throw new IllegalArgumentException(format("Invalid value for %s: null is not allowed", name));
 
-        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized).collect(toSet());
+        // We use LinkedHashSet to preserve the order of properties in error messages. This is
+        // used to avoid confusion in an error message when the CQL/nodetool commands are invoked
+        // with properties in a specific order.
+        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized)
+                                                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
         for (String requiredKeyword : KeyspaceAttributes.requiredKeywords())
         {

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -20,12 +20,14 @@ package org.apache.cassandra.config;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -49,7 +51,6 @@ import org.apache.cassandra.service.disk.usage.DiskUsageMonitor;
 import org.apache.cassandra.utils.LocalizeString;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Configuration settings for guardrails populated from the Yaml file.
@@ -1581,12 +1582,24 @@ public class GuardrailsOptions implements GuardrailsConfig
                                                       "than the fail threshold %s", warn, name, fail));
     }
 
+    /**
+     * See {@code GuardrailsConfigCommandTest}, that relies on the fact that the error messages for invalid properties
+     * are deterministic and contain the list of invalid properties in the same order as they were provided in the command.
+     *
+     * @param properties set of properties to validate.
+     * @param name name of the property for error messages.
+     * @return set of properties converted to lower case.
+     */
     private static Set<String> validateTableProperties(Set<String> properties, String name)
     {
         if (properties == null)
             throw new IllegalArgumentException(format("Invalid value for %s: null is not allowed", name));
 
-        Set<String> lowerCaseProperties = properties.stream().map(String::toLowerCase).collect(toSet());
+        // We use LinkedHashSet to preserve the order of properties in error messages. This is
+        // used to avoid confusion in an error message when the CQL/nodetool commands are invoked
+        // with properties in a specific order.
+        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized)
+                                                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<String> diff = Sets.difference(lowerCaseProperties, TableAttributes.allKeywords());
 
@@ -1601,7 +1614,11 @@ public class GuardrailsOptions implements GuardrailsConfig
         if (properties == null)
             throw new IllegalArgumentException(format("Invalid value for %s: null is not allowed", name));
 
-        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized).collect(toSet());
+        // We use LinkedHashSet to preserve the order of properties in error messages. This is
+        // used to avoid confusion in an error message when the CQL/nodetool commands are invoked
+        // with properties in a specific order.
+        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized)
+                                                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
         for (String requiredKeyword : KeyspaceAttributes.requiredKeywords())
         {

--- a/src/java/org/apache/cassandra/config/GuardrailsOptions.java
+++ b/src/java/org/apache/cassandra/config/GuardrailsOptions.java
@@ -19,10 +19,12 @@
 package org.apache.cassandra.config;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -44,7 +46,6 @@ import org.apache.cassandra.service.disk.usage.DiskUsageMonitor;
 import org.apache.cassandra.utils.LocalizeString;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Configuration settings for guardrails populated from the Yaml file.
@@ -1515,12 +1516,24 @@ public class GuardrailsOptions implements GuardrailsConfig
                                                       "than the fail threshold %s", warn, name, fail));
     }
 
+    /**
+     * See {@code GuardrailsConfigCommandTest}, that relies on the fact that the error messages for invalid properties
+     * are deterministic and contain the list of invalid properties in the same order as they were provided in the command.
+     *
+     * @param properties set of properties to validate.
+     * @param name name of the property for error messages.
+     * @return set of properties converted to lower case.
+     */
     private static Set<String> validateTableProperties(Set<String> properties, String name)
     {
         if (properties == null)
             throw new IllegalArgumentException(format("Invalid value for %s: null is not allowed", name));
 
-        Set<String> lowerCaseProperties = properties.stream().map(String::toLowerCase).collect(toSet());
+        // We use LinkedHashSet to preserve the order of properties in error messages. This is
+        // used to avoid confusion in an error message when the CQL/nodetool commands are invoked
+        // with properties in a specific order.
+        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized)
+                                                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<String> diff = Sets.difference(lowerCaseProperties, TableAttributes.allKeywords());
 
@@ -1535,7 +1548,11 @@ public class GuardrailsOptions implements GuardrailsConfig
         if (properties == null)
             throw new IllegalArgumentException(format("Invalid value for %s: null is not allowed", name));
 
-        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized).collect(toSet());
+        // We use LinkedHashSet to preserve the order of properties in error messages. This is
+        // used to avoid confusion in an error message when the CQL/nodetool commands are invoked
+        // with properties in a specific order.
+        Set<String> lowerCaseProperties = properties.stream().map(LocalizeString::toLowerCaseLocalized)
+                                                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
         for (String requiredKeyword : KeyspaceAttributes.requiredKeywords())
         {

--- a/src/java/org/apache/cassandra/cql3/statements/ExecuteCommandStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ExecuteCommandStatement.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.statements;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.management.CommandAuthorizationException;
+import org.apache.cassandra.management.CommandExecutionArgsSerde;
+import org.apache.cassandra.management.CommandExecutionException;
+import org.apache.cassandra.management.CommandInvokerService;
+import org.apache.cassandra.management.CommandValidationException;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import static org.apache.cassandra.management.ManagementUtils.causeMessages;
+import static org.apache.cassandra.management.ManagementUtils.findRegistryCommand;
+import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
+
+public class ExecuteCommandStatement
+{
+    public static final String COMMAND_RESULT_SCHEMA_EXECUTION_ID = "execution_id";
+    public static final String COMMAND_RESULT_SCHEMA_OUTPUT = "output";
+
+    public static class Raw extends CQLStatement.Raw implements CQLStatement
+    {
+        private final String commandName;
+        private final Map<String, Object> args;
+
+        public Raw(String commandName, Map<String, Object> args)
+        {
+            this.commandName = commandName;
+            this.args = args;
+        }
+
+        public String commandName()
+        {
+            return commandName;
+        }
+
+        public Map<String, Object> args()
+        {
+            return args;
+        }
+
+        public CQLStatement prepare(ClientState state)
+        {
+            return this;
+        }
+
+        public void authorize(ClientState state) throws UnauthorizedException
+        {
+            // TODO: CASSANDRA-XXXXX Restrict command execution to deployments without authentication
+            //  This is a temporary limitation until full authentication support is implemented.
+            if (DatabaseDescriptor.getAuthenticator().requireAuthentication())
+            {
+                throw new UnauthorizedException("Command execution via management port is currently only supported " +
+                                                "when authentication is disabled (AllowAllAuthenticator). " +
+                                                "Full authentication and authorization support will be added in a " +
+                                                "future release.");
+            }
+
+            // Validate login (will succeed with AllowAllAuthenticator)
+            state.validateLogin();
+        }
+
+        @Override
+        public void validate(ClientState state) throws InvalidRequestException
+        {
+            Command<?> command = findRegistryCommand(commandName, CommandInvokerService.instance.getRegistry());
+            if (command == null)
+                throw new InvalidRequestException("Command not found: " + commandName);
+        }
+
+        @Override
+        public ResultMessage execute(QueryState state, QueryOptions options, Dispatcher.RequestTime requestTime)
+        {
+            try
+            {
+                ClientState clientState = state.getClientState();
+                if (!clientState.isInternal && !clientState.isManagement())
+                    throw  new InvalidRequestException("Command execution is only allowed via native management interface");
+
+                Command<?> command = findRegistryCommand(commandName, CommandInvokerService.instance.getRegistry());
+                if (command == null)
+                    throw new InvalidRequestException("Command not found: " + commandName);
+
+                CommandInvokerService.CommandResult result = CommandInvokerService.instance
+                                                             .invokeCommand(commandName,
+                                                                            () -> CommandExecutionArgsSerde.fromMap(args, command.metadata()));
+
+                ResultSet resultSet = getCommandResultSet();
+                resultSet.addColumnValue(bytes(result.getExecutionId()));
+                resultSet.addColumnValue(bytes(result.getOutput()));
+                return new ResultMessage.Rows(resultSet);
+            }
+            catch (CommandAuthorizationException e)
+            {
+                throw new UnauthorizedException(e.getMessage());
+            }
+            catch (CommandValidationException e)
+            {
+                throw new InvalidRequestException(causeMessages(e), e.getCause());
+            }
+            catch (CommandExecutionException e)
+            {
+                throw new CommandRequestExecutionException(e.getExecutionId(),
+                                                           causeMessages(e),
+                                                           e.getCause());
+            }
+        }
+
+        private static ResultSet getCommandResultSet()
+        {
+            ColumnSpecification executionIdColumn = new ColumnSpecification("system",
+                                                                            "command_output",
+                                                                            new ColumnIdentifier(COMMAND_RESULT_SCHEMA_EXECUTION_ID, true),
+                                                                            UUIDType.instance);
+            ColumnSpecification outputColumn = new ColumnSpecification("system",
+                                                                       "command_output",
+                                                                       new ColumnIdentifier(COMMAND_RESULT_SCHEMA_OUTPUT, true),
+                                                                       UTF8Type.instance);
+            return new ResultSet(new ResultSet.ResultMetadata(List.of(executionIdColumn, outputColumn)));
+        }
+
+        public ResultMessage executeLocally(QueryState state, QueryOptions options) throws InvalidRequestException
+        {
+            return execute(state, options, Dispatcher.RequestTime.forImmediateExecution());
+        }
+
+        @Override
+        public AuditLogContext getAuditLogContext()
+        {
+            return new AuditLogContext(AuditLogEntryType.EXECUTE_COMMAND, commandName);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/cql3/statements/ExecuteCommandStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ExecuteCommandStatement.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import org.apache.cassandra.audit.AuditLogContext;
 import org.apache.cassandra.audit.AuditLogEntryType;
+import org.apache.cassandra.auth.CommandResource;
+import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnIdentifier;
@@ -87,12 +89,18 @@ public class ExecuteCommandStatement
             {
                 throw new UnauthorizedException("Command execution via management port is currently only supported " +
                                                 "when authentication is disabled (AllowAllAuthenticator). " +
-                                                "Full authentication and authorization support will be added in a " +
-                                                "future release.");
+                                                "Full authentication support will be added in a future release.");
             }
 
             // Validate login (will succeed with AllowAllAuthenticator)
             state.validateLogin();
+
+            // TODO CASSANDRA-XXXXX Commands invoked via JMX are guarded by JMXResource grants against the command's
+            //  MBean. CommandResource is the CQL-side equivalent, but has no GRANT/REVOKE grammar yet. No grant is
+            //  needed today.
+            Command<?> command = findRegistryCommand(commandName, CommandInvokerService.instance.getRegistry());
+            if (command != null)
+                state.ensurePermission(Permission.EXECUTE, CommandResource.command(commandName));
         }
 
         @Override
@@ -138,6 +146,14 @@ public class ExecuteCommandStatement
                 throw new CommandRequestExecutionException(e.getExecutionId(),
                                                            causeMessages(e),
                                                            e.getCause());
+            }
+            catch (InvalidRequestException | UnauthorizedException e)
+            {
+                throw e;
+            }
+            catch (Exception e)
+            {
+                throw new InvalidRequestException("Unexpected error executing command: " + e.getMessage());
             }
         }
 

--- a/src/java/org/apache/cassandra/cql3/statements/ExecuteCommandStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ExecuteCommandStatement.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.statements;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Throwables;
+
+import org.apache.cassandra.audit.AuditLogContext;
+import org.apache.cassandra.audit.AuditLogEntryType;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.management.CommandAuthorizationException;
+import org.apache.cassandra.management.CommandExecutionArgsSerde;
+import org.apache.cassandra.management.CommandExecutionException;
+import org.apache.cassandra.management.CommandInvokerService;
+import org.apache.cassandra.management.CommandValidationException;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import static org.apache.cassandra.management.ManagementUtils.findRegistryCommand;
+import static org.apache.cassandra.utils.ByteBufferUtil.bytes;
+
+public class ExecuteCommandStatement
+{
+    public static final String COMMAND_RESULT_SCHEMA_EXECUTION_ID = "execution_id";
+    public static final String COMMAND_RESULT_SCHEMA_OUTPUT = "output";
+
+    public static class Raw extends CQLStatement.Raw implements CQLStatement
+    {
+        private final String commandName;
+        private final Map<String, Object> args;
+
+        public Raw(String commandName, Map<String, Object> args)
+        {
+            this.commandName = commandName;
+            this.args = args;
+        }
+
+        public String commandName()
+        {
+            return commandName;
+        }
+
+        public Map<String, Object> args()
+        {
+            return args;
+        }
+
+        public CQLStatement prepare(ClientState state)
+        {
+            return this;
+        }
+
+        public void authorize(ClientState state) throws UnauthorizedException
+        {
+            // TODO: CASSANDRA-XXXXX Restrict command execution to deployments without authentication
+            //  This is a temporary limitation until full authentication support is implemented.
+            if (DatabaseDescriptor.getAuthenticator().requireAuthentication())
+            {
+                throw new UnauthorizedException("Command execution via management port is currently only supported " +
+                                                "when authentication is disabled (AllowAllAuthenticator). " +
+                                                "Full authentication and authorization support will be added in a " +
+                                                "future release.");
+            }
+
+            // Validate login (will succeed with AllowAllAuthenticator)
+            state.validateLogin();
+        }
+
+        @Override
+        public void validate(ClientState state) throws InvalidRequestException
+        {
+            Command<?> command = findRegistryCommand(commandName, CommandInvokerService.instance.getRegistry());
+            if (command == null)
+                throw new InvalidRequestException("Command not found: " + commandName);
+        }
+
+        @Override
+        public ResultMessage execute(QueryState state, QueryOptions options, Dispatcher.RequestTime requestTime)
+        {
+            try
+            {
+                ClientState clientState = state.getClientState();
+                if (!clientState.isInternal && !clientState.isManagement())
+                    throw  new InvalidRequestException("Command execution is only allowed via native management interface");
+
+                Command<?> command = findRegistryCommand(commandName, CommandInvokerService.instance.getRegistry());
+                if (command == null)
+                    throw new InvalidRequestException("Command not found: " + commandName);
+
+                CommandInvokerService.CommandResult result = CommandInvokerService.instance
+                                                             .invokeCommand(commandName,
+                                                                            () -> CommandExecutionArgsSerde.fromMap(args, command.metadata()));
+
+                ResultSet resultSet = getCommandResultSet();
+                resultSet.addColumnValue(bytes(result.getExecutionId()));
+                resultSet.addColumnValue(bytes(result.getOutput()));
+                return new ResultMessage.Rows(resultSet);
+            }
+            catch (CommandAuthorizationException e)
+            {
+                throw new UnauthorizedException(e.getMessage());
+            }
+            catch (CommandValidationException e)
+            {
+                throw new InvalidRequestException(Throwables.getStackTraceAsString(e), e.getCause());
+            }
+            catch (CommandExecutionException e)
+            {
+                throw new CommandRequestExecutionException(e.getExecutionId(),
+                                                           Throwables.getStackTraceAsString(e),
+                                                           e.getCause());
+            }
+        }
+
+        private static ResultSet getCommandResultSet()
+        {
+            ColumnSpecification executionIdColumn = new ColumnSpecification("system",
+                                                                            "command_output",
+                                                                            new ColumnIdentifier(COMMAND_RESULT_SCHEMA_EXECUTION_ID, true),
+                                                                            UUIDType.instance);
+            ColumnSpecification outputColumn = new ColumnSpecification("system",
+                                                                       "command_output",
+                                                                       new ColumnIdentifier(COMMAND_RESULT_SCHEMA_OUTPUT, true),
+                                                                       UTF8Type.instance);
+            return new ResultSet(new ResultSet.ResultMetadata(List.of(executionIdColumn, outputColumn)));
+        }
+
+        public ResultMessage executeLocally(QueryState state, QueryOptions options) throws InvalidRequestException
+        {
+            return execute(state, options, Dispatcher.RequestTime.forImmediateExecution());
+        }
+
+        @Override
+        public AuditLogContext getAuditLogContext()
+        {
+            return new AuditLogContext(AuditLogEntryType.EXECUTE_COMMAND, commandName);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/db/compression/CompressionDictionaryManager.java
+++ b/src/java/org/apache/cassandra/db/compression/CompressionDictionaryManager.java
@@ -177,7 +177,8 @@ public class CompressionDictionaryManager implements CompressionDictionaryManage
         // Validate table supports dictionary compression
         if (!isEnabled)
         {
-            throw new UnsupportedOperationException("Table " + keyspaceName + '.' + tableName + " does not support dictionary compression");
+            throw new IllegalStateException(format("The compression on table %s.%s is not enabled or SSTable compressor is not a dictionary compressor.",
+                                                   keyspaceName, tableName));
         }
 
         // resolve training config and fail fast when invalid, so we do not reach logic which would e.g. flush unnecessarily.
@@ -353,11 +354,11 @@ public class CompressionDictionaryManager implements CompressionDictionaryManage
             if (lastTraining.isAfter(now.minus(config.minTrainingFrequency, ChronoUnit.MINUTES)))
             {
                 Instant nextEarliestTraining = lastTraining.plus(config.minTrainingFrequency, ChronoUnit.MINUTES);
-                throw new IllegalArgumentException(format("The next training or importing can occur only at least after %s from the last training which happened at %s. " +
-                                                          "You can train again no earlier than at %s.",
-                                                          new DurationSpec.IntMinutesBound(config.minTrainingFrequency, TimeUnit.MINUTES),
-                                                          lastTraining,
-                                                          nextEarliestTraining));
+                throw new RuntimeException(format("The next training or importing can occur only at least after %s from the last training which happened at %s. " +
+                                                  "You can train again no earlier than at %s.",
+                                                  new DurationSpec.IntMinutesBound(config.minTrainingFrequency, TimeUnit.MINUTES),
+                                                  lastTraining,
+                                                  nextEarliestTraining));
             }
         }
     }

--- a/src/java/org/apache/cassandra/db/virtual/CIDRFilteringMetricsTable.java
+++ b/src/java/org/apache/cassandra/db/virtual/CIDRFilteringMetricsTable.java
@@ -56,7 +56,7 @@ public class CIDRFilteringMetricsTable implements CIDRFilteringMetricsTableMBean
 {
     public static final String MBEAN_NAME = "org.apache.cassandra.db:type=CIDRFilteringMetricsTable";
 
-    private static final CIDRFilteringMetricsTable instance = new CIDRFilteringMetricsTable();
+    public static final CIDRFilteringMetricsTable instance = new CIDRFilteringMetricsTable();
 
     CIDRFilteringMetricsTable()
     {

--- a/src/java/org/apache/cassandra/exceptions/CommandRequestExecutionException.java
+++ b/src/java/org/apache/cassandra/exceptions/CommandRequestExecutionException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.exceptions;
+
+import java.util.UUID;
+
+public class CommandRequestExecutionException extends RequestExecutionException
+{
+    private final UUID commandExecutionId;
+
+    public CommandRequestExecutionException(UUID commandExecutionId, String msg, Throwable cause)
+    {
+        super(ExceptionCode.COMMAND_FAILED, msg, cause);
+        this.commandExecutionId = commandExecutionId;
+    }
+
+    public CommandRequestExecutionException(UUID commandExecutionId, String msg)
+    {
+        super(ExceptionCode.COMMAND_FAILED, msg);
+        this.commandExecutionId = commandExecutionId;
+    }
+
+    public UUID getCommandExecutionId()
+    {
+        return commandExecutionId;
+    }
+}

--- a/src/java/org/apache/cassandra/exceptions/ExceptionCode.java
+++ b/src/java/org/apache/cassandra/exceptions/ExceptionCode.java
@@ -48,6 +48,7 @@ public enum ExceptionCode
     WRITE_FAILURE       (0x1500),
     CDC_WRITE_FAILURE   (0x1600),
     CAS_WRITE_UNKNOWN   (0x1700),
+    COMMAND_FAILED      (0x1800),
 
     // 2xx: problem validating the request
     SYNTAX_ERROR    (0x2000),

--- a/src/java/org/apache/cassandra/management/CassandraCommandRegistry.java
+++ b/src/java/org/apache/cassandra/management/CassandraCommandRegistry.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandExecutionContext;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.CommandRegistry;
+import org.apache.cassandra.management.api.CommandsProvider;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+
+import static org.apache.cassandra.management.ManagementUtils.loadService;
+
+public class CassandraCommandRegistry implements CommandRegistry
+{
+    private static final Logger logger = LoggerFactory.getLogger(CassandraCommandRegistry.class);
+
+    // TODO CASSANDRA-XXXXX These long-running commands block the calling thread for
+    //  the entire command duration. They are excluded from the management API until a
+    //  ProgressCommand (extends Command) interface is implemented to support long-running
+    //  command execution with progress reporting.
+    static final Set<String> UNSUPPORTED_COMMANDS = Set.of("repair", "consensus_admin");
+
+    private final Map<String, Command<?>> commandMap = new ConcurrentHashMap<>();
+
+    public CassandraCommandRegistry()
+    {
+        for (CommandsProvider provider : loadService(CommandsProvider.class))
+            provider.commands().forEach(this::register);
+    }
+
+    public void register(Command<?> command)
+    {
+        if (UNSUPPORTED_COMMANDS.contains(command.name()))
+        {
+            logger.info("Skipping unsupported command '{}': long-running commands require " +
+                        "ProgressCommand support (not yet implemented)", command.name());
+            return;
+        }
+
+        Command<?> prev = commandMap.putIfAbsent(command.name(), command);
+
+        if (prev != null)
+            throw new IllegalStateException(String.format("Command name conflict: '%s' is already registered",
+                                                          command.name()));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Command<T> command(String name)
+    {
+        return (Command<T>) commandMap.get(name);
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, Command<?>>> commands()
+    {
+        return commandMap.entrySet();
+    }
+
+    @Override
+    public CommandMetadata metadata()
+    {
+        // Return metadata that reflects this is a registry, not a leaf command
+        return new RootCommandMetadata();
+    }
+
+    @Override
+    public String execute(CommandExecutionArgs arguments, CommandExecutionContext context)
+    {
+        // CommandRegistry is not directly executable: routing happens at the invoker/CQL layer.
+        throw new UnsupportedOperationException(
+            String.format("CommandRegistry '%s' is not directly executable. " +
+                         "Specify a subcommand. Available commands: %s",
+                         name(),
+                         String.join(", ", commandMap.keySet())));
+    }
+
+    private class RootCommandMetadata implements CommandMetadata
+    {
+        @Override
+        public String name()
+        {
+            return "root";
+        }
+
+        @Override
+        public String description()
+        {
+            return "Root command registry - use a specific subcommand";
+        }
+
+        @Override
+        public List<OptionMetadata> options()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<ParameterMetadata> parameters()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<CommandMetadata> subcommands()
+        {
+            return commandMap.values().stream()
+                    .map(Command::metadata)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandAuthorizationException.java
+++ b/src/java/org/apache/cassandra/management/CommandAuthorizationException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+public class CommandAuthorizationException extends Exception
+{
+    public CommandAuthorizationException(String msg)
+    {
+        super(msg);
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandExecutionArgsSerde.java
+++ b/src/java/org/apache/cassandra/management/CommandExecutionArgsSerde.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.lang.reflect.Array;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.management.api.ArgumentMetadata;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.management.picocli.PicocliCommandMetadata;
+import org.apache.cassandra.management.picocli.PicocliOptionMetadata;
+import org.apache.cassandra.management.picocli.PicocliParameterMetadata;
+import org.apache.cassandra.management.picocli.TypeConverterRegistry;
+import org.apache.cassandra.utils.JsonUtils;
+
+import static org.apache.cassandra.management.ManagementUtils.normalizeOptionName;
+import static org.apache.cassandra.management.api.ParameterMetadata.COMMAND_POSITIONAL_PARAM_PREFIX;
+
+public class CommandExecutionArgsSerde
+{
+    public static String toJson(CommandExecutionArgs args)
+    {
+        Map<String, Object> params = new LinkedHashMap<>();
+
+        for (Map.Entry<OptionMetadata, Object> entry : args.options().entrySet())
+        {
+            OptionMetadata optionMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            String primaryName = normalizeOptionName(optionMetadata.paramLabel());
+            params.put(primaryName, normalizeJsonValue(value));
+        }
+
+        for (Map.Entry<ParameterMetadata, Object> entry : args.parameters().entrySet())
+        {
+            ParameterMetadata paramMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            int index = paramMetadata.index();
+            String indexKey = COMMAND_POSITIONAL_PARAM_PREFIX + index;
+            params.put(indexKey, normalizeJsonValue(value));
+        }
+
+        return JsonUtils.writeAsJsonString(params);
+    }
+
+    public static CommandExecutionArgs fromJson(String json, CommandMetadata metadata)
+    {
+        if (!(metadata instanceof PicocliCommandMetadata))
+            throw new IllegalArgumentException("CommandMetadata must be PicocliCommandMetadata for picocli commands");
+
+        Map<String, Object> jsonMap = JsonUtils.fromJsonMap(json);
+        Map<OptionMetadata, Object> options = new LinkedHashMap<>();
+        Map<ParameterMetadata, Object> parameters = new LinkedHashMap<>();
+
+        convertFromMap(jsonMap, metadata, options, parameters);
+        return new SimpleCommandExecutionArgs(options, parameters);
+    }
+
+    public static CommandExecutionArgs fromMap(Map<String, Object> format, CommandMetadata metadata)
+    {
+        if (!(metadata instanceof PicocliCommandMetadata))
+            throw new IllegalArgumentException("CommandMetadata must be PicocliCommandMetadata for picocli commands");
+
+        Map<OptionMetadata, Object> options = new LinkedHashMap<>();
+        Map<ParameterMetadata, Object> parameters = new LinkedHashMap<>();
+
+        convertFromMap(format, metadata, options, parameters);
+        return new SimpleCommandExecutionArgs(options, parameters);
+    }
+
+    private static void convertFromMap(Map<String, Object> source,
+                                       CommandMetadata metadata,
+                                       Map<OptionMetadata, Object> options,
+                                       Map<ParameterMetadata, Object> parameters)
+    {
+        for (Map.Entry<String, Object> entry : source.entrySet())
+        {
+            String paramName = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            OptionMetadata option = findOptionByNameIgnoreCase(metadata, paramName);
+            if (option != null)
+            {
+                Object convertedValue = convertValue(value, option);
+                options.put(option, convertedValue);
+                continue;
+            }
+
+            ParameterMetadata param = findParameterByName(metadata, paramName);
+            if (param != null)
+            {
+                Object convertedValue = convertValue(value, param);
+                parameters.put(param, convertedValue);
+            }
+            else
+            {
+                throw new IllegalArgumentException("Unknown parameter: " + paramName);
+            }
+        }
+    }
+
+    /** Convert value using custom converter if provided, otherwise use basic conversion. */
+    private static Object convertValue(Object value, ArgumentMetadata argSpec)
+    {
+        try
+        {
+            // Custom type converters are only supported for picocli-based metadata.
+            if (argSpec instanceof PicocliParameterMetadata)
+                return ((PicocliParameterMetadata) argSpec).convertValue(value);
+            else if (argSpec instanceof PicocliOptionMetadata)
+                return ((PicocliOptionMetadata) argSpec).convertValue(value);
+
+            return TypeConverterRegistry.convertValueBasic(value, argSpec.type());
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new IllegalArgumentException(String.format("Failed to convert value '%s' to type %s: %s",
+                                                             value,
+                                                             argSpec.type().getName(),
+                                                             e.getMessage()), e);
+        }
+    }
+
+    /**
+     * This method converts values from CommandExecutionArgs into JSON-serializable formats before
+     * they're put into a Map(String, Object) that will be serialized to JSON. Different implementations
+     * (e.g., Set, LinkedHashSet) should be normalized to List for consistent JSON output.
+     * <p>
+     * The conversion rules are:
+     * - Converts primitive arrays (String[], int[], etc.) -> Object[] (JSON-serializable)
+     * - Converts any Collection -> List (JSON-serializable)
+     * - Leaves other types unchanged
+     *
+     * @param value the value to convert.
+     * @return the converted value.
+     */
+    private static Object normalizeJsonValue(Object value)
+    {
+        if (value == null)
+            return null;
+
+        if (value.getClass().isArray())
+        {
+            int length = Array.getLength(value);
+            Object[] array = new Object[length];
+            for (int i = 0; i < length; i++)
+                array[i] = normalizeJsonValue(Array.get(value, i));
+            return array;
+        }
+
+        if (value instanceof java.util.Collection)
+        {
+            return ((java.util.Collection<?>) value).stream()
+                                                    .map(CommandExecutionArgsSerde::normalizeJsonValue)
+                                                    .collect(Collectors.toList());
+        }
+
+        return value;
+    }
+
+    /**
+     * Find ParameterMetadata by name (supports both an index format and paramLabel).
+     */
+    private static ParameterMetadata findParameterByName(CommandMetadata metadata, String name)
+    {
+        if (name.startsWith(COMMAND_POSITIONAL_PARAM_PREFIX))
+        {
+            try
+            {
+                int index = Integer.parseInt(name.substring(COMMAND_POSITIONAL_PARAM_PREFIX.length()));
+                for (ParameterMetadata param : metadata.parameters())
+                {
+                    if (param.index() == index)
+                        return param;
+                }
+            }
+            catch (NumberFormatException e)
+            {
+                // Not a valid index format, continue to check paramLabel
+            }
+        }
+
+        for (ParameterMetadata param : metadata.parameters())
+        {
+            String paramLabel = param.paramLabel();
+            if (paramLabel != null && paramLabel.equalsIgnoreCase(name))
+                return param;
+        }
+
+        return null;
+    }
+
+    /**
+     * Find OptionMetadata by name (case-insensitive, normalized).
+     * Matches against paramLabel and all names/aliases.
+     */
+    private static OptionMetadata findOptionByNameIgnoreCase(CommandMetadata metadata, String name)
+    {
+        String normalizedName = normalizeOptionName(name);
+
+        for (OptionMetadata option : metadata.options())
+        {
+            String paramLabel = normalizeOptionName(option.paramLabel());
+            if (paramLabel.equalsIgnoreCase(normalizedName))
+                return option;
+
+            for (String alias : option.names())
+            {
+                String normalizedAlias = normalizeOptionName(alias);
+                if (normalizedAlias.equalsIgnoreCase(normalizedName))
+                    return option;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandExecutionArgsSerde.java
+++ b/src/java/org/apache/cassandra/management/CommandExecutionArgsSerde.java
@@ -157,9 +157,9 @@ public class CommandExecutionArgsSerde
     }
 
     /**
-     * This method converts values from CommandExecutionArgs into JSON-serializable formats before
-     * they're put into a Map(String, Object) that will be serialized to JSON. Different implementations
-     * (e.g., Set, LinkedHashSet) should be normalized to List for consistent JSON output.
+     * Converts a value from CommandExecutionArgs into a JSON-serializable form before it goes into the
+     * Map(String, Object) that is serialized to JSON. Collection implementations (e.g. Set, LinkedHashSet)
+     * are normalized to List so the JSON output stays the same shape.
      * <p>
      * The conversion rules are:
      * - Converts primitive arrays (String[], int[], etc.) -> Object[] (JSON-serializable)

--- a/src/java/org/apache/cassandra/management/CommandExecutionException.java
+++ b/src/java/org/apache/cassandra/management/CommandExecutionException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.UUID;
+
+public class CommandExecutionException extends Exception
+{
+    private final UUID executionId;
+
+    public CommandExecutionException(String message, Throwable cause, UUID executionId)
+    {
+        super(message, cause);
+        this.executionId = executionId;
+    }
+
+    public UUID getExecutionId()
+    {
+        return executionId;
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandInvokerService.java
+++ b/src/java/org/apache/cassandra/management/CommandInvokerService.java
@@ -1,0 +1,508 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import javax.management.ObjectName;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandExecutionContext;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.CommandRegistry;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.serializers.MarshalException;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.Output;
+import org.apache.cassandra.utils.Clock;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.management.ManagementUtils.countCommands;
+import static org.apache.cassandra.management.ManagementUtils.findRegistryCommand;
+import static org.apache.cassandra.management.ManagementUtils.fullCommandName;
+
+/**
+ * Service that manages the command registry lifecycle and execution.
+ * <p>
+ * Similar to StorageService, SnapshotManager the service coordinates various aspects of command management:
+ * - Manages lifecycle (initialization, shutdown)
+ * - Coordinates MBean registration
+ * - Provides command execution coordination
+ * - Integrates with daemon startup
+ * - Manages state (registry, MBean instances)
+ */
+public class CommandInvokerService implements CommandInvokerServiceMBean
+{
+    private static final String MBEAN_DOMAIN = "org.apache.cassandra.management";
+    private static final String MBEAN_TYPE_COMMAND = "Command";
+    private static final int MAX_EXECUTION_HISTORY = 100;
+    private static final Logger logger = LoggerFactory.getLogger(CommandInvokerService.class);
+
+    public static final CommandInvokerService instance = new CommandInvokerService();
+
+    private final BoundedExecutionHistory executionHistory = new BoundedExecutionHistory(MAX_EXECUTION_HISTORY);
+    private final Map<String, ObjectName> commandMBeanNames = new ConcurrentHashMap<>();
+    private final MBeanAccessor accessor = new InternalNodeMBeanAccessor();
+    private final CommandRegistry registry;
+
+    private volatile boolean started = false;
+
+    private CommandInvokerService()
+    {
+        this.registry = new CassandraCommandRegistry();
+    }
+
+    public synchronized void start()
+    {
+        if (started)
+            return;
+
+        logger.info("Starting command service");
+
+        registerCommandMBeansRecursively(registry, "");
+        MBeanWrapper.instance.registerMBean(this, MBEAN_NAME);
+
+        started = true;
+        logger.info("Command service started with '{}' commands", countCommands(registry));
+    }
+
+    public static void shutdown()
+    {
+        instance.stop();
+    }
+
+    public synchronized void stop()
+    {
+        if (!started)
+            return;
+
+        logger.info("Stopping command service");
+
+        unregisterCommandMBeans();
+
+        try
+        {
+            MBeanWrapper.instance.unregisterMBean(MBEAN_NAME);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Failed to unregister CommandInvokerService MBean", e);
+        }
+
+        started = false;
+        logger.info("Command service stopped");
+    }
+
+    public CommandRegistry getRegistry()
+    {
+        return registry;
+    }
+
+    /**
+     * @param fullCommandName Full command name, including command demimiter for subcommands.
+     * @param argumentsSupplier Supplier of command execution arguments.
+     *                          This is used to defer argument construction until after all validation checks are passed.
+     * @return captured output of the command execution.
+     */
+    public CommandResult invokeCommand(String fullCommandName, Supplier<CommandExecutionArgs> argumentsSupplier)
+        throws CommandExecutionException, CommandValidationException, CommandAuthorizationException
+    {
+        if (!started)
+            throw new IllegalStateException("CommandInvokerService is not started");
+
+        Command<?> command = findRegistryCommand(fullCommandName, registry);
+        if (command == null)
+            throw new IllegalArgumentException("Command not found: " + fullCommandName);
+
+        return  invokeCommand(fullCommandName, command, argumentsSupplier);
+    }
+
+    /**
+     * Execute a command by name with the given arguments.
+     *
+     * @param command to execute.
+     * @param argumentsSupplier supplier of command execution arguments.
+     * @return captured output of the command execution.
+     */
+    private CommandResult invokeCommand(String fullCommandName, Command<?> command, Supplier<CommandExecutionArgs> argumentsSupplier)
+        throws CommandExecutionException, CommandValidationException, CommandAuthorizationException
+    {
+        if (!started)
+            throw new IllegalStateException("CommandInvokerService is not started");
+
+        UUID executionId = UUID.randomUUID();
+        CapturingOutput captured = new CapturingOutput();
+        ExecutionHistory record = new ExecutionHistory(executionId, fullCommandName, Clock.Global.currentTimeMillis());
+        CommandExecutionContext executionContext = new ServerCommandExecutionContext(new NodeProbe(accessor, captured.createOutput()));
+        executionHistory.add(record);
+
+        try
+        {
+            // TODO: CASSANDRA-XXXXX. Restrict command execution to environments without authentication
+            //  This is a temporary limitation until full authentication support is implemented.
+            if (DatabaseDescriptor.getAuthenticator().requireAuthentication())
+            {
+                throw new CommandAuthorizationException(format("Command execution '%s' via management port is currently " +
+                                                               "only supported when authentication is disabled " +
+                                                               "(AllowAllAuthenticator). Full authentication and authorization " +
+                                                               "support will be added in a future release.", fullCommandName));
+            }
+
+            logger.info("Executing command '{}' with execution ID: {}", fullCommandName, executionId);
+
+            CommandExecutionArgs arguments = argumentsSupplier.get();
+            validateArguments(arguments, command.metadata());
+
+            // Currently, for picocli-based commands in C*, which have no structured result,
+            // the output is written to the Output in the context.
+            Object ignore = command.execute(arguments, executionContext);
+
+            record.completed(Clock.Global.currentTimeMillis());
+            logger.info("Command '{}' (execution ID: {}) completed successfully", fullCommandName, executionId);
+            return new CommandResult(executionId,
+                                     captured.getCapturedOutput(),
+                                     record.startTime,
+                                     record.endTime - record.startTime);
+        }
+        catch (CommandAuthorizationException e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            logger.error("Command '{}' (execution ID: {}) authorization failed", fullCommandName, executionId, e);
+            throw e;
+        }
+        catch (IllegalStateException | IllegalArgumentException | MarshalException e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            String msg = format("Bad usage for command '%s' (execution ID: %s)", fullCommandName, executionId);
+            logger.error(msg, e);
+            throw new CommandValidationException(msg, e);
+        }
+        catch (Exception e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            String msg = format("Command '%s' (execution ID: %s) execution failed", fullCommandName, executionId);
+            logger.error(msg, e);
+            throw new CommandExecutionException(msg, e, executionId);
+        }
+        catch (Throwable e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            logger.error("Command '{}' (execution ID: {}) unexpected error", fullCommandName, executionId, e);
+            throw new CommandExecutionException(format("Unexpected error while executing '%s': %s",
+                                                       fullCommandName, e.getMessage()),
+                                                e,
+                                                executionId);
+        }
+    }
+
+    @Override
+    public String[] getCommandNames()
+    {
+        List<String> commandNames = new ArrayList<>();
+        collectCommandNamesRecursively(registry, "", commandNames);
+        return commandNames.toArray(new String[0]);
+    }
+
+    @VisibleForTesting
+    List<ExecutionHistory> executionHistory()
+    {
+        return executionHistory.snapshot();
+    }
+
+    /** Validate command arguments against metadata. */
+    protected void validateArguments(CommandExecutionArgs arguments, CommandMetadata metadata)
+    {
+        for (OptionMetadata option : metadata.options())
+        {
+            if (option.required() && !arguments.hasOption(option))
+                throw new IllegalArgumentException(String.format("Required option '%s' is missing", option.paramLabel()));
+        }
+
+        for (ParameterMetadata param : metadata.parameters())
+        {
+            if (param.required() && !arguments.hasParameter(param))
+                throw new IllegalArgumentException(String.format("Required parameter at index %d ('%s') is missing",
+                                                                 param.index(), param.paramLabel()));
+        }
+    }
+
+    private void collectCommandNamesRecursively(CommandRegistry registry,
+                                                String parentCommandName,
+                                                List<String> result)
+    {
+        for (Map.Entry<String, Command<?>> entry : registry.commands())
+        {
+            String commandName = entry.getKey();
+            Command<?> command = entry.getValue();
+
+            String fullCommandName = fullCommandName(parentCommandName, commandName);
+            if (command instanceof CommandRegistry)
+                collectCommandNamesRecursively((CommandRegistry) command, fullCommandName, result);
+            else
+                result.add(fullCommandName);
+        }
+    }
+
+    @Override
+    public int getCommandCount()
+    {
+        return countCommands(registry);
+    }
+
+    @Override
+    public String getCommandMBeanName(String fullCommandName)
+    {
+        ObjectName objectName = commandMBeanNames.get(fullCommandName);
+        if (objectName == null)
+            throw new IllegalArgumentException("Command MBean name not found: " + fullCommandName);
+        return objectName.toString();
+    }
+
+    public boolean isStarted()
+    {
+        return started;
+    }
+
+    private void registerCommandMBeansRecursively(CommandRegistry registry, String parentCommandName)
+    {
+        for (Map.Entry<String, Command<?>> e : registry.commands())
+        {
+            String commandName = e.getKey();
+            Command<?> command = e.getValue();
+            String fullCommandName = fullCommandName(parentCommandName, commandName);
+
+            if (command instanceof CommandRegistry)
+            {
+                registerCommandMBeansRecursively((CommandRegistry) command, fullCommandName);
+            }
+            else
+            {
+                try
+                {
+                    String escapedName = ObjectName.quote(fullCommandName);
+                    ObjectName objectName = new ObjectName(format("%s:type=%s,name=%s",
+                                                                  MBEAN_DOMAIN, MBEAN_TYPE_COMMAND, escapedName));
+                    CommandMBeanAdapter commandMBean = new CommandMBeanAdapter(fullCommandName, command, this::invokeCommand);
+                    MBeanWrapper.instance.registerMBean(commandMBean, objectName, MBeanWrapper.OnException.LOG);
+
+                    ObjectName prev = commandMBeanNames.putIfAbsent(fullCommandName, objectName);
+                    if (prev != null)
+                    {
+                        throw new IllegalStateException("Command name conflict during MBean registration: '" +
+                                                        fullCommandName + "' is already registered");
+                    }
+                    logger.debug("Registered command MBean: {} -> {}", fullCommandName, objectName);
+                }
+                catch (Exception ex)
+                {
+                    logger.warn("Failed to register MBean for command: {}", fullCommandName, ex);
+                }
+            }
+        }
+    }
+
+    private void unregisterCommandMBeans()
+    {
+        for (ObjectName objectName : commandMBeanNames.values())
+            MBeanWrapper.instance.unregisterMBean(objectName, MBeanWrapper.OnException.LOG);
+        commandMBeanNames.clear();
+    }
+
+    @VisibleForTesting
+    static class CapturingOutput
+    {
+        private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        private final PrintStream output = new PrintStream(buffer, true, StandardCharsets.UTF_8);
+        private final PrintStream error = new PrintStream(buffer, true, StandardCharsets.UTF_8);
+
+        public String getCapturedOutput()
+        {
+            output.flush();
+            error.flush();
+            return buffer.toString(StandardCharsets.UTF_8);
+        }
+
+        Output createOutput()
+        {
+            return new Output(output, error);
+        }
+    }
+
+    private static class ServerCommandExecutionContext implements CommandExecutionContext
+    {
+        private final Map<Class<?>, Object> services = new HashMap<>();
+
+        public ServerCommandExecutionContext(NodeProbe probe)
+        {
+            services.put(NodeProbe.class, probe);
+            services.put(Output.class, probe.output());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T service(Class<T> serviceType)
+        {
+            T svc = (T) services.get(serviceType);
+            if (svc == null)
+                throw new IllegalArgumentException("Service not available in this context: " + serviceType.getName());
+            return svc;
+        }
+
+        @Override
+        public Set<Class<?>> services()
+        {
+            return services.keySet();
+        }
+    }
+
+    public static class CommandResult
+    {
+        private final UUID executionId;
+        private final String output;
+        private final long startTime;
+        private final long durationMillis;
+
+        public CommandResult(UUID executionId, String output, long startTime, long durationMillis)
+        {
+            this.executionId = executionId;
+            this.output = output;
+            this.startTime = startTime;
+            this.durationMillis = durationMillis;
+        }
+
+        public UUID getExecutionId()
+        {
+            return executionId;
+        }
+
+        public String getOutput()
+        {
+            return output;
+        }
+
+        public long getStartTime()
+        {
+            return startTime;
+        }
+
+        public long getDurationMillis()
+        {
+            return durationMillis;
+        }
+    }
+
+    /**
+     * Record of a single command execution. Retained in {@link BoundedExecutionHistory} and is
+     * surfaced to operators as command execution history via virtual tables.
+     */
+    static class ExecutionHistory
+    {
+        final UUID executionId;
+        final String commandName;
+        final long startTime;
+        volatile long endTime;
+        volatile boolean success;
+        volatile Throwable error;
+
+        ExecutionHistory(UUID executionId, String commandName, long startTime)
+        {
+            this.executionId = executionId;
+            this.commandName = commandName;
+            this.startTime = startTime;
+        }
+
+        void completed(long endTime)
+        {
+            this.endTime = endTime;
+            this.success = true;
+        }
+
+        void failed(long endTime, Throwable error)
+        {
+            this.endTime = endTime;
+            this.success = false;
+            this.error = error;
+        }
+
+        public UUID executionId() { return executionId; }
+        public String commandName() { return commandName; }
+        public boolean isSuccess() { return success; }
+        public Throwable error() { return error; }
+    }
+
+    private static class BoundedExecutionHistory
+    {
+        private final Deque<ExecutionHistory> dq = new ConcurrentLinkedDeque<>();
+        private final AtomicInteger size = new AtomicInteger(0);
+        private final int maxSize;
+
+        public BoundedExecutionHistory(int maxSize)
+        {
+            this.maxSize = maxSize;
+        }
+
+        public void add(ExecutionHistory info)
+        {
+            dq.offer(info);
+
+            if (size.incrementAndGet() > maxSize)
+            {
+                ExecutionHistory removed = dq.pollFirst();
+                if (removed != null)
+                    size.decrementAndGet();
+            }
+        }
+
+        /** Returns a point-in-time snapshot of the retained records, oldest first. */
+        public List<ExecutionHistory> snapshot()
+        {
+            return new ArrayList<>(dq);
+        }
+    }
+
+    @FunctionalInterface
+    public interface Executor
+    {
+        CommandResult execute(String commandName, Supplier<CommandExecutionArgs> argsSupplier)
+            throws CommandExecutionException, CommandValidationException, CommandAuthorizationException;
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandInvokerService.java
+++ b/src/java/org/apache/cassandra/management/CommandInvokerService.java
@@ -61,14 +61,12 @@ import static org.apache.cassandra.management.ManagementUtils.findRegistryComman
 import static org.apache.cassandra.management.ManagementUtils.fullCommandName;
 
 /**
- * Service that manages the command registry lifecycle and execution.
+ * Owns the command registry and executes commands against it.
  * <p>
- * Similar to StorageService, SnapshotManager the service coordinates various aspects of command management:
- * - Manages lifecycle (initialization, shutdown)
- * - Coordinates MBean registration
- * - Provides command execution coordination
- * - Integrates with daemon startup
- * - Manages state (registry, MBean instances)
+ * Like StorageService and SnapshotManager, this is a daemon-lifetime singleton started from
+ * {@link org.apache.cassandra.service.CassandraDaemon}. It builds the registry at startup, registers one
+ * {@link CommandMBeanAdapter} per command, runs commands on behalf of the JMX and CQL transports, and
+ * unregisters everything on shutdown.
  */
 public class CommandInvokerService implements CommandInvokerServiceMBean
 {
@@ -138,9 +136,9 @@ public class CommandInvokerService implements CommandInvokerServiceMBean
     }
 
     /**
-     * @param fullCommandName Full command name, including command demimiter for subcommands.
+     * @param fullCommandName Full command name, including the command delimiter for subcommands.
      * @param argumentsSupplier Supplier of command execution arguments.
-     *                          This is used to defer argument construction until after all validation checks are passed.
+     *                          Defers argument construction until every validation check has passed.
      * @return captured output of the command execution.
      */
     public CommandResult invokeCommand(String fullCommandName, Supplier<CommandExecutionArgs> argumentsSupplier)
@@ -431,8 +429,8 @@ public class CommandInvokerService implements CommandInvokerServiceMBean
     }
 
     /**
-     * Record of a single command execution. Retained in {@link BoundedExecutionHistory} and is
-     * surfaced to operators as command execution history via virtual tables.
+     * Record of a single command execution. Retained in {@link BoundedExecutionHistory} and exposed to
+     * operators as command execution history through virtual tables.
      */
     static class ExecutionHistory
     {

--- a/src/java/org/apache/cassandra/management/CommandInvokerService.java
+++ b/src/java/org/apache/cassandra/management/CommandInvokerService.java
@@ -53,6 +53,7 @@ import org.apache.cassandra.serializers.MarshalException;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.Output;
 import org.apache.cassandra.utils.Clock;
+import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MBeanWrapper;
 
 import static java.lang.String.format;
@@ -223,6 +224,7 @@ public class CommandInvokerService implements CommandInvokerServiceMBean
         }
         catch (Throwable e)
         {
+            JVMStabilityInspector.inspectThrowable(e);
             record.failed(Clock.Global.currentTimeMillis(), e);
             logger.error("Command '{}' (execution ID: {}) unexpected error", fullCommandName, executionId, e);
             throw new CommandExecutionException(format("Unexpected error while executing '%s': %s",

--- a/src/java/org/apache/cassandra/management/CommandInvokerService.java
+++ b/src/java/org/apache/cassandra/management/CommandInvokerService.java
@@ -1,0 +1,482 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import javax.management.ObjectName;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandExecutionContext;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.CommandRegistry;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.Output;
+import org.apache.cassandra.utils.Clock;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static java.lang.String.format;
+import static org.apache.cassandra.management.ManagementUtils.countCommands;
+import static org.apache.cassandra.management.ManagementUtils.findRegistryCommand;
+import static org.apache.cassandra.management.ManagementUtils.fullCommandName;
+
+/**
+ * Service that manages the command registry lifecycle and execution.
+ * <p>
+ * Similar to StorageService, SnapshotManager the service coordinates various aspects of command management:
+ * - Manages lifecycle (initialization, shutdown)
+ * - Coordinates MBean registration
+ * - Provides command execution coordination
+ * - Integrates with daemon startup
+ * - Manages state (registry, MBean instances)
+ */
+public class CommandInvokerService implements CommandInvokerServiceMBean
+{
+    private static final String MBEAN_DOMAIN = "org.apache.cassandra.management";
+    private static final String MBEAN_TYPE_COMMAND = "Command";
+    private static final int MAX_EXECUTION_HISTORY = 100;
+    private static final Logger logger = LoggerFactory.getLogger(CommandInvokerService.class);
+
+    public static final CommandInvokerService instance = new CommandInvokerService();
+
+    private final BoundedExecutionHistory executionHistory = new BoundedExecutionHistory(MAX_EXECUTION_HISTORY);
+    private final Map<String, ObjectName> commandMBeanNames = new ConcurrentHashMap<>();
+    private final MBeanAccessor accessor = new InternalNodeMBeanAccessor();
+    private final CommandRegistry registry;
+
+    private volatile boolean started = false;
+
+    private CommandInvokerService()
+    {
+        this.registry = new CassandraCommandRegistry();
+    }
+
+    public synchronized void start()
+    {
+        if (started)
+            return;
+
+        logger.info("Starting command service");
+
+        registerCommandMBeansRecursively(registry, "");
+        MBeanWrapper.instance.registerMBean(this, MBEAN_NAME);
+
+        started = true;
+        logger.info("Command service started with '{}' commands", countCommands(registry));
+    }
+
+    public static void shutdown()
+    {
+        instance.stop();
+    }
+
+    public synchronized void stop()
+    {
+        if (!started)
+            return;
+
+        logger.info("Stopping command service");
+
+        unregisterCommandMBeans();
+
+        try
+        {
+            MBeanWrapper.instance.unregisterMBean(MBEAN_NAME);
+        }
+        catch (Exception e)
+        {
+            logger.warn("Failed to unregister CommandInvokerService MBean", e);
+        }
+
+        started = false;
+        logger.info("Command service stopped");
+    }
+
+    public CommandRegistry getRegistry()
+    {
+        return registry;
+    }
+
+    /**
+     * @param fullCommandName Full command name, including command demimiter for subcommands.
+     * @param argumentsSupplier Supplier of command execution arguments.
+     *                          This is used to defer argument construction until after all validation checks are passed.
+     * @return captured output of the command execution.
+     */
+    public CommandResult invokeCommand(String fullCommandName, Supplier<CommandExecutionArgs> argumentsSupplier)
+        throws CommandExecutionException, CommandValidationException, CommandAuthorizationException
+    {
+        if (!started)
+            throw new IllegalStateException("CommandInvokerService is not started");
+
+        Command<?> command = findRegistryCommand(fullCommandName, registry);
+        if (command == null)
+            throw new IllegalArgumentException("Command not found: " + fullCommandName);
+
+        return  invokeCommand(fullCommandName, command, argumentsSupplier);
+    }
+
+    /**
+     * Execute a command by name with the given arguments.
+     *
+     * @param command to execute.
+     * @param argumentsSupplier supplier of command execution arguments.
+     * @return captured output of the command execution.
+     */
+    private CommandResult invokeCommand(String fullCommandName, Command<?> command, Supplier<CommandExecutionArgs> argumentsSupplier)
+        throws CommandExecutionException, CommandValidationException, CommandAuthorizationException
+    {
+        if (!started)
+            throw new IllegalStateException("CommandInvokerService is not started");
+
+        UUID executionId = UUID.randomUUID();
+        CapturingOutput captured = new CapturingOutput();
+        ExecutionHistory record = new ExecutionHistory(fullCommandName, Clock.Global.currentTimeMillis());
+        CommandExecutionContext executionContext = new ServerCommandExecutionContext(new NodeProbe(accessor, captured.createOutput()));
+
+        try
+        {
+            // TODO: CASSANDRA-XXXXX. Restrict command execution to environments without authentication
+            //  This is a temporary limitation until full authentication support is implemented.
+            if (DatabaseDescriptor.getAuthenticator().requireAuthentication())
+            {
+                throw new CommandAuthorizationException(format("Command execution '%s' via management port is currently " +
+                                                               "only supported when authentication is disabled " +
+                                                               "(AllowAllAuthenticator). Full authentication and authorization " +
+                                                               "support will be added in a future release.", fullCommandName));
+            }
+
+            logger.info("Executing command '{}' with execution ID: {}", fullCommandName, executionId);
+            executionHistory.add(record);
+
+            CommandExecutionArgs arguments = argumentsSupplier.get();
+            validateArguments(arguments, command.metadata());
+
+            // Currently, for picocli-based commands in C*, which have no structured result,
+            // the output is written to the Output in the context.
+            Object ignore = command.execute(arguments, executionContext);
+
+            record.completed(Clock.Global.currentTimeMillis());
+            logger.info("Command '{}' (execution ID: {}) completed successfully", fullCommandName, executionId);
+            return new CommandResult(executionId,
+                                     captured.getCapturedOutput(),
+                                     record.startTime,
+                                     record.endTime - record.startTime);
+        }
+        catch (CommandAuthorizationException e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            logger.error("Command '{}' (execution ID: {}) authorization failed", fullCommandName, executionId, e);
+            throw e;
+        }
+        catch (IllegalStateException | IllegalArgumentException e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            String msg = format("Bad usage for command '%s' (execution ID: %s)", fullCommandName, executionId);
+            logger.error(msg, e);
+            throw new CommandValidationException(msg, e);
+        }
+        catch (Exception e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            String msg = format("Command '%s' (execution ID: %s) execution failed", fullCommandName, executionId);
+            logger.error(msg, e);
+            throw new CommandExecutionException(msg, e, executionId);
+        }
+        catch (Throwable e)
+        {
+            record.failed(Clock.Global.currentTimeMillis(), e);
+            logger.error("Command '{}' (execution ID: {}) unexpected error", fullCommandName, executionId, e);
+            throw new CommandExecutionException(format("Unexpected error while executing '%s': %s",
+                                                       fullCommandName, e.getMessage()),
+                                                e,
+                                                executionId);
+        }
+    }
+
+    @Override
+    public String[] getCommandNames()
+    {
+        List<String> commandNames = new ArrayList<>();
+        collectCommandNamesRecursively(registry, "", commandNames);
+        return commandNames.toArray(new String[0]);
+    }
+
+    /** Validate command arguments against metadata. */
+    protected void validateArguments(CommandExecutionArgs arguments, CommandMetadata metadata)
+    {
+        for (OptionMetadata option : metadata.options())
+        {
+            if (option.required() && !arguments.hasOption(option))
+                throw new IllegalArgumentException(String.format("Required option '%s' is missing", option.paramLabel()));
+        }
+
+        for (ParameterMetadata param : metadata.parameters())
+        {
+            if (param.required() && !arguments.hasParameter(param))
+                throw new IllegalArgumentException(String.format("Required parameter at index %d ('%s') is missing",
+                                                                 param.index(), param.paramLabel()));
+        }
+    }
+
+    private void collectCommandNamesRecursively(CommandRegistry registry,
+                                                String parentCommandName,
+                                                List<String> result)
+    {
+        for (Map.Entry<String, Command<?>> entry : registry.commands())
+        {
+            String commandName = entry.getKey();
+            Command<?> command = entry.getValue();
+
+            String fullCommandName = fullCommandName(parentCommandName, commandName);
+            if (command instanceof CommandRegistry)
+                collectCommandNamesRecursively((CommandRegistry) command, fullCommandName, result);
+            else
+                result.add(fullCommandName);
+        }
+    }
+
+    @Override
+    public int getCommandCount()
+    {
+        return countCommands(registry);
+    }
+
+    @Override
+    public String getCommandMBeanName(String fullCommandName)
+    {
+        ObjectName objectName = commandMBeanNames.get(fullCommandName);
+        if (objectName == null)
+            throw new IllegalArgumentException("Command MBean name not found: " + fullCommandName);
+        return objectName.toString();
+    }
+
+    public boolean isStarted()
+    {
+        return started;
+    }
+
+    private void registerCommandMBeansRecursively(CommandRegistry registry, String parentCommandName)
+    {
+        for (Map.Entry<String, Command<?>> e : registry.commands())
+        {
+            String commandName = e.getKey();
+            Command<?> command = e.getValue();
+            String fullCommandName = fullCommandName(parentCommandName, commandName);
+
+            if (command instanceof CommandRegistry)
+            {
+                registerCommandMBeansRecursively((CommandRegistry) command, fullCommandName);
+            }
+            else
+            {
+                try
+                {
+                    String escapedName = ObjectName.quote(fullCommandName);
+                    ObjectName objectName = new ObjectName(format("%s:type=%s,name=%s",
+                                                                  MBEAN_DOMAIN, MBEAN_TYPE_COMMAND, escapedName));
+                    CommandMBeanAdapter commandMBean = new CommandMBeanAdapter(fullCommandName, command, this::invokeCommand);
+                    MBeanWrapper.instance.registerMBean(commandMBean, objectName, MBeanWrapper.OnException.LOG);
+
+                    ObjectName prev = commandMBeanNames.putIfAbsent(fullCommandName, objectName);
+                    if (prev != null)
+                    {
+                        throw new IllegalStateException("Command name conflict during MBean registration: '" +
+                                                        fullCommandName + "' is already registered");
+                    }
+                    logger.debug("Registered command MBean: {} -> {}", fullCommandName, objectName);
+                }
+                catch (Exception ex)
+                {
+                    logger.warn("Failed to register MBean for command: {}", fullCommandName, ex);
+                }
+            }
+        }
+    }
+
+    private void unregisterCommandMBeans()
+    {
+        for (ObjectName objectName : commandMBeanNames.values())
+            MBeanWrapper.instance.unregisterMBean(objectName, MBeanWrapper.OnException.LOG);
+        commandMBeanNames.clear();
+    }
+
+    private static class CapturingOutput
+    {
+        private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        private final PrintStream output = new PrintStream(buffer, true);
+        private final PrintStream error = new PrintStream(buffer, true);
+
+        public String getCapturedOutput()
+        {
+            output.flush();
+            error.flush();
+            return buffer.toString();
+        }
+
+        Output createOutput()
+        {
+            return new Output(output, error);
+        }
+    }
+
+    private static class ServerCommandExecutionContext implements CommandExecutionContext
+    {
+        private final Map<Class<?>, Object> services = new HashMap<>();
+
+        public ServerCommandExecutionContext(NodeProbe probe)
+        {
+            services.put(NodeProbe.class, probe);
+            services.put(Output.class, probe.output());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T service(Class<T> serviceType)
+        {
+            T svc = (T) services.get(serviceType);
+            if (svc == null)
+                throw new IllegalArgumentException("Service not available in this context: " + serviceType.getName());
+            return svc;
+        }
+
+        @Override
+        public Set<Class<?>> services()
+        {
+            return services.keySet();
+        }
+    }
+
+    public static class CommandResult
+    {
+        private final UUID executionId;
+        private final String output;
+        private final long startTime;
+        private final long durationMillis;
+
+        public CommandResult(UUID executionId, String output, long startTime, long durationMillis)
+        {
+            this.executionId = executionId;
+            this.output = output;
+            this.startTime = startTime;
+            this.durationMillis = durationMillis;
+        }
+
+        public UUID getExecutionId()
+        {
+            return executionId;
+        }
+
+        public String getOutput()
+        {
+            return output;
+        }
+
+        public long getStartTime()
+        {
+            return startTime;
+        }
+
+        public long getDurationMillis()
+        {
+            return durationMillis;
+        }
+    }
+
+    private static class ExecutionHistory
+    {
+        final UUID executionId;
+        final String commandName;
+        final long startTime;
+        volatile long endTime;
+        volatile boolean success;
+        volatile Throwable error;
+
+        ExecutionHistory(String commandName, long startTime)
+        {
+            this.executionId = UUID.randomUUID();
+            this.commandName = commandName;
+            this.startTime = startTime;
+        }
+
+        void completed(long endTime)
+        {
+            this.endTime = endTime;
+            this.success = true;
+        }
+
+        void failed(long endTime, Throwable error)
+        {
+            this.endTime = endTime;
+            this.success = false;
+            this.error = error;
+        }
+    }
+
+    private static class BoundedExecutionHistory
+    {
+        private final Deque<ExecutionHistory> dq = new ConcurrentLinkedDeque<>();
+        private final AtomicInteger size = new AtomicInteger(0);
+        private final int maxSize;
+
+        public BoundedExecutionHistory(int maxSize)
+        {
+            this.maxSize = maxSize;
+        }
+
+        public void add(ExecutionHistory info)
+        {
+            dq.offer(info);
+
+            if (size.incrementAndGet() > maxSize)
+            {
+                ExecutionHistory removed = dq.pollFirst();
+                if (removed != null)
+                    size.decrementAndGet();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface Executor
+    {
+        CommandResult execute(String commandName, Supplier<CommandExecutionArgs> argsSupplier)
+            throws CommandExecutionException, CommandValidationException, CommandAuthorizationException;
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandInvokerServiceMBean.java
+++ b/src/java/org/apache/cassandra/management/CommandInvokerServiceMBean.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+/**
+ * MBean interface for CommandInvokerService.
+ * Exposes registry-level operations (not individual commands).
+ */
+public interface CommandInvokerServiceMBean
+{
+    String MBEAN_NAME = "org.apache.cassandra.management:type=CommandInvokerService";
+
+    /**
+     * Get a list of all command names in the registry.
+     * @return array of command names
+     */
+    String[] getCommandNames();
+
+    /**
+     * Get the total number of commands in the registry.
+     * @return number of commands
+     */
+    int getCommandCount();
+
+    /**
+     * Get ObjectName string for a specific command MBean.
+     * @param fullCommandName name of the command
+     * @return ObjectName string for the command MBean
+     * @throws IllegalArgumentException if command not found
+     */
+    String getCommandMBeanName(String fullCommandName);
+}

--- a/src/java/org/apache/cassandra/management/CommandMBeanAdapter.java
+++ b/src/java/org/apache/cassandra/management/CommandMBeanAdapter.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.ReflectionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.management.api.ArgumentMetadata;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.utils.JsonUtils;
+
+import static javax.management.MBeanOperationInfo.ACTION;
+import static javax.management.MBeanOperationInfo.INFO;
+import static org.apache.cassandra.cql3.statements.ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_EXECUTION_ID;
+import static org.apache.cassandra.cql3.statements.ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_OUTPUT;
+import static org.apache.cassandra.management.api.ParameterMetadata.COMMAND_POSITIONAL_PARAM_PREFIX;
+import static org.apache.cassandra.utils.JsonUtils.convertDefaultValue;
+import static org.apache.cassandra.utils.JsonUtils.getJsonType;
+
+/**
+ * Command MBean exposes a single management command to the JMX interface.
+ *
+ * <p>Uses JSON-based parameter format:
+ * <ul>
+ *   <li>Single "invoke" operation with JSON string parameter</li>
+ *   <li>JSON format: {"optionName": "value", "param0": "value", ...}</li>
+ *   <li>Option names: use option name or any alias (e.g., "concurrent-compactors", "--concurrent-compactors")</li>
+ *   <li>Positional parameters: use "param0", "param1", etc. or parameter name</li>
+ *   <li>Returns command output as String</li>
+ * </ul>
+ *
+ * <p>
+ * Invocation:
+ * <pre>
+ * // Command: setconcurrentcompactors --concurrent-compactors 4
+ * mbean.invoke("invoke",
+ *     new Object[]{"{\"concurrent-compactors\": \"4\"}"},
+ *     new String[]{ "String" });
+ *
+ * // Command: getendpoints keyspace table
+ * mbean.invoke("invoke",
+ *     new Object[]{"{\"param0\": \"mykeyspace\", \"param1\": \"mytable\"}"},
+ *     new String[]{ "String" });
+ * </pre>
+ *
+ * <p>The {@code invoke} operation accepts exactly one argument: the JSON string above. Other forms
+ * (e.g. name-value pairs spread across multiple arguments) are not supported and are rejected with an
+ * {@link IllegalArgumentException}.
+ */
+public class CommandMBeanAdapter implements DynamicMBean
+{
+    public static final String INVOKE_METHOD = "invoke";
+    public static final String GET_JSON_SCHEMA_METHOD = "getJsonSchema";
+    public static final String GET_PARAMETER_INFO_METHOD = "getParameterInfo";
+
+    private static final Logger logger = LoggerFactory.getLogger(CommandMBeanAdapter.class);
+
+    private final String fullCommandName;
+    private final CommandMetadata metadata;
+    private final CommandInvokerService.Executor executor;
+
+    public CommandMBeanAdapter(String fullCommandName, Command<?> command, CommandInvokerService.Executor executor)
+    {
+        this.fullCommandName = fullCommandName;
+        this.metadata = command.metadata();
+        this.executor = executor;
+    }
+
+    @Override
+    public MBeanInfo getMBeanInfo()
+    {
+        List<MBeanOperationInfo> operations = new ArrayList<>();
+
+        operations.add(new MBeanOperationInfo(
+        INVOKE_METHOD,
+            "Execute command with JSON parameters. Format: {\"optionName\": \"value\", \"param0\": \"value\", ...}",
+            new MBeanParameterInfo[]{
+                new MBeanParameterInfo("jsonParameters",
+                                       String.class.getName(),
+                                       "JSON object with command parameters. Use getJsonSchema() to see available parameters and types.")
+            },
+            String.class.getName(),
+        ACTION));
+
+        operations.add(new MBeanOperationInfo(
+            GET_JSON_SCHEMA_METHOD,
+            "Get JSON schema describing all available parameters (name -> type mapping)",
+            new MBeanParameterInfo[0],
+            String.class.getName(),
+            INFO));
+
+        operations.add(new MBeanOperationInfo(
+            GET_PARAMETER_INFO_METHOD,
+            "Get information about all available parameters (human-readable format)",
+            new MBeanParameterInfo[0],
+            String.class.getName(),
+            INFO));
+
+        return new MBeanInfo(CommandMBeanAdapter.class.getName(),
+                             metadata.description() != null ? metadata.description() : "Command: " + metadata.name(),
+                             null,
+                             null,
+                             operations.toArray(new MBeanOperationInfo[0]),
+                             null);
+    }
+
+    @Override
+    public Object invoke(String actionName, Object[] params, String[] signature) throws MBeanException, ReflectionException
+    {
+        if (INVOKE_METHOD.equals(actionName))
+        {
+            if (params == null || params.length != 1 || !(params[0] instanceof String))
+                throw new IllegalArgumentException("invoke requires exactly one parameter (JSON string)");
+
+            String jsonParams = (String) params[0];
+            try
+            {
+                CommandInvokerService.CommandResult result = executor.execute(fullCommandName,
+                                                                              () -> CommandExecutionArgsSerde.fromJson(jsonParams, metadata));
+
+                Map<String, Object> jsonResult = new TreeMap<>();
+                jsonResult.put(COMMAND_RESULT_SCHEMA_EXECUTION_ID, result.getExecutionId().toString());
+                jsonResult.put(COMMAND_RESULT_SCHEMA_OUTPUT, result.getOutput());
+                return JsonUtils.writeAsJsonString(jsonResult);
+            }
+            catch (CommandAuthorizationException e)
+            {
+                logger.error("Authorization error executing command: {}", metadata.name(), e);
+                throw new SecurityException("Access Denied: " + e.getMessage());
+            }
+            catch (CommandValidationException e)
+            {
+                logger.error("Validation error for command: {}", metadata.name(), e);
+                throw new IllegalArgumentException(ManagementUtils.causeMessages(e));
+            }
+            catch (CommandExecutionException e)
+            {
+                logger.error("Error executing command: {}", metadata.name(), e);
+                throw new RuntimeException(ManagementUtils.causeMessages(e));
+            }
+            catch (Exception e)
+            {
+                logger.error("Unexpected error executing command: {}", metadata.name(), e);
+                throw new RuntimeException("Unexpected error executing command: " + e.getMessage(), e);
+            }
+        }
+
+        if (GET_JSON_SCHEMA_METHOD.equals(actionName))
+            return getJsonSchema();
+
+        if (GET_PARAMETER_INFO_METHOD.equals(actionName))
+            return getParameterInfo();
+
+        throw new UnsupportedOperationException("Unknown operation: " + actionName);
+    }
+
+    public String getJsonSchema()
+    {
+        try
+        {
+            Map<String, Object> schema = new LinkedHashMap<>();
+            schema.put("$schema", "http://json-schema.org/draft-07/schema#");
+            schema.put("type", "object");
+            schema.put("title", metadata.name());
+            schema.put("description", metadata.description());
+
+            Map<String, Object> properties = new LinkedHashMap<>();
+            List<String> required = new ArrayList<>();
+
+            for (OptionMetadata option : metadata.options())
+            {
+                String primaryName = option.paramLabel();
+                properties.put(primaryName, buildJsonSchemaProperty(option));
+
+                if (option.required())
+                    required.add(primaryName);
+            }
+
+            List<ParameterMetadata> sortedParams = new ArrayList<>(metadata.parameters());
+            sortedParams.sort(Comparator.comparingInt(ParameterMetadata::index));
+
+            for (ParameterMetadata param : sortedParams)
+            {
+                String paramName = COMMAND_POSITIONAL_PARAM_PREFIX + param.index();
+                properties.put(paramName, buildJsonSchemaProperty(param));
+
+                if (param.required())
+                    required.add(paramName);
+            }
+
+            schema.put("properties", properties);
+
+            if (!required.isEmpty())
+                schema.put("required", required);
+
+            return JsonUtils.writeAsPrettyJsonString(schema);
+        }
+        catch (Exception e)
+        {
+            logger.error("Error generating JSON schema for command: {}", metadata.name(), e);
+            throw new RuntimeException("Failed to generate JSON schema: " + e.getMessage(), e);
+        }
+    }
+
+    private Map<String, Object> buildJsonSchemaProperty(ArgumentMetadata arg)
+    {
+        Map<String, Object> prop = new LinkedHashMap<>();
+        prop.put("type", getJsonType(arg.type()));
+
+        if (arg.names() != null && arg.names().length > 0)
+            prop.put("aliases", Arrays.stream(arg.names())
+                                     .filter(name -> !name.equals(arg.paramLabel()))
+                                     .collect(Collectors.toList()));
+
+        if (arg.description() != null && !arg.description().isEmpty())
+            prop.put("description", arg.description());
+
+        String defaultValue = arg.defaultValue();
+        if (defaultValue != null && !defaultValue.isEmpty())
+            prop.put("default", convertDefaultValue(defaultValue, arg.type()));
+
+        if (arg.type().isArray() || List.class.isAssignableFrom(arg.type()))
+        {
+            prop.put("type", "array");
+            Map<String, Object> items = new LinkedHashMap<>();
+            items.put("type", "string");
+            prop.put("items", items);
+        }
+
+        if (arg.type().isEnum())
+        {
+            prop.put("enum", Arrays.stream(arg.type().getEnumConstants())
+                                   .map(Object::toString)
+                                   .collect(Collectors.toList()));
+        }
+
+        return prop;
+    }
+
+    private static String getTypeName(Class<?> type)
+    {
+        return type.getCanonicalName();
+    }
+
+    private String getParameterInfo()
+    {
+        StringBuilder info = new StringBuilder();
+        info.append("Command: ").append(metadata.name()).append('\n');
+        info.append("Description: ").append(metadata.description()).append("\n\n");
+
+        info.append("Options:\n");
+        for (OptionMetadata option : metadata.options())
+        {
+            info.append("  - ").append(option.paramLabel());
+            if (option.names().length > 0)
+                info.append(" (aliases: ").append(String.join(", ", option.names())).append(')');
+            appendRequiredClause(info, getTypeName(option.type()), option.required(), option.description());
+        }
+
+        info.append("\nPositional Parameters:\n");
+        List<ParameterMetadata> sortedParams = new ArrayList<>(metadata.parameters());
+        sortedParams.sort((a, b) -> Integer.compare(a.index(), b.index()));
+
+        for (ParameterMetadata param : sortedParams)
+        {
+            info.append("  - param").append(param.index());
+            if (param.paramLabel() != null && !param.paramLabel().isEmpty())
+                info.append(" (").append(param.paramLabel()).append(')');
+            appendRequiredClause(info, getTypeName(param.type()), param.required(), param.description());
+        }
+
+        return info.toString();
+    }
+
+    private static void appendRequiredClause(StringBuilder info,
+                                             String typeName,
+                                             boolean required,
+                                             String description)
+    {
+        info.append(" [").append(typeName).append(']');
+        if (required)
+            info.append(" [REQUIRED]");
+        if (description != null && !description.isEmpty())
+            info.append("\n    ").append(description);
+        info.append('\n');
+    }
+
+    @Override
+    public Object getAttribute(String attribute) throws AttributeNotFoundException, MBeanException, ReflectionException
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void setAttribute(Attribute attribute) throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public AttributeList getAttributes(String[] attributes)
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public AttributeList setAttributes(AttributeList attributes)
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandMBeanAdapter.java
+++ b/src/java/org/apache/cassandra/management/CommandMBeanAdapter.java
@@ -176,6 +176,11 @@ public class CommandMBeanAdapter implements DynamicMBean
                 logger.error("Error executing command: {}", metadata.name(), e);
                 throw new RuntimeException(ManagementUtils.causeMessages(e));
             }
+            catch (IllegalArgumentException | IllegalStateException e)
+            {
+                logger.error("Bad usage for command: {}", metadata.name(), e);
+                throw e;
+            }
             catch (Exception e)
             {
                 logger.error("Unexpected error executing command: {}", metadata.name(), e);

--- a/src/java/org/apache/cassandra/management/CommandMBeanAdapter.java
+++ b/src/java/org/apache/cassandra/management/CommandMBeanAdapter.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.ReflectionException;
+
+import com.google.common.base.Throwables;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.management.api.ArgumentMetadata;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.serializers.MarshalException;
+import org.apache.cassandra.utils.JsonUtils;
+
+import static javax.management.MBeanOperationInfo.ACTION;
+import static javax.management.MBeanOperationInfo.INFO;
+import static org.apache.cassandra.cql3.statements.ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_EXECUTION_ID;
+import static org.apache.cassandra.cql3.statements.ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_OUTPUT;
+import static org.apache.cassandra.management.api.ParameterMetadata.COMMAND_POSITIONAL_PARAM_PREFIX;
+import static org.apache.cassandra.utils.JsonUtils.convertDefaultValue;
+import static org.apache.cassandra.utils.JsonUtils.getJsonType;
+
+/**
+ * Command MBean exposes a single management command to the JMX interface.
+ *
+ * <p>Uses JSON-based parameter format:
+ * <ul>
+ *   <li>Single "invoke" operation with JSON string parameter</li>
+ *   <li>JSON format: {"optionName": "value", "param0": "value", ...}</li>
+ *   <li>Option names: use option name or any alias (e.g., "concurrent-compactors", "--concurrent-compactors")</li>
+ *   <li>Positional parameters: use "param0", "param1", etc. or parameter name</li>
+ *   <li>Returns command output as String</li>
+ * </ul>
+ *
+ * <p>
+ * Invocation:
+ * <pre>
+ * // Command: setconcurrentcompactors --concurrent-compactors 4
+ * mbean.invoke("invoke",
+ *     new Object[]{"{\"concurrent-compactors\": \"4\"}"},
+ *     new String[]{ "String" });
+ *
+ * // Command: getendpoints keyspace table
+ * mbean.invoke("invoke",
+ *     new Object[]{"{\"param0\": \"mykeyspace\", \"param1\": \"mytable\"}"},
+ *     new String[]{ "String" });
+ * </pre>
+ *
+ * <p>
+ * Alternatively, the parameters can be passed as name-value pairs:
+ * <pre>
+ * // Command: setconcurrentcompactors --concurrent-compactors 4
+ * mbean.invoke("invoke",
+ *     new Object[]{"concurrent-compactors", "4"},
+ *     new String[]{"String", "String"});
+ *
+ * // Command: getendpoints keyspace table
+ * mbean.invoke("invoke",
+ *     new Object[]{"param0", "mykeyspace", "param1", "mytable"},
+ *     new String[]{"String", "String", "String", "String"});
+ * </pre>
+ */
+public class CommandMBeanAdapter implements DynamicMBean
+{
+    public static final String INVOKE_METHOD = "invoke";
+    public static final String GET_JSON_SCHEMA_METHOD = "getJsonSchema";
+    public static final String GET_PARAMETER_INFO_METHOD = "getParameterInfo";
+
+    private static final Logger logger = LoggerFactory.getLogger(CommandMBeanAdapter.class);
+
+    private final String fullCommandName;
+    private final CommandMetadata metadata;
+    private final CommandInvokerService.Executor executor;
+
+    public CommandMBeanAdapter(String fullCommandName, Command<?> command, CommandInvokerService.Executor executor)
+    {
+        this.fullCommandName = fullCommandName;
+        this.metadata = command.metadata();
+        this.executor = executor;
+    }
+
+    @Override
+    public MBeanInfo getMBeanInfo()
+    {
+        List<MBeanOperationInfo> operations = new ArrayList<>();
+
+        operations.add(new MBeanOperationInfo(
+        INVOKE_METHOD,
+            "Execute command with JSON parameters. Format: {\"optionName\": \"value\", \"param0\": \"value\", ...}",
+            new MBeanParameterInfo[]{
+                new MBeanParameterInfo("jsonParameters",
+                                       String.class.getName(),
+                                       "JSON object with command parameters. Use getJsonSchema() to see available parameters and types.")
+            },
+            String.class.getName(),
+        ACTION));
+
+        operations.add(new MBeanOperationInfo(
+            GET_JSON_SCHEMA_METHOD,
+            "Get JSON schema describing all available parameters (name -> type mapping)",
+            new MBeanParameterInfo[0],
+            String.class.getName(),
+            INFO));
+
+        operations.add(new MBeanOperationInfo(
+            GET_PARAMETER_INFO_METHOD,
+            "Get information about all available parameters (human-readable format)",
+            new MBeanParameterInfo[0],
+            String.class.getName(),
+            INFO));
+
+        return new MBeanInfo(CommandMBeanAdapter.class.getName(),
+                             metadata.description() != null ? metadata.description() : "Command: " + metadata.name(),
+                             null,
+                             null,
+                             operations.toArray(new MBeanOperationInfo[0]),
+                             null);
+    }
+
+    @Override
+    public Object invoke(String actionName, Object[] params, String[] signature) throws MBeanException, ReflectionException
+    {
+        if (INVOKE_METHOD.equals(actionName))
+        {
+            if (params == null || params.length != 1)
+                throw new IllegalArgumentException("invoke requires exactly one parameter (JSON string)");
+
+            String jsonParams = (String) params[0];
+            try
+            {
+                CommandInvokerService.CommandResult result = executor.execute(fullCommandName,
+                                                                              () -> CommandExecutionArgsSerde.fromJson(jsonParams, metadata));
+
+                Map<String, Object> jsonResult = new TreeMap<>();
+                jsonResult.put(COMMAND_RESULT_SCHEMA_EXECUTION_ID, result.getExecutionId().toString());
+                jsonResult.put(COMMAND_RESULT_SCHEMA_OUTPUT, result.getOutput());
+                return JsonUtils.writeAsJsonString(jsonResult);
+            }
+            catch (CommandAuthorizationException e)
+            {
+                logger.error("Authorization error executing command: {}", metadata.name(), e);
+                throw new SecurityException("Access Denied: " + e.getMessage());
+            }
+            catch (CommandValidationException | MarshalException e)
+            {
+                logger.error("Validation error for command: {}", metadata.name(), e);
+                throw new IllegalArgumentException(Throwables.getStackTraceAsString(e));
+            }
+            catch (CommandExecutionException e)
+            {
+                logger.error("Error executing command: {}", metadata.name(), e);
+                throw new RuntimeException(Throwables.getStackTraceAsString(e));
+            }
+            catch (Exception e)
+            {
+                logger.error("Unexpected error executing command: {}", metadata.name(), e);
+                throw new RuntimeException("Unexpected error executing command: " + e.getMessage(), e);
+            }
+        }
+
+        if (GET_JSON_SCHEMA_METHOD.equals(actionName))
+            return getJsonSchema();
+
+        if (GET_PARAMETER_INFO_METHOD.equals(actionName))
+            return getParameterInfo();
+
+        throw new UnsupportedOperationException("Unknown operation: " + actionName);
+    }
+
+    public String getJsonSchema()
+    {
+        try
+        {
+            Map<String, Object> schema = new LinkedHashMap<>();
+            schema.put("$schema", "http://json-schema.org/draft-07/schema#");
+            schema.put("type", "object");
+            schema.put("title", metadata.name());
+            schema.put("description", metadata.description());
+
+            Map<String, Object> properties = new LinkedHashMap<>();
+            List<String> required = new ArrayList<>();
+
+            for (OptionMetadata option : metadata.options())
+            {
+                String primaryName = option.paramLabel();
+                properties.put(primaryName, buildJsonSchemaProperty(option));
+
+                if (option.required())
+                    required.add(primaryName);
+            }
+
+            List<ParameterMetadata> sortedParams = new ArrayList<>(metadata.parameters());
+            sortedParams.sort(Comparator.comparingInt(ParameterMetadata::index));
+
+            for (ParameterMetadata param : sortedParams)
+            {
+                String paramName = COMMAND_POSITIONAL_PARAM_PREFIX + param.index();
+                properties.put(paramName, buildJsonSchemaProperty(param));
+
+                if (param.required())
+                    required.add(paramName);
+            }
+
+            schema.put("properties", properties);
+
+            if (!required.isEmpty())
+                schema.put("required", required);
+
+            return JsonUtils.writeAsPrettyJsonString(schema);
+        }
+        catch (Exception e)
+        {
+            logger.error("Error generating JSON schema for command: {}", metadata.name(), e);
+            throw new RuntimeException("Failed to generate JSON schema: " + e.getMessage(), e);
+        }
+    }
+
+    private Map<String, Object> buildJsonSchemaProperty(ArgumentMetadata arg)
+    {
+        Map<String, Object> prop = new LinkedHashMap<>();
+        prop.put("type", getJsonType(arg.type()));
+
+        if (arg.names() != null && arg.names().length > 0)
+            prop.put("aliases", Arrays.stream(arg.names())
+                                     .filter(name -> !name.equals(arg.paramLabel()))
+                                     .collect(Collectors.toList()));
+
+        if (arg.description() != null && !arg.description().isEmpty())
+            prop.put("description", arg.description());
+
+        String defaultValue = arg.defaultValue();
+        if (defaultValue != null && !defaultValue.isEmpty())
+            prop.put("default", convertDefaultValue(defaultValue, arg.type()));
+
+        if (arg.type().isArray() || List.class.isAssignableFrom(arg.type()))
+        {
+            prop.put("type", "array");
+            Map<String, Object> items = new LinkedHashMap<>();
+            items.put("type", "string");
+            prop.put("items", items);
+        }
+
+        if (arg.type().isEnum())
+        {
+            prop.put("enum", Arrays.stream(arg.type().getEnumConstants())
+                                   .map(Object::toString)
+                                   .collect(Collectors.toList()));
+        }
+
+        return prop;
+    }
+
+    private static String getTypeName(Class<?> type)
+    {
+        return type.getCanonicalName();
+    }
+
+    private String getParameterInfo()
+    {
+        StringBuilder info = new StringBuilder();
+        info.append("Command: ").append(metadata.name()).append('\n');
+        info.append("Description: ").append(metadata.description()).append("\n\n");
+
+        info.append("Options:\n");
+        for (OptionMetadata option : metadata.options())
+        {
+            info.append("  - ").append(option.paramLabel());
+            if (option.names().length > 0)
+                info.append(" (aliases: ").append(String.join(", ", option.names())).append(')');
+            appendRequiredClause(info, getTypeName(option.type()), option.required(), option.description());
+        }
+
+        info.append("\nPositional Parameters:\n");
+        List<ParameterMetadata> sortedParams = new ArrayList<>(metadata.parameters());
+        sortedParams.sort((a, b) -> Integer.compare(a.index(), b.index()));
+
+        for (ParameterMetadata param : sortedParams)
+        {
+            info.append("  - param").append(param.index());
+            if (param.paramLabel() != null && !param.paramLabel().isEmpty())
+                info.append(" (").append(param.paramLabel()).append(')');
+            appendRequiredClause(info, getTypeName(param.type()), param.required(), param.description());
+        }
+
+        return info.toString();
+    }
+
+    private static void appendRequiredClause(StringBuilder info,
+                                             String typeName,
+                                             boolean required,
+                                             String description)
+    {
+        info.append(" [").append(typeName).append(']');
+        if (required)
+            info.append(" [REQUIRED]");
+        if (description != null && !description.isEmpty())
+            info.append("\n    ").append(description);
+        info.append('\n');
+    }
+
+    @Override
+    public Object getAttribute(String attribute) throws AttributeNotFoundException, MBeanException, ReflectionException
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void setAttribute(Attribute attribute) throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public AttributeList getAttributes(String[] attributes)
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public AttributeList setAttributes(AttributeList attributes)
+    {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+}

--- a/src/java/org/apache/cassandra/management/CommandValidationException.java
+++ b/src/java/org/apache/cassandra/management/CommandValidationException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+public class CommandValidationException extends Exception
+{
+    public CommandValidationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/java/org/apache/cassandra/management/InternalNodeMBeanAccessor.java
+++ b/src/java/org/apache/cassandra/management/InternalNodeMBeanAccessor.java
@@ -113,27 +113,25 @@ import static org.apache.cassandra.service.CassandraDaemon.SKIP_GC_INSPECTOR;
  * Server-side implementation of {@link MBeanAccessor} for in-process execution.
  *
  * <p>
- * This implementation provides direct access to MBean instances without using JMX,
- * eliminating the need for remote connections or JMX proxies. It is designed for
- * server-side command execution as part of CEP-38 Management API, where commands run
- * in the same JVM as the Cassandra daemon.
+ * Returns MBean instances without going through JMX, for the CEP-38 management API, where commands
+ * run in the same JVM as the Cassandra daemon.
  *
  * <p>
  * Unlike {@link RemoteJmxMBeanAccessor}, this implementation:
  * <ul>
- *   <li>Directly accesses singleton instances (e.g., {@code StorageService.instance})</li>
- *   <li>Does not require network connections or JMX connectors</li>
- *   <li>Provides better performance by avoiding serialization/deserialization</li>
+ *   <li>Reads singleton instances directly (e.g., {@code StorageService.instance})</li>
+ *   <li>Needs no network connection or JMX connector</li>
+ *   <li>Serializes nothing: arguments and results stay as objects</li>
  *   <li>Has no connection state to manage</li>
  *   <li>Works directly with {@link Keyspace} and {@link ColumnFamilyStore} instances</li>
  * </ul>
  *
  * <p>
- * <b>Lazy Initialization</b>: MBean providers are initialized registered for known MBeans.
+ * Providers for the known MBeans are registered up front, but each one resolves its MBean only on
+ * first access.
  *
  * @see MBeanAccessor
  * @see RemoteJmxMBeanAccessor
- * @since 5.1
  */
 public class InternalNodeMBeanAccessor implements MBeanAccessor
 {
@@ -315,26 +313,20 @@ public class InternalNodeMBeanAccessor implements MBeanAccessor
     {
         try
         {
-            // Use the internal MBean server to look up MBean by ObjectName. This leverages existing
-            // JMX infrastructure and avoids the complexity of constructing metric names from Props.
+            // Look the MBean up in the internal MBean server by ObjectName, which reuses the names the
+            // metric factories already built at registration time.
             //
-            // Alternatively, we could use CassandraMetricsRegistry to look up metrics by metric name
-            // (e.g., "org.apache.cassandra.metrics.Keyspace.ReadLatency.mykeyspace"), but this requires
-            // constructing the full metric name from Props, which is problematic.
-            //
-            // The reconstructing the scope problem: Different MetricNameFactory implementations
-            // construct scopes differently:
+            // The alternative is CassandraMetricsRegistry, which looks metrics up by metric name
+            // (e.g., "org.apache.cassandra.metrics.Keyspace.ReadLatency.mykeyspace"). That means rebuilding
+            // the full metric name from Props, and every MetricNameFactory builds its scope differently:
             // - KeyspaceMetrics: scope = keyspace property
             // - TableMetrics: scope = keyspace + '.' + scope property
             // - DefaultNameFactory: scope = scope property
             // - SAI AbstractMetrics: scope = keyspace.table.index.scope (all combined)
             //
-            // To construct metric names from Props, we would need to duplicate scope construction logic
-            // from each factory or refactor to share it. Using ObjectName, in turn, avoids this. We query
-            // MBeanServer using the ObjectName pattern already constructed by factories during registration.
-            //
-            // However, it will be beneficial to revisit this down the line for performance optimizations and
-            // to avoid JMX entanglement, so we could switch it off for in-process access.
+            // So that path would duplicate scope construction from each factory, or require refactoring the
+            // factories to share it. Worth revisiting: it would make in-process lookups cheaper and let us
+            // drop the JMX dependency here.
 
             ObjectName objectName = buildObjectNameFromProps(props);
             return mbeanServer().isRegistered(objectName);

--- a/src/java/org/apache/cassandra/management/InternalNodeMBeanAccessor.java
+++ b/src/java/org/apache/cassandra/management/InternalNodeMBeanAccessor.java
@@ -1,0 +1,508 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.management.JMX;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.apache.cassandra.audit.AuditLogManager;
+import org.apache.cassandra.audit.AuditLogManagerMBean;
+import org.apache.cassandra.auth.AbstractCIDRAuthorizer;
+import org.apache.cassandra.auth.AuthCache;
+import org.apache.cassandra.auth.AuthCacheMBean;
+import org.apache.cassandra.auth.AuthCacheService;
+import org.apache.cassandra.auth.CIDRGroupsMappingManagerMBean;
+import org.apache.cassandra.auth.CIDRPermissionsManagerMBean;
+import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+import org.apache.cassandra.auth.PermissionsCacheMBean;
+import org.apache.cassandra.auth.RolesCacheMBean;
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
+import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.batchlog.BatchlogManagerMBean;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManager;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
+import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.db.guardrails.GuardrailsMBean;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTable;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTableMBean;
+import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.gms.FailureDetectorMBean;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.GossiperMBean;
+import org.apache.cassandra.hints.HintsService;
+import org.apache.cassandra.hints.HintsServiceMBean;
+import org.apache.cassandra.index.Index;
+import org.apache.cassandra.index.SecondaryIndexManager;
+import org.apache.cassandra.locator.DynamicEndpointSnitch;
+import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
+import org.apache.cassandra.locator.EndpointSnitchInfo;
+import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
+import org.apache.cassandra.locator.LocationInfo;
+import org.apache.cassandra.locator.LocationInfoMBean;
+import org.apache.cassandra.locator.NodeProximity;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.metrics.ThreadPoolMetrics;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.MessagingServiceMBean;
+import org.apache.cassandra.profiler.AsyncProfilerMBean;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.ActiveRepairServiceMBean;
+import org.apache.cassandra.service.AsyncProfilerService;
+import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.service.AutoRepairServiceMBean;
+import org.apache.cassandra.service.CacheService;
+import org.apache.cassandra.service.CacheServiceMBean;
+import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.service.GCInspectorMXBean;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.StorageProxyMBean;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.apache.cassandra.service.accord.AccordOperations;
+import org.apache.cassandra.service.accord.AccordOperationsMBean;
+import org.apache.cassandra.service.snapshot.SnapshotManager;
+import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
+import org.apache.cassandra.streaming.StreamManager;
+import org.apache.cassandra.streaming.StreamManagerMBean;
+import org.apache.cassandra.tcm.CMSOperations;
+import org.apache.cassandra.tcm.CMSOperationsMBean;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+import static org.apache.cassandra.service.CassandraDaemon.SKIP_GC_INSPECTOR;
+
+/**
+ * Server-side implementation of {@link MBeanAccessor} for in-process execution.
+ *
+ * <p>
+ * This implementation provides direct access to MBean instances without using JMX,
+ * eliminating the need for remote connections or JMX proxies. It is designed for
+ * server-side command execution as part of CEP-38 Management API, where commands run
+ * in the same JVM as the Cassandra daemon.
+ *
+ * <p>
+ * Unlike {@link RemoteJmxMBeanAccessor}, this implementation:
+ * <ul>
+ *   <li>Directly accesses singleton instances (e.g., {@code StorageService.instance})</li>
+ *   <li>Does not require network connections or JMX connectors</li>
+ *   <li>Provides better performance by avoiding serialization/deserialization</li>
+ *   <li>Has no connection state to manage</li>
+ *   <li>Works directly with {@link Keyspace} and {@link ColumnFamilyStore} instances</li>
+ * </ul>
+ *
+ * <p>
+ * <b>Lazy Initialization</b>: MBean providers are initialized registered for known MBeans.
+ *
+ * @see MBeanAccessor
+ * @see RemoteJmxMBeanAccessor
+ * @since 5.1
+ */
+public class InternalNodeMBeanAccessor implements MBeanAccessor
+{
+    private final Map<Class<?>, MBeanProvider<?>> mBeanProviders = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Object> mBeanCache = new ConcurrentHashMap<>();
+    private final Map<String, Object> metricCache = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new InternalNodeMBeanAccessor using direct instance access.
+     */
+    public InternalNodeMBeanAccessor()
+    {
+        initializeMBeanProviders();
+    }
+
+    /**
+     * Initializes all statically known MBean instances.
+     */
+    private void initializeMBeanProviders()
+    {
+        registerMBeanProvider(AccordOperationsMBean.class, () -> AccordOperations.instance);
+        registerMBeanProvider(ActiveRepairServiceMBean.class, ActiveRepairService::instance);
+        registerMBeanProvider(AuditLogManagerMBean.class, () -> AuditLogManager.instance);
+        registerMBeanProvider(AutoRepairServiceMBean.class, () -> AutoRepairService.instance);
+        registerMBeanProvider(BatchlogManagerMBean.class, () -> BatchlogManager.instance);
+        registerMBeanProvider(CMSOperationsMBean.class, () -> CMSOperations.instance);
+        registerMBeanProvider(CacheServiceMBean.class, () -> CacheService.instance);
+        registerMBeanProvider(CompactionManagerMBean.class, () -> CompactionManager.instance);
+        registerMBeanProvider(DynamicEndpointSnitchMBean.class, this::resolveDynamicEndpointSnitch);
+        registerMBeanProvider(FailureDetectorMBean.class, () -> (FailureDetectorMBean) FailureDetector.instance);
+        registerMBeanProvider(GCInspectorMXBean.class, this::resolveGCInspector);
+        registerMBeanProvider(GossiperMBean.class, () -> Gossiper.instance);
+        registerMBeanProvider(GuardrailsMBean.class, () -> Guardrails.instance);
+        registerMBeanProvider(HintsServiceMBean.class, () -> HintsService.instance);
+        registerMBeanProvider(MemoryMXBean.class, ManagementFactory::getMemoryMXBean);
+        registerMBeanProvider(MessagingServiceMBean.class, MessagingService::instance);
+        registerMBeanProvider(RuntimeMXBean.class, ManagementFactory::getRuntimeMXBean);
+        registerMBeanProvider(SnapshotManagerMBean.class, () -> SnapshotManager.instance);
+        registerMBeanProvider(StorageProxyMBean.class, () -> StorageProxy.instance);
+        registerMBeanProvider(StorageServiceMBean.class, () -> StorageService.instance);
+        registerMBeanProvider(StreamManagerMBean.class, () -> StreamManager.instance);
+        registerMBeanProvider(AsyncProfilerMBean.class, AsyncProfilerService::instance);
+
+        // Utility MBeans are stateless and can be created on demand.
+        // They query DatabaseDescriptor for the current state, so new instances are fine
+        registerMBeanProvider(EndpointSnitchInfoMBean.class, EndpointSnitchInfo::new);
+        registerMBeanProvider(LocationInfoMBean.class, LocationInfo::new);
+
+        // AuthCache MBeans
+        registerMBeanProvider(AuthorizationProxy.JmxPermissionsCacheMBean.class,
+                              () -> findAuthCache(AuthorizationProxy.JmxPermissionsCacheMBean.class));
+        registerMBeanProvider(NetworkPermissionsCacheMBean.class,
+                              () -> findAuthCache(NetworkPermissionsCacheMBean.class));
+        registerMBeanProvider(PasswordAuthenticator.CredentialsCacheMBean.class,
+                              () -> findAuthCache(PasswordAuthenticator.CredentialsCacheMBean.class));
+        registerMBeanProvider(PermissionsCacheMBean.class,
+                              () -> findAuthCache(PermissionsCacheMBean.class));
+        registerMBeanProvider(RolesCacheMBean.class,
+                              () -> findAuthCache(RolesCacheMBean.class));
+
+        // CIDR Auth MBeans
+        registerMBeanProvider(CIDRFilteringMetricsTableMBean.class, () -> CIDRFilteringMetricsTable.instance);
+        registerMBeanProvider(CIDRGroupsMappingManagerMBean.class, () -> AbstractCIDRAuthorizer.cidrGroupsMappingManager);
+        registerMBeanProvider(CIDRPermissionsManagerMBean.class, () -> AbstractCIDRAuthorizer.cidrPermissionsManager);
+    }
+
+    /**
+     * Gets DynamicEndpointSnitch from DatabaseDescriptor if it's a DynamicEndpointSnitch,
+     * otherwise returns null.
+     */
+    private DynamicEndpointSnitchMBean resolveDynamicEndpointSnitch()
+    {
+        if (!DatabaseDescriptor.isDynamicEndpointSnitch())
+            throw new IllegalStateException("DynamicEndpointSnitch has been requested but is not enabled");
+
+        NodeProximity proximity = DatabaseDescriptor.getNodeProximity();
+        assert proximity instanceof DynamicEndpointSnitch;
+
+        return (DynamicEndpointSnitchMBean) proximity;
+    }
+
+    private GCInspectorMXBean resolveGCInspector()
+    {
+        if (SKIP_GC_INSPECTOR)
+            throw new IllegalStateException("GCInspector has been requested but is disabled via SKIP_GC_INSPECTOR flag");
+
+        try
+        {
+            MBeanServer mbs = MBeanWrapper.instance.getMBeanServer();
+            if (mbs == null)
+                return null;
+
+            ObjectName name = new ObjectName(GCInspector.MBEAN_NAME);
+            if (mbs.isRegistered(name))
+                return JMX.newMBeanProxy(mbs, name, GCInspectorMXBean.class);
+        }
+        catch (Exception e)
+        {
+            // Fall through to create a new instance
+        }
+
+        return null;
+    }
+
+    /** Finds an auth cache MBean instance from AuthCacheService. */
+    private <T> T findAuthCache(Class<T> clazz)
+    {
+        Set<AuthCache<?, ?>> caches = AuthCacheService.instance.getCaches();
+        if (caches.isEmpty())
+            return null;
+
+        AuthCacheFinder visitor = new AuthCacheFinder(clazz);
+        for (AuthCache<?, ?> cache : caches)
+        {
+            cache.accept(visitor);
+            Object found = visitor.getCache();
+            if (found == null)
+                continue;
+            return clazz.cast(found);
+        }
+        return null;
+    }
+
+    private <T> void registerMBeanProvider(Class<T> clazz, MBeanProvider<T> locator)
+    {
+        Object prev = mBeanProviders.putIfAbsent(clazz, locator);
+        assert prev == null : "MBean locator for " + clazz.getName() + " is already registered";
+    }
+
+    @Override
+    public <T> T findMBean(Class<T> clazz)
+    {
+        Object cached = mBeanCache.get(clazz);
+        if (cached != null)
+            return clazz.cast(cached);
+
+        Object created = mBeanCache.computeIfAbsent(clazz, k -> {
+            MBeanProvider<?> provider = mBeanProviders.get(k);
+            return provider == null ? null : provider.provide();
+        });
+        return created == null ? null : clazz.cast(created);
+    }
+
+    private MBeanServer mbeanServer()
+    {
+        MBeanServer mbs = MBeanWrapper.instance.getMBeanServer();
+        if (mbs == null)
+            throw new IllegalStateException("The MBean server is not available (MBean registration is disabled on this node)");
+        return mbs;
+    }
+
+    @Override
+    public <T> T findMBeanMetric(Class<T> clazz, Props props)
+    {
+        try
+        {
+            assert clazz.isInterface() && CassandraMetricsRegistry.MetricMBean.class.isAssignableFrom(clazz);
+
+            ObjectName objectName = buildObjectNameFromProps(props);
+            String cacheKey = objectName.getCanonicalName();
+
+            @SuppressWarnings("unchecked")
+            T cached = (T) metricCache.get(cacheKey);
+            if (cached != null)
+                return cached;
+
+            MBeanServer mbs = mbeanServer();
+
+            return clazz.cast(metricCache.computeIfAbsent(cacheKey, k -> JMX.newMBeanProxy(mbs, objectName, clazz)));
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error accessing metric MBean: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isMBeanMetricRegistered(Props props)
+    {
+        try
+        {
+            // Use the internal MBean server to look up MBean by ObjectName. This leverages existing
+            // JMX infrastructure and avoids the complexity of constructing metric names from Props.
+            //
+            // Alternatively, we could use CassandraMetricsRegistry to look up metrics by metric name
+            // (e.g., "org.apache.cassandra.metrics.Keyspace.ReadLatency.mykeyspace"), but this requires
+            // constructing the full metric name from Props, which is problematic.
+            //
+            // The reconstructing the scope problem: Different MetricNameFactory implementations
+            // construct scopes differently:
+            // - KeyspaceMetrics: scope = keyspace property
+            // - TableMetrics: scope = keyspace + '.' + scope property
+            // - DefaultNameFactory: scope = scope property
+            // - SAI AbstractMetrics: scope = keyspace.table.index.scope (all combined)
+            //
+            // To construct metric names from Props, we would need to duplicate scope construction logic
+            // from each factory or refactor to share it. Using ObjectName, in turn, avoids this. We query
+            // MBeanServer using the ObjectName pattern already constructed by factories during registration.
+            //
+            // However, it will be beneficial to revisit this down the line for performance optimizations and
+            // to avoid JMX entanglement, so we could switch it off for in-process access.
+
+            ObjectName objectName = buildObjectNameFromProps(props);
+            return mbeanServer().isRegistered(objectName);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error checking metric MBean registration: " + e.getMessage(), e);
+        }
+    }
+
+    private static ObjectName buildObjectNameFromProps(Props props) throws MalformedObjectNameException
+    {
+        return new ObjectName("org.apache.cassandra.metrics", new Hashtable<>(props.toMap()));
+    }
+
+    @Override
+    public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+    {
+        Keyspace ks = Schema.instance.getKeyspaceInstance(keyspace);
+        if (ks == null)
+            throw new IllegalArgumentException("Keyspace not found: " + keyspace);
+
+        if (!SecondaryIndexManager.isIndexColumnFamily(columnFamily))
+            return ks.getColumnFamilyStore(columnFamily);
+
+        // Secondary-index stores are registered under "base.index" names and are only
+        // reachable through the base table's index manager, not by keyspace lookup.
+        ColumnFamilyStore base = ks.getColumnFamilyStore(SecondaryIndexManager.getParentCfsName(columnFamily));
+        Index index = base.indexManager.getIndexByName(SecondaryIndexManager.getIndexName(columnFamily));
+        if (index == null)
+            throw new IllegalArgumentException(String.format("Index not found: %s.%s", keyspace, columnFamily));
+        return index.getBackingTable()
+                    .orElseThrow(() -> new IllegalArgumentException(String.format("Index %s.%s has no backing table",
+                                                                                  keyspace, columnFamily)));
+    }
+
+    @Override
+    public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+    {
+        Keyspace ks = Schema.instance.getKeyspaceInstance(keyspace);
+        if (ks == null || Schema.instance.getTableMetadata(keyspace, table) == null)
+            throw new IllegalArgumentException(String.format("Table %s.%s does not exist", keyspace, table));
+
+        CompressionDictionaryManager manager = ks.getColumnFamilyStore(table).compressionDictionaryManager();
+        if (!manager.isEnabled())
+            throw new IllegalStateException("The compression on table " + keyspace + '.' + table +
+                                            " is not enabled or SSTable compressor is not a dictionary compressor.");
+        return manager;
+    }
+
+    @Override
+    public List<ThreadPoolInfo> threadPoolInfos()
+    {
+        List<ThreadPoolInfo> infos = new ArrayList<>();
+        for (ThreadPoolMetrics metrics : Metrics.allThreadPoolMetrics())
+            infos.add(new ThreadPoolInfo(metrics.path, metrics.poolName));
+        return infos;
+    }
+
+    @Override
+    public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+    {
+        try
+        {
+            assert type.equals("IndexColumnFamilies") || type.equals("ColumnFamilies");
+
+            List<Map.Entry<String, ColumnFamilyStoreMBean>> mbeans = new ArrayList<>();
+
+            for (Keyspace keyspace : Keyspace.all())
+            {
+                for (ColumnFamilyStore cfs : keyspace.getColumnFamilyStores())
+                {
+                    // Secondary-index backing stores are not registered in the keyspace,
+                    // they are only reachable through the base table's index manager.
+                    if (type.equals("IndexColumnFamilies"))
+                        for (ColumnFamilyStore indexCfs : cfs.indexManager.getAllIndexColumnFamilyStores())
+                            mbeans.add(new AbstractMap.SimpleImmutableEntry<>(keyspace.getName(), indexCfs));
+                    else
+                        mbeans.add(new AbstractMap.SimpleImmutableEntry<>(keyspace.getName(), cfs));
+                }
+            }
+
+            return mbeans;
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error accessing column families", e);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        metricCache.clear();
+        mBeanCache.clear();
+    }
+
+    /**
+     * Functional interface for providing MBean instances lazily.
+     * Used to defer MBean initialization until the MBean is actually accessed.
+     *
+     * @param <T> the MBean interface type
+     */
+    @FunctionalInterface
+    public interface MBeanProvider<T>
+    {
+        /**
+         * @return the MBean instance, or {@code null} if the MBean is not available
+         * @throws RuntimeException if the MBean cannot be provided (e.g., not initialized yet)
+         */
+        T provide();
+    }
+
+    /** Visitor that finds a specific auth cache MBean type from AuthCacheService. */
+    private static class AuthCacheFinder implements AuthCache.MBeanVisitor
+    {
+        private final Class<?> targetType;
+        private Object foundCache;
+
+        AuthCacheFinder(Class<?> targetType)
+        {
+            this.targetType = targetType;
+        }
+
+        @Override
+        public void visitCredentials(PasswordAuthenticator.CredentialsCacheMBean cache)
+        {
+            if (targetType.equals(PasswordAuthenticator.CredentialsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitJmxPermissions(AuthorizationProxy.JmxPermissionsCacheMBean cache)
+        {
+            if (targetType.equals(AuthorizationProxy.JmxPermissionsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitPermissions(PermissionsCacheMBean cache)
+        {
+            if (targetType.equals(PermissionsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitNetwork(NetworkPermissionsCacheMBean cache)
+        {
+            if (targetType.equals(NetworkPermissionsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitRoles(RolesCacheMBean cache)
+        {
+            if (targetType.equals(RolesCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visit(AuthCacheMBean cache)
+        {
+            // No-op. Used for caches without specific MBean types.
+        }
+
+        Object getCache()
+        {
+            return foundCache;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/management/InternalNodeMBeanAccessor.java
+++ b/src/java/org/apache/cassandra/management/InternalNodeMBeanAccessor.java
@@ -1,0 +1,481 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.management.JMX;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.apache.cassandra.audit.AuditLogManager;
+import org.apache.cassandra.audit.AuditLogManagerMBean;
+import org.apache.cassandra.auth.AbstractCIDRAuthorizer;
+import org.apache.cassandra.auth.AuthCache;
+import org.apache.cassandra.auth.AuthCacheMBean;
+import org.apache.cassandra.auth.AuthCacheService;
+import org.apache.cassandra.auth.CIDRGroupsMappingManagerMBean;
+import org.apache.cassandra.auth.CIDRPermissionsManagerMBean;
+import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+import org.apache.cassandra.auth.PermissionsCacheMBean;
+import org.apache.cassandra.auth.RolesCacheMBean;
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
+import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.batchlog.BatchlogManagerMBean;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.ColumnFamilyStore;
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.apache.cassandra.db.Keyspace;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
+import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.db.guardrails.GuardrailsMBean;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTable;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTableMBean;
+import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.gms.FailureDetectorMBean;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.GossiperMBean;
+import org.apache.cassandra.hints.HintsService;
+import org.apache.cassandra.hints.HintsServiceMBean;
+import org.apache.cassandra.locator.DynamicEndpointSnitch;
+import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
+import org.apache.cassandra.locator.EndpointSnitchInfo;
+import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
+import org.apache.cassandra.locator.LocationInfo;
+import org.apache.cassandra.locator.LocationInfoMBean;
+import org.apache.cassandra.locator.NodeProximity;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.metrics.ThreadPoolMetrics;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.MessagingServiceMBean;
+import org.apache.cassandra.profiler.AsyncProfilerMBean;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.ActiveRepairServiceMBean;
+import org.apache.cassandra.service.AsyncProfilerService;
+import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.service.AutoRepairServiceMBean;
+import org.apache.cassandra.service.CacheService;
+import org.apache.cassandra.service.CacheServiceMBean;
+import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.service.GCInspectorMXBean;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.StorageProxyMBean;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.apache.cassandra.service.accord.AccordOperations;
+import org.apache.cassandra.service.accord.AccordOperationsMBean;
+import org.apache.cassandra.service.snapshot.SnapshotManager;
+import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
+import org.apache.cassandra.streaming.StreamManager;
+import org.apache.cassandra.streaming.StreamManagerMBean;
+import org.apache.cassandra.tcm.CMSOperations;
+import org.apache.cassandra.tcm.CMSOperationsMBean;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
+import static org.apache.cassandra.service.CassandraDaemon.SKIP_GC_INSPECTOR;
+
+/**
+ * Server-side implementation of {@link MBeanAccessor} for in-process execution.
+ *
+ * <p>
+ * This implementation provides direct access to MBean instances without using JMX,
+ * eliminating the need for remote connections or JMX proxies. It is designed for
+ * server-side command execution as part of CEP-38 Management API, where commands run
+ * in the same JVM as the Cassandra daemon.
+ *
+ * <p>
+ * Unlike {@link RemoteJmxMBeanAccessor}, this implementation:
+ * <ul>
+ *   <li>Directly accesses singleton instances (e.g., {@code StorageService.instance})</li>
+ *   <li>Does not require network connections or JMX connectors</li>
+ *   <li>Provides better performance by avoiding serialization/deserialization</li>
+ *   <li>Has no connection state to manage</li>
+ *   <li>Works directly with {@link Keyspace} and {@link ColumnFamilyStore} instances</li>
+ * </ul>
+ *
+ * <p>
+ * <b>Lazy Initialization</b>: MBean providers are initialized registered for known MBeans.
+ *
+ * @see MBeanAccessor
+ * @see RemoteJmxMBeanAccessor
+ * @since 5.1
+ */
+public class InternalNodeMBeanAccessor implements MBeanAccessor
+{
+    private final Map<Class<?>, MBeanProvider<?>> mBeanProviders = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Object> mBeanCache = new ConcurrentHashMap<>();
+    private final Map<String, Object> metricCache = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new InternalNodeMBeanAccessor using direct instance access.
+     */
+    public InternalNodeMBeanAccessor()
+    {
+        initializeMBeanProviders();
+    }
+
+    /**
+     * Initializes all statically known MBean instances.
+     */
+    private void initializeMBeanProviders()
+    {
+        registerMBeanProvider(AccordOperationsMBean.class, () -> AccordOperations.instance);
+        registerMBeanProvider(ActiveRepairServiceMBean.class, ActiveRepairService::instance);
+        registerMBeanProvider(AuditLogManagerMBean.class, () -> AuditLogManager.instance);
+        registerMBeanProvider(AutoRepairServiceMBean.class, () -> AutoRepairService.instance);
+        registerMBeanProvider(BatchlogManagerMBean.class, () -> BatchlogManager.instance);
+        registerMBeanProvider(CMSOperationsMBean.class, () -> CMSOperations.instance);
+        registerMBeanProvider(CacheServiceMBean.class, () -> CacheService.instance);
+        registerMBeanProvider(CompactionManagerMBean.class, () -> CompactionManager.instance);
+        registerMBeanProvider(DynamicEndpointSnitchMBean.class, this::resolveDynamicEndpointSnitch);
+        registerMBeanProvider(FailureDetectorMBean.class, () -> (FailureDetectorMBean) FailureDetector.instance);
+        registerMBeanProvider(GCInspectorMXBean.class, this::resolveGCInspector);
+        registerMBeanProvider(GossiperMBean.class, () -> Gossiper.instance);
+        registerMBeanProvider(GuardrailsMBean.class, () -> Guardrails.instance);
+        registerMBeanProvider(HintsServiceMBean.class, () -> HintsService.instance);
+        registerMBeanProvider(MemoryMXBean.class, ManagementFactory::getMemoryMXBean);
+        registerMBeanProvider(MessagingServiceMBean.class, MessagingService::instance);
+        registerMBeanProvider(RuntimeMXBean.class, ManagementFactory::getRuntimeMXBean);
+        registerMBeanProvider(SnapshotManagerMBean.class, () -> SnapshotManager.instance);
+        registerMBeanProvider(StorageProxyMBean.class, () -> StorageProxy.instance);
+        registerMBeanProvider(StorageServiceMBean.class, () -> StorageService.instance);
+        registerMBeanProvider(StreamManagerMBean.class, () -> StreamManager.instance);
+        registerMBeanProvider(AsyncProfilerMBean.class, AsyncProfilerService::instance);
+
+        // Utility MBeans are stateless and can be created on demand.
+        // They query DatabaseDescriptor for the current state, so new instances are fine
+        registerMBeanProvider(EndpointSnitchInfoMBean.class, EndpointSnitchInfo::new);
+        registerMBeanProvider(LocationInfoMBean.class, LocationInfo::new);
+
+        // AuthCache MBeans
+        registerMBeanProvider(AuthorizationProxy.JmxPermissionsCacheMBean.class,
+                              () -> findAuthCache(AuthorizationProxy.JmxPermissionsCacheMBean.class));
+        registerMBeanProvider(NetworkPermissionsCacheMBean.class,
+                              () -> findAuthCache(NetworkPermissionsCacheMBean.class));
+        registerMBeanProvider(PasswordAuthenticator.CredentialsCacheMBean.class,
+                              () -> findAuthCache(PasswordAuthenticator.CredentialsCacheMBean.class));
+        registerMBeanProvider(PermissionsCacheMBean.class,
+                              () -> findAuthCache(PermissionsCacheMBean.class));
+        registerMBeanProvider(RolesCacheMBean.class,
+                              () -> findAuthCache(RolesCacheMBean.class));
+
+        // CIDR Auth MBeans
+        registerMBeanProvider(CIDRFilteringMetricsTableMBean.class, () -> CIDRFilteringMetricsTable.instance);
+        registerMBeanProvider(CIDRGroupsMappingManagerMBean.class, () -> AbstractCIDRAuthorizer.cidrGroupsMappingManager);
+        registerMBeanProvider(CIDRPermissionsManagerMBean.class, () -> AbstractCIDRAuthorizer.cidrPermissionsManager);
+    }
+
+    /**
+     * Gets DynamicEndpointSnitch from DatabaseDescriptor if it's a DynamicEndpointSnitch,
+     * otherwise returns null.
+     */
+    private DynamicEndpointSnitchMBean resolveDynamicEndpointSnitch()
+    {
+        if (!DatabaseDescriptor.isDynamicEndpointSnitch())
+            throw new IllegalStateException("DynamicEndpointSnitch has been requested but is not enabled");
+
+        NodeProximity proximity = DatabaseDescriptor.getNodeProximity();
+        assert proximity instanceof DynamicEndpointSnitch;
+
+        return (DynamicEndpointSnitchMBean) proximity;
+    }
+
+    private GCInspectorMXBean resolveGCInspector()
+    {
+        if (SKIP_GC_INSPECTOR)
+            throw new IllegalStateException("GCInspector has been requested but is disabled via SKIP_GC_INSPECTOR flag");
+
+        try
+        {
+            MBeanServer mbs = MBeanWrapper.instance.getMBeanServer();
+            if (mbs == null)
+                return null;
+
+            ObjectName name = new ObjectName(GCInspector.MBEAN_NAME);
+            if (mbs.isRegistered(name))
+                return JMX.newMBeanProxy(mbs, name, GCInspectorMXBean.class);
+        }
+        catch (Exception e)
+        {
+            // Fall through to create a new instance
+        }
+
+        return null;
+    }
+
+    /** Finds an auth cache MBean instance from AuthCacheService. */
+    private <T> T findAuthCache(Class<T> clazz)
+    {
+        Set<AuthCache<?, ?>> caches = AuthCacheService.instance.getCaches();
+        if (caches.isEmpty())
+            return null;
+
+        AuthCacheFinder visitor = new AuthCacheFinder(clazz);
+        for (AuthCache<?, ?> cache : caches)
+        {
+            cache.accept(visitor);
+            Object found = visitor.getCache();
+            if (found == null)
+                continue;
+            return clazz.cast(found);
+        }
+        return null;
+    }
+
+    private <T> void registerMBeanProvider(Class<T> clazz, MBeanProvider<T> locator)
+    {
+        Object prev = mBeanProviders.putIfAbsent(clazz, locator);
+        assert prev == null : "MBean locator for " + clazz.getName() + " is already registered";
+    }
+
+    @Override
+    public <T> T findMBean(Class<T> clazz)
+    {
+        Object cached = mBeanCache.get(clazz);
+        if (cached != null)
+            return clazz.cast(cached);
+
+        Object prev =  mBeanCache.computeIfAbsent(clazz, k -> {
+            MBeanProvider<?> provider = mBeanProviders.get(k);
+            return provider == null ? null : provider.provide();
+        });
+        if (prev == null)
+            throw new RuntimeException("MBean of type " + clazz.getName() + " is not registered");
+        return clazz.cast(prev);
+    }
+
+    @Override
+    public <T> T findMBeanMetric(Class<T> clazz, Props props)
+    {
+        try
+        {
+            assert clazz.isInterface() && CassandraMetricsRegistry.MetricMBean.class.isAssignableFrom(clazz);
+
+            ObjectName objectName = buildObjectNameFromProps(props);
+            String cacheKey = objectName.getCanonicalName();
+
+            @SuppressWarnings("unchecked")
+            T cached = (T) metricCache.get(cacheKey);
+            if (cached != null)
+                return cached;
+
+            return clazz.cast(metricCache.computeIfAbsent(cacheKey, k -> JMX.newMBeanProxy(MBeanWrapper.instance.getMBeanServer(), objectName, clazz)));
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error accessing metric MBean: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isMBeanMetricRegistered(Props props)
+    {
+        try
+        {
+            // Use the internal MBean server to look up MBean by ObjectName. This leverages existing
+            // JMX infrastructure and avoids the complexity of constructing metric names from Props.
+            //
+            // Alternatively, we could use CassandraMetricsRegistry to look up metrics by metric name
+            // (e.g., "org.apache.cassandra.metrics.Keyspace.ReadLatency.mykeyspace"), but this requires
+            // constructing the full metric name from Props, which is problematic.
+            //
+            // The reconstructing the scope problem: Different MetricNameFactory implementations
+            // construct scopes differently:
+            // - KeyspaceMetrics: scope = keyspace property
+            // - TableMetrics: scope = keyspace + '.' + scope property
+            // - DefaultNameFactory: scope = scope property
+            // - SAI AbstractMetrics: scope = keyspace.table.index.scope (all combined)
+            //
+            // To construct metric names from Props, we would need to duplicate scope construction logic
+            // from each factory or refactor to share it. Using ObjectName, in turn, avoids this. We query
+            // MBeanServer using the ObjectName pattern already constructed by factories during registration.
+            //
+            // However, it will be beneficial to revisit this down the line for performance optimizations and
+            // to avoid JMX entanglement, so we could switch it off for in-process access.
+
+            ObjectName objectName = buildObjectNameFromProps(props);
+            MBeanServer mbs = MBeanWrapper.instance.getMBeanServer();
+            return mbs.isRegistered(objectName);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error checking metric MBean registration: " + e.getMessage(), e);
+        }
+    }
+
+    private static ObjectName buildObjectNameFromProps(Props props) throws MalformedObjectNameException
+    {
+        return new ObjectName("org.apache.cassandra.metrics", new Hashtable<>(props.toMap()));
+    }
+
+    @Override
+    public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+    {
+        Keyspace ks = Schema.instance.getKeyspaceInstance(keyspace);
+        if (ks == null)
+            throw new IllegalArgumentException("Keyspace not found: " + keyspace);
+        return ks.getColumnFamilyStore(columnFamily);
+    }
+
+    @Override
+    public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+    {
+        Keyspace ks = Schema.instance.getKeyspaceInstance(keyspace);
+        if (ks == null)
+            throw new IllegalArgumentException(String.format("Table %s.%s does not exist", keyspace, table));
+        ColumnFamilyStore cfs = ks.getColumnFamilyStore(table);
+        return cfs.compressionDictionaryManager();
+    }
+
+    @Override
+    public List<ThreadPoolInfo> threadPoolInfos()
+    {
+        List<ThreadPoolInfo> infos = new ArrayList<>();
+        for (ThreadPoolMetrics metrics : Metrics.allThreadPoolMetrics())
+            infos.add(new ThreadPoolInfo(metrics.path, metrics.poolName));
+        return infos;
+    }
+
+    @Override
+    public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+    {
+        try
+        {
+            assert type.equals("IndexColumnFamilies") || type.equals("ColumnFamilies");
+
+            List<Map.Entry<String, ColumnFamilyStoreMBean>> mbeans = new ArrayList<>();
+
+            for (Keyspace keyspace : Keyspace.all())
+            {
+                for (ColumnFamilyStore cfs : keyspace.getColumnFamilyStores())
+                {
+                    if (type.equals("IndexColumnFamilies") && !cfs.isIndex())
+                        continue;
+                    if (type.equals("ColumnFamilies") && cfs.isIndex())
+                        continue;
+
+                    mbeans.add(new AbstractMap.SimpleImmutableEntry<>(keyspace.getName(), cfs));
+                }
+            }
+
+            return mbeans;
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error accessing column families", e);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        metricCache.clear();
+        mBeanCache.clear();
+    }
+
+    /**
+     * Functional interface for providing MBean instances lazily.
+     * Used to defer MBean initialization until the MBean is actually accessed.
+     *
+     * @param <T> the MBean interface type
+     */
+    @FunctionalInterface
+    public interface MBeanProvider<T>
+    {
+        /**
+         * @return the MBean instance, or {@code null} if the MBean is not available
+         * @throws RuntimeException if the MBean cannot be provided (e.g., not initialized yet)
+         */
+        T provide();
+    }
+
+    /** Visitor that finds a specific auth cache MBean type from AuthCacheService. */
+    private static class AuthCacheFinder implements AuthCache.MBeanVisitor
+    {
+        private final Class<?> targetType;
+        private Object foundCache;
+
+        AuthCacheFinder(Class<?> targetType)
+        {
+            this.targetType = targetType;
+        }
+
+        @Override
+        public void visitCredentials(PasswordAuthenticator.CredentialsCacheMBean cache)
+        {
+            if (targetType.equals(PasswordAuthenticator.CredentialsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitJmxPermissions(AuthorizationProxy.JmxPermissionsCacheMBean cache)
+        {
+            if (targetType.equals(AuthorizationProxy.JmxPermissionsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitPermissions(PermissionsCacheMBean cache)
+        {
+            if (targetType.equals(PermissionsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitNetwork(NetworkPermissionsCacheMBean cache)
+        {
+            if (targetType.equals(NetworkPermissionsCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visitRoles(RolesCacheMBean cache)
+        {
+            if (targetType.equals(RolesCacheMBean.class))
+                foundCache = cache;
+        }
+
+        @Override
+        public void visit(AuthCacheMBean cache)
+        {
+            // No-op. Used for caches without specific MBean types.
+        }
+
+        Object getCache()
+        {
+            return foundCache;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/management/MBeanAccessor.java
+++ b/src/java/org/apache/cassandra/management/MBeanAccessor.java
@@ -36,8 +36,8 @@ public interface MBeanAccessor extends AutoCloseable
     /**
      * Finds statically known MBeans by MBean class name.
      * @param clazz the MBean class.
-     * @return MBean class or {@code null} if not found.
      * @param <T> the MBean type.
+     * @return the MBean instance, or {@code null} if not found.
      */
     @Nullable
     <T> T findMBean(Class<T> clazz);

--- a/src/java/org/apache/cassandra/management/MBeanAccessor.java
+++ b/src/java/org/apache/cassandra/management/MBeanAccessor.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+
+public interface MBeanAccessor extends AutoCloseable
+{
+    /**
+     * Finds statically known MBeans by MBean class name.
+     * @param clazz the MBean class.
+     * @return MBean class or {@code null} if not found.
+     * @param <T> the MBean type.
+     */
+    @Nullable
+    <T> T findMBean(Class<T> clazz);
+    <T> T findMBeanMetric(Class<T> clazz, Props props);
+    boolean isMBeanMetricRegistered(Props props);
+
+    ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily);
+    CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table);
+
+    /** List of thread pool MBeans with associated path and pool name. */
+    List<ThreadPoolInfo> threadPoolInfos();
+    /** List of column family MBeans with associated keyspace name. */
+    List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type);
+
+    /** {@inheritDoc} */
+    @Override
+    default void close() { }
+
+    default CassandraMetricsRegistry.JmxCounterMBean findMBeanCounter(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxCounterMBean.class, props);
+    }
+
+    default CassandraMetricsRegistry.JmxGaugeMBean findMBeanGauge(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxGaugeMBean.class, props);
+    }
+
+    default CassandraMetricsRegistry.JmxMeterMBean findMBeanMeter(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxMeterMBean.class, props);
+    }
+
+    default CassandraMetricsRegistry.JmxTimerMBean findMBeanTimer(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxTimerMBean.class, props);
+    }
+
+    default CassandraMetricsRegistry.JmxHistogramMBean findMBeanHistogram(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxHistogramMBean.class, props);
+    }
+
+    class Props
+    {
+        private final Map<String, String> values = Maps.newLinkedHashMap();
+
+        public Props(String type, String path, String keyspace, String table, String scope, String name)
+        {
+            if (type == null || type.isEmpty())
+                throw new IllegalArgumentException("type is required");
+            values.put("type", type);
+            if (path != null)
+                values.put("path", path);
+            if (keyspace != null)
+                values.put("keyspace", keyspace);
+            if (table != null)
+                values.put("table", table);
+            if (scope != null)
+                values.put("scope", scope);
+            if (name != null)
+                values.put("name", name);
+        }
+
+        public static Props metric(String type, String name)
+        {
+            return new Props(type, null, null, null, null, name);
+        }
+
+        public static Props scoped(String type, String scope, String name)
+        {
+            return new Props(type, null, null, null, scope, name);
+        }
+
+        public static Props threadPool(String type, String path, String scope, String name)
+        {
+            return new Props(type, path, null, null, scope, name);
+        }
+
+        public static Props sai(String type, String keyspace, String table, String scope, String name)
+        {
+            return new Props(type, null, keyspace, table, scope, name);
+        }
+
+        public static Props columnFamily(String type, String keyspace, String scope, String name)
+        {
+            return new Props(type, null, keyspace, null, scope, name);
+        }
+
+        public static Props keyspace(String type, String keyspace, String name)
+        {
+            return new Props(type, null, keyspace, null, null, name);
+        }
+
+        public Map<String, String> toMap()
+        {
+            return ImmutableMap.copyOf(values);
+        }
+    }
+
+    class ThreadPoolInfo
+    {
+        private final String path;
+        private final String poolName;
+
+        public ThreadPoolInfo(String path, String poolName)
+        {
+            this.path = path;
+            this.poolName = poolName;
+        }
+
+        public String path()
+        {
+            return path;
+        }
+        public String poolName()
+        {
+            return poolName;
+        }
+        public String scope()
+        {
+            return path + '.' + poolName;
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/management/ManagementUtils.java
+++ b/src/java/org/apache/cassandra/management/ManagementUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandRegistry;
+
+import picocli.CommandLine;
+
+public final class ManagementUtils
+{
+    public static final String COMMAND_NAME_DELIMITER = ".";
+
+    public static <S> Iterable<S> loadService(Class<S> serviceClz)
+    {
+        return AccessController.doPrivileged((PrivilegedAction<Iterable<S>>) () -> ServiceLoader.load(serviceClz));
+    }
+
+    public static int countCommands(CommandRegistry registry)
+    {
+        int count = 0;
+        for (Map.Entry<String, Command<?>> entry : registry.commands())
+        {
+            Command<?> cmd = entry.getValue();
+            if (cmd instanceof CommandRegistry)
+                count += countCommands((CommandRegistry) cmd);
+            else
+                count++;
+        }
+        return count;
+    }
+
+    public static String stripAngleBrackets(String name)
+    {
+        if (name == null || name.isEmpty())
+            return name;
+
+        String trimmed = name.trim();
+
+        if (trimmed.length() >= 2 &&
+            trimmed.charAt(0) == '<' &&
+            trimmed.charAt(trimmed.length() - 1) == '>')
+        {
+            return trimmed.substring(1, trimmed.length() - 1).trim();
+        }
+
+        return name;
+    }
+
+    /** Normalize the option name by stripping leading dashes. */
+    public static String normalizeOptionName(String name)
+    {
+        if (name.startsWith("--"))
+            return name.substring(2);
+        else if (name.startsWith("-"))
+            return name.substring(1);
+        return name;
+    }
+
+    /**
+     * Builds a concise, client-safe error string from a throwable's cause chain: the distinct, non-empty
+     * messages of the throwable and its causes, joined by {@code ": "}. Unlike a full stack trace, this
+     * exposes only the human-readable messages (which command validation/usage errors rely on) without
+     * leaking internal class names, file paths or line numbers. The full stack trace is logged separately
+     * server-side.
+     */
+    public static String causeMessages(Throwable t)
+    {
+        Set<String> messages = new LinkedHashSet<>();
+        for (Throwable cause : Throwables.getCausalChain(t))
+        {
+            String message = cause.getMessage();
+            if (Strings.isNullOrEmpty(message))
+                continue;
+            // Skip a message already represented by an ancestor.
+            if (messages.stream().anyMatch(existing -> existing.contains(message)))
+                continue;
+            messages.add(message);
+        }
+        return messages.isEmpty() ? t.getClass().getSimpleName() : String.join(": ", messages);
+    }
+
+    public static String fullCommandName(String parent, String name)
+    {
+        return Strings.isNullOrEmpty(parent) ? name : String.join(COMMAND_NAME_DELIMITER, parent, name);
+    }
+
+    public static <T> String fullCommandName(List<T> parentCommands, Function<T, String> nameExtractor)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (T part : parentCommands)
+        {
+            String extracted = nameExtractor.apply(part);
+            if (Strings.isNullOrEmpty(extracted))
+                continue;
+            if (sb.length() > 0)
+                sb.append(COMMAND_NAME_DELIMITER);
+            sb.append(extracted);
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T findRegistryCommand(String fullCommandName, CommandRegistry registry)
+    {
+        String[] parts = fullCommandName.split('\\' + COMMAND_NAME_DELIMITER, 2);
+        Command<?> cmd = registry.command(parts[0]);
+        if (cmd == null)
+            return null;
+
+        if (parts.length == 1)
+            return (T) cmd;
+
+        if (cmd instanceof CommandRegistry)
+            return findRegistryCommand(parts[1], (CommandRegistry) cmd);
+
+        return null;
+    }
+
+    public static Class<?> elementType(CommandLine.Model.ArgSpec spec)
+    {
+        Class<?> type = spec.type();
+        if (!type.isArray() && !java.util.Collection.class.isAssignableFrom(type))
+            return null;
+
+        Class<?>[] auxiliaryTypes = spec.auxiliaryTypes();
+        return auxiliaryTypes == null || auxiliaryTypes.length == 0 ? null : auxiliaryTypes[0];
+    }
+}

--- a/src/java/org/apache/cassandra/management/ManagementUtils.java
+++ b/src/java/org/apache/cassandra/management/ManagementUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+
+import com.google.common.base.Strings;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandRegistry;
+
+public final class ManagementUtils
+{
+    public static final String COMMAND_NAME_DELIMITER = ".";
+
+    public static <S> Iterable<S> loadService(Class<S> serviceClz)
+    {
+        return AccessController.doPrivileged((PrivilegedAction<Iterable<S>>) () -> ServiceLoader.load(serviceClz));
+    }
+
+    public static int countCommands(CommandRegistry registry)
+    {
+        int count = 0;
+        for (Map.Entry<String, Command<?>> entry : registry.commands())
+        {
+            Command<?> cmd = entry.getValue();
+            if (cmd instanceof CommandRegistry)
+                count += countCommands((CommandRegistry) cmd);
+            else
+                count++;
+        }
+        return count;
+    }
+
+    public static String stripAngleBrackets(String name)
+    {
+        if (name == null || name.isEmpty())
+            return name;
+
+        String trimmed = name.trim();
+
+        if (trimmed.length() >= 2 &&
+            trimmed.charAt(0) == '<' &&
+            trimmed.charAt(trimmed.length() - 1) == '>')
+        {
+            return trimmed.substring(1, trimmed.length() - 1).trim();
+        }
+
+        return name;
+    }
+
+    /** Normalize the option name by stripping leading dashes. */
+    public static String normalizeOptionName(String name)
+    {
+        if (name.startsWith("--"))
+            return name.substring(2);
+        else if (name.startsWith("-"))
+            return name.substring(1);
+        return name;
+    }
+
+    public static String fullCommandName(String parent, String name)
+    {
+        return Strings.isNullOrEmpty(parent) ? name : String.join(COMMAND_NAME_DELIMITER, parent, name);
+    }
+
+    public static <T> String fullCommandName(List<T> parentCommands, Function<T, String> nameExtractor)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (T part : parentCommands)
+        {
+            String extracted = nameExtractor.apply(part);
+            if (Strings.isNullOrEmpty(extracted))
+                continue;
+            if (sb.length() > 0)
+                sb.append(COMMAND_NAME_DELIMITER);
+            sb.append(extracted);
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T findRegistryCommand(String fullCommandName, CommandRegistry registry)
+    {
+        String[] parts = fullCommandName.split('\\' + COMMAND_NAME_DELIMITER, 2);
+        Command<?> cmd = registry.command(parts[0]);
+        if (cmd == null)
+            return null;
+
+        if (parts.length == 1)
+            return (T) cmd;
+
+        if (cmd instanceof CommandRegistry)
+            return findRegistryCommand(parts[1], (CommandRegistry) cmd);
+
+        return null;
+    }
+}

--- a/src/java/org/apache/cassandra/management/SimpleCommandExecutionArgs.java
+++ b/src/java/org/apache/cassandra/management/SimpleCommandExecutionArgs.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+
+public class SimpleCommandExecutionArgs implements CommandExecutionArgs
+{
+    private final Map<OptionMetadata, Object> options;
+    private final Map<ParameterMetadata, Object> parameters;
+
+    public SimpleCommandExecutionArgs(Map<OptionMetadata, Object> options,
+                                      Map<ParameterMetadata, Object> parameters)
+    {
+        this.options = new LinkedHashMap<>(options);
+        this.parameters = new LinkedHashMap<>(parameters);
+    }
+
+    @Override
+    public Map<ParameterMetadata, Object> parameters()
+    {
+        return parameters;
+    }
+
+    @Override
+    public Map<OptionMetadata, Object> options()
+    {
+        return options;
+    }
+
+    @Override
+    public boolean hasParameter(ParameterMetadata param)
+    {
+        return parameters.containsKey(param);
+    }
+
+    @Override
+    public boolean hasOption(OptionMetadata option)
+    {
+        return options.containsKey(option);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SimpleCommandExecutionArgs{" +
+               "options=" + options +
+               ", parameters=" + parameters +
+               '}';
+    }
+}

--- a/src/java/org/apache/cassandra/management/api/ArgumentMetadata.java
+++ b/src/java/org/apache/cassandra/management/api/ArgumentMetadata.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+public interface ArgumentMetadata
+{
+    String[] names();
+    String paramLabel();
+
+    String description();
+    Class<?> type();
+    String defaultValue();
+    boolean required();
+    /** "0" (flag), "1", "0..1", "0..*" */
+    String arity();
+}

--- a/src/java/org/apache/cassandra/management/api/Command.java
+++ b/src/java/org/apache/cassandra/management/api/Command.java
@@ -35,7 +35,7 @@ package org.apache.cassandra.management.api;
  */
 public interface Command<R>
 {
-    /** Get command metadata - replaces argClass() from the cep-38 doc with richer information. */
+    /** Command metadata. Replaces argClass() from the CEP-38 doc, carrying more than just the argument type. */
     CommandMetadata metadata();
 
     /**

--- a/src/java/org/apache/cassandra/management/api/Command.java
+++ b/src/java/org/apache/cassandra/management/api/Command.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+/**
+ * A management command following the Command java-pattern. Each command is a self-describing,
+ * executable unit that exposes its {@link CommandMetadata} and can be invoked uniformly by
+ * the {@link org.apache.cassandra.management.CommandInvokerService} regardless of the
+ * transport: JMX or CQL.
+ * <p>
+ * The type parameter {@code R} is the structured result type returned by
+ * {@link #execute(CommandExecutionArgs, CommandExecutionContext)}. Existing picocli-based
+ * commands return {@code Void} and write output via services obtained from the context;
+ * new commands may return a typed result for protocol-level serialization.
+ *
+ * @param <R> the command result type, or {@link Void} for commands that only produce
+ *            side-effect output through the execution context
+ * @see CommandRegistry
+ */
+public interface Command<R>
+{
+    /** Get command metadata - replaces argClass() from the cep-38 doc with richer information. */
+    CommandMetadata metadata();
+
+    /**
+     * Execute the command.
+     *
+     * @param arguments command arguments.
+     * @param context execution context providing access to services via {@link CommandExecutionContext#service(Class)}.
+     * @return structured data result, or {@code null} for commands that only produce
+     *         side effect output (e.g. existing picocli-based commands).
+     */
+    R execute(CommandExecutionArgs arguments, CommandExecutionContext context);
+
+    default String name() { return metadata().name(); }
+    default String description() { return metadata().description(); }
+}

--- a/src/java/org/apache/cassandra/management/api/CommandExecutionArgs.java
+++ b/src/java/org/apache/cassandra/management/api/CommandExecutionArgs.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+import java.util.Map;
+
+public interface CommandExecutionArgs
+{
+    /** @return Map of parameter metadata to their values. */
+    Map<ParameterMetadata, Object> parameters();
+    /** @return Map of option metadata to their values. */
+    Map<OptionMetadata, Object> options();
+
+    boolean hasParameter(ParameterMetadata param);
+    boolean hasOption(OptionMetadata option);
+}

--- a/src/java/org/apache/cassandra/management/api/CommandExecutionContext.java
+++ b/src/java/org/apache/cassandra/management/api/CommandExecutionContext.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+import java.util.Set;
+
+/**
+ * Provides execution-time services to a {@link Command}. The context acts as a typed service
+ * locator so that the API package ({@code management.api}) carries no compile-time dependency
+ * on tool-specific classes such as {@code NodeProbe} or {@code Output}.
+ * <p>
+ * Adapter layers retrieve the concrete services they need:
+ * <pre>{@code
+ *     NodeProbe probe = context.service(NodeProbe.class);
+ *     Output    out   = context.service(Output.class);
+ * }</pre>
+ * New commands that do not require legacy tool types can request MBean interfaces directly:
+ * <pre>{@code
+ *     StorageServiceMBean ss = context.service(StorageServiceMBean.class);
+ * }</pre>
+ */
+public interface CommandExecutionContext
+{
+    /**
+     * Returns the service instance of the requested type, or throws
+     * {@link IllegalArgumentException} if the service is not available in this context.
+     *
+     * @param serviceType the class of the desired service
+     * @param <T> service type
+     * @return a non-null service instance
+     * @throws IllegalArgumentException if the service is not available
+     */
+    <T> T service(Class<T> serviceType);
+
+    /**
+     * Retrieves the set of all service types that are available within the current execution context.
+     * @return a set of classes representing the types of services accessible via this context.
+     */
+    Set<Class<?>> services();
+}

--- a/src/java/org/apache/cassandra/management/api/CommandMetadata.java
+++ b/src/java/org/apache/cassandra/management/api/CommandMetadata.java
@@ -33,8 +33,8 @@ import java.util.List;
  *   <li>{@link org.apache.cassandra.management.CommandExecutionArgsSerde} to serialize/deserialize
  *       command arguments to and from JSON or CQL row maps.</li>
  *   <li>{@link org.apache.cassandra.management.CommandInvokerService} to look up and invoke
- *       commands over existing MBean interfaces (only intefaces and corresponding implementaions
- *       are used, JMX might be disabled).;</li>
+ *       commands over existing MBean interfaces (only the interfaces and their implementations are
+ *       used, so this works with JMX disabled).</li>
  *   <li>CQL syntax {@code COMMAND} to validate and convert user-supplied arguments.</li>
  * </ul>
  * <p>

--- a/src/java/org/apache/cassandra/management/api/CommandMetadata.java
+++ b/src/java/org/apache/cassandra/management/api/CommandMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+import java.util.List;
+
+/**
+ * CommandMetadata is a protocol-agnostic descriptor of a management command's structure
+ * and metadata information.
+ * <p>
+ * Each {@link Command} exposes a {@code CommandMetadata} that describes the command's name,
+ * human-readable description, optional aliases, accepted options (named flags/values),
+ * positional parameters, and subcommands.
+ * <p>
+ * This metadata is used by:
+ * <ul>
+ *   <li>{@link org.apache.cassandra.management.CommandExecutionArgsSerde} to serialize/deserialize
+ *       command arguments to and from JSON or CQL row maps.</li>
+ *   <li>{@link org.apache.cassandra.management.CommandInvokerService} to look up and invoke
+ *       commands over existing MBean interfaces (only intefaces and corresponding implementaions
+ *       are used, JMX might be disabled).;</li>
+ *   <li>CQL syntax {@code COMMAND} to validate and convert user-supplied arguments.</li>
+ * </ul>
+ * <p>
+ * The interface intentionally has no {@code parent()} accessor. Parent-child relationships are
+ * owned by the {@link org.apache.cassandra.management.CassandraCommandRegistry} (and its
+ * underlying {@link CommandRegistry} contract) rather than by individual commands, so that
+ * a command can be registered in different registries.
+ */
+public interface CommandMetadata
+{
+    String name();
+    String description();
+
+    List<OptionMetadata> options();
+    List<ParameterMetadata> parameters();
+    List<CommandMetadata> subcommands();
+}

--- a/src/java/org/apache/cassandra/management/api/CommandRegistry.java
+++ b/src/java/org/apache/cassandra/management/api/CommandRegistry.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+import java.util.Map;
+
+/**
+ * Registry that knows all of its subcommands and acts as a composite command for hierarchy.
+ * Allows registering and retrieving commands by name.
+ * <p>
+ * For example, nodetool commands structure is like:
+ * <pre>
+ * NodetoolCommand (parent)
+ *   ├── setconcurrentcompactors (leaf command, implemented via Command interface)
+ *   ├── compressiondictionary (parent command, implemented via CommandRegistry interface)
+ *   │   ├── train (leaf)
+ *   │   ├── list (leaf)
+ *   │   ├── export (leaf)
+ *   │   └── import (leaf)
+ *   ├── decommission (parent)
+ *   │   └── abort (leaf)
+ *   └── ... 100+ more commands
+ * </pre>
+ */
+public interface CommandRegistry extends Command<String>
+{
+    <T> Command<T> command(String name);
+    Iterable<Map.Entry<String, Command<?>>> commands();
+}

--- a/src/java/org/apache/cassandra/management/api/CommandsProvider.java
+++ b/src/java/org/apache/cassandra/management/api/CommandsProvider.java
@@ -21,10 +21,10 @@ package org.apache.cassandra.management.api;
 import java.util.Collection;
 
 /**
- * Pluggable component that is responsible for providing a list of commands for management API.
+ * Pluggable source of the commands the management API exposes.
  */
 public interface CommandsProvider
 {
-    /** Gets all supported by these provider commands. */
+    /** Returns every command this provider supports. */
     Collection<Command<?>> commands();
 }

--- a/src/java/org/apache/cassandra/management/api/CommandsProvider.java
+++ b/src/java/org/apache/cassandra/management/api/CommandsProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+import java.util.Collection;
+
+/**
+ * Pluggable component that is responsible for providing a list of commands for management API.
+ */
+public interface CommandsProvider
+{
+    /** Gets all supported by these provider commands. */
+    Collection<Command<?>> commands();
+}

--- a/src/java/org/apache/cassandra/management/api/OptionMetadata.java
+++ b/src/java/org/apache/cassandra/management/api/OptionMetadata.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+public interface OptionMetadata extends ArgumentMetadata
+{
+}

--- a/src/java/org/apache/cassandra/management/api/ParameterMetadata.java
+++ b/src/java/org/apache/cassandra/management/api/ParameterMetadata.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.api;
+
+public interface ParameterMetadata extends ArgumentMetadata
+{
+    String COMMAND_POSITIONAL_PARAM_PREFIX = "param";
+    int index();
+}

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandAdapter.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandAdapter.java
@@ -63,13 +63,10 @@ public class PicocliCommandAdapter implements Command<Void>
 
         PicocliCommandArgsConverter.toCommand(arguments, userCommand);
 
-        // Alternatively, we can convert CommandExecutionArgs to String[] and let picocli handle
-        // the parsing and execution; however, Cassandra validates a lot of arguments inside the
-        // command's execution body (historically this was done because of Airline limitations).
-        //
-        // Double parsing and validation of arguments is not ideal, and it doesn't make sense
-        // to rely on picocli either. Verdict: it doesn't make sense to rely on picocli argument
-        // validation and error handling here.
+        // Alternatively, we could convert CommandExecutionArgs back to String[] and let picocli parse and
+        // execute; however, Cassandra validates a lot of arguments inside the command's execution body
+        // (historically because of Airline limitations), so that would parse and validate everything twice.
+        // Hence picocli's argument validation and error handling are not used here.
         if (userCommand instanceof Runnable)
         {
             ((Runnable) userCommand).run();

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandAdapter.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandAdapter.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.lang.reflect.Field;
+
+import javax.inject.Inject;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandExecutionContext;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.Output;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+
+import picocli.CommandLine;
+
+public class PicocliCommandAdapter implements Command<Void>
+{
+    private final Class<? extends AbstractCommand> commandClass;
+    private final CommandMetadata commandMetadata;
+
+    public PicocliCommandAdapter(Class<? extends AbstractCommand> commandClass)
+    {
+        this.commandClass = commandClass;
+        this.commandMetadata = PicocliCommandMetadata.from(commandClass);
+        if (!(commandMetadata instanceof PicocliCommandMetadata))
+            throw new IllegalStateException("CommandMetadata must be PicocliCommandMetadata for picocli commands");
+    }
+
+    @Override
+    public CommandMetadata metadata()
+    {
+        return commandMetadata;
+    }
+
+    @Override
+    public Void execute(CommandExecutionArgs arguments, CommandExecutionContext context)
+    {
+        Output output = context.service(Output.class);
+        CommandLine commandLine = new CommandLine(commandClass, new InjectCassandraContext(output));
+        Object userCommand = commandLine.getCommand();
+
+        if (userCommand instanceof AbstractCommand)
+            ((AbstractCommand) userCommand).probe(context.service(NodeProbe.class));
+
+        PicocliCommandArgsConverter.toCommand(arguments, userCommand);
+
+        // Alternatively, we can convert CommandExecutionArgs to String[] and let picocli handle
+        // the parsing and execution; however, Cassandra validates a lot of arguments inside the
+        // command's execution body (historically this was done because of Airline limitations).
+        //
+        // Double parsing and validation of arguments is not ideal, and it doesn't make sense
+        // to rely on picocli either. Verdict: it doesn't make sense to rely on picocli argument
+        // validation and error handling here.
+        if (userCommand instanceof Runnable)
+        {
+            ((Runnable) userCommand).run();
+            return null;
+        }
+        else
+        {
+            throw new RuntimeException(String.format("Unsupported command type: %s. " +
+                                                     "Command class must implement Runnable to be executed.",
+                                                     userCommand.getClass().getName()));
+        }
+    }
+
+    private static class InjectCassandraContext implements CommandLine.IFactory
+    {
+        private final Output output;
+        private final CommandLine.IFactory fallback;
+
+        public InjectCassandraContext(Output output)
+        {
+            this.fallback = CommandLine.defaultFactory();
+            this.output = output;
+        }
+
+        @Override
+        public <K> K create(Class<K> cls)
+        {
+            try
+            {
+                K bean = this.fallback.create(cls);
+                Class<?> beanClass = bean.getClass();
+                do
+                {
+                    Field[] fields = beanClass.getDeclaredFields();
+                    for (Field field : fields)
+                    {
+                        if (!field.isAnnotationPresent(Inject.class))
+                            continue;
+                        
+                        field.setAccessible(true);
+                        if (field.getType().equals(Output.class))
+                        {
+                            field.set(bean, output);
+                        }
+                        else
+                        {
+                            throw new RuntimeException("Unsupported injectable field type: " + field.getType() +
+                                                       " in class " + beanClass.getName() + ". " +
+                                                       "Only Output is supported for injection.");
+                        }
+                    }
+                }
+                while ((beanClass = beanClass.getSuperclass()) != null);
+                return bean;
+            }
+            catch (Exception e)
+            {
+                throw new CommandLine.InitializationException("Failed to create instance of " + cls, e);
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandArgsConverter.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandArgsConverter.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.cassandra.management.SimpleCommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+
+public class PicocliCommandArgsConverter
+{
+    /**
+     * Extract command arguments from an AbstractCommand instance using picocli reflection.
+     *
+     * @param command the command instance to extract arguments from
+     * @return CommandExecutionArgs containing all options and parameters from the command
+     */
+    public static <T> CommandExecutionArgs fromCommand(T command)
+    {
+        CommandMetadata metadata = PicocliCommandMetadata.from(command);
+        PicocliCommandMetadata picocliMetadata = (PicocliCommandMetadata) metadata;
+        CommandSpec spec = picocliMetadata.getCommandSpec();
+
+        Map<OptionMetadata, Object> options = new LinkedHashMap<>();
+        Map<ParameterMetadata, Object> parameters = new LinkedHashMap<>();
+
+        for (CommandLine.Model.OptionSpec optionSpec : spec.options())
+        {
+            if (!optionSpec.isOption())
+                continue;
+
+            Object value = optionSpec.getValue();
+            if (value == null)
+                continue;
+
+            if (optionSpec.type() == boolean.class || optionSpec.type() == Boolean.class)
+            {
+                if (Boolean.TRUE.equals(value))
+                    options.put(new PicocliOptionMetadata(optionSpec), Boolean.TRUE);
+            }
+            else
+            {
+                options.put(new PicocliOptionMetadata(optionSpec), value);
+            }
+        }
+
+        for (CommandLine.Model.PositionalParamSpec paramSpec : spec.positionalParameters())
+        {
+            if (!paramSpec.isPositional())
+                continue;
+
+            Object value = paramSpec.getValue();
+            if (value != null)
+                parameters.put(new PicocliParameterMetadata(paramSpec), value);
+        }
+
+        return new SimpleCommandExecutionArgs(options, parameters);
+    }
+
+    /**
+     * Populate an AbstractCommand instance with values from CommandExecutionArgs using picocli setters.
+     *
+     * @param args the CommandExecutionArgs containing values to set
+     * @param command the command instance to populate
+     */
+    public static <T> void toCommand(CommandExecutionArgs args, T command)
+    {
+        CommandMetadata metadata = PicocliCommandMetadata.from(command);
+        PicocliCommandMetadata picocliMetadata = (PicocliCommandMetadata) metadata;
+        CommandSpec spec = picocliMetadata.getCommandSpec();
+        Map<OptionMetadata, CommandLine.Model.OptionSpec> optionMap = buildOptionSpecMap(spec);
+        Map<ParameterMetadata, CommandLine.Model.PositionalParamSpec> paramMap = buildParameterSpecMap(spec);
+
+        for (Map.Entry<OptionMetadata, Object> entry : args.options().entrySet())
+        {
+            OptionMetadata optionMetadata = entry.getKey();
+            // This value is already converted to the correct type in CommandExecutionArgs.
+            Object convertedValue = entry.getValue();
+
+            if (convertedValue == null)
+                continue;
+
+            CommandLine.Model.OptionSpec optionSpec = optionMap.get(optionMetadata);
+            if (optionSpec == null)
+            {
+                optionSpec = findOptionSpecByName(spec, optionMetadata.names());
+                if (optionSpec == null)
+                    throw new IllegalArgumentException("Option not found in command spec: " + Arrays.toString(optionMetadata.names()));
+            }
+
+            try
+            {
+                optionSpec.setter().set(convertedValue);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Failed to set option " + optionMetadata.names()[0] +
+                                           " with value " + convertedValue, e);
+            }
+        }
+
+        for (Map.Entry<ParameterMetadata, Object> entry : args.parameters().entrySet())
+        {
+            ParameterMetadata paramMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            CommandLine.Model.PositionalParamSpec paramSpec = paramMap.get(paramMetadata);
+            if (paramSpec == null)
+            {
+                paramSpec = findParameterSpecByIndex(spec, paramMetadata.index());
+                if (paramSpec == null)
+                    throw new IllegalArgumentException("Parameter not found in command spec at index: " + paramMetadata.index());
+            }
+
+            try
+            {
+                paramSpec.setter().set(value);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Failed to set parameter at index " + paramMetadata.index() +
+                                           " with value " + value, e);
+            }
+        }
+    }
+
+    private static Map<OptionMetadata, CommandLine.Model.OptionSpec> buildOptionSpecMap(CommandSpec spec)
+    {
+        Map<OptionMetadata, CommandLine.Model.OptionSpec> map = new LinkedHashMap<>();
+        for (CommandLine.Model.OptionSpec optionSpec : spec.options())
+        {
+            if (optionSpec.isOption())
+                map.put(new PicocliOptionMetadata(optionSpec), optionSpec);
+        }
+        return map;
+    }
+
+    private static Map<ParameterMetadata, CommandLine.Model.PositionalParamSpec> buildParameterSpecMap(CommandSpec spec)
+    {
+        Map<ParameterMetadata, CommandLine.Model.PositionalParamSpec> map = new LinkedHashMap<>();
+        for (CommandLine.Model.PositionalParamSpec paramSpec : spec.positionalParameters())
+        {
+            if (paramSpec.isPositional())
+                map.put(new PicocliParameterMetadata(paramSpec), paramSpec);
+        }
+        return map;
+    }
+
+    private static CommandLine.Model.OptionSpec findOptionSpecByName(CommandSpec spec, String[] names)
+    {
+        for (CommandLine.Model.OptionSpec optionSpec : spec.options())
+        {
+            for (String name : names)
+            {
+                if (java.util.Arrays.asList(optionSpec.names()).contains(name))
+                    return optionSpec;
+            }
+        }
+        return null;
+    }
+
+    private static CommandLine.Model.PositionalParamSpec findParameterSpecByIndex(CommandSpec spec, int index)
+    {
+        for (CommandLine.Model.PositionalParamSpec paramSpec : spec.positionalParameters())
+        {
+            CommandLine.Range indexRange = paramSpec.index();
+            if (index >= indexRange.min() && index <= indexRange.max())
+                return paramSpec;
+        }
+        return null;
+    }
+}

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandMetadata.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+
+/**
+ * Implementation of CommandMetadata that extracts metadata from picocli CommandSpec.
+ */
+public class PicocliCommandMetadata implements CommandMetadata
+{
+    private final CommandSpec commandSpec;
+
+    public PicocliCommandMetadata(CommandSpec commandSpec)
+    {
+        this.commandSpec = commandSpec;
+    }
+
+    /**
+     * Create CommandMetadata from a command class.
+     */
+    public static CommandMetadata from(Class<?> commandClass)
+    {
+        CommandSpec spec = CommandSpec.forAnnotatedObject(commandClass);
+        return new PicocliCommandMetadata(spec);
+    }
+
+    /**
+     * Create CommandMetadata from a command instance.
+     */
+    public static CommandMetadata from(Object commandInstance)
+    {
+        CommandSpec spec = CommandSpec.forAnnotatedObject(commandInstance);
+        return new PicocliCommandMetadata(spec);
+    }
+
+    @Override
+    public String name()
+    {
+        return commandSpec.name();
+    }
+
+    @Override
+    public String description()
+    {
+        String[] description = commandSpec.usageMessage().description();
+        if (description == null || description.length == 0)
+            return "";
+        return String.join("\n", description);
+    }
+
+    @Override
+    public List<OptionMetadata> options()
+    {
+        List<OptionMetadata> options = new ArrayList<>();
+        for (CommandLine.Model.OptionSpec option : commandSpec.options())
+        {
+            if (option.isOption())
+                options.add(new PicocliOptionMetadata(option));
+        }
+        return options;
+    }
+
+    @Override
+    public List<ParameterMetadata> parameters()
+    {
+        List<ParameterMetadata> parameters = new ArrayList<>();
+        for (CommandLine.Model.PositionalParamSpec positional : commandSpec.positionalParameters())
+        {
+            if (positional.isPositional())
+                parameters.add(new PicocliParameterMetadata(positional));
+        }
+        return parameters;
+    }
+
+    @Override
+    public List<CommandMetadata> subcommands()
+    {
+        return commandSpec.subcommands().values().stream()
+                .map(subcommand -> new PicocliCommandMetadata(subcommand.getCommandSpec()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the underlying CommandSpec for advanced usage.
+     */
+    public CommandSpec getCommandSpec()
+    {
+        return commandSpec;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof PicocliCommandMetadata)) return false;
+        PicocliCommandMetadata that = (PicocliCommandMetadata) o;
+        return Objects.equals(commandSpec, that.commandSpec);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(commandSpec);
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandMetadata.java
@@ -108,7 +108,7 @@ public class PicocliCommandMetadata implements CommandMetadata
     }
 
     /**
-     * Get the underlying CommandSpec for advanced usage.
+     * Returns the underlying CommandSpec.
      */
     public CommandSpec getCommandSpec()
     {

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandRegistryAdapter.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandRegistryAdapter.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandExecutionContext;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.CommandRegistry;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+
+/**
+ * Adapter that wraps a picocli command with subcommands and implements CommandRegistry
+ * using the Composite pattern. This allows hierarchical picocli commands to be used
+ * as CommandRegistry instances.
+ * <p>
+ * For example, {@code CompressionDictionaryCommandGroup} has subcommands (train, list, export, import),
+ * so it would be wrapped by this adapter to provide a CommandRegistry interface.
+ * <p>
+ * The adapter recursively adapts subcommands:
+ * <ul>
+ *   <li>If a subcommand has subcommands -> creates another {@code PicocliCommandRegistryAdapter}</li>
+ *   <li>If a subcommand is a leaf -> creates a {@code PicocliCommandAdapter}</li>
+ * </ul>
+ */
+public class PicocliCommandRegistryAdapter implements CommandRegistry
+{
+    private final CommandSpec commandSpec;
+    private final CommandMetadata commandMetadata;
+    private final Map<String, Command<?>> subcommandMap = new ConcurrentHashMap<>();
+
+    /**
+     * Create an adapter for a picocli command class that has subcommands.
+     * @param commandClass the picocli command class (must have subcommands)
+     */
+    public PicocliCommandRegistryAdapter(Class<? extends AbstractCommand> commandClass)
+    {
+        this.commandSpec = CommandSpec.forAnnotatedObject(commandClass);
+        this.commandMetadata = new PicocliCommandMetadata(commandSpec);
+        
+        if (commandSpec.subcommands().isEmpty())
+        {
+            throw new IllegalArgumentException(
+                String.format("Command class %s does not have subcommands. " +
+                             "Use PicocliCommandAdapter for leaf commands.",
+                             commandClass.getName()));
+        }
+
+        for (Map.Entry<String, CommandLine> e : commandSpec.subcommands().entrySet())
+            adaptSubcommands(e.getKey(), e.getValue());
+    }
+
+    /**
+     * Recursively adapt all subcommands from the picocli command. Uses a Composite pattern:
+     * subcommands with subcommands become registries, leaf subcommands become command adapters.
+     */
+    private void adaptSubcommands(String commandName, CommandLine command)
+    {
+        CommandSpec subcommandSpec = command.getCommandSpec();
+        Command<?> adaptedCommand;
+
+        if (!subcommandSpec.subcommands().isEmpty())
+        {
+            adaptedCommand = new PicocliCommandRegistryAdapter(command.getCommand());
+        }
+        else
+        {
+            Class<?> subcommandClass = command.getCommand().getClass();
+            if (!AbstractCommand.class.isAssignableFrom(subcommandClass))
+            {
+                throw new IllegalArgumentException(
+                String.format("Subcommand class %s is not an AbstractCommand and cannot be adapted. " +
+                              "Only AbstractCommand subclasses are supported for leaf commands.",
+                              subcommandClass.getName()));
+            }
+
+            adaptedCommand = new PicocliCommandAdapter((Class<? extends AbstractCommand>) subcommandClass);
+        }
+
+        subcommandMap.put(commandName, adaptedCommand);
+
+        for (String alias : subcommandSpec.aliases())
+            subcommandMap.putIfAbsent(alias, adaptedCommand);
+    }
+
+    @Override
+    public CommandMetadata metadata()
+    {
+        return commandMetadata;
+    }
+
+    @Override
+    public String execute(CommandExecutionArgs arguments, CommandExecutionContext context)
+    {
+        // CommandRegistry is not directly executable: routing happens at the invoker/CQL layer.
+        throw new UnsupportedOperationException(
+            String.format("CommandRegistry '%s' is not directly executable. " +
+                         "Specify a subcommand. Available commands: %s",
+                         name(),
+                         String.join(", ", subcommandMap.keySet())));
+    }
+
+    @Override
+    public Command<?> command(String name)
+    {
+        return subcommandMap.get(name);
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, Command<?>>> commands()
+    {
+        return subcommandMap.entrySet();
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandRegistryAdapter.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandRegistryAdapter.java
@@ -83,7 +83,7 @@ public class PicocliCommandRegistryAdapter implements CommandRegistry
 
         if (!subcommandSpec.subcommands().isEmpty())
         {
-            adaptedCommand = new PicocliCommandRegistryAdapter(command.getCommand());
+            adaptedCommand = new PicocliCommandRegistryAdapter((Class<? extends AbstractCommand>) command.getCommand().getClass());
         }
         else
         {

--- a/src/java/org/apache/cassandra/management/picocli/PicocliCommandsProvider.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliCommandsProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandsProvider;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.NodetoolCommand;
+
+import picocli.CommandLine;
+
+public class PicocliCommandsProvider implements CommandsProvider
+{
+    @Override
+    public Collection<Command<?>> commands()
+    {
+        CommandLine commandLine = new CommandLine(NodetoolCommand.class);
+        List<Command<?>> commands = new ArrayList<>();
+        
+        commandLine.getSubcommands().forEach((name, subcommandLine) -> {
+            if (!subcommandLine.getCommandSpec().subcommands().isEmpty())
+            {
+                @SuppressWarnings("unchecked")
+                Class<? extends AbstractCommand> abstractCommandClass =
+                    (Class<? extends AbstractCommand>) subcommandLine.getCommand().getClass();
+                commands.add(new PicocliCommandRegistryAdapter(abstractCommandClass));
+            }
+            else
+            {
+                Class<?> commandClass = subcommandLine.getCommand().getClass();
+                if (AbstractCommand.class.isAssignableFrom(commandClass))
+                {
+                    @SuppressWarnings("unchecked")
+                    Class<? extends AbstractCommand> abstractCommandClass =
+                        (Class<? extends AbstractCommand>) commandClass;
+                    commands.add(new PicocliCommandAdapter(abstractCommandClass));
+                }
+            }
+        });
+        
+        return commands;
+    }
+}

--- a/src/java/org/apache/cassandra/management/picocli/PicocliMetadataExtractor.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliMetadataExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+
+/**
+ * Utility class for extracting command metadata from picocli-annotated command classes.
+ */
+public class PicocliMetadataExtractor
+{
+    /**
+     * Extract CommandMetadata from an AbstractCommand class.
+     *
+     * @param commandClass The command class annotated with picocli @Command
+     * @return CommandMetadata extracted from the command class
+     */
+    public static CommandMetadata extract(Class<? extends AbstractCommand> commandClass)
+    {
+        return PicocliCommandMetadata.from(commandClass);
+    }
+
+    /**
+     * Extract CommandMetadata from a command instance.
+     *
+     * @param commandInstance The command instance
+     * @return CommandMetadata extracted from the command instance
+     */
+    public static CommandMetadata extract(Object commandInstance)
+    {
+        if  (commandInstance instanceof AbstractCommand)
+            return PicocliCommandMetadata.from(commandInstance);
+        throw new IllegalArgumentException("Unsupported command instance type: " + commandInstance.getClass().getName());
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/PicocliOptionMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliOptionMetadata.java
@@ -122,7 +122,7 @@ public class PicocliOptionMetadata implements OptionMetadata
     }
 
     /**
-     * Get the underlying OptionSpec for advanced usage.
+     * Returns the underlying OptionSpec.
      */
     public OptionSpec getOptionSpec()
     {

--- a/src/java/org/apache/cassandra/management/picocli/PicocliOptionMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliOptionMetadata.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.google.common.base.Strings;
+
+import org.apache.cassandra.management.api.OptionMetadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.OptionSpec;
+
+import static org.apache.cassandra.management.ManagementUtils.elementType;
+import static org.apache.cassandra.management.ManagementUtils.stripAngleBrackets;
+
+/**
+ * Implementation of OptionMetadata that extracts metadata from picocli OptionSpec.
+ */
+public class PicocliOptionMetadata implements OptionMetadata
+{
+    private final OptionSpec optionSpec;
+
+    public PicocliOptionMetadata(OptionSpec optionSpec)
+    {
+        this.optionSpec = optionSpec;
+    }
+
+    @Override
+    public String[] names()
+    {
+        return optionSpec.names();
+    }
+
+    @Override
+    public String description()
+    {
+        String[] description = optionSpec.description();
+        if (description == null || description.length == 0)
+            return "";
+        return String.join("\n", description);
+    }
+
+    @Override
+    public Class<?> type()
+    {
+        return optionSpec.type();
+    }
+
+    @Override
+    public String defaultValue()
+    {
+        Object defaultValue = optionSpec.defaultValue();
+        if (defaultValue == null)
+        {
+            if (optionSpec.type() == boolean.class || optionSpec.type() == Boolean.class)
+                return "false";
+            return "";
+        }
+
+        return defaultValue.toString();
+    }
+
+    @Override
+    public boolean required()
+    {
+        return optionSpec.required();
+    }
+
+    @Override
+    public String arity()
+    {
+        CommandLine.Range arity = optionSpec.arity();
+        int min = arity.min();
+        int max = arity.max();
+        
+        if (min == 0 && max == 0)
+            return "0";
+        
+        if (min == max)
+            return String.valueOf(min);
+        else if (max == Integer.MAX_VALUE)
+            return min + "..*";
+        else
+            return min + ".." + max;
+    }
+
+    @Override
+    public String paramLabel()
+    {
+        String paramLabel = optionSpec.paramLabel();
+        Object userObject = optionSpec.userObject();
+
+        return Strings.isNullOrEmpty(paramLabel) ?
+               ((java.lang.reflect.Field) userObject).getName() :
+               stripAngleBrackets(paramLabel);
+    }
+
+    /**
+     * Check if this is a boolean flag option.
+     */
+    public boolean isFlag()
+    {
+        return optionSpec.arity().max() == 0;
+    }
+
+    /**
+     * Get the underlying OptionSpec for advanced usage.
+     */
+    public OptionSpec getOptionSpec()
+    {
+        return optionSpec;
+    }
+
+    public Object convertValue(Object value) throws Exception
+    {
+        TypeConverter<?> customConverter = typeConverter() == null ? null : typeConverter()[0];
+        return customConverter == null ?
+               TypeConverterRegistry.convertValueBasic(value, type(), elementType(optionSpec)) :
+               customConverter.convert(value.toString());
+    }
+
+    private TypeConverter<?>[] typeConverter()
+    {
+        return TypeConverter.createFrom(optionSpec);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof PicocliOptionMetadata)) return false;
+        PicocliOptionMetadata that = (PicocliOptionMetadata) o;
+        return Objects.equals(optionSpec, that.optionSpec);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(optionSpec);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PicocliOptionMetadata{" +
+               "names=" + Arrays.toString(names()) +
+               '}';
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/PicocliOptionMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliOptionMetadata.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.google.common.base.Strings;
+
+import org.apache.cassandra.management.api.OptionMetadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.OptionSpec;
+
+import static org.apache.cassandra.management.ManagementUtils.stripAngleBrackets;
+
+/**
+ * Implementation of OptionMetadata that extracts metadata from picocli OptionSpec.
+ */
+public class PicocliOptionMetadata implements OptionMetadata
+{
+    private final OptionSpec optionSpec;
+
+    public PicocliOptionMetadata(OptionSpec optionSpec)
+    {
+        this.optionSpec = optionSpec;
+    }
+
+    @Override
+    public String[] names()
+    {
+        return optionSpec.names();
+    }
+
+    @Override
+    public String description()
+    {
+        String[] description = optionSpec.description();
+        if (description == null || description.length == 0)
+            return "";
+        return String.join("\n", description);
+    }
+
+    @Override
+    public Class<?> type()
+    {
+        return optionSpec.type();
+    }
+
+    @Override
+    public String defaultValue()
+    {
+        Object defaultValue = optionSpec.defaultValue();
+        if (defaultValue == null)
+        {
+            if (optionSpec.type() == boolean.class || optionSpec.type() == Boolean.class)
+                return "false";
+            return "";
+        }
+
+        return defaultValue.toString();
+    }
+
+    @Override
+    public boolean required()
+    {
+        return optionSpec.required();
+    }
+
+    @Override
+    public String arity()
+    {
+        CommandLine.Range arity = optionSpec.arity();
+        int min = arity.min();
+        int max = arity.max();
+        
+        if (min == 0 && max == 0)
+            return "0";
+        
+        if (min == max)
+            return String.valueOf(min);
+        else if (max == Integer.MAX_VALUE)
+            return min + "..*";
+        else
+            return min + ".." + max;
+    }
+
+    @Override
+    public String paramLabel()
+    {
+        String paramLabel = optionSpec.paramLabel();
+        Object userObject = optionSpec.userObject();
+
+        return Strings.isNullOrEmpty(paramLabel) ?
+               ((java.lang.reflect.Field) userObject).getName() :
+               stripAngleBrackets(paramLabel);
+    }
+
+    /**
+     * Check if this is a boolean flag option.
+     */
+    public boolean isFlag()
+    {
+        return optionSpec.arity().max() == 0;
+    }
+
+    /**
+     * Get the underlying OptionSpec for advanced usage.
+     */
+    public OptionSpec getOptionSpec()
+    {
+        return optionSpec;
+    }
+
+    public Object convertValue(Object value) throws Exception
+    {
+        TypeConverter<?> customConverter = typeConverter() == null ? null : typeConverter()[0];
+        return customConverter == null ?
+               TypeConverterRegistry.convertValueBasic(value, type()) :
+               customConverter.convert(value.toString());
+    }
+
+    private TypeConverter<?>[] typeConverter()
+    {
+        return TypeConverter.createFrom(optionSpec);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof PicocliOptionMetadata)) return false;
+        PicocliOptionMetadata that = (PicocliOptionMetadata) o;
+        return Objects.equals(optionSpec, that.optionSpec);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(optionSpec);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PicocliOptionMetadata{" +
+               "names=" + Arrays.toString(names()) +
+               '}';
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/PicocliParameterMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliParameterMetadata.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.cassandra.management.api.ParameterMetadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.PositionalParamSpec;
+
+import static org.apache.cassandra.management.ManagementUtils.elementType;
+import static org.apache.cassandra.management.ManagementUtils.stripAngleBrackets;
+
+/**
+ * Implementation of ParameterMetadata that extracts metadata from picocli PositionalParamSpec.
+ */
+public class PicocliParameterMetadata implements ParameterMetadata
+{
+    private final PositionalParamSpec positionalParamSpec;
+
+    public PicocliParameterMetadata(PositionalParamSpec positionalParamSpec)
+    {
+        this.positionalParamSpec = positionalParamSpec;
+    }
+
+    @Override
+    public String[] names()
+    {
+        String name;
+        String paramLabel = positionalParamSpec.paramLabel();
+        Object userObject = positionalParamSpec.userObject();
+
+        if (paramLabel != null && !paramLabel.isEmpty())
+            name = stripAngleBrackets(paramLabel);
+        else if (userObject instanceof java.lang.reflect.Field)
+            name = ((java.lang.reflect.Field) userObject).getName();
+        else
+            name = COMMAND_POSITIONAL_PARAM_PREFIX + index();
+
+        return new String[] { name };
+    }
+
+    @Override
+    public String paramLabel()
+    {
+        return stripAngleBrackets(positionalParamSpec.paramLabel());
+    }
+
+    @Override
+    public String description()
+    {
+        String[] description = positionalParamSpec.description();
+        if (description == null || description.length == 0)
+            return "";
+        return String.join("\n", description);
+    }
+
+    @Override
+    public Class<?> type()
+    {
+        return positionalParamSpec.type();
+    }
+
+    @Override
+    public String defaultValue()
+    {
+        return "";
+    }
+
+    @Override
+    public int index()
+    {
+        return positionalParamSpec.index().min();
+    }
+
+    @Override
+    public boolean required()
+    {
+        return positionalParamSpec.arity().min() > 0;
+    }
+
+    @Override
+    public String arity()
+    {
+        CommandLine.Range arity = positionalParamSpec.arity();
+        int min = arity.min();
+        int max = arity.max();
+        
+        if (min == max)
+            return String.valueOf(min);
+        else if (max == Integer.MAX_VALUE)
+            return min + "..*";
+        else
+            return min + ".." + max;
+    }
+
+    /**
+     * Get the underlying PositionalParamSpec for advanced usage.
+     */
+    public PositionalParamSpec getPositionalParamSpec()
+    {
+        return positionalParamSpec;
+    }
+
+    public Object convertValue(Object value) throws Exception
+    {
+        TypeConverter<?> customConverter = typeConverter() == null ? null : typeConverter()[0];
+        return customConverter == null ?
+               TypeConverterRegistry.convertValueBasic(value, type(), elementType(positionalParamSpec)) :
+               customConverter.convert(value.toString());
+    }
+
+    private TypeConverter<?>[] typeConverter()
+    {
+        return TypeConverter.createFrom(positionalParamSpec);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof PicocliParameterMetadata)) return false;
+        PicocliParameterMetadata that = (PicocliParameterMetadata) o;
+        return Objects.equals(positionalParamSpec, that.positionalParamSpec);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(positionalParamSpec);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PicocliParameterMetadata{" +
+               "names=" + Arrays.toString(names()) +
+               '}';
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/PicocliParameterMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliParameterMetadata.java
@@ -113,7 +113,7 @@ public class PicocliParameterMetadata implements ParameterMetadata
     }
 
     /**
-     * Get the underlying PositionalParamSpec for advanced usage.
+     * Returns the underlying PositionalParamSpec.
      */
     public PositionalParamSpec getPositionalParamSpec()
     {

--- a/src/java/org/apache/cassandra/management/picocli/PicocliParameterMetadata.java
+++ b/src/java/org/apache/cassandra/management/picocli/PicocliParameterMetadata.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.cassandra.management.api.ParameterMetadata;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.PositionalParamSpec;
+
+import static org.apache.cassandra.management.ManagementUtils.stripAngleBrackets;
+
+/**
+ * Implementation of ParameterMetadata that extracts metadata from picocli PositionalParamSpec.
+ */
+public class PicocliParameterMetadata implements ParameterMetadata
+{
+    private final PositionalParamSpec positionalParamSpec;
+
+    public PicocliParameterMetadata(PositionalParamSpec positionalParamSpec)
+    {
+        this.positionalParamSpec = positionalParamSpec;
+    }
+
+    @Override
+    public String[] names()
+    {
+        String name;
+        String paramLabel = positionalParamSpec.paramLabel();
+        Object userObject = positionalParamSpec.userObject();
+
+        if (paramLabel != null && !paramLabel.isEmpty())
+            name = stripAngleBrackets(paramLabel);
+        else if (userObject instanceof java.lang.reflect.Field)
+            name = ((java.lang.reflect.Field) userObject).getName();
+        else
+            name = COMMAND_POSITIONAL_PARAM_PREFIX + index();
+
+        return new String[] { name };
+    }
+
+    @Override
+    public String paramLabel()
+    {
+        return stripAngleBrackets(positionalParamSpec.paramLabel());
+    }
+
+    @Override
+    public String description()
+    {
+        String[] description = positionalParamSpec.description();
+        if (description == null || description.length == 0)
+            return "";
+        return String.join("\n", description);
+    }
+
+    @Override
+    public Class<?> type()
+    {
+        return positionalParamSpec.type();
+    }
+
+    @Override
+    public String defaultValue()
+    {
+        return "";
+    }
+
+    @Override
+    public int index()
+    {
+        return positionalParamSpec.index().min();
+    }
+
+    @Override
+    public boolean required()
+    {
+        return positionalParamSpec.arity().min() > 0;
+    }
+
+    @Override
+    public String arity()
+    {
+        CommandLine.Range arity = positionalParamSpec.arity();
+        int min = arity.min();
+        int max = arity.max();
+        
+        if (min == max)
+            return String.valueOf(min);
+        else if (max == Integer.MAX_VALUE)
+            return min + "..*";
+        else
+            return min + ".." + max;
+    }
+
+    /**
+     * Get the underlying PositionalParamSpec for advanced usage.
+     */
+    public PositionalParamSpec getPositionalParamSpec()
+    {
+        return positionalParamSpec;
+    }
+
+    public Object convertValue(Object value) throws Exception
+    {
+        TypeConverter<?> customConverter = typeConverter() == null ? null : typeConverter()[0];
+        return customConverter == null ?
+               TypeConverterRegistry.convertValueBasic(value, type()) :
+               customConverter.convert(value.toString());
+    }
+
+    private TypeConverter<?>[] typeConverter()
+    {
+        return TypeConverter.createFrom(positionalParamSpec);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof PicocliParameterMetadata)) return false;
+        PicocliParameterMetadata that = (PicocliParameterMetadata) o;
+        return Objects.equals(positionalParamSpec, that.positionalParamSpec);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(positionalParamSpec);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PicocliParameterMetadata{" +
+               "names=" + Arrays.toString(names()) +
+               '}';
+    }
+}
+

--- a/src/java/org/apache/cassandra/management/picocli/TypeConverter.java
+++ b/src/java/org/apache/cassandra/management/picocli/TypeConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.util.Arrays;
+
+import picocli.CommandLine;
+
+public interface TypeConverter<R>
+{
+    R convert(String value) throws Exception;
+
+    static TypeConverter<?>[] createFrom(CommandLine.Model.ArgSpec argSpec)
+    {
+        CommandLine.ITypeConverter<?>[] converters = argSpec.converters();
+        return converters == null || converters.length == 0 ?
+               null :
+               Arrays.stream(converters)
+                     .map(c -> (TypeConverter<Object>) c::convert)
+                     .toArray(TypeConverter<?>[]::new);
+    }
+}

--- a/src/java/org/apache/cassandra/management/picocli/TypeConverterRegistry.java
+++ b/src/java/org/apache/cassandra/management/picocli/TypeConverterRegistry.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class TypeConverterRegistry
+{
+    private static final Map<Class<?>, TypeConverter<?>> converters = new LinkedHashMap<>();
+
+    static
+    {
+        register(boolean.class, (TypeConverter<Boolean>) Boolean::parseBoolean);
+        register(int.class, (TypeConverter<Integer>) Integer::parseInt);
+        register(long.class, (TypeConverter<Long>) Long::parseLong);
+        register(double.class, (TypeConverter<Double>) Double::parseDouble);
+        register(float.class, (TypeConverter<Float>) Float::parseFloat);
+        register(byte.class, (TypeConverter<Byte>) Byte::parseByte);
+        register(short.class, (TypeConverter<Short>) Short::parseShort);
+        register(char.class, value -> {
+            if (value.length() != 1)
+                throw new IllegalArgumentException("Cannot convert to char: " + value);
+            return value.charAt(0);
+        });
+        register(Boolean.class, (TypeConverter<Boolean>) Boolean::parseBoolean);
+        register(Integer.class, (TypeConverter<Integer>) Integer::parseInt);
+        register(Long.class, (TypeConverter<Long>) Long::parseLong);
+        register(Double.class, (TypeConverter<Double>) Double::parseDouble);
+        register(Float.class, (TypeConverter<Float>) Float::parseFloat);
+        register(Byte.class, (TypeConverter<Byte>) Byte::parseByte);
+        register(Short.class, (TypeConverter<Short>) Short::parseShort);
+        register(String.class, (TypeConverter<String>) value -> value);
+        register(Character.class, value -> {
+            if (value.length() != 1)
+                throw new IllegalArgumentException("Cannot convert to Character: " + value);
+            return value.charAt(0);
+        });
+        register(Object.class, value -> value);
+    }
+
+    private static void register(Class<?> type, TypeConverter<?> converter)
+    {
+        converters.put(type, converter);
+    }
+
+    public static <T> Object convertValueBasic(Object value, Class<T> targetType) throws Exception
+    {
+        return convertValueBasic(value, targetType, null);
+    }
+
+    public static <T> Object convertValueBasic(Object value, Class<T> targetType, Class<?> elementType) throws Exception
+    {
+        if (value == null)
+            return null;
+
+        // Arrays and collections must be handled before the assignable short-circuit below: a
+        // List<String> is already assignable to List, but its elements still need per-element
+        // conversion when the declared element type is not String.
+        if (targetType.isArray() || Collection.class.isAssignableFrom(targetType))
+            return convertToArrayOrCollection(value, targetType, elementType);
+
+        if (targetType.isAssignableFrom(value.getClass()))
+            return value;
+
+        String stringValue = value.toString();
+        if (isBasicType(targetType))
+        {
+            TypeConverter<?> converter = converters.get(targetType);
+            if (converter == null)
+                throw new IllegalStateException(String.format("No converter registered for basic type: %s",
+                                                              targetType.getName()));
+            return converter.convert(stringValue);
+        }
+
+        if (targetType.isEnum())
+            return getEnumTypeConverter(targetType).convert(stringValue);
+
+        throw new IllegalArgumentException(String.format("No converter available for type: %s.", targetType.getName()));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> TypeConverter<T> getEnumTypeConverter(Class<T> type)
+    {
+        return value -> {
+            for (T constant : type.getEnumConstants())
+                if (((Enum<?>) constant).name().equalsIgnoreCase(value))
+                    return constant;
+            throw new IllegalArgumentException("No enum constant " + type.getCanonicalName() + '.' + value);
+        };
+    }
+
+    private static Object convertToArrayOrCollection(Object value, Class<?> targetType, Class<?> elementType) throws Exception
+    {
+        Collection<?> sourceCollection;
+        if (value instanceof Collection)
+            sourceCollection = (Collection<?>) value;
+        else if (value.getClass().isArray())
+        {
+            int length = Array.getLength(value);
+            List<Object> list = new ArrayList<>(length);
+            for (int i = 0; i < length; i++)
+                list.add(Array.get(value, i));
+            sourceCollection = list;
+        }
+        else
+            throw new IllegalArgumentException("Cannot convert " + value.getClass() + " to " + targetType);
+
+        if (targetType.isArray())
+        {
+            Class<?> componentType = targetType.getComponentType();
+            Object targetArray = Array.newInstance(componentType, sourceCollection.size());
+            int index = 0;
+            for (Object item : sourceCollection)
+            {
+                Object convertedItem = convertValueBasic(item, componentType);
+                Array.set(targetArray, index++, convertedItem);
+            }
+            return targetArray;
+        }
+
+        Collection<Object> targetCollection;
+        if (targetType == List.class || List.class.isAssignableFrom(targetType))
+            targetCollection = new ArrayList<>();
+        else if (SortedSet.class.isAssignableFrom(targetType))
+            targetCollection = new TreeSet<>();
+        else if (targetType == Set.class || Set.class.isAssignableFrom(targetType))
+            targetCollection = new LinkedHashSet<>();
+        else
+            targetCollection = new ArrayList<>();
+
+        if (elementType == null)
+            targetCollection.addAll(sourceCollection);
+        else
+            for (Object item : sourceCollection)
+                targetCollection.add(convertValueBasic(item, elementType));
+
+        return targetCollection;
+    }
+
+    private static boolean isBasicType(Class<?> type)
+    {
+        return type == String.class ||
+               type == boolean.class || type == Boolean.class ||
+               type == int.class || type == Integer.class ||
+               type == long.class || type == Long.class ||
+               type == double.class || type == Double.class ||
+               type == float.class || type == Float.class ||
+               type == byte.class || type == Byte.class ||
+               type == short.class || type == Short.class ||
+               type == char.class || type == Character.class;
+    }
+}

--- a/src/java/org/apache/cassandra/management/picocli/TypeConverterRegistry.java
+++ b/src/java/org/apache/cassandra/management/picocli/TypeConverterRegistry.java
@@ -35,7 +35,7 @@ public class TypeConverterRegistry
 
     static
     {
-        register(boolean.class, (TypeConverter<Boolean>) Boolean::parseBoolean);
+        register(boolean.class, (TypeConverter<Boolean>) TypeConverterRegistry::parseStrictBoolean);
         register(int.class, (TypeConverter<Integer>) Integer::parseInt);
         register(long.class, (TypeConverter<Long>) Long::parseLong);
         register(double.class, (TypeConverter<Double>) Double::parseDouble);
@@ -47,7 +47,7 @@ public class TypeConverterRegistry
                 throw new IllegalArgumentException("Cannot convert to char: " + value);
             return value.charAt(0);
         });
-        register(Boolean.class, (TypeConverter<Boolean>) Boolean::parseBoolean);
+        register(Boolean.class, (TypeConverter<Boolean>) TypeConverterRegistry::parseStrictBoolean);
         register(Integer.class, (TypeConverter<Integer>) Integer::parseInt);
         register(Long.class, (TypeConverter<Long>) Long::parseLong);
         register(Double.class, (TypeConverter<Double>) Double::parseDouble);
@@ -66,6 +66,15 @@ public class TypeConverterRegistry
     private static void register(Class<?> type, TypeConverter<?> converter)
     {
         converters.put(type, converter);
+    }
+
+    private static boolean parseStrictBoolean(String value)
+    {
+        if ("true".equalsIgnoreCase(value))
+            return true;
+        if ("false".equalsIgnoreCase(value))
+            return false;
+        throw new IllegalArgumentException("Cannot convert to boolean: " + value);
     }
 
     public static <T> Object convertValueBasic(Object value, Class<T> targetType) throws Exception

--- a/src/java/org/apache/cassandra/management/picocli/TypeConverterRegistry.java
+++ b/src/java/org/apache/cassandra/management/picocli/TypeConverterRegistry.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management.picocli;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class TypeConverterRegistry
+{
+    private static final Map<Class<?>, TypeConverter<?>> converters = new LinkedHashMap<>();
+
+    static
+    {
+        register(boolean.class, (TypeConverter<Boolean>) Boolean::parseBoolean);
+        register(int.class, (TypeConverter<Integer>) Integer::parseInt);
+        register(long.class, (TypeConverter<Long>) Long::parseLong);
+        register(double.class, (TypeConverter<Double>) Double::parseDouble);
+        register(float.class, (TypeConverter<Float>) Float::parseFloat);
+        register(byte.class, (TypeConverter<Byte>) Byte::parseByte);
+        register(short.class, (TypeConverter<Short>) Short::parseShort);
+        register(char.class, value -> {
+            if (value.length() != 1)
+                throw new IllegalArgumentException("Cannot convert to char: " + value);
+            return value.charAt(0);
+        });
+        register(Boolean.class, (TypeConverter<Boolean>) Boolean::parseBoolean);
+        register(Integer.class, (TypeConverter<Integer>) Integer::parseInt);
+        register(Long.class, (TypeConverter<Long>) Long::parseLong);
+        register(Double.class, (TypeConverter<Double>) Double::parseDouble);
+        register(Float.class, (TypeConverter<Float>) Float::parseFloat);
+        register(Byte.class, (TypeConverter<Byte>) Byte::parseByte);
+        register(Short.class, (TypeConverter<Short>) Short::parseShort);
+        register(String.class, (TypeConverter<String>) value -> value);
+        register(Character.class, value -> {
+            if (value.length() != 1)
+                throw new IllegalArgumentException("Cannot convert to Character: " + value);
+            return value.charAt(0);
+        });
+        register(Object.class, value -> value);
+    }
+
+    private static void register(Class<?> type, TypeConverter<?> converter)
+    {
+        converters.put(type, converter);
+    }
+
+    public static <T> Object convertValueBasic(Object value, Class<T> targetType) throws Exception
+    {
+        if (value == null)
+            return null;
+
+        if (targetType.isAssignableFrom(value.getClass()))
+            return value;
+
+        String stringValue = value.toString();
+        if (isBasicType(targetType))
+        {
+            TypeConverter<?> converter = converters.get(targetType);
+            if (converter == null)
+                throw new IllegalStateException(String.format("No converter registered for basic type: %s",
+                                                              targetType.getName()));
+            return converter.convert(stringValue);
+        }
+
+        if (targetType.isEnum())
+            return getEnumTypeConverter(targetType).convert(stringValue);
+
+        if (targetType.isArray() || Collection.class.isAssignableFrom(targetType))
+            return convertToArrayOrCollection(value, targetType);
+
+        throw new IllegalArgumentException(String.format("No converter available for type: %s.", targetType.getName()));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> TypeConverter<T> getEnumTypeConverter(Class<T> type)
+    {
+        return value -> {
+            for (T constant : type.getEnumConstants())
+                if (((Enum<?>) constant).name().equalsIgnoreCase(value))
+                    return constant;
+            throw new IllegalArgumentException("No enum constant " + type.getCanonicalName() + '.' + value);
+        };
+    }
+
+    private static Object convertToArrayOrCollection(Object value, Class<?> targetType) throws Exception
+    {
+        Collection<?> sourceCollection;
+        if (value instanceof Collection)
+            sourceCollection = (Collection<?>) value;
+        else if (value.getClass().isArray())
+        {
+            int length = Array.getLength(value);
+            List<Object> list = new ArrayList<>(length);
+            for (int i = 0; i < length; i++)
+                list.add(Array.get(value, i));
+            sourceCollection = list;
+        }
+        else
+            throw new IllegalArgumentException("Cannot convert " + value.getClass() + " to " + targetType);
+
+        if (targetType.isArray())
+        {
+            Class<?> componentType = targetType.getComponentType();
+            Object targetArray = Array.newInstance(componentType, sourceCollection.size());
+            int index = 0;
+            for (Object item : sourceCollection)
+            {
+                Object convertedItem = convertValueBasic(item, componentType);
+                Array.set(targetArray, index++, convertedItem);
+            }
+            return targetArray;
+        }
+
+        Collection<Object> targetCollection;
+        if (targetType == List.class || List.class.isAssignableFrom(targetType))
+            targetCollection = new ArrayList<>();
+        else if (targetType == Set.class || Set.class.isAssignableFrom(targetType))
+            targetCollection = new LinkedHashSet<>();
+        else if (SortedSet.class.isAssignableFrom(targetType))
+            targetCollection = new TreeSet<>();
+        else
+            targetCollection = new ArrayList<>();
+
+        targetCollection.addAll(sourceCollection);
+        return targetCollection;
+    }
+
+    private static boolean isBasicType(Class<?> type)
+    {
+        return type == String.class ||
+               type == boolean.class || type == Boolean.class ||
+               type == int.class || type == Integer.class ||
+               type == long.class || type == Long.class ||
+               type == double.class || type == Double.class ||
+               type == float.class || type == Float.class ||
+               type == byte.class || type == Byte.class ||
+               type == short.class || type == Short.class ||
+               type == char.class || type == Character.class;
+    }
+}

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -80,6 +80,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Locator;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.net.StartupClusterConnectivityChecker;
@@ -99,6 +100,7 @@ import org.apache.cassandra.tcm.RegistrationStatus;
 import org.apache.cassandra.tcm.Startup;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
+import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.JVMStabilityInspector;
@@ -219,6 +221,7 @@ public class CassandraDaemon
 
     static final CassandraDaemon instance = new CassandraDaemon();
 
+    private volatile NativeTransportManagementService nativeTransportManagementService;
     private volatile NativeTransportService nativeTransportService;
     private JMXConnectorServer jmxServer;
 
@@ -397,6 +400,9 @@ public class CassandraDaemon
         setCompactionStrategyOverrides(Schema.instance.getKeyspaces());
         // re-enable auto-compaction after replay, so correct disk boundaries are used
         enableAutoCompaction(Schema.instance.getKeyspaces());
+
+        // Initialize command service (after JMX, before StorageService.initServer)
+        CommandInvokerService.instance.start();
 
         // start server internals
         StorageService.instance.registerDaemon(this);
@@ -669,6 +675,9 @@ public class CassandraDaemon
 
     public synchronized void initializeClientTransports()
     {
+        if (nativeTransportManagementService == null)
+            nativeTransportManagementService = new NativeTransportManagementService();
+
         // Native transport
         if (nativeTransportService == null)
             nativeTransportService = new NativeTransportService();
@@ -756,6 +765,9 @@ public class CassandraDaemon
         Set<InetAddressAndPort> peers = new HashSet<>(ClusterMetadata.current().directory.allJoinedEndpoints());
         connectivityChecker.execute(peers, ep -> locator.location(ep).datacenter);
 
+        // start management transports first.
+        startManagementTransport();
+
         // check to see if transports may start else return without starting.  This is needed when in survey mode or
         // when bootstrap has not completed.
         try
@@ -784,6 +796,16 @@ public class CassandraDaemon
             logger.info("Not starting native transport as requested. Use JMX (StorageService->startNativeTransport()) or nodetool (enablebinary) to start it");
     }
 
+    private void startManagementTransport()
+    {
+        if (NativeTransportManagementService.enabled())
+        {
+            if (nativeTransportManagementService == null)
+                throw new IllegalStateException("setup() must be called first for CassandraDaemon");
+            nativeTransportManagementService.start();
+        }
+    }
+
     /**
      * Stop the daemon, ideally in an idempotent manner.
      *
@@ -795,6 +817,7 @@ public class CassandraDaemon
         // jsvc takes care of taking the rest down
         logger.info("Cassandra shutting down...");
         destroyClientTransports();
+        CommandInvokerService.instance.stop();
         StorageService.instance.setRpcReady(false);
 
         if (jmxServer != null)
@@ -816,6 +839,9 @@ public class CassandraDaemon
         stopNativeTransport();
         if (nativeTransportService != null)
             nativeTransportService.destroy();
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.destroy();
+        Dispatcher.shutdown();
     }
 
     /**
@@ -996,12 +1022,18 @@ public class CassandraDaemon
 
     public void clearConnectionHistory()
     {
-        nativeTransportService.clearConnectionHistory();
+        if (nativeTransportService != null)
+            nativeTransportService.clearConnectionHistory();
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.clearConnectionHistory();
     }
 
     public void disconnectUser(Predicate<AuthenticatedUser> userPredicate)
     {
-        nativeTransportService.disconnect(userPredicate);
+        if (nativeTransportService != null)
+            nativeTransportService.disconnect(userPredicate);
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.disconnect(userPredicate);
     }
 
     private void exitOrFail(int code, String message)

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -80,6 +80,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Locator;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.net.StartupClusterConnectivityChecker;
@@ -99,6 +100,7 @@ import org.apache.cassandra.tcm.RegistrationStatus;
 import org.apache.cassandra.tcm.Startup;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
+import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.JVMStabilityInspector;
@@ -218,6 +220,7 @@ public class CassandraDaemon
 
     static final CassandraDaemon instance = new CassandraDaemon();
 
+    private volatile NativeTransportManagementService nativeTransportManagementService;
     private volatile NativeTransportService nativeTransportService;
     private JMXConnectorServer jmxServer;
 
@@ -396,6 +399,9 @@ public class CassandraDaemon
         setCompactionStrategyOverrides(Schema.instance.getKeyspaces());
         // re-enable auto-compaction after replay, so correct disk boundaries are used
         enableAutoCompaction(Schema.instance.getKeyspaces());
+
+        // Initialize command service (after JMX, before StorageService.initServer)
+        CommandInvokerService.instance.start();
 
         // start server internals
         StorageService.instance.registerDaemon(this);
@@ -668,6 +674,9 @@ public class CassandraDaemon
 
     public synchronized void initializeClientTransports()
     {
+        if (nativeTransportManagementService == null)
+            nativeTransportManagementService = new NativeTransportManagementService();
+
         // Native transport
         if (nativeTransportService == null)
             nativeTransportService = new NativeTransportService();
@@ -755,6 +764,9 @@ public class CassandraDaemon
         Set<InetAddressAndPort> peers = new HashSet<>(ClusterMetadata.current().directory.allJoinedEndpoints());
         connectivityChecker.execute(peers, ep -> locator.location(ep).datacenter);
 
+        // start management transports first.
+        startManagementTransport();
+
         // check to see if transports may start else return without starting.  This is needed when in survey mode or
         // when bootstrap has not completed.
         try
@@ -783,6 +795,16 @@ public class CassandraDaemon
             logger.info("Not starting native transport as requested. Use JMX (StorageService->startNativeTransport()) or nodetool (enablebinary) to start it");
     }
 
+    private void startManagementTransport()
+    {
+        if (NativeTransportManagementService.enabled())
+        {
+            if (nativeTransportManagementService == null)
+                throw new IllegalStateException("setup() must be called first for CassandraDaemon");
+            nativeTransportManagementService.start();
+        }
+    }
+
     /**
      * Stop the daemon, ideally in an idempotent manner.
      *
@@ -794,6 +816,7 @@ public class CassandraDaemon
         // jsvc takes care of taking the rest down
         logger.info("Cassandra shutting down...");
         destroyClientTransports();
+        CommandInvokerService.instance.stop();
         StorageService.instance.setRpcReady(false);
 
         if (jmxServer != null)
@@ -815,6 +838,9 @@ public class CassandraDaemon
         stopNativeTransport();
         if (nativeTransportService != null)
             nativeTransportService.destroy();
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.destroy();
+        Dispatcher.shutdown();
     }
 
     /**
@@ -995,12 +1021,18 @@ public class CassandraDaemon
 
     public void clearConnectionHistory()
     {
-        nativeTransportService.clearConnectionHistory();
+        if (nativeTransportService != null)
+            nativeTransportService.clearConnectionHistory();
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.clearConnectionHistory();
     }
 
     public void disconnectUser(Predicate<AuthenticatedUser> userPredicate)
     {
-        nativeTransportService.disconnect(userPredicate);
+        if (nativeTransportService != null)
+            nativeTransportService.disconnect(userPredicate);
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.disconnect(userPredicate);
     }
 
     private void exitOrFail(int code, String message)

--- a/src/java/org/apache/cassandra/service/CassandraDaemon.java
+++ b/src/java/org/apache/cassandra/service/CassandraDaemon.java
@@ -80,6 +80,7 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.Locator;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.net.StartupClusterConnectivityChecker;
@@ -99,6 +100,7 @@ import org.apache.cassandra.tcm.RegistrationStatus;
 import org.apache.cassandra.tcm.Startup;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.tcm.membership.NodeState;
+import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.JMXServerUtils;
 import org.apache.cassandra.utils.JVMStabilityInspector;
@@ -123,6 +125,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.JAVA_VM_NA
 import static org.apache.cassandra.config.CassandraRelevantProperties.OVERRIDE_COMPACTION_ENTITIES;
 import static org.apache.cassandra.config.CassandraRelevantProperties.OVERRIDE_COMPACTION_PARAMS;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SIZE_RECORDER_INTERVAL;
+import static org.apache.cassandra.config.CassandraRelevantProperties.START_NATIVE_MANAGEMENT_TRANSPORT;
 import static org.apache.cassandra.config.CassandraRelevantProperties.START_NATIVE_TRANSPORT;
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.createMetricsKeyspaceTables;
 import static org.apache.cassandra.schema.SchemaConstants.VIRTUAL_METRICS;
@@ -218,6 +221,7 @@ public class CassandraDaemon
 
     static final CassandraDaemon instance = new CassandraDaemon();
 
+    private volatile NativeTransportManagementService nativeTransportManagementService;
     private volatile NativeTransportService nativeTransportService;
     private JMXConnectorServer jmxServer;
 
@@ -388,6 +392,9 @@ public class CassandraDaemon
 
         // Prepared statements
         QueryProcessor.instance.preloadPreparedStatements();
+
+        // Initialize command service (after JMX, before StorageService.initServer)
+        CommandInvokerService.instance.start();
 
         // start server internals
         StorageService.instance.registerDaemon(this);
@@ -665,6 +672,9 @@ public class CassandraDaemon
 
     public synchronized void initializeClientTransports()
     {
+        if (nativeTransportManagementService == null)
+            nativeTransportManagementService = new NativeTransportManagementService();
+
         // Native transport
         if (nativeTransportService == null)
             nativeTransportService = new NativeTransportService();
@@ -752,6 +762,9 @@ public class CassandraDaemon
         Set<InetAddressAndPort> peers = new HashSet<>(ClusterMetadata.current().directory.allJoinedEndpoints());
         connectivityChecker.execute(peers, ep -> locator.location(ep).datacenter);
 
+        // start management transports first.
+        startManagementTransport();
+
         // check to see if transports may start else return without starting.  This is needed when in survey mode or
         // when bootstrap has not completed.
         try
@@ -780,6 +793,16 @@ public class CassandraDaemon
             logger.info("Not starting native transport as requested. Use JMX (StorageService->startNativeTransport()) or nodetool (enablebinary) to start it");
     }
 
+    private void startManagementTransport()
+    {
+        if (START_NATIVE_MANAGEMENT_TRANSPORT.getBoolean() || DatabaseDescriptor.startNativeTransportManagement())
+        {
+            if (nativeTransportManagementService == null)
+                throw new IllegalStateException("setup() must be called first for CassandraDaemon");
+            nativeTransportManagementService.start();
+        }
+    }
+
     /**
      * Stop the daemon, ideally in an idempotent manner.
      *
@@ -791,6 +814,7 @@ public class CassandraDaemon
         // jsvc takes care of taking the rest down
         logger.info("Cassandra shutting down...");
         destroyClientTransports();
+        CommandInvokerService.instance.stop();
         StorageService.instance.setRpcReady(false);
 
         if (jmxServer != null)
@@ -812,6 +836,9 @@ public class CassandraDaemon
         stopNativeTransport();
         if (nativeTransportService != null)
             nativeTransportService.destroy();
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.destroy();
+        Dispatcher.shutdown();
     }
 
     /**
@@ -992,12 +1019,18 @@ public class CassandraDaemon
 
     public void clearConnectionHistory()
     {
-        nativeTransportService.clearConnectionHistory();
+        if (nativeTransportService != null)
+            nativeTransportService.clearConnectionHistory();
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.clearConnectionHistory();
     }
 
     public void disconnectUser(Predicate<AuthenticatedUser> userPredicate)
     {
-        nativeTransportService.disconnect(userPredicate);
+        if (nativeTransportService != null)
+            nativeTransportService.disconnect(userPredicate);
+        if (nativeTransportManagementService != null)
+            nativeTransportManagementService.disconnect(userPredicate);
     }
 
     private void exitOrFail(int code, String message)

--- a/src/java/org/apache/cassandra/service/ClientState.java
+++ b/src/java/org/apache/cassandra/service/ClientState.java
@@ -151,6 +151,9 @@ public class ClientState
     // Driver String for the client
     private volatile String driverName;
     private volatile String driverVersion;
+
+    // Whether this client is connected via the management native transport port
+    private volatile boolean isManagement;
     
     // Options provided by the client
     private volatile Map<String,String> clientOptions;
@@ -217,6 +220,7 @@ public class ClientState
         this.driverName = source.driverName;
         this.driverVersion = source.driverVersion;
         this.clientOptions = source.clientOptions;
+        this.isManagement = source.isManagement;
     }
 
     /**
@@ -361,7 +365,17 @@ public class ClientState
     {
         this.driverVersion = driverVersion;
     }
-    
+
+    public boolean isManagement()
+    {
+        return isManagement;
+    }
+
+    public void setManagement(boolean isManagement)
+    {
+        this.isManagement = isManagement;
+    }
+
     public void setClientOptions(Map<String,String> clientOptions)
     {
         this.clientOptions = ImmutableMap.copyOf(clientOptions);

--- a/src/java/org/apache/cassandra/service/ClientState.java
+++ b/src/java/org/apache/cassandra/service/ClientState.java
@@ -147,6 +147,9 @@ public class ClientState
     // Driver String for the client
     private volatile String driverName;
     private volatile String driverVersion;
+
+    // Whether this client is connected via the management native transport port
+    private volatile boolean isManagement;
     
     // Options provided by the client
     private volatile Map<String,String> clientOptions;
@@ -212,6 +215,7 @@ public class ClientState
         this.driverName = source.driverName;
         this.driverVersion = source.driverVersion;
         this.clientOptions = source.clientOptions;
+        this.isManagement = source.isManagement;
     }
 
     /**
@@ -356,7 +360,17 @@ public class ClientState
     {
         this.driverVersion = driverVersion;
     }
-    
+
+    public boolean isManagement()
+    {
+        return isManagement;
+    }
+
+    public void setManagement(boolean isManagement)
+    {
+        this.isManagement = isManagement;
+    }
+
     public void setClientOptions(Map<String,String> clientOptions)
     {
         this.clientOptions = ImmutableMap.copyOf(clientOptions);

--- a/src/java/org/apache/cassandra/service/NativeTransportManagementService.java
+++ b/src/java/org/apache/cassandra/service/NativeTransportManagementService.java
@@ -41,8 +41,8 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.START_NATI
 import static org.apache.cassandra.service.NativeTransportService.useEpoll;
 
 /**
- * Manages the native management transport server on port {@code 11211}.
- * This service is independent of NativeTransportService and can only be
+ * Manages the native management transport server, listening on {@code native_transport_management_port}
+ * ({@code 11211} by default). This service is independent of NativeTransportService and can only be
  * enabled/disabled via configuration or system property (not at runtime).
  */
 public class NativeTransportManagementService implements CassandraDaemon.Server

--- a/src/java/org/apache/cassandra/service/NativeTransportManagementService.java
+++ b/src/java/org/apache/cassandra/service/NativeTransportManagementService.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.EncryptionOptions;
+import org.apache.cassandra.transport.Server;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.Version;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.START_NATIVE_MANAGEMENT_TRANSPORT;
+import static org.apache.cassandra.service.NativeTransportService.useEpoll;
+
+/**
+ * Manages the native management transport server on port {@code 11211}.
+ * This service is independent of NativeTransportService and can only be
+ * enabled/disabled via configuration or system property (not at runtime).
+ */
+public class NativeTransportManagementService implements CassandraDaemon.Server
+{
+    private static final Logger logger = LoggerFactory.getLogger(NativeTransportManagementService.class);
+
+    private Server server = null;
+    private EventLoopGroup workerGroup;
+
+    private volatile boolean initialized = false;
+
+    @VisibleForTesting
+    synchronized void initialize()
+    {
+        if (initialized)
+            return;
+
+        if (useEpoll())
+        {
+            workerGroup = new EpollEventLoopGroup();
+            logger.info("Management transport Netty using native Epoll event loop");
+        }
+        else
+        {
+            workerGroup = new NioEventLoopGroup();
+            logger.info("Management transport Netty using Java NIO event loop");
+        }
+
+        logger.info("Management transport Netty Version: {}", Version.identify().entrySet());
+
+        int managementPort = DatabaseDescriptor.getNativeTransportManagementPort();
+        InetAddress addr = DatabaseDescriptor.getRpcManagementAddress();
+
+        EncryptionOptions.TlsEncryptionPolicy encryptionPolicy = DatabaseDescriptor.getNativeProtocolEncryptionOptions()
+                                                                                   .tlsEncryptionPolicy();
+
+        server = new Server.Builder()
+                 .withEventLoopGroup(workerGroup)
+                 .withHost(addr)
+                 .withTlsEncryptionPolicy(encryptionPolicy)
+                 .withPort(managementPort)
+                 .withManagementConnectionFlag(true)
+                 .build();
+
+        initialized = true;
+    }
+
+    /**
+     * @return whether the management transport should start: the
+     * {@code cassandra.start_native_management_transport} system property wins when set,
+     * otherwise the {@code start_native_transport_management} yaml setting decides.
+     */
+    public static boolean enabled()
+    {
+        if (START_NATIVE_MANAGEMENT_TRANSPORT.getString() != null)
+            return START_NATIVE_MANAGEMENT_TRANSPORT.getBoolean();
+        return DatabaseDescriptor.startNativeTransportManagement();
+    }
+
+    public void start()
+    {
+        if (!enabled())
+        {
+            logger.info("Management transport is disabled via configuration and will not start.");
+            return;
+        }
+
+        initialize();
+        server.start();
+        logger.info("Management transport started on port: {}", server.socket.getPort());
+    }
+
+    public void stop()
+    {
+        if (server != null)
+            server.stop(false);
+    }
+
+    public void destroy()
+    {
+        stop();
+        if (server == null)
+            return;
+
+        server = null;
+        if (workerGroup != null)
+            workerGroup.shutdownGracefully(3, 5, TimeUnit.SECONDS).awaitUninterruptibly();
+
+        initialized = false;
+    }
+
+    /** @return true if the management transport server is running. */
+    public boolean isRunning()
+    {
+        return server != null && server.isRunning();
+    }
+
+    /** Clears connection history for this service's server. */
+    public void clearConnectionHistory()
+    {
+        if (server != null)
+            server.clearConnectionHistory();
+    }
+
+    /** Disconnects users matching the predicate from this service's server. */
+    public void disconnect(Predicate<AuthenticatedUser> userPredicate)
+    {
+        if (server != null)
+            server.disconnect(userPredicate);
+    }
+
+    @VisibleForTesting
+    public EventLoopGroup getWorkerGroup()
+    {
+        return workerGroup;
+    }
+}

--- a/src/java/org/apache/cassandra/service/NativeTransportManagementService.java
+++ b/src/java/org/apache/cassandra/service/NativeTransportManagementService.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.EncryptionOptions;
+import org.apache.cassandra.transport.Server;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.Version;
+
+import static org.apache.cassandra.service.NativeTransportService.useEpoll;
+
+/**
+ * Manages the native management transport server on port {@code 11211}.
+ * This service is independent of NativeTransportService and can only be
+ * enabled/disabled via configuration (not at runtime).
+ */
+public class NativeTransportManagementService implements CassandraDaemon.Server
+{
+    private static final Logger logger = LoggerFactory.getLogger(NativeTransportManagementService.class);
+
+    private Server server = null;
+    private EventLoopGroup workerGroup;
+
+    private volatile boolean initialized = false;
+
+    @VisibleForTesting
+    synchronized void initialize()
+    {
+        if (initialized)
+            return;
+
+        if (useEpoll())
+        {
+            workerGroup = new EpollEventLoopGroup();
+            logger.info("Management transport Netty using native Epoll event loop");
+        }
+        else
+        {
+            workerGroup = new NioEventLoopGroup();
+            logger.info("Management transport Netty using Java NIO event loop");
+        }
+
+        logger.info("Management transport Netty Version: {}", Version.identify().entrySet());
+
+        int managementPort = DatabaseDescriptor.getNativeTransportManagementPort();
+        InetAddress addr = DatabaseDescriptor.getRpcManagementAddress();
+
+        EncryptionOptions.TlsEncryptionPolicy encryptionPolicy = DatabaseDescriptor.getNativeProtocolEncryptionOptions()
+                                                                                   .tlsEncryptionPolicy();
+
+        server = new Server.Builder()
+                 .withEventLoopGroup(workerGroup)
+                 .withHost(addr)
+                 .withTlsEncryptionPolicy(encryptionPolicy)
+                 .withPort(managementPort)
+                 .withManagementConnectionFlag(true)
+                 .build();
+
+        initialized = true;
+    }
+
+    public void start()
+    {
+        if (!DatabaseDescriptor.startNativeTransportManagement())
+        {
+            logger.info("Management transport is disabled via configuration and will not start.");
+            return;
+        }
+
+        initialize();
+        server.start();
+        logger.info("Management transport started on port: {}", server.socket.getPort());
+    }
+
+    public void stop()
+    {
+        if (server != null)
+            server.stop(false);
+    }
+
+    public void destroy()
+    {
+        stop();
+        if (server == null)
+            return;
+
+        server = null;
+        if (workerGroup != null)
+            workerGroup.shutdownGracefully(3, 5, TimeUnit.SECONDS).awaitUninterruptibly();
+
+        initialized = false;
+    }
+
+    /** @return true if the management transport server is running. */
+    public boolean isRunning()
+    {
+        return server != null && server.isRunning();
+    }
+
+    /** Clears connection history for this service's server. */
+    public void clearConnectionHistory()
+    {
+        if (server != null)
+            server.clearConnectionHistory();
+    }
+
+    /** Disconnects users matching the predicate from this service's server. */
+    public void disconnect(Predicate<AuthenticatedUser> userPredicate)
+    {
+        if (server != null)
+            server.disconnect(userPredicate);
+    }
+
+    @VisibleForTesting
+    public EventLoopGroup getWorkerGroup()
+    {
+        return workerGroup;
+    }
+}

--- a/src/java/org/apache/cassandra/service/NativeTransportService.java
+++ b/src/java/org/apache/cassandra/service/NativeTransportService.java
@@ -30,7 +30,6 @@ import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.metrics.ClientMetrics;
-import org.apache.cassandra.transport.Dispatcher;
 import org.apache.cassandra.transport.Server;
 import org.apache.cassandra.utils.NativeLibrary;
 
@@ -45,7 +44,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.NATIVE_EPO
 /**
  * Handles native transport server lifecycle and associated resources. Lazily initialized.
  */
-public class NativeTransportService
+public class NativeTransportService implements CassandraDaemon.Server
 {
 
     private static final Logger logger = LoggerFactory.getLogger(NativeTransportService.class);
@@ -126,8 +125,6 @@ public class NativeTransportService
         // shutdown executors used by netty for native transport server
         if (workerGroup != null)
             workerGroup.shutdownGracefully(3, 5, TimeUnit.SECONDS).awaitUninterruptibly();
-
-        Dispatcher.shutdown();
     }
 
     /**

--- a/src/java/org/apache/cassandra/tools/INodeProbeFactory.java
+++ b/src/java/org/apache/cassandra/tools/INodeProbeFactory.java
@@ -32,11 +32,11 @@ class NodeProbeFactory implements INodeProbeFactory
 
     public NodeProbe create(String host, int port) throws IOException
     {
-        return new NodeProbe(host, port);
+        return new NodeProbe(new RemoteJmxMBeanAccessor(host, port));
     }
 
     public NodeProbe create(String host, int port, String username, String password) throws IOException
     {
-        return new NodeProbe(host, port, username, password);
+        return new NodeProbe(new RemoteJmxMBeanAccessor(host, port, username, password));
     }
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -116,16 +116,13 @@ import org.apache.cassandra.utils.NativeLibrary;
  * A client wrapper (or Receiver in the command pattern) for performing administrative
  * and monitoring operations on a Cassandra node.
  * <p>
- * NodeProbe provides a high-level interface to interact with a Cassandra node through JMX.
- * It abstracts the complexity of JMX connections and MBean lookups, providing convenient methods for common
- * administrative tasks such as compaction, repair, snapshots, and cluster management.
- * <p>
- * This class is primarily used by command-line tools like {@code nodetool} to execute administrative
- * commands against remote or local Cassandra nodes. It can work with both remote JMX connections (via
- * {@link RemoteJmxMBeanAccessor}) and local in-process accessors for server-side execution.
+ * NodeProbe looks up MBeans through an {@link MBeanAccessor} and wraps them in methods for compaction,
+ * repair, snapshots and cluster management. Command-line tools such as {@code nodetool} use it to run
+ * administrative commands against a remote or local node: remote nodes through
+ * {@link RemoteJmxMBeanAccessor}, the local node through an in-process accessor.
  *
- * <h3>Execution Modes</h3>
- * <h4>Client-Side Execution (up to 5.x)</h4>
+ * <h2>Execution modes</h2>
+ * <h3>Client-side execution (up to 5.x)</h3>
  * <p>
  * When used with {@link RemoteJmxMBeanAccessor}, NodeProbe connects to a remote Cassandra node via JMX:
  * <pre>{@code
@@ -135,30 +132,21 @@ import org.apache.cassandra.utils.NativeLibrary;
  * }
  * }</pre>
  *
- * <h4>Server-Side Execution (CEP-38)</h4>
+ * <h3>Server-side execution (CEP-38)</h3>
  * <p>
- * As part of <a href="https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-38">CEP-38</a>, NodeProbe can be
- * used for server-side command execution through the management API. In this mode, NodeProbe operates in-process
- * using a local {@link MBeanAccessor} that directly accesses the platform MBean server, eliminating the need for
- * remote JMX connections.
+ * As part of <a href="https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-38">CEP-38</a>, NodeProbe also
+ * runs in-process for server-side command execution through the management API. There it uses a local
+ * {@link MBeanAccessor} that reads the platform MBean server directly, so there is no JMX connection, no RMI
+ * hop and no serialization of arguments or results. The API is the same in both modes, so
+ * {@link CommandInvokerService} runs the same commands over JMX and over the native protocol.
  *
- * <p>Server-side execution provides several advantages:
- * <ul>
- *   <li><b>No Network Overhead:</b> Direct in-process access to MBeans without JMX/RMI overhead</li>
- *   <li><b>Better Performance:</b> No serialization/deserialization of JMX calls</li>
- *   <li><b>Unified API:</b> Same NodeProbe interface works for both client and server-side execution</li>
- *   <li><b>Management API Integration:</b> Commands can be executed via {@link CommandInvokerService} and exposed
- *       through various protocols (native protocol, REST, etc.)</li>
- * </ul>
- *
- * <h2>Thread Safety</h2>
+ * <h2>Thread safety</h2>
  * <p>NodeProbe instances are not thread-safe. Each thread should use its own instance, or external
  * synchronization must be provided when sharing instances across threads.
  *
- * <h2>Lazy Initialization</h2>
- * <p>MBean proxies are initialized lazily on first access to reduce overhead for operations that
- * don't require all MBeans. This is particularly beneficial for testing scenarios where only a
- * subset of functionality is needed.
+ * <h2>Lazy initialization</h2>
+ * <p>MBean proxies are initialized lazily on first access, so a caller that touches a few MBeans does not
+ * pay for creating the rest.
  *
  * @see MBeanAccessor
  * @see RemoteJmxMBeanAccessor

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -19,21 +19,17 @@ package org.apache.cassandra.tools;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
 import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.rmi.ConnectException;
-import java.rmi.server.RMIClientSocketFactory;
-import java.rmi.server.RMISocketFactory;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -44,26 +40,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
-import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
-import javax.management.IntrospectionException;
-import javax.management.JMX;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanException;
-import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.TabularData;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
-import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -72,43 +57,29 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
-import org.apache.cassandra.audit.AuditLogManager;
 import org.apache.cassandra.audit.AuditLogManagerMBean;
 import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.audit.AuditLogOptionsCompositeData;
-import org.apache.cassandra.auth.AuthCache;
 import org.apache.cassandra.auth.AuthCacheMBean;
-import org.apache.cassandra.auth.CIDRGroupsMappingManager;
 import org.apache.cassandra.auth.CIDRGroupsMappingManagerMBean;
-import org.apache.cassandra.auth.CIDRPermissionsManager;
 import org.apache.cassandra.auth.CIDRPermissionsManagerMBean;
-import org.apache.cassandra.auth.NetworkPermissionsCache;
 import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
 import org.apache.cassandra.auth.PasswordAuthenticator;
-import org.apache.cassandra.auth.PermissionsCache;
 import org.apache.cassandra.auth.PermissionsCacheMBean;
-import org.apache.cassandra.auth.RolesCache;
 import org.apache.cassandra.auth.RolesCacheMBean;
 import org.apache.cassandra.auth.jmx.AuthorizationProxy;
-import org.apache.cassandra.batchlog.BatchlogManager;
 import org.apache.cassandra.batchlog.BatchlogManagerMBean;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
-import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionManagerMBean;
 import org.apache.cassandra.db.compression.CompressionDictionaryDetailsTabularData;
 import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
 import org.apache.cassandra.db.compression.TrainingState;
-import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.guardrails.GuardrailsMBean;
-import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTable;
 import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTableMBean;
 import org.apache.cassandra.fql.FullQueryLoggerOptions;
 import org.apache.cassandra.fql.FullQueryLoggerOptionsCompositeData;
-import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.gms.FailureDetectorMBean;
-import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.GossiperMBean;
-import org.apache.cassandra.hints.HintsService;
 import org.apache.cassandra.hints.HintsServiceMBean;
 import org.apache.cassandra.index.sai.metrics.IndexGroupMetrics;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
@@ -116,61 +87,85 @@ import org.apache.cassandra.index.sai.metrics.TableStateMetrics;
 import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.locator.LocationInfoMBean;
-import org.apache.cassandra.metrics.CIDRAuthorizerMetrics;
+import org.apache.cassandra.management.CommandInvokerService;
+import org.apache.cassandra.management.MBeanAccessor;
 import org.apache.cassandra.metrics.CQLMetrics;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
-import org.apache.cassandra.metrics.DefaultNameFactory;
 import org.apache.cassandra.metrics.StorageMetrics;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.metrics.ThreadPoolMetrics;
-import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.MessagingServiceMBean;
 import org.apache.cassandra.profiler.AsyncProfilerMBean;
 import org.apache.cassandra.service.ActiveRepairServiceMBean;
-import org.apache.cassandra.service.AsyncProfilerService;
-import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.AutoRepairServiceMBean;
-import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.service.CacheServiceMBean;
-import org.apache.cassandra.service.GCInspector;
 import org.apache.cassandra.service.GCInspectorMXBean;
-import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.StorageProxyMBean;
 import org.apache.cassandra.service.StorageServiceMBean;
-import org.apache.cassandra.service.accord.AccordOperations;
 import org.apache.cassandra.service.accord.AccordOperationsMBean;
 import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
 import org.apache.cassandra.streaming.StreamManagerMBean;
 import org.apache.cassandra.streaming.StreamState;
 import org.apache.cassandra.streaming.management.StreamStateCompositeData;
-import org.apache.cassandra.tcm.CMSOperations;
 import org.apache.cassandra.tcm.CMSOperationsMBean;
 import org.apache.cassandra.tools.RepairRunner.RepairCmd;
 import org.apache.cassandra.tools.nodetool.GetTimeout;
 import org.apache.cassandra.utils.NativeLibrary;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SSL_ENABLE;
-
 /**
- * JMX client operations for Cassandra.
+ * A client wrapper (or Receiver in the command pattern) for performing administrative
+ * and monitoring operations on a Cassandra node.
+ * <p>
+ * NodeProbe provides a high-level interface to interact with a Cassandra node through JMX.
+ * It abstracts the complexity of JMX connections and MBean lookups, providing convenient methods for common
+ * administrative tasks such as compaction, repair, snapshots, and cluster management.
+ * <p>
+ * This class is primarily used by command-line tools like {@code nodetool} to execute administrative
+ * commands against remote or local Cassandra nodes. It can work with both remote JMX connections (via
+ * {@link RemoteJmxMBeanAccessor}) and local in-process accessors for server-side execution.
+ *
+ * <h3>Execution Modes</h3>
+ * <h4>Client-Side Execution (up to 5.x)</h4>
+ * <p>
+ * When used with {@link RemoteJmxMBeanAccessor}, NodeProbe connects to a remote Cassandra node via JMX:
+ * <pre>{@code
+ * MBeanAccessor accessor = new RemoteJmxMBeanAccessor("localhost", 7199);
+ * try (NodeProbe probe = new NodeProbe(accessor)) {
+ *     probe.forceKeyspaceCleanup(System.out, 1, "mykeyspace");
+ * }
+ * }</pre>
+ *
+ * <h4>Server-Side Execution (CEP-38)</h4>
+ * <p>
+ * As part of <a href="https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-38">CEP-38</a>, NodeProbe can be
+ * used for server-side command execution through the management API. In this mode, NodeProbe operates in-process
+ * using a local {@link MBeanAccessor} that directly accesses the platform MBean server, eliminating the need for
+ * remote JMX connections.
+ *
+ * <p>Server-side execution provides several advantages:
+ * <ul>
+ *   <li><b>No Network Overhead:</b> Direct in-process access to MBeans without JMX/RMI overhead</li>
+ *   <li><b>Better Performance:</b> No serialization/deserialization of JMX calls</li>
+ *   <li><b>Unified API:</b> Same NodeProbe interface works for both client and server-side execution</li>
+ *   <li><b>Management API Integration:</b> Commands can be executed via {@link CommandInvokerService} and exposed
+ *       through various protocols (native protocol, REST, etc.)</li>
+ * </ul>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>NodeProbe instances are not thread-safe. Each thread should use its own instance, or external
+ * synchronization must be provided when sharing instances across threads.
+ *
+ * <h2>Lazy Initialization</h2>
+ * <p>MBean proxies are initialized lazily on first access to reduce overhead for operations that
+ * don't require all MBeans. This is particularly beneficial for testing scenarios where only a
+ * subset of functionality is needed.
+ *
+ * @see MBeanAccessor
+ * @see RemoteJmxMBeanAccessor
+ * @see CommandInvokerService
  */
 public class NodeProbe implements AutoCloseable
 {
-    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
-    private static final String ssObjName = "org.apache.cassandra.db:type=StorageService";
-    public static final int defaultPort = 7199;
-
-    static long JMX_NOTIFICATION_POLL_INTERVAL_SECONDS = NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS.getLong();
-
-    final String host;
-    final int port;
-    private String username;
-    private String password;
-
-
-    protected JMXConnector jmxc;
-    protected MBeanServerConnection mbeanServerConn;
     protected CompactionManagerMBean compactionProxy;
     protected StorageServiceMBean ssProxy;
     protected SnapshotManagerMBean snapshotProxy;
@@ -199,190 +194,67 @@ public class NodeProbe implements AutoCloseable
     protected AutoRepairServiceMBean autoRepairProxy;
     protected AsyncProfilerMBean asyncProfilerProxy;
     protected GuardrailsMBean grProxy;
-    protected volatile Output output;
-
     protected CIDRFilteringMetricsTableMBean cfmProxy;
 
-    /**
-     * Creates a NodeProbe using the specified JMX host, port, username, and password.
-     *
-     * @param host hostname or IP address of the JMX agent
-     * @param port TCP port of the remote JMX agent
-     * @throws IOException on connection failures
-     */
-    public NodeProbe(String host, int port, String username, String password) throws IOException
-    {
-        assert username != null && !username.isEmpty() && password != null && !password.isEmpty()
-               : "neither username nor password can be blank";
+    private final MBeanAccessor mBeanAccessor;
+    protected volatile Output output;
 
-        this.host = host;
-        this.port = port;
-        this.username = username;
-        this.password = password;
-        this.output = Output.CONSOLE;
-        connect();
+    /**
+     * Creates a NodeProbe using the specified MBeanAccessor.
+     * @param mBeanAccessor the provider to use for obtaining MBeans.
+     */
+    public NodeProbe(MBeanAccessor mBeanAccessor)
+    {
+        this(mBeanAccessor, Output.CONSOLE);
     }
 
-    /**
-     * Creates a NodeProbe using the specified JMX host and port.
-     *
-     * @param host hostname or IP address of the JMX agent
-     * @param port TCP port of the remote JMX agent
-     * @throws IOException on connection failures
-     */
-    public NodeProbe(String host, int port) throws IOException
+    public NodeProbe(MBeanAccessor mBeanAccessor, Output output)
     {
-        this.host = host;
-        this.port = port;
-        this.output = Output.CONSOLE;
-        connect();
+        this.mBeanAccessor = mBeanAccessor;
+        this.output = output;
+        lazyInitMBeans();
+    }
+
+    public void close() throws Exception
+    {
+        mBeanAccessor.close();
     }
 
     /**
-     * Creates a NodeProbe using the specified JMX host and default port.
-     *
-     * @param host hostname or IP address of the JMX agent
-     * @throws IOException on connection failures
+     * Initialize all MBeans lazily, so that tests that don't need them
+     * don't pay the cost of creating all the proxies.
      */
-    public NodeProbe(String host) throws IOException
+    private void lazyInitMBeans()
     {
-        this.host = host;
-        this.port = defaultPort;
-        this.output = Output.CONSOLE;
-        connect();
-    }
-
-    protected NodeProbe()
-    {
-        // this constructor is only used for extensions to rewrite their own connect method
-        this.host = "";
-        this.port = 0;
-        this.output = Output.CONSOLE;
-    }
-
-    /**
-     * Create a connection to the JMX agent and setup the M[X]Bean proxies.
-     *
-     * @throws IOException on connection failures
-     */
-    protected void connect() throws IOException
-    {
-        String host = this.host;
-        if (host.contains(":"))
-        {
-            // Use square brackets to surround IPv6 addresses to fix CASSANDRA-7669 and CASSANDRA-17581
-            host = "[" + host + "]";
-        }
-        JMXServiceURL jmxUrl = new JMXServiceURL(String.format(fmtUrl, host, port));
-        Map<String, Object> env = new HashMap<String, Object>();
-        if (username != null)
-        {
-            String[] creds = { username, password };
-            env.put(JMXConnector.CREDENTIALS, creds);
-        }
-
-        env.put("com.sun.jndi.rmi.factory.socket", getRMIClientSocketFactory());
-
-        jmxc = JMXConnectorFactory.connect(jmxUrl, env);
-        mbeanServerConn = jmxc.getMBeanServerConnection();
-
-        try
-        {
-            ObjectName name = new ObjectName(ssObjName);
-            ssProxy = JMX.newMBeanProxy(mbeanServerConn, name, StorageServiceMBean.class);
-            name = new ObjectName(SnapshotManagerMBean.MBEAN_NAME);
-            snapshotProxy = JMX.newMBeanProxy(mbeanServerConn, name, SnapshotManagerMBean.class);
-            name = new ObjectName(CMSOperations.MBEAN_OBJECT_NAME);
-            cmsProxy = JMX.newMBeanProxy(mbeanServerConn, name, CMSOperationsMBean.class);
-            name = new ObjectName(AccordOperations.MBEAN_OBJECT_NAME);
-            accordProxy = JMX.newMBeanProxy(mbeanServerConn, name, AccordOperationsMBean.class);
-            name = new ObjectName(MessagingService.MBEAN_NAME);
-            msProxy = JMX.newMBeanProxy(mbeanServerConn, name, MessagingServiceMBean.class);
-            name = new ObjectName(StreamManagerMBean.OBJECT_NAME);
-            streamProxy = JMX.newMBeanProxy(mbeanServerConn, name, StreamManagerMBean.class);
-            name = new ObjectName(CompactionManager.MBEAN_OBJECT_NAME);
-            compactionProxy = JMX.newMBeanProxy(mbeanServerConn, name, CompactionManagerMBean.class);
-            name = new ObjectName(FailureDetector.MBEAN_NAME);
-            fdProxy = JMX.newMBeanProxy(mbeanServerConn, name, FailureDetectorMBean.class);
-            name = new ObjectName(CacheService.MBEAN_NAME);
-            cacheService = JMX.newMBeanProxy(mbeanServerConn, name, CacheServiceMBean.class);
-            name = new ObjectName(StorageProxy.MBEAN_NAME);
-            spProxy = JMX.newMBeanProxy(mbeanServerConn, name, StorageProxyMBean.class);
-            name = new ObjectName(HintsService.MBEAN_NAME);
-            hsProxy = JMX.newMBeanProxy(mbeanServerConn, name, HintsServiceMBean.class);
-            name = new ObjectName(GCInspector.MBEAN_NAME);
-            gcProxy = JMX.newMBeanProxy(mbeanServerConn, name, GCInspectorMXBean.class);
-            name = new ObjectName(Gossiper.MBEAN_NAME);
-            gossProxy = JMX.newMBeanProxy(mbeanServerConn, name, GossiperMBean.class);
-            name = new ObjectName(BatchlogManager.MBEAN_NAME);
-            bmProxy = JMX.newMBeanProxy(mbeanServerConn, name, BatchlogManagerMBean.class);
-            name = new ObjectName(ActiveRepairServiceMBean.MBEAN_NAME);
-            arsProxy = JMX.newMBeanProxy(mbeanServerConn, name, ActiveRepairServiceMBean.class);
-            name = new ObjectName(AuditLogManager.MBEAN_NAME);
-            almProxy = JMX.newMBeanProxy(mbeanServerConn, name, AuditLogManagerMBean.class);
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + PasswordAuthenticator.CredentialsCacheMBean.CACHE_NAME);
-            ccProxy = JMX.newMBeanProxy(mbeanServerConn, name, PasswordAuthenticator.CredentialsCacheMBean.class);
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + AuthorizationProxy.JmxPermissionsCacheMBean.CACHE_NAME);
-            jpcProxy = JMX.newMBeanProxy(mbeanServerConn, name, AuthorizationProxy.JmxPermissionsCacheMBean.class);
-
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + NetworkPermissionsCache.CACHE_NAME);
-            npcProxy = JMX.newMBeanProxy(mbeanServerConn, name, NetworkPermissionsCacheMBean.class);
-
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + PermissionsCache.CACHE_NAME);
-            pcProxy = JMX.newMBeanProxy(mbeanServerConn, name, PermissionsCacheMBean.class);
-
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + RolesCache.CACHE_NAME);
-            rcProxy = JMX.newMBeanProxy(mbeanServerConn, name, RolesCacheMBean.class);
-
-            name = new ObjectName(CIDRPermissionsManager.MBEAN_NAME);
-            cpbProxy = JMX.newMBeanProxy(mbeanServerConn, name, CIDRPermissionsManagerMBean.class);
-
-            name = new ObjectName(CIDRGroupsMappingManager.MBEAN_NAME);
-            cmbProxy = JMX.newMBeanProxy(mbeanServerConn, name, CIDRGroupsMappingManagerMBean.class);
-
-            name = new ObjectName(CIDRFilteringMetricsTable.MBEAN_NAME);
-            cfmProxy = JMX.newMBeanProxy(mbeanServerConn, name, CIDRFilteringMetricsTableMBean.class);
-
-            name = new ObjectName(AutoRepairService.MBEAN_NAME);
-            autoRepairProxy = JMX.newMBeanProxy(mbeanServerConn, name, AutoRepairServiceMBean.class);
-
-            name = new ObjectName(AsyncProfilerService.MBEAN_NAME);
-            asyncProfilerProxy = JMX.newMBeanProxy(mbeanServerConn, name, AsyncProfilerMBean.class);
-
-            name = new ObjectName(Guardrails.MBEAN_NAME);
-            grProxy = JMX.newMBeanProxy(mbeanServerConn, name, GuardrailsMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(
-                    "Invalid ObjectName? Please report this as a bug.", e);
-        }
-
-        memProxy = ManagementFactory.newPlatformMXBeanProxy(mbeanServerConn,
-                ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
-        runtimeProxy = ManagementFactory.newPlatformMXBeanProxy(
-                mbeanServerConn, ManagementFactory.RUNTIME_MXBEAN_NAME, RuntimeMXBean.class);
-    }
-
-    private RMIClientSocketFactory getRMIClientSocketFactory()
-    {
-        if (SSL_ENABLE.getBoolean())
-            return new SslRMIClientSocketFactory();
-        else
-            return RMISocketFactory.getDefaultSocketFactory();
-    }
-
-    public void close() throws IOException
-    {
-        try
-        {
-            jmxc.close();
-        }
-        catch (ConnectException e)
-        {
-            // result of 'stopdaemon' command - i.e. if close() call fails, the daemon is shutdown
-            System.out.println("Cassandra has shutdown.");
-        }
+        ssProxy = LazyMBeanProxy.create(mBeanAccessor, StorageServiceMBean.class);
+        compactionProxy = LazyMBeanProxy.create(mBeanAccessor, CompactionManagerMBean.class);
+        snapshotProxy = LazyMBeanProxy.create(mBeanAccessor, SnapshotManagerMBean.class);
+        cmsProxy = LazyMBeanProxy.create(mBeanAccessor, CMSOperationsMBean.class);
+        accordProxy = LazyMBeanProxy.create(mBeanAccessor, AccordOperationsMBean.class);
+        gossProxy = LazyMBeanProxy.create(mBeanAccessor, GossiperMBean.class);
+        memProxy = LazyMBeanProxy.create(mBeanAccessor, MemoryMXBean.class);
+        gcProxy = LazyMBeanProxy.create(mBeanAccessor, GCInspectorMXBean.class);
+        runtimeProxy = LazyMBeanProxy.create(mBeanAccessor, RuntimeMXBean.class);
+        streamProxy = LazyMBeanProxy.create(mBeanAccessor, StreamManagerMBean.class);
+        msProxy = LazyMBeanProxy.create(mBeanAccessor, MessagingServiceMBean.class);
+        fdProxy = LazyMBeanProxy.create(mBeanAccessor, FailureDetectorMBean.class);
+        cacheService = LazyMBeanProxy.create(mBeanAccessor, CacheServiceMBean.class);
+        spProxy = LazyMBeanProxy.create(mBeanAccessor, StorageProxyMBean.class);
+        hsProxy = LazyMBeanProxy.create(mBeanAccessor, HintsServiceMBean.class);
+        bmProxy = LazyMBeanProxy.create(mBeanAccessor, BatchlogManagerMBean.class);
+        arsProxy = LazyMBeanProxy.create(mBeanAccessor, ActiveRepairServiceMBean.class);
+        almProxy = LazyMBeanProxy.create(mBeanAccessor, AuditLogManagerMBean.class);
+        ccProxy = LazyMBeanProxy.create(mBeanAccessor, PasswordAuthenticator.CredentialsCacheMBean.class);
+        jpcProxy = LazyMBeanProxy.create(mBeanAccessor, AuthorizationProxy.JmxPermissionsCacheMBean.class);
+        npcProxy = LazyMBeanProxy.create(mBeanAccessor, NetworkPermissionsCacheMBean.class);
+        cpbProxy = LazyMBeanProxy.create(mBeanAccessor, CIDRPermissionsManagerMBean.class);
+        cmbProxy = LazyMBeanProxy.create(mBeanAccessor, CIDRGroupsMappingManagerMBean.class);
+        pcProxy = LazyMBeanProxy.create(mBeanAccessor, PermissionsCacheMBean.class);
+        rcProxy = LazyMBeanProxy.create(mBeanAccessor, RolesCacheMBean.class);
+        autoRepairProxy = LazyMBeanProxy.create(mBeanAccessor, AutoRepairServiceMBean.class);
+        grProxy = LazyMBeanProxy.create(mBeanAccessor, GuardrailsMBean.class);
+        cfmProxy = LazyMBeanProxy.create(mBeanAccessor, CIDRFilteringMetricsTableMBean.class);
+        asyncProfilerProxy = LazyMBeanProxy.create(mBeanAccessor, AsyncProfilerMBean.class);
     }
 
     public void setOutput(Output output)
@@ -582,7 +454,7 @@ public class NodeProbe implements AutoCloseable
     {
         List<RepairRunner> runners = new ArrayList<>(cmds.size());
         for (RepairCmd cmd : cmds)
-            runners.add(new RepairRunner(out, jmxc, ssProxy, cmd));
+            runners.add(new RepairRunner(out, mBeanAccessor, ssProxy, cmd));
 
         try
         {
@@ -832,23 +704,14 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.effectiveOwnershipWithPort(keyspace);
     }
 
-    public MBeanServerConnection getMbeanServerConn()
+    public MBeanAccessor getMBeanAccessor()
     {
-        return mbeanServerConn;
+        return mBeanAccessor;
     }
 
     public CacheServiceMBean getCacheServiceMBean()
     {
-        String cachePath = "org.apache.cassandra.db:type=Caches";
-
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName(cachePath), CacheServiceMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(CacheServiceMBean.class);
     }
 
     public double[] getAndResetGCStats()
@@ -860,7 +723,7 @@ public class NodeProbe implements AutoCloseable
     {
         try
         {
-            return new ColumnFamilyStoreMBeanIterator(mbeanServerConn);
+            return new ColumnFamilyStoreMBeanIterator(mBeanAccessor);
         }
         catch (MalformedObjectNameException e)
         {
@@ -1274,67 +1137,30 @@ public class NodeProbe implements AutoCloseable
 
     public EndpointSnitchInfoMBean getEndpointSnitchInfoProxy()
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName("org.apache.cassandra.db:type=EndpointSnitchInfo"), EndpointSnitchInfoMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(EndpointSnitchInfoMBean.class);
     }
 
     public DynamicEndpointSnitchMBean getDynamicEndpointSnitchInfoProxy()
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName("org.apache.cassandra.db:type=DynamicEndpointSnitch"), DynamicEndpointSnitchMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(DynamicEndpointSnitchMBean.class);
     }
 
     public LocationInfoMBean getLocationInfoProxy()
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName("org.apache.cassandra.db:type=LocationInfo"), LocationInfoMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(LocationInfoMBean.class);
     }
 
     public ColumnFamilyStoreMBean getCfsProxy(String ks, String cf)
     {
-        ColumnFamilyStoreMBean cfsProxy = null;
         try
         {
             String type = cf.contains(".") ? "IndexColumnFamilies" : "ColumnFamilies";
-            Set<ObjectName> beans = mbeanServerConn.queryNames(
-                    new ObjectName("org.apache.cassandra.db:type=*" + type +",keyspace=" + ks + ",columnfamily=" + cf), null);
-
-            if (beans.isEmpty())
-                throw new MalformedObjectNameException("couldn't find that bean");
-            assert beans.size() == 1;
-            for (ObjectName bean : beans)
-                cfsProxy = JMX.newMBeanProxy(mbeanServerConn, bean, ColumnFamilyStoreMBean.class);
+            return mBeanAccessor.findColumnFamily(type, ks, cf);
         }
-        catch (MalformedObjectNameException mone)
+        catch (Exception e)
         {
-            System.err.println("ColumnFamilyStore for " + ks + "/" + cf + " not found.");
-            System.exit(1);
+            throw new IllegalArgumentException("ColumnFamilyStore for " + ks + '/' + cf + " not found: " + e.getMessage(), e);
         }
-        catch (IOException e)
-        {
-            System.err.println("ColumnFamilyStore for " + ks + "/" + cf + " not found: " + e);
-            System.exit(1);
-        }
-
-        return cfsProxy;
     }
 
     public StorageProxyMBean getSpProxy()
@@ -1876,39 +1702,23 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getCacheMetric(String cacheType, String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch(metricName)
-            {
-                case "Capacity":
-                case "Entries":
-                case "HitRate":
-                case "Size":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=" + metricName),
-                            CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "Requests":
-                case "Hits":
-                case "Misses":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=" + metricName),
-                            CassandraMetricsRegistry.JmxMeterMBean.class).getCount();
-                case "MissLatency":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=" + metricName),
-                            CassandraMetricsRegistry.JmxTimerMBean.class).getMean();
-                case "MissLatencyUnit":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=MissLatency"),
-                            CassandraMetricsRegistry.JmxTimerMBean.class).getDurationUnit();
-                default:
-                    throw new RuntimeException("Unknown Cache metric name " + metricName);
-
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "Capacity":
+            case "Entries":
+            case "HitRate":
+            case "Size":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.scoped("Cache", cacheType, metricName)).getValue();
+            case "Requests":
+            case "Hits":
+            case "Misses":
+                return mBeanAccessor.findMBeanMeter(MBeanAccessor.Props.scoped("Cache", cacheType, metricName)).getCount();
+            case "MissLatency":
+                return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.scoped("Cache", cacheType, metricName)).getMean();
+            case "MissLatencyUnit":
+                return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.scoped("Cache", cacheType, "MissLatency")).getDurationUnit();
+            default:
+                throw new RuntimeException("Unknown Cache metric name " + metricName);
         }
     }
 
@@ -1920,162 +1730,93 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getBufferPoolMetric(String poolType, String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch (metricName)
-            {
-                case "UsedSize":
-                case "OverflowSize":
-                case "Capacity":
-                case "Size":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                           new ObjectName("org.apache.cassandra.metrics:type=BufferPool,scope=" + poolType + ",name=" + metricName),
-                           CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "Hits":
-                case "Misses":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                    new ObjectName("org.apache.cassandra.metrics:type=BufferPool,scope=" + poolType + ",name=" + metricName),
-                    CassandraMetricsRegistry.JmxMeterMBean.class).getCount();
-                default:
-                    throw new RuntimeException("Unknown BufferPool metric name " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "UsedSize":
+            case "OverflowSize":
+            case "Capacity":
+            case "Size":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.scoped("BufferPool", poolType, metricName)).getValue();
+            case "Hits":
+            case "Misses":
+                return mBeanAccessor.findMBeanMeter(MBeanAccessor.Props.scoped("BufferPool", poolType, metricName)).getCount();
+            default:
+                throw new RuntimeException("Unknown BufferPool metric name " + metricName);
         }
     }
 
     /**
-     * Retrieve a CQL metric value by name. Works generically for any metric registered under
-     * {@code org.apache.cassandra.metrics:type=CQL,name=<metricName>} by inspecting the MBean
-     * attributes at runtime, without requiring knowledge of the underlying metric type.
+     * Retrieve a CQL metric value by name, for metrics registered under
+     * {@code org.apache.cassandra.metrics:type=CQL,name=<metricName>}.
+     * @param metricName one of the metric names registered by {@link CQLMetrics}
      */
     public Object getCQLMetric(String metricName)
     {
-        try
+        switch (metricName)
         {
-            ObjectName objectName = new ObjectName(DefaultNameFactory.GROUP_NAME + ":type=" + CQLMetrics.TYPE_NAME + ",name=" + metricName);
-            for (MBeanAttributeInfo attr : mbeanServerConn.getMBeanInfo(objectName).getAttributes())
-            {
-                String name = attr.getName();
-                if ("Value".equals(name) || "Count".equals(name))
-                    return mbeanServerConn.getAttribute(objectName, name);
-            }
-            throw new RuntimeException("No readable value attribute for CQL metric: " + metricName);
-        }
-        catch (MalformedObjectNameException | InstanceNotFoundException | IntrospectionException |
-               ReflectionException | AttributeNotFoundException | MBeanException | IOException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static Multimap<String, String> getJmxThreadPools(MBeanServerConnection mbeanServerConn)
-    {
-        try
-        {
-            Multimap<String, String> threadPools = HashMultimap.create();
-
-            Set<ObjectName> threadPoolObjectNames = mbeanServerConn.queryNames(
-                    new ObjectName("org.apache.cassandra.metrics:type=ThreadPools,*"),
-                    null);
-
-            for (ObjectName oName : threadPoolObjectNames)
-            {
-                threadPools.put(oName.getKeyProperty("path"), oName.getKeyProperty("scope"));
-            }
-
-            return threadPools;
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException("Bad query to JMX server: ", e);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error getting threadpool names from JMX", e);
+            case "PreparedStatementsCount":
+            case "PreparedStatementsRatio":
+            case "PreparedStatementsCacheSize":
+            case "PreparedStatementsCacheCapacity":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.metric(CQLMetrics.TYPE_NAME, metricName)).getValue();
+            case "RegularStatementsExecuted":
+            case "PreparedStatementsExecuted":
+            case "PreparedStatementsEvicted":
+            case "UseStatementsExecuted":
+                return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.metric(CQLMetrics.TYPE_NAME, metricName)).getCount();
+            default:
+                throw new RuntimeException("Unknown CQL metric name " + metricName);
         }
     }
 
     public Object getThreadPoolMetric(String pathName, String poolName, String metricName)
     {
-      String name = String.format("org.apache.cassandra.metrics:type=ThreadPools,path=%s,scope=%s,name=%s",
-              pathName, poolName, metricName);
+        if (!mBeanAccessor.isMBeanMetricRegistered(MBeanAccessor.Props.threadPool("ThreadPools", pathName, poolName, metricName)))
+        {
+            return "N/A";
+        }
 
-      try
-      {
-          ObjectName oName = new ObjectName(name);
-          if (!mbeanServerConn.isRegistered(oName))
-          {
-              return "N/A";
-          }
-
-          switch (metricName)
-          {
-              case ThreadPoolMetrics.ACTIVE_TASKS:
-              case ThreadPoolMetrics.PENDING_TASKS:
-              case ThreadPoolMetrics.COMPLETED_TASKS:
-              case ThreadPoolMetrics.CORE_POOL_SIZE:
-              case ThreadPoolMetrics.MAX_POOL_SIZE:
-              case ThreadPoolMetrics.MAX_TASKS_QUEUED:
-                  return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-              case ThreadPoolMetrics.TOTAL_BLOCKED_TASKS:
-              case ThreadPoolMetrics.CURRENTLY_BLOCKED_TASKS:
-                  return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-              default:
-                  throw new AssertionError("Unknown ThreadPools metric name " + metricName);
-          }
-      }
-      catch (Exception e)
-      {
-          throw new RuntimeException("Error reading: " + name, e);
-      }
+        switch (metricName)
+        {
+            case ThreadPoolMetrics.ACTIVE_TASKS:
+            case ThreadPoolMetrics.PENDING_TASKS:
+            case ThreadPoolMetrics.COMPLETED_TASKS:
+            case ThreadPoolMetrics.CORE_POOL_SIZE:
+            case ThreadPoolMetrics.MAX_POOL_SIZE:
+            case ThreadPoolMetrics.MAX_TASKS_QUEUED:
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.threadPool("ThreadPools", pathName, poolName, metricName)).getValue();
+            case ThreadPoolMetrics.TOTAL_BLOCKED_TASKS:
+            case ThreadPoolMetrics.CURRENTLY_BLOCKED_TASKS:
+                return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.threadPool("ThreadPools", pathName, poolName, metricName)).getCount();
+            default:
+                throw new RuntimeException("Unknown ThreadPools metric name " + metricName);
+        }
     }
 
     public Object getSaiMetric(String ks, String cf, String metricName)
     {
-        try
-        {
-            String scope = getSaiMetricScope(metricName);
-            String objectNameStr = String.format("org.apache.cassandra.metrics:type=StorageAttachedIndex,keyspace=%s,table=%s,scope=%s,name=%s",ks, cf, scope, metricName);
-            ObjectName oName = new ObjectName(objectNameStr);
+        String scope = getSaiMetricScope(metricName);
+        MBeanAccessor.Props props = MBeanAccessor.Props.sai("StorageAttachedIndex", ks, cf, scope, metricName);
+        if (!mBeanAccessor.isMBeanMetricRegistered(props))
+            return null;
 
-            Set<ObjectName> matchingMBeans = mbeanServerConn.queryNames(oName, null);
-            if (matchingMBeans.isEmpty())
-                return null;
-
-            return getSaiMetricValue(metricName, oName);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException("Invalid ObjectName format: " + e.getMessage(), e);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error accessing MBean server: " + e.getMessage(), e);
-        }
-    }
-
-    private Object getSaiMetricValue(String metricName, ObjectName oName) throws IOException
-    {
         switch (metricName)
         {
             case "QueryLatency":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxTimerMBean.class);
+                return mBeanAccessor.findMBeanTimer(props);
             case "PostFilteringReadLatency":
             case "SSTableIndexesHit":
             case "IndexSegmentsHit":
             case "RowsFiltered":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);
+                return mBeanAccessor.findMBeanHistogram(props);
             case "DiskUsedBytes":
             case "TotalIndexCount":
             case "TotalQueryableIndexCount":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
+                return mBeanAccessor.findMBeanGauge(props).getValue();
             case "TotalQueryTimeouts":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
+                return mBeanAccessor.findMBeanCounter(props).getCount();
             default:
-                throw new IllegalArgumentException("Unknown metric name: " + metricName);
+                throw new RuntimeException("Unknown metric name: " + metricName);
         }
     }
 
@@ -2097,7 +1838,7 @@ public class NodeProbe implements AutoCloseable
             case "TotalQueryableIndexCount":
                 return TableStateMetrics.TABLE_STATE_METRIC_TYPE;
             default:
-                throw new IllegalArgumentException("Unknown metric name: " + metricName);
+                throw new RuntimeException("Unknown metric name: " + metricName);
         }
     }
 
@@ -2105,10 +1846,13 @@ public class NodeProbe implements AutoCloseable
      * Retrieve threadpool paths and names for threadpools with metrics.
      * @return Multimap from path (internal, request, etc.) to name
      */
-    public Multimap<String, String> getThreadPools()
-    {
-        return getJmxThreadPools(mbeanServerConn);
-    }
+        public Multimap<String, String> getThreadPools()
+        {
+            Multimap<String, String> threadPools = HashMultimap.create();
+            for (MBeanAccessor.ThreadPoolInfo info : mBeanAccessor.threadPoolInfos())
+                threadPools.put(info.path(), info.poolName());
+            return threadPools;
+        }
 
     public int getNumberOfTables()
     {
@@ -2123,92 +1867,85 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getColumnFamilyMetric(String ks, String cf, String metricName)
     {
-        try
+        MBeanAccessor.Props props;
+        if (!Strings.isNullOrEmpty(ks) && !Strings.isNullOrEmpty(cf))
         {
-            ObjectName oName = null;
-            if (!Strings.isNullOrEmpty(ks) && !Strings.isNullOrEmpty(cf))
-            {
-                String type = cf.contains(".") ? "IndexTable" : "Table";
-                oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=%s,keyspace=%s,scope=%s,name=%s", type, ks, cf, metricName));
-            }
-            else if (!Strings.isNullOrEmpty(ks))
-            {
-                oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=Keyspace,keyspace=%s,name=%s", ks, metricName));
-            }
-            else
-            {
-                oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=Table,name=%s", metricName));
-            }
-            switch(metricName)
-            {
-                case "BloomFilterDiskSpaceUsed":
-                case "BloomFilterFalsePositives":
-                case "BloomFilterFalseRatio":
-                case "BloomFilterOffHeapMemoryUsed":
-                case "IndexSummaryOffHeapMemoryUsed":
-                case "CompressionDictionariesMemoryUsed":
-                case "CompressionMetadataOffHeapMemoryUsed":
-                case "CompressionRatio":
-                case "EstimatedColumnCountHistogram":
-                case "EstimatedPartitionSizeHistogram":
-                case "EstimatedPartitionCount":
-                case "KeyCacheHitRate":
-                case "LiveSSTableCount":
-                case "MaxSSTableDuration":
-                case "MaxSSTableSize":
-                case "OldVersionSSTableCount":
-                case "MaxPartitionSize":
-                case "MeanPartitionSize":
-                case "MemtableColumnsCount":
-                case "MemtableLiveDataSize":
-                case "MemtableOffHeapSize":
-                case "MinPartitionSize":
-                case "PercentRepaired":
-                case "BytesRepaired":
-                case "BytesUnrepaired":
-                case "BytesPendingRepair":
-                case "RecentBloomFilterFalsePositives":
-                case "RecentBloomFilterFalseRatio":
-                case "SnapshotsSize":
-                    return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "LiveDiskSpaceUsed":
-                case "MemtableSwitchCount":
-                case "SpeculativeRetries":
-                case "TotalDiskSpaceUsed":
-                case "WriteTotalLatency":
-                case "ReadTotalLatency":
-                case "PendingFlushes":
-                {
-                    // these are gauges for keyspace metrics, not counters
-                    if (!Strings.isNullOrEmpty(ks) &&
-                        Strings.isNullOrEmpty(cf) &&
-                        (metricName.equals("TotalDiskSpaceUsed") ||
-                         metricName.equals("LiveDiskSpaceUsed") ||
-                         metricName.equals("MemtableSwitchCount")))
-                    {
-                        return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                    }
-                    else
-                    {
-                        return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-                    }
-                }
-                case "CoordinatorReadLatency":
-                case "CoordinatorScanLatency":
-                case "ReadLatency":
-                case "WriteLatency":
-                    return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxTimerMBean.class);
-                case "LiveScannedHistogram":
-                case "SSTablesPerReadHistogram":
-                case "TombstoneScannedHistogram":
-                    return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);
-                default:
-                    throw new RuntimeException("Unknown table metric " + metricName);
-            }
+            String type = cf.contains(".") ? "IndexTable" : "Table";
+            props = MBeanAccessor.Props.columnFamily(type, ks, cf, metricName);
         }
-        catch (MalformedObjectNameException e)
+        else if (!Strings.isNullOrEmpty(ks))
         {
-            throw new RuntimeException(e);
+            props = MBeanAccessor.Props.keyspace("Keyspace", ks, metricName);
+        }
+        else
+        {
+            props = MBeanAccessor.Props.metric("Table", metricName);
+        }
+        switch (metricName)
+        {
+            case "BloomFilterDiskSpaceUsed":
+            case "BloomFilterFalsePositives":
+            case "BloomFilterFalseRatio":
+            case "BloomFilterOffHeapMemoryUsed":
+            case "IndexSummaryOffHeapMemoryUsed":
+            case "CompressionDictionariesMemoryUsed":
+            case "CompressionMetadataOffHeapMemoryUsed":
+            case "CompressionRatio":
+            case "EstimatedColumnCountHistogram":
+            case "EstimatedPartitionSizeHistogram":
+            case "EstimatedPartitionCount":
+            case "KeyCacheHitRate":
+            case "LiveSSTableCount":
+            case "MaxSSTableDuration":
+            case "MaxSSTableSize":
+            case "OldVersionSSTableCount":
+            case "MaxPartitionSize":
+            case "MeanPartitionSize":
+            case "MemtableColumnsCount":
+            case "MemtableLiveDataSize":
+            case "MemtableOffHeapSize":
+            case "MinPartitionSize":
+            case "PercentRepaired":
+            case "BytesRepaired":
+            case "BytesUnrepaired":
+            case "BytesPendingRepair":
+            case "RecentBloomFilterFalsePositives":
+            case "RecentBloomFilterFalseRatio":
+            case "SnapshotsSize":
+                return mBeanAccessor.findMBeanGauge(props).getValue();
+            case "LiveDiskSpaceUsed":
+            case "MemtableSwitchCount":
+            case "SpeculativeRetries":
+            case "TotalDiskSpaceUsed":
+            case "WriteTotalLatency":
+            case "ReadTotalLatency":
+            case "PendingFlushes":
+            {
+                // these are gauges for keyspace metrics, not counters
+                if (!Strings.isNullOrEmpty(ks) &&
+                    Strings.isNullOrEmpty(cf) &&
+                    (metricName.equals("TotalDiskSpaceUsed") ||
+                     metricName.equals("LiveDiskSpaceUsed") ||
+                     metricName.equals("MemtableSwitchCount")))
+                {
+                    return mBeanAccessor.findMBeanGauge(props).getValue();
+                }
+                else
+                {
+                    return mBeanAccessor.findMBeanCounter(props).getCount();
+                }
+            }
+            case "CoordinatorReadLatency":
+            case "CoordinatorScanLatency":
+            case "ReadLatency":
+            case "WriteLatency":
+                return mBeanAccessor.findMBeanTimer(props);
+            case "LiveScannedHistogram":
+            case "SSTablesPerReadHistogram":
+            case "TombstoneScannedHistogram":
+                return mBeanAccessor.findMBeanHistogram(props);
+            default:
+                throw new RuntimeException("Unknown table metric " + metricName);
         }
     }
 
@@ -2218,30 +1955,12 @@ public class NodeProbe implements AutoCloseable
      */
     public CassandraMetricsRegistry.JmxTimerMBean getProxyMetric(String scope)
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn,
-                    new ObjectName("org.apache.cassandra.metrics:type=ClientRequest,scope=" + scope + ",name=Latency"),
-                    CassandraMetricsRegistry.JmxTimerMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.scoped("ClientRequest", scope, "Latency"));
     }
 
     public CassandraMetricsRegistry.JmxTimerMBean getMessagingQueueWaitMetrics(String verb)
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn,
-                                     new ObjectName("org.apache.cassandra.metrics:name=" + verb + "-WaitLatency,type=Messaging"),
-                                     CassandraMetricsRegistry.JmxTimerMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.metric("Messaging", verb + "-WaitLatency"));
     }
 
     /**
@@ -2252,35 +1971,22 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getCompactionMetric(String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch(metricName)
-            {
-                case "BytesCompacted":
-                case "CompressedBytesCompacted":
-                case "CompactionsAborted":
-                case "CompactionsReduced":
-                case "SSTablesDroppedFromCompaction":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Compaction,name=" + metricName),
-                            CassandraMetricsRegistry.JmxCounterMBean.class);
-                case "CompletedTasks":
-                case "PendingTasks":
-                case "PendingTasksByTableName":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Compaction,name=" + metricName),
-                            CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "TotalCompactionsCompleted":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Compaction,name=" + metricName),
-                            CassandraMetricsRegistry.JmxMeterMBean.class);
-                default:
-                    throw new RuntimeException("Unknown compaction metric " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "BytesCompacted":
+            case "CompressedBytesCompacted":
+            case "CompactionsAborted":
+            case "CompactionsReduced":
+            case "SSTablesDroppedFromCompaction":
+                return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.metric("Compaction", metricName));
+            case "CompletedTasks":
+            case "PendingTasks":
+            case "PendingTasksByTableName":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.metric("Compaction", metricName)).getValue();
+            case "TotalCompactionsCompleted":
+                return mBeanAccessor.findMBeanMeter(MBeanAccessor.Props.metric("Compaction", metricName));
+            default:
+                throw new RuntimeException("Unknown compaction metric " + metricName);
         }
     }
 
@@ -2290,65 +1996,15 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getClientMetric(String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch(metricName)
-            {
-                case "connections": // List<Map<String,String>> - list of all native connections and their properties
-                case "connectedNativeClients": // number of connected native clients
-                case "connectedNativeClientsByUser": // number of native clients by username
-                case "clientsByProtocolVersion": // number of native clients by protocol version
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Client,name=" + metricName),
-                            CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                default:
-                    throw new RuntimeException("Unknown client metric " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Object getCidrFilteringMetric(String metricName)
-    {
-        try
-        {
-            switch(metricName)
-            {
-                case CIDRAuthorizerMetrics.CIDR_CHECKS_LATENCY:
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                                             new ObjectName("org.apache.cassandra.metrics:type=CIDRAuthorization,name="
-                                                            + metricName),
-                                             CassandraMetricsRegistry.JmxTimerMBean.class).getMean();
-                case CIDRAuthorizerMetrics.CIDR_GROUPS_CACHE_RELOAD_COUNT:
-                    return JMX.newMBeanProxy(
-                        mbeanServerConn,
-                        new ObjectName("org.apache.cassandra.metrics:type=CIDRGroupsMappingCache,name=" + metricName),
-                        CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-                case CIDRAuthorizerMetrics.CIDR_GROUPS_CACHE_RELOAD_LATENCY:
-                case CIDRAuthorizerMetrics.LOOKUP_CIDR_GROUPS_FOR_IP_LATENCY:
-                    return JMX.newMBeanProxy(
-                        mbeanServerConn,
-                        new ObjectName("org.apache.cassandra.metrics:type=CIDRGroupsMappingCache,name=" + metricName),
-                        CassandraMetricsRegistry.JmxTimerMBean.class).getMean();
-                default:
-                    if (metricName.contains(CIDRAuthorizerMetrics.CIDR_ACCESSES_REJECTED_COUNT_PREFIX) ||
-                        metricName.contains(CIDRAuthorizerMetrics.CIDR_ACCESSES_ACCEPTED_COUNT_PREFIX))
-                    {
-                        return JMX.newMBeanProxy(
-                            mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=mymetricname,name=" + metricName),
-                            CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-                    }
-
-                    throw new RuntimeException("Unknown metric " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "connections": // List<Map<String,String>> - list of all native connections and their properties
+            case "connectedNativeClients": // number of connected native clients
+            case "connectedNativeClientsByUser": // number of native clients by username
+            case "clientsByProtocolVersion": // number of native clients by protocol version
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.metric("Client", metricName)).getValue();
+            default:
+                throw new RuntimeException("Unknown client metric " + metricName);
         }
     }
 
@@ -2368,16 +2024,7 @@ public class NodeProbe implements AutoCloseable
      */
     public long getStorageMetric(String metricName)
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn,
-                    new ObjectName("org.apache.cassandra.metrics:type=Storage,name=" + metricName),
-                    CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.metric("Storage", metricName)).getCount();
     }
 
     public Double[] metricPercentilesAsArray(CassandraMetricsRegistry.JmxHistogramMBean metric)
@@ -2439,8 +2086,8 @@ public class NodeProbe implements AutoCloseable
         BootstrapMonitor monitor = new BootstrapMonitor(out);
         try
         {
-            if (jmxc != null)
-                jmxc.addConnectionNotificationListener(monitor, null, null);
+            if (mBeanAccessor instanceof RemoteJmxMBeanAccessor)
+                ((RemoteJmxMBeanAccessor) mBeanAccessor).getJmxConnector().addConnectionNotificationListener(monitor, null, null);
             ssProxy.addNotificationListener(monitor, null, null);
             if (ssProxy.resumeBootstrap())
             {
@@ -2463,8 +2110,8 @@ public class NodeProbe implements AutoCloseable
             try
             {
                 ssProxy.removeNotificationListener(monitor);
-                if (jmxc != null)
-                    jmxc.removeConnectionNotificationListener(monitor);
+                if (mBeanAccessor instanceof RemoteJmxMBeanAccessor)
+                    ((RemoteJmxMBeanAccessor) mBeanAccessor).getJmxConnector().removeConnectionNotificationListener(monitor);
             }
             catch (Throwable e)
             {
@@ -2838,15 +2485,15 @@ public class NodeProbe implements AutoCloseable
         }
         catch (Exception e)
         {
-            if (e.getCause() instanceof InstanceNotFoundException)
+            if (Throwables.getRootCause(e) instanceof InstanceNotFoundException)
             {
                 String message = String.format("Table %s.%s does not exist or does not support dictionary compression",
                                                keyspace, table);
-                throw new IllegalArgumentException(message);
+                throw new RuntimeException(message);
             }
             else
             {
-                throw new IOException(e.getMessage());
+                throw e;
             }
         }
     }
@@ -2882,78 +2529,100 @@ public class NodeProbe implements AutoCloseable
 
     private CompressionDictionaryManagerMBean getDictionaryManagerProxy(String keyspace, String table) throws IOException
     {
-        // Construct table-specific MBean name
-        String mbeanName = CompressionDictionaryManagerMBean.MBEAN_NAME + ",keyspace=" + keyspace + ",table=" + table;
-        try
+        return mBeanAccessor.findCompressionDictionary(keyspace, table);
+    }
+
+    /**
+     * A dynamic proxy that lazily looks up the MBean the first time a method is invoked.
+     * @param <T> the MBean interface type.
+     */
+    private static class LazyMBeanProxy<T> implements java.lang.reflect.InvocationHandler
+    {
+        private final MBeanAccessor provider;
+        private final Class<T> mbeanClass;
+        private volatile T delegate;
+
+        LazyMBeanProxy(MBeanAccessor provider, Class<T> mbeanClass)
         {
-            ObjectName objectName = new ObjectName(mbeanName);
-            return JMX.newMBeanProxy(mbeanServerConn, objectName, CompressionDictionaryManagerMBean.class);
+            this.provider = provider;
+            this.mbeanClass = mbeanClass;
         }
-        catch (MalformedObjectNameException e)
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
         {
-            throw new IOException("Invalid keyspace or table name", e);
+            if (delegate == null)
+            {
+                synchronized (this)
+                {
+                    if (delegate == null)
+                        delegate = provider.findMBean(mbeanClass);
+                }
+            }
+
+            if (delegate == null)
+                throw new RuntimeException(new InstanceNotFoundException(mbeanClass.getSimpleName() + " is not available on this node"));
+
+            try
+            {
+                return method.invoke(delegate, args);
+            }
+            catch (InvocationTargetException e)
+            {
+                Throwable cause = e.getCause();
+                if (cause == null)
+                    throw e;
+                throw cause;
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        static <T> T create(MBeanAccessor provider, Class<T> mbeanClass)
+        {
+            return (T) Proxy.newProxyInstance(mbeanClass.getClassLoader(),
+                                              new Class<?>[]{ mbeanClass },
+                                              new LazyMBeanProxy<>(provider, mbeanClass));
         }
     }
 }
 
 class ColumnFamilyStoreMBeanIterator implements Iterator<Map.Entry<String, ColumnFamilyStoreMBean>>
 {
-    private MBeanServerConnection mbeanServerConn;
     Iterator<Entry<String, ColumnFamilyStoreMBean>> mbeans;
 
-    public ColumnFamilyStoreMBeanIterator(MBeanServerConnection mbeanServerConn)
+    public ColumnFamilyStoreMBeanIterator(MBeanAccessor accessor)
         throws MalformedObjectNameException, NullPointerException, IOException
     {
-        this.mbeanServerConn = mbeanServerConn;
-        List<Entry<String, ColumnFamilyStoreMBean>> cfMbeans = getCFSMBeans(mbeanServerConn, "ColumnFamilies");
-        cfMbeans.addAll(getCFSMBeans(mbeanServerConn, "IndexColumnFamilies"));
-        Collections.sort(cfMbeans, new Comparator<Entry<String, ColumnFamilyStoreMBean>>()
-        {
-            public int compare(Entry<String, ColumnFamilyStoreMBean> e1, Entry<String, ColumnFamilyStoreMBean> e2)
-            {
-                //compare keyspace, then CF name, then normal vs. index
-                int keyspaceNameCmp = e1.getKey().compareTo(e2.getKey());
-                if(keyspaceNameCmp != 0)
-                    return keyspaceNameCmp;
+        List<Entry<String, ColumnFamilyStoreMBean>> cfMbeans = accessor.findColumnFamilies("ColumnFamilies");
+        cfMbeans.addAll(accessor.findColumnFamilies("IndexColumnFamilies"));
+        cfMbeans.sort((e1, e2) -> {
+            //compare keyspace, then CF name, then normal vs. index
+            int keyspaceNameCmp = e1.getKey().compareTo(e2.getKey());
+            if (keyspaceNameCmp != 0)
+                return keyspaceNameCmp;
 
-                // get CF name and split it for index name
-                String e1CF[] = e1.getValue().getTableName().split("\\.");
-                String e2CF[] = e2.getValue().getTableName().split("\\.");
-                assert e1CF.length <= 2 && e2CF.length <= 2 : "unexpected split count for table name";
+            // get CF name and split it for index name
+            String e1CF[] = e1.getValue().getTableName().split("\\.");
+            String e2CF[] = e2.getValue().getTableName().split("\\.");
+            assert e1CF.length <= 2 && e2CF.length <= 2 : "unexpected split count for table name";
 
-                //if neither are indexes, just compare CF names
-                if(e1CF.length == 1 && e2CF.length == 1)
-                    return e1CF[0].compareTo(e2CF[0]);
+            //if neither are indexes, just compare CF names
+            if (e1CF.length == 1 && e2CF.length == 1)
+                return e1CF[0].compareTo(e2CF[0]);
 
-                //check if it's the same CF
-                int cfNameCmp = e1CF[0].compareTo(e2CF[0]);
-                if(cfNameCmp != 0)
-                    return cfNameCmp;
+            //check if it's the same CF
+            int cfNameCmp = e1CF[0].compareTo(e2CF[0]);
+            if (cfNameCmp != 0)
+                return cfNameCmp;
 
-                // if both are indexes (for the same CF), compare them
-                if(e1CF.length == 2 && e2CF.length == 2)
-                    return e1CF[1].compareTo(e2CF[1]);
+            // if both are indexes (for the same CF), compare them
+            if (e1CF.length == 2 && e2CF.length == 2)
+                return e1CF[1].compareTo(e2CF[1]);
 
-                //if length of e1CF is 1, it's not an index, so sort it higher
-                return e1CF.length == 1 ? 1 : -1;
-            }
+            //if length of e1CF is 1, it's not an index, so sort it higher
+            return e1CF.length == 1 ? 1 : -1;
         });
         mbeans = cfMbeans.iterator();
-    }
-
-    private List<Entry<String, ColumnFamilyStoreMBean>> getCFSMBeans(MBeanServerConnection mbeanServerConn, String type)
-            throws MalformedObjectNameException, IOException
-    {
-        ObjectName query = new ObjectName("org.apache.cassandra.db:type=" + type +",*");
-        Set<ObjectName> cfObjects = mbeanServerConn.queryNames(query, null);
-        List<Entry<String, ColumnFamilyStoreMBean>> mbeans = new ArrayList<Entry<String, ColumnFamilyStoreMBean>>(cfObjects.size());
-        for(ObjectName n : cfObjects)
-        {
-            String keyspaceName = n.getKeyProperty("keyspace");
-            ColumnFamilyStoreMBean cfsProxy = JMX.newMBeanProxy(mbeanServerConn, n, ColumnFamilyStoreMBean.class);
-            mbeans.add(new AbstractMap.SimpleImmutableEntry<String, ColumnFamilyStoreMBean>(keyspaceName, cfsProxy));
-        }
-        return mbeans;
     }
 
     public boolean hasNext()

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -19,21 +19,17 @@ package org.apache.cassandra.tools;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
 import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.rmi.ConnectException;
-import java.rmi.server.RMIClientSocketFactory;
-import java.rmi.server.RMISocketFactory;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -45,17 +41,10 @@ import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
 import javax.management.InstanceNotFoundException;
-import javax.management.JMX;
-import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.TabularData;
-import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
-import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
@@ -67,43 +56,29 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
-import org.apache.cassandra.audit.AuditLogManager;
 import org.apache.cassandra.audit.AuditLogManagerMBean;
 import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.audit.AuditLogOptionsCompositeData;
-import org.apache.cassandra.auth.AuthCache;
 import org.apache.cassandra.auth.AuthCacheMBean;
-import org.apache.cassandra.auth.CIDRGroupsMappingManager;
 import org.apache.cassandra.auth.CIDRGroupsMappingManagerMBean;
-import org.apache.cassandra.auth.CIDRPermissionsManager;
 import org.apache.cassandra.auth.CIDRPermissionsManagerMBean;
-import org.apache.cassandra.auth.NetworkPermissionsCache;
 import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
 import org.apache.cassandra.auth.PasswordAuthenticator;
-import org.apache.cassandra.auth.PermissionsCache;
 import org.apache.cassandra.auth.PermissionsCacheMBean;
-import org.apache.cassandra.auth.RolesCache;
 import org.apache.cassandra.auth.RolesCacheMBean;
 import org.apache.cassandra.auth.jmx.AuthorizationProxy;
-import org.apache.cassandra.batchlog.BatchlogManager;
 import org.apache.cassandra.batchlog.BatchlogManagerMBean;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
-import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionManagerMBean;
 import org.apache.cassandra.db.compression.CompressionDictionaryDetailsTabularData;
 import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
 import org.apache.cassandra.db.compression.TrainingState;
-import org.apache.cassandra.db.guardrails.Guardrails;
 import org.apache.cassandra.db.guardrails.GuardrailsMBean;
-import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTable;
 import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTableMBean;
 import org.apache.cassandra.fql.FullQueryLoggerOptions;
 import org.apache.cassandra.fql.FullQueryLoggerOptionsCompositeData;
-import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.gms.FailureDetectorMBean;
-import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.GossiperMBean;
-import org.apache.cassandra.hints.HintsService;
 import org.apache.cassandra.hints.HintsServiceMBean;
 import org.apache.cassandra.index.sai.metrics.IndexGroupMetrics;
 import org.apache.cassandra.index.sai.metrics.TableQueryMetrics;
@@ -111,59 +86,84 @@ import org.apache.cassandra.index.sai.metrics.TableStateMetrics;
 import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.locator.LocationInfoMBean;
-import org.apache.cassandra.metrics.CIDRAuthorizerMetrics;
+import org.apache.cassandra.management.CommandInvokerService;
+import org.apache.cassandra.management.MBeanAccessor;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.StorageMetrics;
 import org.apache.cassandra.metrics.TableMetrics;
 import org.apache.cassandra.metrics.ThreadPoolMetrics;
-import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.MessagingServiceMBean;
 import org.apache.cassandra.profiler.AsyncProfilerMBean;
 import org.apache.cassandra.service.ActiveRepairServiceMBean;
-import org.apache.cassandra.service.AsyncProfilerService;
-import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.AutoRepairServiceMBean;
-import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.service.CacheServiceMBean;
-import org.apache.cassandra.service.GCInspector;
 import org.apache.cassandra.service.GCInspectorMXBean;
-import org.apache.cassandra.service.StorageProxy;
 import org.apache.cassandra.service.StorageProxyMBean;
 import org.apache.cassandra.service.StorageServiceMBean;
-import org.apache.cassandra.service.accord.AccordOperations;
 import org.apache.cassandra.service.accord.AccordOperationsMBean;
 import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
 import org.apache.cassandra.streaming.StreamManagerMBean;
 import org.apache.cassandra.streaming.StreamState;
 import org.apache.cassandra.streaming.management.StreamStateCompositeData;
-import org.apache.cassandra.tcm.CMSOperations;
 import org.apache.cassandra.tcm.CMSOperationsMBean;
 import org.apache.cassandra.tools.RepairRunner.RepairCmd;
 import org.apache.cassandra.tools.nodetool.GetTimeout;
 import org.apache.cassandra.utils.NativeLibrary;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS;
-import static org.apache.cassandra.config.CassandraRelevantProperties.SSL_ENABLE;
-
 /**
- * JMX client operations for Cassandra.
+ * A client wrapper (or Receiver in the command pattern) for performing administrative
+ * and monitoring operations on a Cassandra node.
+ * <p>
+ * NodeProbe provides a high-level interface to interact with a Cassandra node through JMX.
+ * It abstracts the complexity of JMX connections and MBean lookups, providing convenient methods for common
+ * administrative tasks such as compaction, repair, snapshots, and cluster management.
+ * <p>
+ * This class is primarily used by command-line tools like {@code nodetool} to execute administrative
+ * commands against remote or local Cassandra nodes. It can work with both remote JMX connections (via
+ * {@link RemoteJmxMBeanAccessor}) and local in-process accessors for server-side execution.
+ *
+ * <h3>Execution Modes</h3>
+ * <h4>Client-Side Execution (up to 5.x)</h4>
+ * <p>
+ * When used with {@link RemoteJmxMBeanAccessor}, NodeProbe connects to a remote Cassandra node via JMX:
+ * <pre>{@code
+ * MBeanAccessor accessor = new RemoteJmxMBeanAccessor("localhost", 7199);
+ * try (NodeProbe probe = new NodeProbe(accessor)) {
+ *     probe.forceKeyspaceCleanup(System.out, 1, "mykeyspace");
+ * }
+ * }</pre>
+ *
+ * <h4>Server-Side Execution (CEP-38)</h4>
+ * <p>
+ * As part of <a href="https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-38">CEP-38</a>, NodeProbe can be
+ * used for server-side command execution through the management API. In this mode, NodeProbe operates in-process
+ * using a local {@link MBeanAccessor} that directly accesses the platform MBean server, eliminating the need for
+ * remote JMX connections.
+ *
+ * <p>Server-side execution provides several advantages:
+ * <ul>
+ *   <li><b>No Network Overhead:</b> Direct in-process access to MBeans without JMX/RMI overhead</li>
+ *   <li><b>Better Performance:</b> No serialization/deserialization of JMX calls</li>
+ *   <li><b>Unified API:</b> Same NodeProbe interface works for both client and server-side execution</li>
+ *   <li><b>Management API Integration:</b> Commands can be executed via {@link CommandInvokerService} and exposed
+ *       through various protocols (native protocol, REST, etc.)</li>
+ * </ul>
+ *
+ * <h2>Thread Safety</h2>
+ * <p>NodeProbe instances are not thread-safe. Each thread should use its own instance, or external
+ * synchronization must be provided when sharing instances across threads.
+ *
+ * <h2>Lazy Initialization</h2>
+ * <p>MBean proxies are initialized lazily on first access to reduce overhead for operations that
+ * don't require all MBeans. This is particularly beneficial for testing scenarios where only a
+ * subset of functionality is needed.
+ *
+ * @see MBeanAccessor
+ * @see RemoteJmxMBeanAccessor
+ * @see CommandInvokerService
  */
 public class NodeProbe implements AutoCloseable
 {
-    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
-    private static final String ssObjName = "org.apache.cassandra.db:type=StorageService";
-    public static final int defaultPort = 7199;
-
-    static long JMX_NOTIFICATION_POLL_INTERVAL_SECONDS = NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS.getLong();
-
-    final String host;
-    final int port;
-    private String username;
-    private String password;
-
-
-    protected JMXConnector jmxc;
-    protected MBeanServerConnection mbeanServerConn;
     protected CompactionManagerMBean compactionProxy;
     protected StorageServiceMBean ssProxy;
     protected SnapshotManagerMBean snapshotProxy;
@@ -192,190 +192,67 @@ public class NodeProbe implements AutoCloseable
     protected AutoRepairServiceMBean autoRepairProxy;
     protected AsyncProfilerMBean asyncProfilerProxy;
     protected GuardrailsMBean grProxy;
-    protected volatile Output output;
-
     protected CIDRFilteringMetricsTableMBean cfmProxy;
 
-    /**
-     * Creates a NodeProbe using the specified JMX host, port, username, and password.
-     *
-     * @param host hostname or IP address of the JMX agent
-     * @param port TCP port of the remote JMX agent
-     * @throws IOException on connection failures
-     */
-    public NodeProbe(String host, int port, String username, String password) throws IOException
-    {
-        assert username != null && !username.isEmpty() && password != null && !password.isEmpty()
-               : "neither username nor password can be blank";
+    private final MBeanAccessor mBeanAccessor;
+    protected volatile Output output;
 
-        this.host = host;
-        this.port = port;
-        this.username = username;
-        this.password = password;
-        this.output = Output.CONSOLE;
-        connect();
+    /**
+     * Creates a NodeProbe using the specified MBeanAccessor.
+     * @param mBeanAccessor the provider to use for obtaining MBeans.
+     */
+    public NodeProbe(MBeanAccessor mBeanAccessor)
+    {
+        this(mBeanAccessor, Output.CONSOLE);
     }
 
-    /**
-     * Creates a NodeProbe using the specified JMX host and port.
-     *
-     * @param host hostname or IP address of the JMX agent
-     * @param port TCP port of the remote JMX agent
-     * @throws IOException on connection failures
-     */
-    public NodeProbe(String host, int port) throws IOException
+    public NodeProbe(MBeanAccessor mBeanAccessor, Output output)
     {
-        this.host = host;
-        this.port = port;
-        this.output = Output.CONSOLE;
-        connect();
+        this.mBeanAccessor = mBeanAccessor;
+        this.output = output;
+        lazyInitMBeans();
+    }
+
+    public void close() throws Exception
+    {
+        mBeanAccessor.close();
     }
 
     /**
-     * Creates a NodeProbe using the specified JMX host and default port.
-     *
-     * @param host hostname or IP address of the JMX agent
-     * @throws IOException on connection failures
+     * Initialize all MBeans lazily, so that tests that don't need them
+     * don't pay the cost of creating all the proxies.
      */
-    public NodeProbe(String host) throws IOException
+    private void lazyInitMBeans()
     {
-        this.host = host;
-        this.port = defaultPort;
-        this.output = Output.CONSOLE;
-        connect();
-    }
-
-    protected NodeProbe()
-    {
-        // this constructor is only used for extensions to rewrite their own connect method
-        this.host = "";
-        this.port = 0;
-        this.output = Output.CONSOLE;
-    }
-
-    /**
-     * Create a connection to the JMX agent and setup the M[X]Bean proxies.
-     *
-     * @throws IOException on connection failures
-     */
-    protected void connect() throws IOException
-    {
-        String host = this.host;
-        if (host.contains(":"))
-        {
-            // Use square brackets to surround IPv6 addresses to fix CASSANDRA-7669 and CASSANDRA-17581
-            host = "[" + host + "]";
-        }
-        JMXServiceURL jmxUrl = new JMXServiceURL(String.format(fmtUrl, host, port));
-        Map<String, Object> env = new HashMap<String, Object>();
-        if (username != null)
-        {
-            String[] creds = { username, password };
-            env.put(JMXConnector.CREDENTIALS, creds);
-        }
-
-        env.put("com.sun.jndi.rmi.factory.socket", getRMIClientSocketFactory());
-
-        jmxc = JMXConnectorFactory.connect(jmxUrl, env);
-        mbeanServerConn = jmxc.getMBeanServerConnection();
-
-        try
-        {
-            ObjectName name = new ObjectName(ssObjName);
-            ssProxy = JMX.newMBeanProxy(mbeanServerConn, name, StorageServiceMBean.class);
-            name = new ObjectName(SnapshotManagerMBean.MBEAN_NAME);
-            snapshotProxy = JMX.newMBeanProxy(mbeanServerConn, name, SnapshotManagerMBean.class);
-            name = new ObjectName(CMSOperations.MBEAN_OBJECT_NAME);
-            cmsProxy = JMX.newMBeanProxy(mbeanServerConn, name, CMSOperationsMBean.class);
-            name = new ObjectName(AccordOperations.MBEAN_OBJECT_NAME);
-            accordProxy = JMX.newMBeanProxy(mbeanServerConn, name, AccordOperationsMBean.class);
-            name = new ObjectName(MessagingService.MBEAN_NAME);
-            msProxy = JMX.newMBeanProxy(mbeanServerConn, name, MessagingServiceMBean.class);
-            name = new ObjectName(StreamManagerMBean.OBJECT_NAME);
-            streamProxy = JMX.newMBeanProxy(mbeanServerConn, name, StreamManagerMBean.class);
-            name = new ObjectName(CompactionManager.MBEAN_OBJECT_NAME);
-            compactionProxy = JMX.newMBeanProxy(mbeanServerConn, name, CompactionManagerMBean.class);
-            name = new ObjectName(FailureDetector.MBEAN_NAME);
-            fdProxy = JMX.newMBeanProxy(mbeanServerConn, name, FailureDetectorMBean.class);
-            name = new ObjectName(CacheService.MBEAN_NAME);
-            cacheService = JMX.newMBeanProxy(mbeanServerConn, name, CacheServiceMBean.class);
-            name = new ObjectName(StorageProxy.MBEAN_NAME);
-            spProxy = JMX.newMBeanProxy(mbeanServerConn, name, StorageProxyMBean.class);
-            name = new ObjectName(HintsService.MBEAN_NAME);
-            hsProxy = JMX.newMBeanProxy(mbeanServerConn, name, HintsServiceMBean.class);
-            name = new ObjectName(GCInspector.MBEAN_NAME);
-            gcProxy = JMX.newMBeanProxy(mbeanServerConn, name, GCInspectorMXBean.class);
-            name = new ObjectName(Gossiper.MBEAN_NAME);
-            gossProxy = JMX.newMBeanProxy(mbeanServerConn, name, GossiperMBean.class);
-            name = new ObjectName(BatchlogManager.MBEAN_NAME);
-            bmProxy = JMX.newMBeanProxy(mbeanServerConn, name, BatchlogManagerMBean.class);
-            name = new ObjectName(ActiveRepairServiceMBean.MBEAN_NAME);
-            arsProxy = JMX.newMBeanProxy(mbeanServerConn, name, ActiveRepairServiceMBean.class);
-            name = new ObjectName(AuditLogManager.MBEAN_NAME);
-            almProxy = JMX.newMBeanProxy(mbeanServerConn, name, AuditLogManagerMBean.class);
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + PasswordAuthenticator.CredentialsCacheMBean.CACHE_NAME);
-            ccProxy = JMX.newMBeanProxy(mbeanServerConn, name, PasswordAuthenticator.CredentialsCacheMBean.class);
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + AuthorizationProxy.JmxPermissionsCacheMBean.CACHE_NAME);
-            jpcProxy = JMX.newMBeanProxy(mbeanServerConn, name, AuthorizationProxy.JmxPermissionsCacheMBean.class);
-
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + NetworkPermissionsCache.CACHE_NAME);
-            npcProxy = JMX.newMBeanProxy(mbeanServerConn, name, NetworkPermissionsCacheMBean.class);
-
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + PermissionsCache.CACHE_NAME);
-            pcProxy = JMX.newMBeanProxy(mbeanServerConn, name, PermissionsCacheMBean.class);
-
-            name = new ObjectName(AuthCache.MBEAN_NAME_BASE + RolesCache.CACHE_NAME);
-            rcProxy = JMX.newMBeanProxy(mbeanServerConn, name, RolesCacheMBean.class);
-
-            name = new ObjectName(CIDRPermissionsManager.MBEAN_NAME);
-            cpbProxy = JMX.newMBeanProxy(mbeanServerConn, name, CIDRPermissionsManagerMBean.class);
-
-            name = new ObjectName(CIDRGroupsMappingManager.MBEAN_NAME);
-            cmbProxy = JMX.newMBeanProxy(mbeanServerConn, name, CIDRGroupsMappingManagerMBean.class);
-
-            name = new ObjectName(CIDRFilteringMetricsTable.MBEAN_NAME);
-            cfmProxy = JMX.newMBeanProxy(mbeanServerConn, name, CIDRFilteringMetricsTableMBean.class);
-
-            name = new ObjectName(AutoRepairService.MBEAN_NAME);
-            autoRepairProxy = JMX.newMBeanProxy(mbeanServerConn, name, AutoRepairServiceMBean.class);
-
-            name = new ObjectName(AsyncProfilerService.MBEAN_NAME);
-            asyncProfilerProxy = JMX.newMBeanProxy(mbeanServerConn, name, AsyncProfilerMBean.class);
-
-            name = new ObjectName(Guardrails.MBEAN_NAME);
-            grProxy = JMX.newMBeanProxy(mbeanServerConn, name, GuardrailsMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(
-                    "Invalid ObjectName? Please report this as a bug.", e);
-        }
-
-        memProxy = ManagementFactory.newPlatformMXBeanProxy(mbeanServerConn,
-                ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
-        runtimeProxy = ManagementFactory.newPlatformMXBeanProxy(
-                mbeanServerConn, ManagementFactory.RUNTIME_MXBEAN_NAME, RuntimeMXBean.class);
-    }
-
-    private RMIClientSocketFactory getRMIClientSocketFactory()
-    {
-        if (SSL_ENABLE.getBoolean())
-            return new SslRMIClientSocketFactory();
-        else
-            return RMISocketFactory.getDefaultSocketFactory();
-    }
-
-    public void close() throws IOException
-    {
-        try
-        {
-            jmxc.close();
-        }
-        catch (ConnectException e)
-        {
-            // result of 'stopdaemon' command - i.e. if close() call fails, the daemon is shutdown
-            System.out.println("Cassandra has shutdown.");
-        }
+        ssProxy = LazyMBeanProxy.create(mBeanAccessor, StorageServiceMBean.class);
+        compactionProxy = LazyMBeanProxy.create(mBeanAccessor, CompactionManagerMBean.class);
+        snapshotProxy = LazyMBeanProxy.create(mBeanAccessor, SnapshotManagerMBean.class);
+        cmsProxy = LazyMBeanProxy.create(mBeanAccessor, CMSOperationsMBean.class);
+        accordProxy = LazyMBeanProxy.create(mBeanAccessor, AccordOperationsMBean.class);
+        gossProxy = LazyMBeanProxy.create(mBeanAccessor, GossiperMBean.class);
+        memProxy = LazyMBeanProxy.create(mBeanAccessor, MemoryMXBean.class);
+        gcProxy = LazyMBeanProxy.create(mBeanAccessor, GCInspectorMXBean.class);
+        runtimeProxy = LazyMBeanProxy.create(mBeanAccessor, RuntimeMXBean.class);
+        streamProxy = LazyMBeanProxy.create(mBeanAccessor, StreamManagerMBean.class);
+        msProxy = LazyMBeanProxy.create(mBeanAccessor, MessagingServiceMBean.class);
+        fdProxy = LazyMBeanProxy.create(mBeanAccessor, FailureDetectorMBean.class);
+        cacheService = LazyMBeanProxy.create(mBeanAccessor, CacheServiceMBean.class);
+        spProxy = LazyMBeanProxy.create(mBeanAccessor, StorageProxyMBean.class);
+        hsProxy = LazyMBeanProxy.create(mBeanAccessor, HintsServiceMBean.class);
+        bmProxy = LazyMBeanProxy.create(mBeanAccessor, BatchlogManagerMBean.class);
+        arsProxy = LazyMBeanProxy.create(mBeanAccessor, ActiveRepairServiceMBean.class);
+        almProxy = LazyMBeanProxy.create(mBeanAccessor, AuditLogManagerMBean.class);
+        ccProxy = LazyMBeanProxy.create(mBeanAccessor, PasswordAuthenticator.CredentialsCacheMBean.class);
+        jpcProxy = LazyMBeanProxy.create(mBeanAccessor, AuthorizationProxy.JmxPermissionsCacheMBean.class);
+        npcProxy = LazyMBeanProxy.create(mBeanAccessor, NetworkPermissionsCacheMBean.class);
+        cpbProxy = LazyMBeanProxy.create(mBeanAccessor, CIDRPermissionsManagerMBean.class);
+        cmbProxy = LazyMBeanProxy.create(mBeanAccessor, CIDRGroupsMappingManagerMBean.class);
+        pcProxy = LazyMBeanProxy.create(mBeanAccessor, PermissionsCacheMBean.class);
+        rcProxy = LazyMBeanProxy.create(mBeanAccessor, RolesCacheMBean.class);
+        autoRepairProxy = LazyMBeanProxy.create(mBeanAccessor, AutoRepairServiceMBean.class);
+        grProxy = LazyMBeanProxy.create(mBeanAccessor, GuardrailsMBean.class);
+        cfmProxy = LazyMBeanProxy.create(mBeanAccessor, CIDRFilteringMetricsTableMBean.class);
+        asyncProfilerProxy = LazyMBeanProxy.create(mBeanAccessor, AsyncProfilerMBean.class);
     }
 
     public void setOutput(Output output)
@@ -561,7 +438,7 @@ public class NodeProbe implements AutoCloseable
     {
         List<RepairRunner> runners = new ArrayList<>(cmds.size());
         for (RepairCmd cmd : cmds)
-            runners.add(new RepairRunner(out, jmxc, ssProxy, cmd));
+            runners.add(new RepairRunner(out, mBeanAccessor, ssProxy, cmd));
 
         try
         {
@@ -811,23 +688,14 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.effectiveOwnershipWithPort(keyspace);
     }
 
-    public MBeanServerConnection getMbeanServerConn()
+    public MBeanAccessor getMBeanAccessor()
     {
-        return mbeanServerConn;
+        return mBeanAccessor;
     }
 
     public CacheServiceMBean getCacheServiceMBean()
     {
-        String cachePath = "org.apache.cassandra.db:type=Caches";
-
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName(cachePath), CacheServiceMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(CacheServiceMBean.class);
     }
 
     public double[] getAndResetGCStats()
@@ -839,7 +707,7 @@ public class NodeProbe implements AutoCloseable
     {
         try
         {
-            return new ColumnFamilyStoreMBeanIterator(mbeanServerConn);
+            return new ColumnFamilyStoreMBeanIterator(mBeanAccessor);
         }
         catch (MalformedObjectNameException e)
         {
@@ -1253,38 +1121,17 @@ public class NodeProbe implements AutoCloseable
 
     public EndpointSnitchInfoMBean getEndpointSnitchInfoProxy()
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName("org.apache.cassandra.db:type=EndpointSnitchInfo"), EndpointSnitchInfoMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(EndpointSnitchInfoMBean.class);
     }
 
     public DynamicEndpointSnitchMBean getDynamicEndpointSnitchInfoProxy()
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName("org.apache.cassandra.db:type=DynamicEndpointSnitch"), DynamicEndpointSnitchMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(DynamicEndpointSnitchMBean.class);
     }
 
     public LocationInfoMBean getLocationInfoProxy()
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName("org.apache.cassandra.db:type=LocationInfo"), LocationInfoMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBean(LocationInfoMBean.class);
     }
 
     public ColumnFamilyStoreMBean getCfsProxy(String ks, String cf)
@@ -1293,24 +1140,11 @@ public class NodeProbe implements AutoCloseable
         try
         {
             String type = cf.contains(".") ? "IndexColumnFamilies" : "ColumnFamilies";
-            Set<ObjectName> beans = mbeanServerConn.queryNames(
-                    new ObjectName("org.apache.cassandra.db:type=*" + type +",keyspace=" + ks + ",columnfamily=" + cf), null);
-
-            if (beans.isEmpty())
-                throw new MalformedObjectNameException("couldn't find that bean");
-            assert beans.size() == 1;
-            for (ObjectName bean : beans)
-                cfsProxy = JMX.newMBeanProxy(mbeanServerConn, bean, ColumnFamilyStoreMBean.class);
+            return mBeanAccessor.findColumnFamily(type, ks, cf);
         }
-        catch (MalformedObjectNameException mone)
-        {
-            System.err.println("ColumnFamilyStore for " + ks + "/" + cf + " not found.");
-            System.exit(1);
-        }
-        catch (IOException e)
+        catch (Exception e)
         {
             System.err.println("ColumnFamilyStore for " + ks + "/" + cf + " not found: " + e);
-            System.exit(1);
         }
 
         return cfsProxy;
@@ -1855,39 +1689,23 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getCacheMetric(String cacheType, String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch(metricName)
-            {
-                case "Capacity":
-                case "Entries":
-                case "HitRate":
-                case "Size":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=" + metricName),
-                            CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "Requests":
-                case "Hits":
-                case "Misses":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=" + metricName),
-                            CassandraMetricsRegistry.JmxMeterMBean.class).getCount();
-                case "MissLatency":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=" + metricName),
-                            CassandraMetricsRegistry.JmxTimerMBean.class).getMean();
-                case "MissLatencyUnit":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=" + cacheType + ",name=MissLatency"),
-                            CassandraMetricsRegistry.JmxTimerMBean.class).getDurationUnit();
-                default:
-                    throw new RuntimeException("Unknown Cache metric name " + metricName);
-
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "Capacity":
+            case "Entries":
+            case "HitRate":
+            case "Size":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.scoped("Cache", cacheType, metricName)).getValue();
+            case "Requests":
+            case "Hits":
+            case "Misses":
+                return mBeanAccessor.findMBeanMeter(MBeanAccessor.Props.scoped("Cache", cacheType, metricName)).getCount();
+            case "MissLatency":
+                return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.scoped("Cache", cacheType, metricName)).getMean();
+            case "MissLatencyUnit":
+                return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.scoped("Cache", cacheType, "MissLatency")).getDurationUnit();
+            default:
+                throw new RuntimeException("Unknown Cache metric name " + metricName);
         }
     }
 
@@ -1899,137 +1717,69 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getBufferPoolMetric(String poolType, String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch (metricName)
-            {
-                case "UsedSize":
-                case "OverflowSize":
-                case "Capacity":
-                case "Size":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                           new ObjectName("org.apache.cassandra.metrics:type=BufferPool,scope=" + poolType + ",name=" + metricName),
-                           CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "Hits":
-                case "Misses":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                    new ObjectName("org.apache.cassandra.metrics:type=BufferPool,scope=" + poolType + ",name=" + metricName),
-                    CassandraMetricsRegistry.JmxMeterMBean.class).getCount();
-                default:
-                    throw new RuntimeException("Unknown BufferPool metric name " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static Multimap<String, String> getJmxThreadPools(MBeanServerConnection mbeanServerConn)
-    {
-        try
-        {
-            Multimap<String, String> threadPools = HashMultimap.create();
-
-            Set<ObjectName> threadPoolObjectNames = mbeanServerConn.queryNames(
-                    new ObjectName("org.apache.cassandra.metrics:type=ThreadPools,*"),
-                    null);
-
-            for (ObjectName oName : threadPoolObjectNames)
-            {
-                threadPools.put(oName.getKeyProperty("path"), oName.getKeyProperty("scope"));
-            }
-
-            return threadPools;
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException("Bad query to JMX server: ", e);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error getting threadpool names from JMX", e);
+            case "UsedSize":
+            case "OverflowSize":
+            case "Capacity":
+            case "Size":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.scoped("BufferPool", poolType, metricName)).getValue();
+            case "Hits":
+            case "Misses":
+                return mBeanAccessor.findMBeanMeter(MBeanAccessor.Props.scoped("BufferPool", poolType, metricName)).getCount();
+            default:
+                throw new RuntimeException("Unknown BufferPool metric name " + metricName);
         }
     }
 
     public Object getThreadPoolMetric(String pathName, String poolName, String metricName)
     {
-      String name = String.format("org.apache.cassandra.metrics:type=ThreadPools,path=%s,scope=%s,name=%s",
-              pathName, poolName, metricName);
+        if (!mBeanAccessor.isMBeanMetricRegistered(MBeanAccessor.Props.threadPool("ThreadPools", pathName, poolName, metricName)))
+        {
+            return "N/A";
+        }
 
-      try
-      {
-          ObjectName oName = new ObjectName(name);
-          if (!mbeanServerConn.isRegistered(oName))
-          {
-              return "N/A";
-          }
-
-          switch (metricName)
-          {
-              case ThreadPoolMetrics.ACTIVE_TASKS:
-              case ThreadPoolMetrics.PENDING_TASKS:
-              case ThreadPoolMetrics.COMPLETED_TASKS:
-              case ThreadPoolMetrics.CORE_POOL_SIZE:
-              case ThreadPoolMetrics.MAX_POOL_SIZE:
-              case ThreadPoolMetrics.MAX_TASKS_QUEUED:
-                  return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-              case ThreadPoolMetrics.TOTAL_BLOCKED_TASKS:
-              case ThreadPoolMetrics.CURRENTLY_BLOCKED_TASKS:
-                  return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-              default:
-                  throw new AssertionError("Unknown ThreadPools metric name " + metricName);
-          }
-      }
-      catch (Exception e)
-      {
-          throw new RuntimeException("Error reading: " + name, e);
-      }
+        switch (metricName)
+        {
+            case ThreadPoolMetrics.ACTIVE_TASKS:
+            case ThreadPoolMetrics.PENDING_TASKS:
+            case ThreadPoolMetrics.COMPLETED_TASKS:
+            case ThreadPoolMetrics.CORE_POOL_SIZE:
+            case ThreadPoolMetrics.MAX_POOL_SIZE:
+            case ThreadPoolMetrics.MAX_TASKS_QUEUED:
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.threadPool("ThreadPools", pathName, poolName, metricName)).getValue();
+            case ThreadPoolMetrics.TOTAL_BLOCKED_TASKS:
+            case ThreadPoolMetrics.CURRENTLY_BLOCKED_TASKS:
+                return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.threadPool("ThreadPools", pathName, poolName, metricName)).getCount();
+            default:
+                throw new RuntimeException("Unknown ThreadPools metric name " + metricName);
+        }
     }
 
     public Object getSaiMetric(String ks, String cf, String metricName)
     {
-        try
-        {
-            String scope = getSaiMetricScope(metricName);
-            String objectNameStr = String.format("org.apache.cassandra.metrics:type=StorageAttachedIndex,keyspace=%s,table=%s,scope=%s,name=%s",ks, cf, scope, metricName);
-            ObjectName oName = new ObjectName(objectNameStr);
+        String scope = getSaiMetricScope(metricName);
+        MBeanAccessor.Props props = MBeanAccessor.Props.sai("StorageAttachedIndex", ks, cf, scope, metricName);
+        if (!mBeanAccessor.isMBeanMetricRegistered(props))
+            return null;
 
-            Set<ObjectName> matchingMBeans = mbeanServerConn.queryNames(oName, null);
-            if (matchingMBeans.isEmpty())
-                return null;
-
-            return getSaiMetricValue(metricName, oName);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException("Invalid ObjectName format: " + e.getMessage(), e);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Error accessing MBean server: " + e.getMessage(), e);
-        }
-    }
-
-    private Object getSaiMetricValue(String metricName, ObjectName oName) throws IOException
-    {
         switch (metricName)
         {
             case "QueryLatency":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxTimerMBean.class);
+                return mBeanAccessor.findMBeanTimer(props);
             case "PostFilteringReadLatency":
             case "SSTableIndexesHit":
             case "IndexSegmentsHit":
             case "RowsFiltered":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);
+                return mBeanAccessor.findMBeanHistogram(props);
             case "DiskUsedBytes":
             case "TotalIndexCount":
             case "TotalQueryableIndexCount":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
+                return mBeanAccessor.findMBeanGauge(props).getValue();
             case "TotalQueryTimeouts":
-                return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
+                return mBeanAccessor.findMBeanCounter(props).getCount();
             default:
-                throw new IllegalArgumentException("Unknown metric name: " + metricName);
+                throw new RuntimeException("Unknown metric name: " + metricName);
         }
     }
 
@@ -2051,7 +1801,7 @@ public class NodeProbe implements AutoCloseable
             case "TotalQueryableIndexCount":
                 return TableStateMetrics.TABLE_STATE_METRIC_TYPE;
             default:
-                throw new IllegalArgumentException("Unknown metric name: " + metricName);
+                throw new RuntimeException("Unknown metric name: " + metricName);
         }
     }
 
@@ -2059,10 +1809,13 @@ public class NodeProbe implements AutoCloseable
      * Retrieve threadpool paths and names for threadpools with metrics.
      * @return Multimap from path (internal, request, etc.) to name
      */
-    public Multimap<String, String> getThreadPools()
-    {
-        return getJmxThreadPools(mbeanServerConn);
-    }
+        public Multimap<String, String> getThreadPools()
+        {
+            Multimap<String, String> threadPools = HashMultimap.create();
+            for (MBeanAccessor.ThreadPoolInfo info : mBeanAccessor.threadPoolInfos())
+                threadPools.put(info.path(), info.poolName());
+            return threadPools;
+        }
 
     public int getNumberOfTables()
     {
@@ -2077,92 +1830,85 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getColumnFamilyMetric(String ks, String cf, String metricName)
     {
-        try
+        MBeanAccessor.Props props;
+        if (!Strings.isNullOrEmpty(ks) && !Strings.isNullOrEmpty(cf))
         {
-            ObjectName oName = null;
-            if (!Strings.isNullOrEmpty(ks) && !Strings.isNullOrEmpty(cf))
-            {
-                String type = cf.contains(".") ? "IndexTable" : "Table";
-                oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=%s,keyspace=%s,scope=%s,name=%s", type, ks, cf, metricName));
-            }
-            else if (!Strings.isNullOrEmpty(ks))
-            {
-                oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=Keyspace,keyspace=%s,name=%s", ks, metricName));
-            }
-            else
-            {
-                oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=Table,name=%s", metricName));
-            }
-            switch(metricName)
-            {
-                case "BloomFilterDiskSpaceUsed":
-                case "BloomFilterFalsePositives":
-                case "BloomFilterFalseRatio":
-                case "BloomFilterOffHeapMemoryUsed":
-                case "IndexSummaryOffHeapMemoryUsed":
-                case "CompressionDictionariesMemoryUsed":
-                case "CompressionMetadataOffHeapMemoryUsed":
-                case "CompressionRatio":
-                case "EstimatedColumnCountHistogram":
-                case "EstimatedPartitionSizeHistogram":
-                case "EstimatedPartitionCount":
-                case "KeyCacheHitRate":
-                case "LiveSSTableCount":
-                case "MaxSSTableDuration":
-                case "MaxSSTableSize":
-                case "OldVersionSSTableCount":
-                case "MaxPartitionSize":
-                case "MeanPartitionSize":
-                case "MemtableColumnsCount":
-                case "MemtableLiveDataSize":
-                case "MemtableOffHeapSize":
-                case "MinPartitionSize":
-                case "PercentRepaired":
-                case "BytesRepaired":
-                case "BytesUnrepaired":
-                case "BytesPendingRepair":
-                case "RecentBloomFilterFalsePositives":
-                case "RecentBloomFilterFalseRatio":
-                case "SnapshotsSize":
-                    return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "LiveDiskSpaceUsed":
-                case "MemtableSwitchCount":
-                case "SpeculativeRetries":
-                case "TotalDiskSpaceUsed":
-                case "WriteTotalLatency":
-                case "ReadTotalLatency":
-                case "PendingFlushes":
-                {
-                    // these are gauges for keyspace metrics, not counters
-                    if (!Strings.isNullOrEmpty(ks) &&
-                        Strings.isNullOrEmpty(cf) &&
-                        (metricName.equals("TotalDiskSpaceUsed") ||
-                         metricName.equals("LiveDiskSpaceUsed") ||
-                         metricName.equals("MemtableSwitchCount")))
-                    {
-                        return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                    }
-                    else
-                    {
-                        return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-                    }
-                }
-                case "CoordinatorReadLatency":
-                case "CoordinatorScanLatency":
-                case "ReadLatency":
-                case "WriteLatency":
-                    return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxTimerMBean.class);
-                case "LiveScannedHistogram":
-                case "SSTablesPerReadHistogram":
-                case "TombstoneScannedHistogram":
-                    return JMX.newMBeanProxy(mbeanServerConn, oName, CassandraMetricsRegistry.JmxHistogramMBean.class);
-                default:
-                    throw new RuntimeException("Unknown table metric " + metricName);
-            }
+            String type = cf.contains(".") ? "IndexTable" : "Table";
+            props = MBeanAccessor.Props.columnFamily(type, ks, cf, metricName);
         }
-        catch (MalformedObjectNameException e)
+        else if (!Strings.isNullOrEmpty(ks))
         {
-            throw new RuntimeException(e);
+            props = MBeanAccessor.Props.keyspace("Keyspace", ks, metricName);
+        }
+        else
+        {
+            props = MBeanAccessor.Props.metric("Table", metricName);
+        }
+        switch (metricName)
+        {
+            case "BloomFilterDiskSpaceUsed":
+            case "BloomFilterFalsePositives":
+            case "BloomFilterFalseRatio":
+            case "BloomFilterOffHeapMemoryUsed":
+            case "IndexSummaryOffHeapMemoryUsed":
+            case "CompressionDictionariesMemoryUsed":
+            case "CompressionMetadataOffHeapMemoryUsed":
+            case "CompressionRatio":
+            case "EstimatedColumnCountHistogram":
+            case "EstimatedPartitionSizeHistogram":
+            case "EstimatedPartitionCount":
+            case "KeyCacheHitRate":
+            case "LiveSSTableCount":
+            case "MaxSSTableDuration":
+            case "MaxSSTableSize":
+            case "OldVersionSSTableCount":
+            case "MaxPartitionSize":
+            case "MeanPartitionSize":
+            case "MemtableColumnsCount":
+            case "MemtableLiveDataSize":
+            case "MemtableOffHeapSize":
+            case "MinPartitionSize":
+            case "PercentRepaired":
+            case "BytesRepaired":
+            case "BytesUnrepaired":
+            case "BytesPendingRepair":
+            case "RecentBloomFilterFalsePositives":
+            case "RecentBloomFilterFalseRatio":
+            case "SnapshotsSize":
+                return mBeanAccessor.findMBeanGauge(props).getValue();
+            case "LiveDiskSpaceUsed":
+            case "MemtableSwitchCount":
+            case "SpeculativeRetries":
+            case "TotalDiskSpaceUsed":
+            case "WriteTotalLatency":
+            case "ReadTotalLatency":
+            case "PendingFlushes":
+            {
+                // these are gauges for keyspace metrics, not counters
+                if (!Strings.isNullOrEmpty(ks) &&
+                    Strings.isNullOrEmpty(cf) &&
+                    (metricName.equals("TotalDiskSpaceUsed") ||
+                     metricName.equals("LiveDiskSpaceUsed") ||
+                     metricName.equals("MemtableSwitchCount")))
+                {
+                    return mBeanAccessor.findMBeanGauge(props).getValue();
+                }
+                else
+                {
+                    return mBeanAccessor.findMBeanCounter(props).getCount();
+                }
+            }
+            case "CoordinatorReadLatency":
+            case "CoordinatorScanLatency":
+            case "ReadLatency":
+            case "WriteLatency":
+                return mBeanAccessor.findMBeanTimer(props);
+            case "LiveScannedHistogram":
+            case "SSTablesPerReadHistogram":
+            case "TombstoneScannedHistogram":
+                return mBeanAccessor.findMBeanHistogram(props);
+            default:
+                throw new RuntimeException("Unknown table metric " + metricName);
         }
     }
 
@@ -2172,30 +1918,12 @@ public class NodeProbe implements AutoCloseable
      */
     public CassandraMetricsRegistry.JmxTimerMBean getProxyMetric(String scope)
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn,
-                    new ObjectName("org.apache.cassandra.metrics:type=ClientRequest,scope=" + scope + ",name=Latency"),
-                    CassandraMetricsRegistry.JmxTimerMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.scoped("ClientRequest", scope, "Latency"));
     }
 
     public CassandraMetricsRegistry.JmxTimerMBean getMessagingQueueWaitMetrics(String verb)
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn,
-                                     new ObjectName("org.apache.cassandra.metrics:name=" + verb + "-WaitLatency,type=Messaging"),
-                                     CassandraMetricsRegistry.JmxTimerMBean.class);
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBeanTimer(MBeanAccessor.Props.metric("Messaging", verb + "-WaitLatency"));
     }
 
     /**
@@ -2206,34 +1934,21 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getCompactionMetric(String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch(metricName)
-            {
-                case "BytesCompacted":
-                case "CompactionsAborted":
-                case "CompactionsReduced":
-                case "SSTablesDroppedFromCompaction":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Compaction,name=" + metricName),
-                            CassandraMetricsRegistry.JmxCounterMBean.class);
-                case "CompletedTasks":
-                case "PendingTasks":
-                case "PendingTasksByTableName":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Compaction,name=" + metricName),
-                            CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                case "TotalCompactionsCompleted":
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Compaction,name=" + metricName),
-                            CassandraMetricsRegistry.JmxMeterMBean.class);
-                default:
-                    throw new RuntimeException("Unknown compaction metric " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "BytesCompacted":
+            case "CompactionsAborted":
+            case "CompactionsReduced":
+            case "SSTablesDroppedFromCompaction":
+                return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.metric("Compaction", metricName));
+            case "CompletedTasks":
+            case "PendingTasks":
+            case "PendingTasksByTableName":
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.metric("Compaction", metricName)).getValue();
+            case "TotalCompactionsCompleted":
+                return mBeanAccessor.findMBeanMeter(MBeanAccessor.Props.metric("Compaction", metricName));
+            default:
+                throw new RuntimeException("Unknown compaction metric " + metricName);
         }
     }
 
@@ -2243,65 +1958,15 @@ public class NodeProbe implements AutoCloseable
      */
     public Object getClientMetric(String metricName)
     {
-        try
+        switch (metricName)
         {
-            switch(metricName)
-            {
-                case "connections": // List<Map<String,String>> - list of all native connections and their properties
-                case "connectedNativeClients": // number of connected native clients
-                case "connectedNativeClientsByUser": // number of native clients by username
-                case "clientsByProtocolVersion": // number of native clients by protocol version
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=Client,name=" + metricName),
-                            CassandraMetricsRegistry.JmxGaugeMBean.class).getValue();
-                default:
-                    throw new RuntimeException("Unknown client metric " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Object getCidrFilteringMetric(String metricName)
-    {
-        try
-        {
-            switch(metricName)
-            {
-                case CIDRAuthorizerMetrics.CIDR_CHECKS_LATENCY:
-                    return JMX.newMBeanProxy(mbeanServerConn,
-                                             new ObjectName("org.apache.cassandra.metrics:type=CIDRAuthorization,name="
-                                                            + metricName),
-                                             CassandraMetricsRegistry.JmxTimerMBean.class).getMean();
-                case CIDRAuthorizerMetrics.CIDR_GROUPS_CACHE_RELOAD_COUNT:
-                    return JMX.newMBeanProxy(
-                        mbeanServerConn,
-                        new ObjectName("org.apache.cassandra.metrics:type=CIDRGroupsMappingCache,name=" + metricName),
-                        CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-                case CIDRAuthorizerMetrics.CIDR_GROUPS_CACHE_RELOAD_LATENCY:
-                case CIDRAuthorizerMetrics.LOOKUP_CIDR_GROUPS_FOR_IP_LATENCY:
-                    return JMX.newMBeanProxy(
-                        mbeanServerConn,
-                        new ObjectName("org.apache.cassandra.metrics:type=CIDRGroupsMappingCache,name=" + metricName),
-                        CassandraMetricsRegistry.JmxTimerMBean.class).getMean();
-                default:
-                    if (metricName.contains(CIDRAuthorizerMetrics.CIDR_ACCESSES_REJECTED_COUNT_PREFIX) ||
-                        metricName.contains(CIDRAuthorizerMetrics.CIDR_ACCESSES_ACCEPTED_COUNT_PREFIX))
-                    {
-                        return JMX.newMBeanProxy(
-                            mbeanServerConn,
-                            new ObjectName("org.apache.cassandra.metrics:type=mymetricname,name=" + metricName),
-                            CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-                    }
-
-                    throw new RuntimeException("Unknown metric " + metricName);
-            }
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
+            case "connections": // List<Map<String,String>> - list of all native connections and their properties
+            case "connectedNativeClients": // number of connected native clients
+            case "connectedNativeClientsByUser": // number of native clients by username
+            case "clientsByProtocolVersion": // number of native clients by protocol version
+                return mBeanAccessor.findMBeanGauge(MBeanAccessor.Props.metric("Client", metricName)).getValue();
+            default:
+                throw new RuntimeException("Unknown client metric " + metricName);
         }
     }
 
@@ -2321,16 +1986,7 @@ public class NodeProbe implements AutoCloseable
      */
     public long getStorageMetric(String metricName)
     {
-        try
-        {
-            return JMX.newMBeanProxy(mbeanServerConn,
-                    new ObjectName("org.apache.cassandra.metrics:type=Storage,name=" + metricName),
-                    CassandraMetricsRegistry.JmxCounterMBean.class).getCount();
-        }
-        catch (MalformedObjectNameException e)
-        {
-            throw new RuntimeException(e);
-        }
+        return mBeanAccessor.findMBeanCounter(MBeanAccessor.Props.metric("Storage", metricName)).getCount();
     }
 
     public Double[] metricPercentilesAsArray(CassandraMetricsRegistry.JmxHistogramMBean metric)
@@ -2392,8 +2048,8 @@ public class NodeProbe implements AutoCloseable
         BootstrapMonitor monitor = new BootstrapMonitor(out);
         try
         {
-            if (jmxc != null)
-                jmxc.addConnectionNotificationListener(monitor, null, null);
+            if (mBeanAccessor instanceof RemoteJmxMBeanAccessor)
+                ((RemoteJmxMBeanAccessor) mBeanAccessor).getJmxConnector().addConnectionNotificationListener(monitor, null, null);
             ssProxy.addNotificationListener(monitor, null, null);
             if (ssProxy.resumeBootstrap())
             {
@@ -2416,8 +2072,8 @@ public class NodeProbe implements AutoCloseable
             try
             {
                 ssProxy.removeNotificationListener(monitor);
-                if (jmxc != null)
-                    jmxc.removeConnectionNotificationListener(monitor);
+                if (mBeanAccessor instanceof RemoteJmxMBeanAccessor)
+                    ((RemoteJmxMBeanAccessor) mBeanAccessor).getJmxConnector().removeConnectionNotificationListener(monitor);
             }
             catch (Throwable e)
             {
@@ -2795,11 +2451,11 @@ public class NodeProbe implements AutoCloseable
             {
                 String message = String.format("Table %s.%s does not exist or does not support dictionary compression",
                                                keyspace, table);
-                throw new IllegalArgumentException(message);
+                throw new RuntimeException(message);
             }
             else
             {
-                throw new IOException(e.getMessage());
+                throw e;
             }
         }
     }
@@ -2835,78 +2491,97 @@ public class NodeProbe implements AutoCloseable
 
     private CompressionDictionaryManagerMBean getDictionaryManagerProxy(String keyspace, String table) throws IOException
     {
-        // Construct table-specific MBean name
-        String mbeanName = CompressionDictionaryManagerMBean.MBEAN_NAME + ",keyspace=" + keyspace + ",table=" + table;
-        try
+        return mBeanAccessor.findCompressionDictionary(keyspace, table);
+    }
+
+    /**
+     * A dynamic proxy that lazily looks up the MBean the first time a method is invoked.
+     * @param <T> the MBean interface type.
+     */
+    private static class LazyMBeanProxy<T> implements java.lang.reflect.InvocationHandler
+    {
+        private final MBeanAccessor provider;
+        private final Class<T> mbeanClass;
+        private volatile T delegate;
+
+        LazyMBeanProxy(MBeanAccessor provider, Class<T> mbeanClass)
         {
-            ObjectName objectName = new ObjectName(mbeanName);
-            return JMX.newMBeanProxy(mbeanServerConn, objectName, CompressionDictionaryManagerMBean.class);
+            this.provider = provider;
+            this.mbeanClass = mbeanClass;
         }
-        catch (MalformedObjectNameException e)
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
         {
-            throw new IOException("Invalid keyspace or table name", e);
+            if (delegate == null)
+            {
+                synchronized (this)
+                {
+                    if (delegate == null)
+                        delegate = provider.findMBean(mbeanClass);
+                }
+            }
+
+            try
+            {
+                return method.invoke(delegate, args);
+            }
+            catch (InvocationTargetException e)
+            {
+                Throwable cause = e.getCause();
+                if (cause == null)
+                    throw e;
+                throw cause;
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        static <T> T create(MBeanAccessor provider, Class<T> mbeanClass)
+        {
+            return (T) Proxy.newProxyInstance(mbeanClass.getClassLoader(),
+                                              new Class<?>[]{ mbeanClass },
+                                              new LazyMBeanProxy<>(provider, mbeanClass));
         }
     }
 }
 
 class ColumnFamilyStoreMBeanIterator implements Iterator<Map.Entry<String, ColumnFamilyStoreMBean>>
 {
-    private MBeanServerConnection mbeanServerConn;
     Iterator<Entry<String, ColumnFamilyStoreMBean>> mbeans;
 
-    public ColumnFamilyStoreMBeanIterator(MBeanServerConnection mbeanServerConn)
+    public ColumnFamilyStoreMBeanIterator(MBeanAccessor accessor)
         throws MalformedObjectNameException, NullPointerException, IOException
     {
-        this.mbeanServerConn = mbeanServerConn;
-        List<Entry<String, ColumnFamilyStoreMBean>> cfMbeans = getCFSMBeans(mbeanServerConn, "ColumnFamilies");
-        cfMbeans.addAll(getCFSMBeans(mbeanServerConn, "IndexColumnFamilies"));
-        Collections.sort(cfMbeans, new Comparator<Entry<String, ColumnFamilyStoreMBean>>()
-        {
-            public int compare(Entry<String, ColumnFamilyStoreMBean> e1, Entry<String, ColumnFamilyStoreMBean> e2)
-            {
-                //compare keyspace, then CF name, then normal vs. index
-                int keyspaceNameCmp = e1.getKey().compareTo(e2.getKey());
-                if(keyspaceNameCmp != 0)
-                    return keyspaceNameCmp;
+        List<Entry<String, ColumnFamilyStoreMBean>> cfMbeans = accessor.findColumnFamilies("ColumnFamilies");
+        cfMbeans.addAll(accessor.findColumnFamilies("IndexColumnFamilies"));
+        cfMbeans.sort((e1, e2) -> {
+            //compare keyspace, then CF name, then normal vs. index
+            int keyspaceNameCmp = e1.getKey().compareTo(e2.getKey());
+            if (keyspaceNameCmp != 0)
+                return keyspaceNameCmp;
 
-                // get CF name and split it for index name
-                String e1CF[] = e1.getValue().getTableName().split("\\.");
-                String e2CF[] = e2.getValue().getTableName().split("\\.");
-                assert e1CF.length <= 2 && e2CF.length <= 2 : "unexpected split count for table name";
+            // get CF name and split it for index name
+            String e1CF[] = e1.getValue().getTableName().split("\\.");
+            String e2CF[] = e2.getValue().getTableName().split("\\.");
+            assert e1CF.length <= 2 && e2CF.length <= 2 : "unexpected split count for table name";
 
-                //if neither are indexes, just compare CF names
-                if(e1CF.length == 1 && e2CF.length == 1)
-                    return e1CF[0].compareTo(e2CF[0]);
+            //if neither are indexes, just compare CF names
+            if (e1CF.length == 1 && e2CF.length == 1)
+                return e1CF[0].compareTo(e2CF[0]);
 
-                //check if it's the same CF
-                int cfNameCmp = e1CF[0].compareTo(e2CF[0]);
-                if(cfNameCmp != 0)
-                    return cfNameCmp;
+            //check if it's the same CF
+            int cfNameCmp = e1CF[0].compareTo(e2CF[0]);
+            if (cfNameCmp != 0)
+                return cfNameCmp;
 
-                // if both are indexes (for the same CF), compare them
-                if(e1CF.length == 2 && e2CF.length == 2)
-                    return e1CF[1].compareTo(e2CF[1]);
+            // if both are indexes (for the same CF), compare them
+            if (e1CF.length == 2 && e2CF.length == 2)
+                return e1CF[1].compareTo(e2CF[1]);
 
-                //if length of e1CF is 1, it's not an index, so sort it higher
-                return e1CF.length == 1 ? 1 : -1;
-            }
+            //if length of e1CF is 1, it's not an index, so sort it higher
+            return e1CF.length == 1 ? 1 : -1;
         });
         mbeans = cfMbeans.iterator();
-    }
-
-    private List<Entry<String, ColumnFamilyStoreMBean>> getCFSMBeans(MBeanServerConnection mbeanServerConn, String type)
-            throws MalformedObjectNameException, IOException
-    {
-        ObjectName query = new ObjectName("org.apache.cassandra.db:type=" + type +",*");
-        Set<ObjectName> cfObjects = mbeanServerConn.queryNames(query, null);
-        List<Entry<String, ColumnFamilyStoreMBean>> mbeans = new ArrayList<Entry<String, ColumnFamilyStoreMBean>>(cfObjects.size());
-        for(ObjectName n : cfObjects)
-        {
-            String keyspaceName = n.getKeyProperty("keyspace");
-            ColumnFamilyStoreMBean cfsProxy = JMX.newMBeanProxy(mbeanServerConn, n, ColumnFamilyStoreMBean.class);
-            mbeans.add(new AbstractMap.SimpleImmutableEntry<String, ColumnFamilyStoreMBean>(keyspaceName, cfsProxy));
-        }
-        return mbeans;
     }
 
     public boolean hasNext()

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -39,9 +39,13 @@ import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileWriter;
+import org.apache.cassandra.tools.nodetool.CqlConnect;
 import org.apache.cassandra.tools.nodetool.JmxConnect;
 import org.apache.cassandra.tools.nodetool.NodetoolCommand;
 import org.apache.cassandra.tools.nodetool.layout.CassandraCliHelpLayout;
+import org.apache.cassandra.tools.nodetool.strategy.CommandExecutionStrategy;
+import org.apache.cassandra.tools.nodetool.strategy.NodetoolConnectionException;
+import org.apache.cassandra.tools.nodetool.strategy.ProtocolAwareExecutionStrategy;
 import org.apache.cassandra.utils.FBUtilities;
 
 import picocli.CommandLine;
@@ -104,7 +108,7 @@ public class NodeTool
             commandLine.setErr(new PrintWriter(output.err, true));
 
             configureCliLayout(commandLine);
-            commandLine.setExecutionStrategy(JmxConnect::executionStrategy)
+            commandLine.setExecutionStrategy(ProtocolAwareExecutionStrategy::executionStrategy)
                        .setExecutionExceptionHandler((ex, c, arg) -> {
                            // Used for backward compatibility, some commands are validated when a command is run.
                            if (ex instanceof IllegalArgumentException |
@@ -114,7 +118,25 @@ public class NodeTool
                                return 1;
                            }
 
-                           err(Throwables.getRootCause(ex));
+                           NodetoolConnectionException connectFailure = Throwables.getCausalChain(ex).stream()
+                                                                                  .filter(NodetoolConnectionException.class::isInstance)
+                                                                                  .map(NodetoolConnectionException.class::cast)
+                                                                                  .findFirst().orElse(null);
+                           if (connectFailure != null)
+                           {
+                               output.err.println("nodetool: " + connectFailure.getMessage());
+                               return 1;
+                           }
+
+                           // CASSANDRA-11537 friendly error message when server is not ready
+                           Throwable root = Throwables.getRootCause(ex);
+                           if (root instanceof InstanceNotFoundException)
+                           {
+                               badUse(new IllegalArgumentException("Server is not initialized yet, cannot run nodetool."));
+                               return 1;
+                           }
+
+                           err(root);
                            return 2;
                        })
                        .setParameterExceptionHandler((ex, arg) -> {
@@ -195,8 +217,18 @@ public class NodeTool
 
     public static CommandLine createCommandLine(CommandLine.IFactory factory) throws Exception
     {
-        return new CommandLine(new NodetoolCommand(), factory)
-                   .addMixin(JmxConnect.MIXIN_KEY, factory.create(JmxConnect.class));
+        CommandLine commandLine = new CommandLine(new NodetoolCommand(), factory);
+        CommandExecutionStrategy.Type strategyType = ProtocolAwareExecutionStrategy.getExecutionStrategyTypeFromEnvAndSys();
+        switch (strategyType)
+        {
+            case CQL:
+                return commandLine.addMixin(strategyType.toString(), factory.create(CqlConnect.class));
+            case STATIC_MBEAN:
+            case COMMAND_MBEAN:
+                return commandLine.addMixin(strategyType.toString(), factory.create(JmxConnect.class));
+            default:
+                throw new IllegalStateException("Unknown execution strategy: " + strategyType);
+        }
     }
 
     private static void configureCliLayout(CommandLine commandLine)
@@ -229,10 +261,6 @@ public class NodeTool
 
     protected void err(Throwable e)
     {
-        // CASSANDRA-11537: friendly error message when server is not ready
-        if (e instanceof InstanceNotFoundException)
-            throw new IllegalArgumentException("Server is not initialized yet, cannot run nodetool.");
-
         output.err.println("error: " + e.getMessage());
         output.err.println("-- StackTrace --");
         output.err.println(getStackTraceAsString(e));

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -218,6 +218,9 @@ public class NodeTool
     public static CommandLine createCommandLine(CommandLine.IFactory factory) throws Exception
     {
         CommandLine commandLine = new CommandLine(new NodetoolCommand(), factory);
+        // Match the case-insensitive enum matching of the CQL/JSON management path
+        // (see TypeConverterRegistry's enum converter).
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
         CommandExecutionStrategy.Type strategyType = ProtocolAwareExecutionStrategy.getExecutionStrategyTypeFromEnvAndSys();
         switch (strategyType)
         {

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -218,9 +218,6 @@ public class NodeTool
     public static CommandLine createCommandLine(CommandLine.IFactory factory) throws Exception
     {
         CommandLine commandLine = new CommandLine(new NodetoolCommand(), factory);
-        // Match the case-insensitive enum matching of the CQL/JSON management path
-        // (see TypeConverterRegistry's enum converter).
-        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
         CommandExecutionStrategy.Type strategyType = ProtocolAwareExecutionStrategy.getExecutionStrategyTypeFromEnvAndSys();
         switch (strategyType)
         {

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -39,9 +39,12 @@ import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileWriter;
+import org.apache.cassandra.tools.nodetool.CqlConnect;
 import org.apache.cassandra.tools.nodetool.JmxConnect;
 import org.apache.cassandra.tools.nodetool.NodetoolCommand;
 import org.apache.cassandra.tools.nodetool.layout.CassandraCliHelpLayout;
+import org.apache.cassandra.tools.nodetool.strategy.CommandExecutionStrategy;
+import org.apache.cassandra.tools.nodetool.strategy.ProtocolAwareExecutionStrategy;
 import org.apache.cassandra.utils.FBUtilities;
 
 import picocli.CommandLine;
@@ -104,7 +107,7 @@ public class NodeTool
             commandLine.setErr(new PrintWriter(output.err, true));
 
             configureCliLayout(commandLine);
-            commandLine.setExecutionStrategy(JmxConnect::executionStrategy)
+            commandLine.setExecutionStrategy(ProtocolAwareExecutionStrategy::executionStrategy)
                        .setExecutionExceptionHandler((ex, c, arg) -> {
                            // Used for backward compatibility, some commands are validated when a command is run.
                            if (ex instanceof IllegalArgumentException |
@@ -114,7 +117,15 @@ public class NodeTool
                                return 1;
                            }
 
-                           err(Throwables.getRootCause(ex));
+                           // CASSANDRA-11537 friendly error message when server is not ready
+                           Throwable root = Throwables.getRootCause(ex);
+                           if (root instanceof InstanceNotFoundException)
+                           {
+                               badUse(new IllegalArgumentException("Server is not initialized yet, cannot run nodetool."));
+                               return 1;
+                           }
+
+                           err(root);
                            return 2;
                        })
                        .setParameterExceptionHandler((ex, arg) -> {
@@ -195,8 +206,18 @@ public class NodeTool
 
     public static CommandLine createCommandLine(CommandLine.IFactory factory) throws Exception
     {
-        return new CommandLine(new NodetoolCommand(), factory)
-                   .addMixin(JmxConnect.MIXIN_KEY, factory.create(JmxConnect.class));
+        CommandLine commandLine = new CommandLine(new NodetoolCommand(), factory);
+        CommandExecutionStrategy.Type strategyType = ProtocolAwareExecutionStrategy.getExecutionStrategyTypeFromEnvAndSys();
+        switch (strategyType)
+        {
+            case CQL:
+                return commandLine.addMixin(strategyType.toString(), factory.create(CqlConnect.class));
+            case STATIC_MBEAN:
+            case COMMAND_MBEAN:
+                return commandLine.addMixin(strategyType.toString(), factory.create(JmxConnect.class));
+            default:
+                throw new IllegalStateException("Unknown execution strategy: " + strategyType);
+        }
     }
 
     private static void configureCliLayout(CommandLine commandLine)
@@ -229,10 +250,6 @@ public class NodeTool
 
     protected void err(Throwable e)
     {
-        // CASSANDRA-11537: friendly error message when server is not ready
-        if (e instanceof InstanceNotFoundException)
-            throw new IllegalArgumentException("Server is not initialized yet, cannot run nodetool.");
-
         output.err.println("error: " + e.getMessage());
         output.err.println("-- StackTrace --");
         output.err.println(getStackTraceAsString(e));

--- a/src/java/org/apache/cassandra/tools/Output.java
+++ b/src/java/org/apache/cassandra/tools/Output.java
@@ -33,9 +33,19 @@ public class Output
         this.err = err;
     }
 
+    public void printInfo(String msg)
+    {
+        out.println(msg);
+    }
+
     public void printInfo(String msg, Object... args)
     {
         out.printf(msg, args);
+    }
+
+    public void printError(String msg)
+    {
+        err.println(msg);
     }
 
     public void printError(String msg, Object... args)

--- a/src/java/org/apache/cassandra/tools/RemoteJmxMBeanAccessor.java
+++ b/src/java/org/apache/cassandra/tools/RemoteJmxMBeanAccessor.java
@@ -130,7 +130,7 @@ public class RemoteJmxMBeanAccessor implements MBeanAccessor
     private volatile boolean connected = false;
 
     /**
-     * Creates a NodeProbe using the specified JMX host, port, username, and password.
+     * Creates an accessor for the specified JMX host and port, authenticating with the given credentials.
      *
      * @param host hostname or IP address of the JMX agent
      * @param port TCP port of the remote JMX agent
@@ -147,7 +147,7 @@ public class RemoteJmxMBeanAccessor implements MBeanAccessor
     }
 
     /**
-     * Creates a NodeProbe using the specified JMX host and port.
+     * Creates an accessor for the specified JMX host and port.
      *
      * @param host hostname or IP address of the JMX agent
      * @param port TCP port of the remote JMX agent
@@ -159,7 +159,7 @@ public class RemoteJmxMBeanAccessor implements MBeanAccessor
     }
 
     /**
-     * Creates a NodeProbe using the specified JMX host and default port.
+     * Creates an accessor for the specified JMX host on the default port.
      *
      * @param host hostname or IP address of the JMX agent
      */

--- a/src/java/org/apache/cassandra/tools/RemoteJmxMBeanAccessor.java
+++ b/src/java/org/apache/cassandra/tools/RemoteJmxMBeanAccessor.java
@@ -1,0 +1,479 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.rmi.ConnectException;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMISocketFactory;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.management.JMX;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+
+import com.google.common.base.Throwables;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.audit.AuditLogManager;
+import org.apache.cassandra.audit.AuditLogManagerMBean;
+import org.apache.cassandra.auth.AuthCache;
+import org.apache.cassandra.auth.CIDRGroupsMappingManager;
+import org.apache.cassandra.auth.CIDRGroupsMappingManagerMBean;
+import org.apache.cassandra.auth.CIDRPermissionsManager;
+import org.apache.cassandra.auth.CIDRPermissionsManagerMBean;
+import org.apache.cassandra.auth.NetworkPermissionsCache;
+import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+import org.apache.cassandra.auth.PermissionsCache;
+import org.apache.cassandra.auth.PermissionsCacheMBean;
+import org.apache.cassandra.auth.RolesCache;
+import org.apache.cassandra.auth.RolesCacheMBean;
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
+import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.batchlog.BatchlogManagerMBean;
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
+import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.db.guardrails.GuardrailsMBean;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTable;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTableMBean;
+import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.gms.FailureDetectorMBean;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.GossiperMBean;
+import org.apache.cassandra.hints.HintsService;
+import org.apache.cassandra.hints.HintsServiceMBean;
+import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
+import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
+import org.apache.cassandra.locator.LocationInfoMBean;
+import org.apache.cassandra.management.MBeanAccessor;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.MessagingServiceMBean;
+import org.apache.cassandra.profiler.AsyncProfilerMBean;
+import org.apache.cassandra.service.ActiveRepairServiceMBean;
+import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.service.AutoRepairServiceMBean;
+import org.apache.cassandra.service.CacheService;
+import org.apache.cassandra.service.CacheServiceMBean;
+import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.service.GCInspectorMXBean;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.StorageProxyMBean;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.apache.cassandra.service.accord.AccordOperations;
+import org.apache.cassandra.service.accord.AccordOperationsMBean;
+import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
+import org.apache.cassandra.streaming.StreamManagerMBean;
+import org.apache.cassandra.tcm.CMSOperations;
+import org.apache.cassandra.tcm.CMSOperationsMBean;
+import org.apache.cassandra.tools.nodetool.strategy.NodetoolConnectionException;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSL_ENABLE;
+
+public class RemoteJmxMBeanAccessor implements MBeanAccessor
+{
+    private final Map<Class<?>, Object> clazzMBanRegistry = new HashMap<>();
+    private final Map<String, Object> namedMBeanRegistry = new ConcurrentHashMap<>();
+
+    public static final int defaultPort = 7199;
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoteJmxMBeanAccessor.class);
+    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
+
+    final String host;
+    final int port;
+    private String username;
+    private String password;
+
+    protected JMXConnector jmxc;
+    protected MBeanServerConnection mbeanServerConn;
+
+    private volatile boolean connected = false;
+
+    /**
+     * Creates a NodeProbe using the specified JMX host, port, username, and password.
+     *
+     * @param host hostname or IP address of the JMX agent
+     * @param port TCP port of the remote JMX agent
+     */
+    public RemoteJmxMBeanAccessor(String host, int port, String username, String password)
+    {
+        assert username != null && !username.isEmpty() && password != null && !password.isEmpty()
+        : "neither username nor password can be blank";
+
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+    }
+
+    /**
+     * Creates a NodeProbe using the specified JMX host and port.
+     *
+     * @param host hostname or IP address of the JMX agent
+     * @param port TCP port of the remote JMX agent
+     */
+    public RemoteJmxMBeanAccessor(String host, int port)
+    {
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Creates a NodeProbe using the specified JMX host and default port.
+     *
+     * @param host hostname or IP address of the JMX agent
+     */
+    public RemoteJmxMBeanAccessor(String host)
+    {
+        this(host, defaultPort);
+    }
+
+    /**
+     * Create a connection to the JMX agent and set up the M[X]Bean proxies.
+     */
+    protected void connect()
+    {
+        if (connected)
+            return;
+
+        synchronized (this)
+        {
+            if (connected)
+                return;
+
+            try
+            {
+                String host = this.host;
+                if (host.contains(":"))
+                {
+                    // Use square brackets to surround IPv6 addresses to fix CASSANDRA-7669 and CASSANDRA-17581
+                    host = '[' + host + ']';
+                }
+                JMXServiceURL jmxUrl = new JMXServiceURL(String.format(fmtUrl, host, port));
+                Map<String, Object> env = new HashMap<>();
+                if (username != null)
+                {
+                    String[] creds = { username, password };
+                    env.put(JMXConnector.CREDENTIALS, creds);
+                }
+
+                env.put("com.sun.jndi.rmi.factory.socket", getRMIClientSocketFactory());
+
+                jmxc = JMXConnectorFactory.connect(jmxUrl, env);
+                mbeanServerConn = jmxc.getMBeanServerConnection();
+
+                registerMBeanProxy(StorageServiceMBean.class, "org.apache.cassandra.db:type=StorageService");
+                registerMBeanProxy(SnapshotManagerMBean.class, SnapshotManagerMBean.MBEAN_NAME);
+                registerMBeanProxy(CMSOperationsMBean.class, CMSOperations.MBEAN_OBJECT_NAME);
+                registerMBeanProxy(AccordOperationsMBean.class, AccordOperations.MBEAN_OBJECT_NAME);
+                registerMBeanProxy(MessagingServiceMBean.class, MessagingService.MBEAN_NAME);
+                registerMBeanProxy(StreamManagerMBean.class, StreamManagerMBean.OBJECT_NAME);
+                registerMBeanProxy(CompactionManagerMBean.class, CompactionManager.MBEAN_OBJECT_NAME);
+                registerMBeanProxy(FailureDetectorMBean.class, FailureDetector.MBEAN_NAME);
+                registerMBeanProxy(CacheServiceMBean.class, CacheService.MBEAN_NAME);
+                registerMBeanProxy(StorageProxyMBean.class, StorageProxy.MBEAN_NAME);
+                registerMBeanProxy(HintsServiceMBean.class, HintsService.MBEAN_NAME);
+                registerMBeanProxy(GCInspectorMXBean.class, GCInspector.MBEAN_NAME);
+                registerMBeanProxy(GossiperMBean.class, Gossiper.MBEAN_NAME);
+                registerMBeanProxy(BatchlogManagerMBean.class, BatchlogManager.MBEAN_NAME);
+                registerMBeanProxy(ActiveRepairServiceMBean.class, ActiveRepairServiceMBean.MBEAN_NAME);
+                registerMBeanProxy(AuditLogManagerMBean.class, AuditLogManager.MBEAN_NAME);
+                registerMBeanProxy(PasswordAuthenticator.CredentialsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + PasswordAuthenticator.CredentialsCacheMBean.CACHE_NAME);
+                registerMBeanProxy(AuthorizationProxy.JmxPermissionsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + AuthorizationProxy.JmxPermissionsCacheMBean.CACHE_NAME);
+                registerMBeanProxy(NetworkPermissionsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + NetworkPermissionsCache.CACHE_NAME);
+                registerMBeanProxy(PermissionsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + PermissionsCache.CACHE_NAME);
+                registerMBeanProxy(RolesCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + RolesCache.CACHE_NAME);
+                registerMBeanProxy(CIDRPermissionsManagerMBean.class, CIDRPermissionsManager.MBEAN_NAME);
+                registerMBeanProxy(CIDRGroupsMappingManagerMBean.class, CIDRGroupsMappingManager.MBEAN_NAME);
+                registerMBeanProxy(CIDRFilteringMetricsTableMBean.class, CIDRFilteringMetricsTable.MBEAN_NAME);
+                registerMBeanProxy(AutoRepairServiceMBean.class, AutoRepairService.MBEAN_NAME);
+                registerMBeanProxy(GuardrailsMBean.class, Guardrails.MBEAN_NAME);
+
+                registerPlatformMBeanProxy(MemoryMXBean.class, ManagementFactory.MEMORY_MXBEAN_NAME);
+                registerPlatformMBeanProxy(RuntimeMXBean.class, ManagementFactory.RUNTIME_MXBEAN_NAME);
+
+                registerMBeanProxy(EndpointSnitchInfoMBean.class, "org.apache.cassandra.db:type=EndpointSnitchInfo");
+                registerMBeanProxy(DynamicEndpointSnitchMBean.class, "org.apache.cassandra.db:type=DynamicEndpointSnitch");
+                registerMBeanProxy(LocationInfoMBean.class, "org.apache.cassandra.db:type=LocationInfo");
+                registerMBeanProxy(AsyncProfilerMBean.class, AsyncProfilerMBean.MBEAN_NAME);
+            }
+            catch (MalformedObjectNameException e)
+            {
+                close();
+                throw new RuntimeException("Invalid ObjectName? Please report this as a bug.", e);
+            }
+            catch (IOException | SecurityException e)
+            {
+                close();
+                Throwable rootCause = Throwables.getRootCause(e);
+                throw new NodetoolConnectionException(String.format("Failed to connect to '%s:%s' - %s: '%s'.",
+                                                                    host, port,
+                                                                    rootCause.getClass().getSimpleName(),
+                                                                    rootCause.getMessage()),
+                                                      e);
+            }
+
+            connected = true;
+        }
+    }
+
+    protected <T> void registerMBean(Class<T> clazz, T mbean)
+    {
+        clazzMBanRegistry.put(clazz, mbean);
+    }
+
+    @Override
+    public <T> T findMBean(Class<T> clazz)
+    {
+        connect();
+        return clazzMBanRegistry.get(clazz) == null ? null : clazz.cast(clazzMBanRegistry.get(clazz));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T findMBeanMetric(Class<T> clazz, Props props)
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            ObjectName objectName = new ObjectName("org.apache.cassandra.metrics", new Hashtable<>(props.toMap()));
+            T result = (T) namedMBeanRegistry.computeIfAbsent(objectName.getCanonicalName(),
+                                                              ignore -> JMX.newMBeanProxy(mbeanServerConn, objectName, clazz));
+            return clazz.cast(result);
+        });
+    }
+
+    @Override
+    public boolean isMBeanMetricRegistered(Props props)
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            ObjectName objectName = new ObjectName("org.apache.cassandra.metrics", new Hashtable<>(props.toMap()));
+            return mbeanServerConn.isRegistered(objectName);
+        });
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxCounterMBean findMBeanCounter(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxCounterMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxGaugeMBean findMBeanGauge(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxGaugeMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxMeterMBean findMBeanMeter(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxMeterMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxTimerMBean findMBeanTimer(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxTimerMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxHistogramMBean findMBeanHistogram(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxHistogramMBean.class, props);
+    }
+
+    @Override
+    public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            Set<ObjectName> beans = mbeanServerConn.queryNames(new ObjectName("org.apache.cassandra.db:type=*" + type +
+                                                                              ",keyspace=" + keyspace +
+                                                                              ",columnfamily=" + columnFamily), null);
+            if (beans.isEmpty())
+                throw new MalformedObjectNameException("couldn't find that bean");
+
+            assert beans.size() == 1;
+            return JMX.newMBeanProxy(mbeanServerConn, beans.iterator().next(), ColumnFamilyStoreMBean.class);
+        });
+    }
+
+    @Override
+    public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+    {
+        List<Map.Entry<String, ColumnFamilyStoreMBean>> keyspaces = findColumnFamilies("ColumnFamilies");
+        Optional<ColumnFamilyStoreMBean> cfsMBean = keyspaces.stream()
+                                                             .filter(e -> e.getKey().equals(keyspace))
+                                                             .map(Map.Entry::getValue)
+                                                             .filter(mbean -> mbean.getTableName().equals(table))
+                                                             .findAny();
+        if  (keyspaces.isEmpty() || cfsMBean.isEmpty())
+            throw new IllegalArgumentException(String.format("Table %s.%s does not exist", keyspace, table));
+
+        return withExceptionHandling(() -> {
+            connect();
+            String mbeanName = CompressionDictionaryManagerMBean.MBEAN_NAME + ",keyspace=" + keyspace + ",table=" + table;
+            if (!mbeanServerConn.isRegistered(new ObjectName(mbeanName)))
+                throw new IllegalStateException("The compression on table " + keyspace + '.' + table + " is not enabled or SSTable compressor is not a dictionary compressor.");
+            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName(mbeanName), CompressionDictionaryManagerMBean.class);
+        });
+    }
+
+    @Override
+    public List<ThreadPoolInfo> threadPoolInfos()
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            Set<ObjectName> threadPoolObjectNames = mbeanServerConn.queryNames(new ObjectName("org.apache.cassandra.metrics:type=ThreadPools,*"), null);
+            return threadPoolObjectNames.stream()
+                                        .map(oName -> new ThreadPoolInfo(oName.getKeyProperty("path"), oName.getKeyProperty("scope")))
+                                        .collect(Collectors.toList());
+        });
+    }
+
+    @Override
+    public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+    {
+        return withExceptionHandling(() -> {
+            assert type.equals("IndexColumnFamilies") || type.equals("ColumnFamilies");
+            connect();
+
+            ObjectName query = new ObjectName("org.apache.cassandra.db:type=" + type + ",*");
+            Set<ObjectName> cfObjects = mbeanServerConn.queryNames(query, null);
+
+            List<Map.Entry<String, ColumnFamilyStoreMBean>> mbeans = new ArrayList<>(cfObjects.size());
+            for (ObjectName objectName : cfObjects)
+            {
+                ColumnFamilyStoreMBean cfsProxy = JMX.newMBeanProxy(mbeanServerConn, objectName, ColumnFamilyStoreMBean.class);
+                mbeans.add(new AbstractMap.SimpleImmutableEntry<>(objectName.getKeyProperty("keyspace"), cfsProxy));
+            }
+            return mbeans;
+        });
+    }
+
+    public JMXConnector getJmxConnector()
+    {
+        connect();
+        return jmxc;
+    }
+
+    public MBeanServerConnection getMBeanServerConnection()
+    {
+        connect();
+        return mbeanServerConn;
+    }
+
+    @Override
+    public void close()
+    {
+        if (jmxc == null)
+            return;
+
+        try
+        {
+            jmxc.close();
+        }
+        catch (ConnectException e)
+        {
+            // result of stopdaemon command, if close() call fails, the daemon is shutdown
+            logger.error("Cassandra has shutdown.");
+        }
+        catch (IOException e)
+        {
+            logger.error("Failed to close connection to '{}:{}'.", host, port, e);
+        }
+        finally
+        {
+            jmxc = null;
+            mbeanServerConn = null;
+            connected = false;
+            clazzMBanRegistry.clear();
+            namedMBeanRegistry.clear();
+        }
+    }
+
+    private <T> void registerMBeanProxy(Class<T> clazz, String objectName) throws MalformedObjectNameException
+    {
+        registerMBean(clazz, JMX.newMBeanProxy(mbeanServerConn, new ObjectName(objectName), clazz));
+    }
+
+    private <T> void registerPlatformMBeanProxy(Class<T> clazz, String objectName) throws IOException
+    {
+        registerMBean(clazz, ManagementFactory.newPlatformMXBeanProxy(mbeanServerConn, objectName, clazz));
+    }
+
+    private RMIClientSocketFactory getRMIClientSocketFactory()
+    {
+        if (SSL_ENABLE.getBoolean())
+            return new SslRMIClientSocketFactory();
+        else
+            return RMISocketFactory.getDefaultSocketFactory();
+    }
+
+    private static <T> T withExceptionHandling(MBeanSupplier<T> op)
+    {
+        try
+        {
+            return op.get();
+        }
+        catch (MalformedObjectNameException e)
+        {
+            throw new RuntimeException("Invalid ObjectName? Requested MBean may not exist. " +
+                                       "Please check the parameters e.g. keyspace name, table name and try again.", e);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Could not connect to MBean server. Please check that the JMX port is correct and open.", e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface MBeanSupplier<T>
+    {
+        T get() throws MalformedObjectNameException, IOException;
+    }
+}

--- a/src/java/org/apache/cassandra/tools/RemoteJmxMBeanAccessor.java
+++ b/src/java/org/apache/cassandra/tools/RemoteJmxMBeanAccessor.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMISocketFactory;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.management.JMX;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.audit.AuditLogManager;
+import org.apache.cassandra.audit.AuditLogManagerMBean;
+import org.apache.cassandra.auth.AuthCache;
+import org.apache.cassandra.auth.CIDRGroupsMappingManager;
+import org.apache.cassandra.auth.CIDRGroupsMappingManagerMBean;
+import org.apache.cassandra.auth.CIDRPermissionsManager;
+import org.apache.cassandra.auth.CIDRPermissionsManagerMBean;
+import org.apache.cassandra.auth.NetworkPermissionsCache;
+import org.apache.cassandra.auth.NetworkPermissionsCacheMBean;
+import org.apache.cassandra.auth.PasswordAuthenticator;
+import org.apache.cassandra.auth.PermissionsCache;
+import org.apache.cassandra.auth.PermissionsCacheMBean;
+import org.apache.cassandra.auth.RolesCache;
+import org.apache.cassandra.auth.RolesCacheMBean;
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
+import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.batchlog.BatchlogManagerMBean;
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
+import org.apache.cassandra.db.guardrails.Guardrails;
+import org.apache.cassandra.db.guardrails.GuardrailsMBean;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTable;
+import org.apache.cassandra.db.virtual.CIDRFilteringMetricsTableMBean;
+import org.apache.cassandra.gms.FailureDetector;
+import org.apache.cassandra.gms.FailureDetectorMBean;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.GossiperMBean;
+import org.apache.cassandra.hints.HintsService;
+import org.apache.cassandra.hints.HintsServiceMBean;
+import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
+import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
+import org.apache.cassandra.locator.LocationInfoMBean;
+import org.apache.cassandra.management.MBeanAccessor;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.MessagingServiceMBean;
+import org.apache.cassandra.profiler.AsyncProfilerMBean;
+import org.apache.cassandra.service.ActiveRepairServiceMBean;
+import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.service.AutoRepairServiceMBean;
+import org.apache.cassandra.service.CacheService;
+import org.apache.cassandra.service.CacheServiceMBean;
+import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.service.GCInspectorMXBean;
+import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.StorageProxyMBean;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.apache.cassandra.service.accord.AccordOperations;
+import org.apache.cassandra.service.accord.AccordOperationsMBean;
+import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
+import org.apache.cassandra.streaming.StreamManagerMBean;
+import org.apache.cassandra.tcm.CMSOperations;
+import org.apache.cassandra.tcm.CMSOperationsMBean;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.SSL_ENABLE;
+
+public class RemoteJmxMBeanAccessor implements MBeanAccessor
+{
+    private final Map<Class<?>, Object> clazzMBanRegistry = new HashMap<>();
+    private final Map<String, Object> namedMBeanRegistry = new ConcurrentHashMap<>();
+
+    public static final int defaultPort = 7199;
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoteJmxMBeanAccessor.class);
+    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
+
+    final String host;
+    final int port;
+    private String username;
+    private String password;
+
+    protected JMXConnector jmxc;
+    protected MBeanServerConnection mbeanServerConn;
+
+    private volatile boolean connected = false;
+
+    /**
+     * Creates a NodeProbe using the specified JMX host, port, username, and password.
+     *
+     * @param host hostname or IP address of the JMX agent
+     * @param port TCP port of the remote JMX agent
+     */
+    public RemoteJmxMBeanAccessor(String host, int port, String username, String password)
+    {
+        assert username != null && !username.isEmpty() && password != null && !password.isEmpty()
+        : "neither username nor password can be blank";
+
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+    }
+
+    /**
+     * Creates a NodeProbe using the specified JMX host and port.
+     *
+     * @param host hostname or IP address of the JMX agent
+     * @param port TCP port of the remote JMX agent
+     */
+    public RemoteJmxMBeanAccessor(String host, int port)
+    {
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Creates a NodeProbe using the specified JMX host and default port.
+     *
+     * @param host hostname or IP address of the JMX agent
+     */
+    public RemoteJmxMBeanAccessor(String host)
+    {
+        this(host, defaultPort);
+    }
+
+    /**
+     * Create a connection to the JMX agent and set up the M[X]Bean proxies.
+     */
+    protected void connect()
+    {
+        if (connected)
+            return;
+
+        synchronized (this)
+        {
+            if (connected)
+                return;
+
+            try
+            {
+                String host = this.host;
+                if (host.contains(":"))
+                {
+                    // Use square brackets to surround IPv6 addresses to fix CASSANDRA-7669 and CASSANDRA-17581
+                    host = '[' + host + ']';
+                }
+                JMXServiceURL jmxUrl = new JMXServiceURL(String.format(fmtUrl, host, port));
+                Map<String, Object> env = new HashMap<>();
+                if (username != null)
+                {
+                    String[] creds = { username, password };
+                    env.put(JMXConnector.CREDENTIALS, creds);
+                }
+
+                env.put("com.sun.jndi.rmi.factory.socket", getRMIClientSocketFactory());
+
+                jmxc = JMXConnectorFactory.connect(jmxUrl, env);
+                mbeanServerConn = jmxc.getMBeanServerConnection();
+
+                registerMBeanProxy(StorageServiceMBean.class, "org.apache.cassandra.db:type=StorageService");
+                registerMBeanProxy(SnapshotManagerMBean.class, SnapshotManagerMBean.MBEAN_NAME);
+                registerMBeanProxy(CMSOperationsMBean.class, CMSOperations.MBEAN_OBJECT_NAME);
+                registerMBeanProxy(AccordOperationsMBean.class, AccordOperations.MBEAN_OBJECT_NAME);
+                registerMBeanProxy(MessagingServiceMBean.class, MessagingService.MBEAN_NAME);
+                registerMBeanProxy(StreamManagerMBean.class, StreamManagerMBean.OBJECT_NAME);
+                registerMBeanProxy(CompactionManagerMBean.class, CompactionManager.MBEAN_OBJECT_NAME);
+                registerMBeanProxy(FailureDetectorMBean.class, FailureDetector.MBEAN_NAME);
+                registerMBeanProxy(CacheServiceMBean.class, CacheService.MBEAN_NAME);
+                registerMBeanProxy(StorageProxyMBean.class, StorageProxy.MBEAN_NAME);
+                registerMBeanProxy(HintsServiceMBean.class, HintsService.MBEAN_NAME);
+                registerMBeanProxy(GCInspectorMXBean.class, GCInspector.MBEAN_NAME);
+                registerMBeanProxy(GossiperMBean.class, Gossiper.MBEAN_NAME);
+                registerMBeanProxy(BatchlogManagerMBean.class, BatchlogManager.MBEAN_NAME);
+                registerMBeanProxy(ActiveRepairServiceMBean.class, ActiveRepairServiceMBean.MBEAN_NAME);
+                registerMBeanProxy(AuditLogManagerMBean.class, AuditLogManager.MBEAN_NAME);
+                registerMBeanProxy(PasswordAuthenticator.CredentialsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + PasswordAuthenticator.CredentialsCacheMBean.CACHE_NAME);
+                registerMBeanProxy(AuthorizationProxy.JmxPermissionsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + AuthorizationProxy.JmxPermissionsCacheMBean.CACHE_NAME);
+                registerMBeanProxy(NetworkPermissionsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + NetworkPermissionsCache.CACHE_NAME);
+                registerMBeanProxy(PermissionsCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + PermissionsCache.CACHE_NAME);
+                registerMBeanProxy(RolesCacheMBean.class,
+                                   AuthCache.MBEAN_NAME_BASE + RolesCache.CACHE_NAME);
+                registerMBeanProxy(CIDRPermissionsManagerMBean.class, CIDRPermissionsManager.MBEAN_NAME);
+                registerMBeanProxy(CIDRGroupsMappingManagerMBean.class, CIDRGroupsMappingManager.MBEAN_NAME);
+                registerMBeanProxy(CIDRFilteringMetricsTableMBean.class, CIDRFilteringMetricsTable.MBEAN_NAME);
+                registerMBeanProxy(AutoRepairServiceMBean.class, AutoRepairService.MBEAN_NAME);
+                registerMBeanProxy(GuardrailsMBean.class, Guardrails.MBEAN_NAME);
+
+                registerPlatformMBeanProxy(MemoryMXBean.class, ManagementFactory.MEMORY_MXBEAN_NAME);
+                registerPlatformMBeanProxy(RuntimeMXBean.class, ManagementFactory.RUNTIME_MXBEAN_NAME);
+
+                registerMBeanProxy(EndpointSnitchInfoMBean.class, "org.apache.cassandra.db:type=EndpointSnitchInfo");
+                registerMBeanProxy(DynamicEndpointSnitchMBean.class, "org.apache.cassandra.db:type=DynamicEndpointSnitch");
+                registerMBeanProxy(LocationInfoMBean.class, "org.apache.cassandra.db:type=LocationInfo");
+                registerMBeanProxy(AsyncProfilerMBean.class, AsyncProfilerMBean.MBEAN_NAME);
+            }
+            catch (MalformedObjectNameException e)
+            {
+                close();
+                throw new RuntimeException("Invalid ObjectName? Please report this as a bug.", e);
+            }
+            catch (IOException e)
+            {
+                close();
+                throw new RuntimeException("Could not connect to MBean server. Please check that the JMX port is correct and open.", e);
+            }
+
+            connected = true;
+        }
+    }
+
+    protected <T> void registerMBean(Class<T> clazz, T mbean)
+    {
+        clazzMBanRegistry.put(clazz, mbean);
+    }
+
+    @Override
+    public <T> T findMBean(Class<T> clazz)
+    {
+        connect();
+        return clazzMBanRegistry.get(clazz) == null ? null : clazz.cast(clazzMBanRegistry.get(clazz));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T findMBeanMetric(Class<T> clazz, Props props)
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            ObjectName objectName = new ObjectName("org.apache.cassandra.metrics", new Hashtable<>(props.toMap()));
+            T result = (T) namedMBeanRegistry.computeIfAbsent(objectName.getCanonicalName(),
+                                                              ignore -> JMX.newMBeanProxy(mbeanServerConn, objectName, clazz));
+            return clazz.cast(result);
+        });
+    }
+
+    @Override
+    public boolean isMBeanMetricRegistered(Props props)
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            ObjectName objectName = new ObjectName("org.apache.cassandra.metrics", new Hashtable<>(props.toMap()));
+            return mbeanServerConn.isRegistered(objectName);
+        });
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxCounterMBean findMBeanCounter(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxCounterMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxGaugeMBean findMBeanGauge(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxGaugeMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxMeterMBean findMBeanMeter(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxMeterMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxTimerMBean findMBeanTimer(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxTimerMBean.class, props);
+    }
+
+    @Override
+    public CassandraMetricsRegistry.JmxHistogramMBean findMBeanHistogram(Props props)
+    {
+        return findMBeanMetric(CassandraMetricsRegistry.JmxHistogramMBean.class, props);
+    }
+
+    @Override
+    public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            Set<ObjectName> beans = mbeanServerConn.queryNames(new ObjectName("org.apache.cassandra.db:type=*" + type +
+                                                                              ",keyspace=" + keyspace +
+                                                                              ",columnfamily=" + columnFamily), null);
+            if (beans.isEmpty())
+                throw new MalformedObjectNameException("couldn't find that bean");
+
+            assert beans.size() == 1;
+            return JMX.newMBeanProxy(mbeanServerConn, beans.iterator().next(), ColumnFamilyStoreMBean.class);
+        });
+    }
+
+    @Override
+    public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+    {
+        List<Map.Entry<String, ColumnFamilyStoreMBean>> keyspaces = findColumnFamilies("ColumnFamilies");
+        Optional<ColumnFamilyStoreMBean> cfsMBean = keyspaces.stream()
+                                                             .filter(e -> e.getKey().equals(keyspace))
+                                                             .map(Map.Entry::getValue)
+                                                             .filter(mbean -> mbean.getTableName().equals(table))
+                                                             .findAny();
+        if  (keyspaces.isEmpty() || cfsMBean.isEmpty())
+            throw new IllegalArgumentException(String.format("Table %s.%s does not exist", keyspace, table));
+
+        return withExceptionHandling(() -> {
+            connect();
+            String mbeanName = CompressionDictionaryManagerMBean.MBEAN_NAME + ",keyspace=" + keyspace + ",table=" + table;
+            if (!mbeanServerConn.isRegistered(new ObjectName(mbeanName)))
+                throw new IllegalStateException("The compression on table " + keyspace + '.' + table + " is not enabled or SSTable compressor is not a dictionary compressor.");
+            return JMX.newMBeanProxy(mbeanServerConn, new ObjectName(mbeanName), CompressionDictionaryManagerMBean.class);
+        });
+    }
+
+    @Override
+    public List<ThreadPoolInfo> threadPoolInfos()
+    {
+        return withExceptionHandling(() -> {
+            connect();
+            Set<ObjectName> threadPoolObjectNames = mbeanServerConn.queryNames(new ObjectName("org.apache.cassandra.metrics:type=ThreadPools,*"), null);
+            return threadPoolObjectNames.stream()
+                                        .map(oName -> new ThreadPoolInfo(oName.getKeyProperty("path"), oName.getKeyProperty("scope")))
+                                        .collect(Collectors.toList());
+        });
+    }
+
+    @Override
+    public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+    {
+        return withExceptionHandling(() -> {
+            assert type.equals("IndexColumnFamilies") || type.equals("ColumnFamilies");
+            connect();
+
+            ObjectName query = new ObjectName("org.apache.cassandra.db:type=" + type + ",*");
+            Set<ObjectName> cfObjects = mbeanServerConn.queryNames(query, null);
+
+            List<Map.Entry<String, ColumnFamilyStoreMBean>> mbeans = new ArrayList<>(cfObjects.size());
+            for (ObjectName objectName : cfObjects)
+            {
+                ColumnFamilyStoreMBean cfsProxy = JMX.newMBeanProxy(mbeanServerConn, objectName, ColumnFamilyStoreMBean.class);
+                mbeans.add(new AbstractMap.SimpleImmutableEntry<>(objectName.getKeyProperty("keyspace"), cfsProxy));
+            }
+            return mbeans;
+        });
+    }
+
+    public JMXConnector getJmxConnector()
+    {
+        connect();
+        return jmxc;
+    }
+
+    public MBeanServerConnection getMBeanServerConnection()
+    {
+        connect();
+        return mbeanServerConn;
+    }
+
+    @Override
+    public void close()
+    {
+        if (jmxc == null)
+            return;
+
+        try
+        {
+            jmxc.close();
+            jmxc = null;
+            mbeanServerConn = null;
+            connected = false;
+        }
+        catch (IOException e)
+        {
+            // result of 'stopdaemon' command - i.e. if close() call fails, the daemon is shutdown
+            logger.error("Cassandra has shutdown.");
+        }
+    }
+
+    private <T> void registerMBeanProxy(Class<T> clazz, String objectName) throws MalformedObjectNameException
+    {
+        registerMBean(clazz, JMX.newMBeanProxy(mbeanServerConn, new ObjectName(objectName), clazz));
+    }
+
+    private <T> void registerPlatformMBeanProxy(Class<T> clazz, String objectName) throws IOException
+    {
+        registerMBean(clazz, ManagementFactory.newPlatformMXBeanProxy(mbeanServerConn, objectName, clazz));
+    }
+
+    private RMIClientSocketFactory getRMIClientSocketFactory()
+    {
+        if (SSL_ENABLE.getBoolean())
+            return new SslRMIClientSocketFactory();
+        else
+            return RMISocketFactory.getDefaultSocketFactory();
+    }
+
+    private static <T> T withExceptionHandling(MBeanSupplier<T> op)
+    {
+        try
+        {
+            return op.get();
+        }
+        catch (MalformedObjectNameException e)
+        {
+            throw new RuntimeException("Invalid ObjectName? Requested MBean may not exist. " +
+                                       "Please check the parameters e.g. keyspace name, table name and try again.", e);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Could not connect to MBean server. Please check that the JMX port is correct and open.", e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface MBeanSupplier<T>
+    {
+        T get() throws MalformedObjectNameException, IOException;
+    }
+}

--- a/src/java/org/apache/cassandra/tools/RepairRunner.java
+++ b/src/java/org/apache/cassandra/tools/RepairRunner.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.management.ListenerNotFoundException;
 import javax.management.remote.JMXConnector;
 
+import org.apache.cassandra.management.MBeanAccessor;
 import org.apache.cassandra.service.ActiveRepairService.ParentRepairStatus;
 import org.apache.cassandra.service.StorageServiceMBean;
 import org.apache.cassandra.utils.Closeable;
@@ -34,9 +35,9 @@ import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.apache.cassandra.utils.progress.jmx.JMXNotificationProgressListener;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.cassandra.config.CassandraRelevantProperties.NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS;
 import static org.apache.cassandra.service.ActiveRepairService.ParentRepairStatus.FAILED;
 import static org.apache.cassandra.service.ActiveRepairService.ParentRepairStatus.valueOf;
-import static org.apache.cassandra.tools.NodeProbe.JMX_NOTIFICATION_POLL_INTERVAL_SECONDS;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
 import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
@@ -46,6 +47,8 @@ import static org.apache.cassandra.utils.progress.ProgressEventType.PROGRESS;
 
 public class RepairRunner extends JMXNotificationProgressListener implements Closeable
 {
+    private final long JMX_NOTIFICATION_POLL_INTERVAL_SECONDS = NODETOOL_JMX_NOTIFICATION_POLL_INTERVAL_SECONDS.getLong();
+
     public static abstract class RepairCmd
     {
         private final String keyspace;
@@ -60,6 +63,7 @@ public class RepairRunner extends JMXNotificationProgressListener implements Clo
     private final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
 
     private final PrintStream out;
+    /** The connector to monitor the JMX connection state, so it can be {@code null} for server-side tools. */
     private final JMXConnector jmxc;
     private final StorageServiceMBean ssProxy;
     private final Condition condition = newOneTimeCondition();
@@ -68,10 +72,10 @@ public class RepairRunner extends JMXNotificationProgressListener implements Clo
     private Integer cmd;
     private volatile Exception error;
 
-    public RepairRunner(PrintStream out, JMXConnector jmxc, StorageServiceMBean ssProxy, RepairCmd repairCmd)
+    public RepairRunner(PrintStream out, MBeanAccessor accessor, StorageServiceMBean ssProxy, RepairCmd repairCmd)
     {
         this.out = out;
-        this.jmxc = jmxc;
+        this.jmxc = accessor instanceof RemoteJmxMBeanAccessor ? ((RemoteJmxMBeanAccessor) accessor).getJmxConnector() : null;
         this.ssProxy = ssProxy;
         this.repairCmd = repairCmd;
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/AbstractCommand.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/AbstractCommand.java
@@ -73,7 +73,7 @@ public abstract class AbstractCommand implements Runnable
      * @return {@code true} if the command is required to connect to the node, {@code false} otherwise.
      * @throws ExecutionException if an error occurs during preparation and execution must be aborted.
      */
-    protected boolean shouldConnect() throws ExecutionException
+    public boolean shouldConnect() throws ExecutionException
     {
         return true;
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CMSAdmin.java
@@ -303,6 +303,8 @@ public class CMSAdmin extends AbstractCommand
     @Command(name = "dump", description = "Dumps cluster metadata into a file")
     public static class DumpClusterMetadata extends AbstractCommand
     {
+        // TODO CASSANDRA-XXXXX @ArgGroup cannot be populated by the remote (CQL/MBean) execution path,
+        //  this should be avoided to keep the command hierarchy flat for all interfaces
         @ArgGroup(exclusive = false, multiplicity = "0..1")
         DumpOptions dumpOptions;
 

--- a/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
@@ -136,9 +136,10 @@ public class CompressionDictionaryCommandGroup
                     else if (TrainingStatus.FAILED == status)
                     {
                         err.printf("%nTraining failed for %s.%s%n", keyspace, table);
+                        String failureMessage = null;
                         try
                         {
-                            String failureMessage = trainingState.getFailureMessage();
+                            failureMessage = trainingState.getFailureMessage();
                             if (failureMessage != null && !failureMessage.isEmpty())
                             {
                                 err.printf("Reason: %s%n", failureMessage);
@@ -148,19 +149,23 @@ public class CompressionDictionaryCommandGroup
                         {
                             // If we can't get the failure message, just continue without it
                         }
-                        System.exit(1);
+                        throw new RuntimeException(String.format("Training failed for %s.%s. Reason: %s",
+                                                                 keyspace, table, failureMessage == null ?
+                                                                                  "undefined" : failureMessage));
                     }
 
                     Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
                 }
 
-                err.printf("%nTraining did not complete within expected timeframe (10 minutes).%n");
-                System.exit(1);
+                throw new RuntimeException("Training did not complete within expected timeframe (10 minutes).");
+            }
+            catch (IllegalArgumentException | IllegalStateException e)
+            {
+                throw new IllegalArgumentException("Failed to trigger training: " + e.getMessage(), e);
             }
             catch (Exception e)
             {
-                err.printf("Failed to trigger training: %s%n", e.getMessage());
-                System.exit(1);
+                throw new RuntimeException("Failed to trigger training: " + e.getMessage(), e);
             }
         }
 
@@ -187,7 +192,7 @@ public class CompressionDictionaryCommandGroup
                 catch (Throwable t)
                 {
                     err.println("Invalid value for " + MAX_DICT_SIZE_PARAM_NAME + ": " + t.getMessage());
-                    System.exit(1);
+                    throw t;
                 }
             }
 
@@ -200,7 +205,7 @@ public class CompressionDictionaryCommandGroup
                 catch (Throwable t)
                 {
                     err.println("Invalid value for " + MAX_TOTAL_SAMPLE_SIZE_PARAM_NAME + ": " + t.getMessage());
-                    System.exit(1);
+                    throw t;
                 }
             }
         }
@@ -283,7 +288,7 @@ public class CompressionDictionaryCommandGroup
             if (dictId <= 0 && dictId != -1)
             {
                 probe.output().err.printf("Dictionary id has to be strictly positive number.%n");
-                System.exit(1);
+                throw  new IllegalArgumentException("Dictionary id has to be strictly positive number.");
             }
 
             try
@@ -304,7 +309,9 @@ public class CompressionDictionaryCommandGroup
                     probe.output().err.printf("Dictionary%s does not exist for %s.%s.%n",
                                               dictId == -1 ? "" : " with id " + dictId,
                                               keyspace, table);
-                    System.exit(1);
+                    throw new IllegalArgumentException(String.format("Dictionary%s does not exist for %s.%s.",
+                                                                     dictId == -1 ? "" : " with id " + dictId,
+                                                                     keyspace, table));
                 }
 
                 CompressionDictionaryDataObject dataObject = CompressionDictionaryDetailsTabularData.fromCompositeData(compressionDictionary);
@@ -314,7 +321,7 @@ public class CompressionDictionaryCommandGroup
             catch (Throwable e)
             {
                 probe.output().err.printf("Failed to export dictionary: %s%n", e.getMessage());
-                System.exit(1);
+                throw new RuntimeException(e);
             }
         }
     }
@@ -339,19 +346,22 @@ public class CompressionDictionaryCommandGroup
                 CompositeData compositeData = CompressionDictionaryDetailsTabularData.fromCompressionDictionaryDataObject(dictionaryDataObject);
                 probe.importCompressionDictionary(compositeData);
             }
+            catch (IllegalStateException | IllegalArgumentException ex)
+            {
+                // These exceptions are threated as the command input was invalid, so we don't need to wrap them.
+                throw ex;
+            }
             catch (ValueInstantiationException ex)
             {
                 // we catch this when validation of data object fails - that will happen when
                 // JSON is invalid, and we attempt to deserialize it to data object by Jackson
                 // We can fail fast on the client, so we will never reach Cassandra node with a payload
                 // which would fail there too, so we do not contact a node unnecessarily.
-                probe.output().err.printf("Unable to import dictionary JSON: %s%n", ex.getCause().getMessage());
-                System.exit(1);
+                throw new RuntimeException(String.format("Unable to import dictionary JSON: %s%n", ex.getCause().getMessage()), ex);
             }
             catch (Throwable t)
             {
-                probe.output().err.printf("Unable to import dictionary JSON: %s%n", t.getMessage());
-                System.exit(1);
+                throw new RuntimeException(String.format("Unable to import dictionary JSON: %s%n", t.getMessage()), t);
             }
         }
 
@@ -360,17 +370,17 @@ public class CompressionDictionaryCommandGroup
             if (!dictionaryFile.exists())
             {
                 probe.output().err.printf("Path %s does not exist.%n", dictionaryPath);
-                System.exit(1);
+                throw  new IllegalArgumentException("Path " + dictionaryPath + " does not exist.");
             }
             if (!dictionaryFile.isFile())
             {
                 probe.output().err.printf("Path %s is not a file.%n", dictionaryPath);
-                System.exit(1);
+                throw  new IllegalArgumentException("Path " + dictionaryPath + " is not a file.");
             }
             if (!dictionaryFile.isReadable())
             {
                 probe.output().err.printf("Path %s is not readable.%n", dictionaryPath);
-                System.exit(1);
+                throw  new IllegalArgumentException("Path " + dictionaryPath + " is not readable.");
             }
         }
     }
@@ -431,8 +441,7 @@ public class CompressionDictionaryCommandGroup
             }
             catch (Exception e)
             {
-                probe.output().err.printf("Failed to list dictionaries: %s%n", e.getMessage());
-                System.exit(1);
+                throw new RuntimeException("Failed to list dictionaries: " + e.getMessage(), e);
             }
         }
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
@@ -348,7 +348,7 @@ public class CompressionDictionaryCommandGroup
             }
             catch (IllegalStateException | IllegalArgumentException ex)
             {
-                // These exceptions are threated as the command input was invalid, so we don't need to wrap them.
+                // These exceptions already mean the command input was invalid, so don't wrap them.
                 throw ex;
             }
             catch (ValueInstantiationException ex)

--- a/src/java/org/apache/cassandra/tools/nodetool/CqlConnect.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CqlConnect.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.io.IOException;
+
+import com.google.common.base.Throwables;
+
+import org.apache.cassandra.config.CassandraRelevantEnv;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.nodetool.strategy.NodetoolConnectionException;
+import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.transport.SimpleClient;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Command options for NodeTool commands that are executed via CQL.
+ */
+@Command(name = "cqlconnect", description = "Connect to a Cassandra node via CQL")
+public class CqlConnect extends AbstractCommand implements AutoCloseable
+{
+    private static final int DEFAULT_CQL_PORT = 11211;
+
+    /** The command specification, used to access command-specific properties. */
+    @Spec
+    protected CommandSpec spec; // injected by picocli
+
+    @Option(names = { "-h", "--host" }, description = "Node hostname or ip address", arity = "0..1")
+    private String host = "127.0.0.1";
+
+    @Option(names = { "-p", "--port" }, description = "Remote CQL native transport port number", arity = "0..1")
+    private int port = DEFAULT_CQL_PORT;
+
+    @Option(names =  { "--diagnostic" }, description = "Enable diagnostic output for troubleshooting connection issues")
+    private boolean diagnostic = false;
+
+    private volatile SimpleClient client;
+
+    /**
+     * Initialize the CQL connection to the Cassandra node using the provided options.
+     */
+    public void run()
+    {
+        if (client != null)
+            return;
+
+        try
+        {
+            if (diagnostic)
+                output.printInfo("Connecting to %s:%s via CQL...%n", host, port);
+
+            SimpleClient.Builder builder = SimpleClient.builder(host, port)
+                                                       .protocolVersion(ProtocolVersion.V5)
+                                                       .requestTimeoutSeconds(requestTimeoutSeconds());
+            client = builder.build();
+            client.connect(false);
+        }
+        catch (IOException e)
+        {
+            Throwable rootCause = Throwables.getRootCause(e);
+            throw new NodetoolConnectionException(String.format("Failed to connect to '%s:%s' via CQL - %s: '%s'.",
+                                                                host, port,
+                                                                rootCause.getClass().getSimpleName(),
+                                                                rootCause.getMessage()),
+                                                  e);
+        }
+    }
+
+    public SimpleClient client()
+    {
+        return client;
+    }
+
+    /**
+     * Long-running commands are executed asynchronously by default, but some commands (e.g. info)
+     * are still synchronous and may need longer than {@link SimpleClient#TIMEOUT_SECONDS} to
+     * respond; {@code 0} waits indefinitely.
+     */
+    private static long requestTimeoutSeconds()
+    {
+        String env = CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS.getString();
+        if (env == null)
+            return CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS.getLong();
+
+        try
+        {
+            return Long.parseLong(env);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new IllegalArgumentException(String.format("Invalid value for environment variable '%s': " +
+                                                             "expected a number of seconds but was '%s'",
+                                                             CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS.getKey(),
+                                                             env));
+        }
+    }
+
+    @Override
+    protected void execute(NodeProbe probe)
+    {
+        assert probe == null;
+        run();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        if (client != null)
+        {
+            try
+            {
+                client.close();
+            }
+            finally
+            {
+                client = null;
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/CqlConnect.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CqlConnect.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.io.IOException;
+
+import com.google.common.base.Throwables;
+
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.transport.SimpleClient;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.InitializationException;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Command options for NodeTool commands that are executed via CQL.
+ */
+@Command(name = "cqlconnect", description = "Connect to a Cassandra node via CQL")
+public class CqlConnect extends AbstractCommand implements AutoCloseable
+{
+    private static final int DEFAULT_CQL_PORT = 11211;
+
+    /** The command specification, used to access command-specific properties. */
+    @Spec
+    protected CommandSpec spec; // injected by picocli
+
+    @Option(names = { "-h", "--host" }, description = "Node hostname or ip address", arity = "0..1")
+    private String host = "127.0.0.1";
+
+    @Option(names = { "-p", "--port" }, description = "Remote CQL native transport port number", arity = "0..1")
+    private int port = DEFAULT_CQL_PORT;
+
+    @Option(names =  { "--diagnostic" }, description = "Enable diagnostic output for troubleshooting connection issues")
+    private boolean diagnostic = false;
+
+    private volatile SimpleClient client;
+
+    /**
+     * Initialize the CQL connection to the Cassandra node using the provided options.
+     */
+    public void run()
+    {
+        if (client != null)
+            return;
+
+        try
+        {
+            if (diagnostic)
+                output.printInfo("Connecting to %s:%s via CQL...%n", host, port);
+
+            SimpleClient.Builder builder = SimpleClient.builder(host, port).protocolVersion(ProtocolVersion.V5);
+            client = builder.build();
+            client.connect(false);
+        }
+        catch (IOException e)
+        {
+            Throwable rootCause = Throwables.getRootCause(e);
+            output.printError("nodetool: Failed to connect to '%s:%s' via CQL - %s: '%s'.%n", host, port,
+                         rootCause.getClass().getSimpleName(), rootCause.getMessage());
+            throw new InitializationException("Failed to connect to CQL", e);
+        }
+    }
+
+    public SimpleClient client()
+    {
+        return client;
+    }
+
+    @Override
+    protected void execute(NodeProbe probe)
+    {
+        assert probe == null;
+        run();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        if (client != null)
+        {
+            try
+            {
+                client.close();
+            }
+            finally
+            {
+                client = null;
+            }
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/ForceCompact.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/ForceCompact.java
@@ -61,6 +61,7 @@ public class ForceCompact extends AbstractCommand
         try
         {
             probe.forceCompactionKeysIgnoringGcGrace(keyspaceName, tableName, partitionKeysIgnoreGcGrace);
+            probe.output().printInfo("Force compaction performed for keyspace '%s', table '%s'", keyspaceName, tableName);
         }
         catch (Exception e)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/History.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/History.java
@@ -51,7 +51,7 @@ public class History extends AbstractCommand implements LocalCommand
     }
 
     @Override
-    protected boolean shouldConnect() throws CommandLine.ExecutionException
+    public boolean shouldConnect() throws CommandLine.ExecutionException
     {
         return false;
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/History.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/History.java
@@ -51,7 +51,7 @@ public class History extends AbstractCommand
     }
 
     @Override
-    protected boolean shouldConnect() throws CommandLine.ExecutionException
+    public boolean shouldConnect() throws CommandLine.ExecutionException
     {
         return false;
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/Info.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Info.java
@@ -26,6 +26,8 @@ import java.util.Map.Entry;
 
 import javax.management.InstanceNotFoundException;
 
+import com.google.common.base.Throwables;
+
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.service.CacheServiceMBean;
@@ -73,7 +75,7 @@ public class Info extends AbstractCommand
         catch (RuntimeException e)
         {
             // offheap-metrics introduced in 2.1.3 - older versions do not have the appropriate mbeans
-            if (!(e.getCause() instanceof InstanceNotFoundException))
+            if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                 throw e;
         }
 
@@ -152,7 +154,7 @@ public class Info extends AbstractCommand
         }
         catch (RuntimeException e)
         {
-            if (!(e.getCause() instanceof InstanceNotFoundException))
+            if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                 throw e;
 
             // Chunk cache is not on.
@@ -168,7 +170,7 @@ public class Info extends AbstractCommand
         }
         catch (RuntimeException e)
         {
-            if (!(e.getCause() instanceof InstanceNotFoundException))
+            if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                 throw e;
 
             // network cache is not on.

--- a/src/java/org/apache/cassandra/tools/nodetool/Info.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Info.java
@@ -26,6 +26,8 @@ import java.util.Map.Entry;
 
 import javax.management.InstanceNotFoundException;
 
+import com.google.common.base.Throwables;
+
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.service.CacheServiceMBean;
@@ -73,7 +75,7 @@ public class Info extends AbstractCommand
         catch (RuntimeException e)
         {
             // offheap-metrics introduced in 2.1.3 - older versions do not have the appropriate mbeans
-            if (!(e.getCause() instanceof InstanceNotFoundException))
+            if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                 throw e;
         }
 
@@ -135,7 +137,7 @@ public class Info extends AbstractCommand
         }
         catch (RuntimeException e)
         {
-            if (!(e.getCause() instanceof InstanceNotFoundException))
+            if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                 throw e;
 
             // Chunk cache is not on.
@@ -151,7 +153,7 @@ public class Info extends AbstractCommand
         }
         catch (RuntimeException e)
         {
-            if (!(e.getCause() instanceof InstanceNotFoundException))
+            if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                 throw e;
 
             // network cache is not on.

--- a/src/java/org/apache/cassandra/tools/nodetool/JmxConnect.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/JmxConnect.java
@@ -22,7 +22,6 @@ import java.io.Console;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Scanner;
 
 import javax.inject.Inject;
@@ -32,21 +31,15 @@ import com.google.common.base.Throwables;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.tools.INodeProbeFactory;
 import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.nodetool.strategy.NodetoolConnectionException;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ExecutionException;
-import picocli.CommandLine.IExecutionStrategy;
-import picocli.CommandLine.InitializationException;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParameterException;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.RunLast;
 import picocli.CommandLine.Spec;
 
 import static java.lang.Integer.parseInt;
-import static org.apache.cassandra.tools.NodeProbe.defaultPort;
+import static org.apache.cassandra.tools.RemoteJmxMBeanAccessor.defaultPort;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -57,8 +50,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 @Command(name = "connect", description = "Connect to a Cassandra node via JMX")
 public class JmxConnect extends AbstractCommand implements AutoCloseable
 {
-    public static final String MIXIN_KEY = "jmx";
-
     /** The command specification, used to access command-specific properties. */
     @Spec
     protected CommandSpec spec; // injected by picocli
@@ -80,30 +71,6 @@ public class JmxConnect extends AbstractCommand implements AutoCloseable
 
     @Inject
     private INodeProbeFactory nodeProbeFactory;
-
-    /**
-     * This method is called by picocli and used depending on the execution strategy.
-     * @param parseResult The parsed command line.
-     * @return The exit code.
-     */
-    public static int executionStrategy(ParseResult parseResult)
-    {
-        CommandSpec jmx = parseResult.commandSpec().mixins().get(MIXIN_KEY);
-        if (jmx == null)
-            throw new InitializationException("No JmxConnect command found in the top-level hierarchy");
-
-        try (JmxConnectionCommandInvoker invoker = new JmxConnectionCommandInvoker((JmxConnect) jmx.userObject()))
-        {
-            return invoker.execute(parseResult);
-        }
-        catch (JmxConnectionCommandInvoker.CloseException e)
-        {
-            jmx.commandLine()
-               .getErr()
-               .println("Failed to connect to JMX: " + e.getMessage());
-            return jmx.commandLine().getExitCodeExceptionMapper().getExitCode(e);
-        }
-    }
 
     /**
      * Initialize the JMX connection to the Cassandra node using the provided options.
@@ -129,9 +96,11 @@ public class JmxConnect extends AbstractCommand implements AutoCloseable
         catch (IOException | SecurityException e)
         {
             Throwable rootCause = Throwables.getRootCause(e);
-            output.printError("nodetool: Failed to connect to '%s:%s' - %s: '%s'.%n", host, port,
-                         rootCause.getClass().getSimpleName(), rootCause.getMessage());
-            throw new InitializationException("Failed to connect to JMX", e);
+            throw new NodetoolConnectionException(String.format("Failed to connect to '%s:%s' - %s: '%s'.",
+                                                                host, port,
+                                                                rootCause.getClass().getSimpleName(),
+                                                                rootCause.getMessage()),
+                                                  e);
         }
     }
 
@@ -183,61 +152,13 @@ public class JmxConnect extends AbstractCommand implements AutoCloseable
         return password;
     }
 
-    private static class JmxConnectionCommandInvoker implements IExecutionStrategy, AutoCloseable
+    public String getHost()
     {
-        private final JmxConnect connect;
+        return host;
+    }
 
-        public JmxConnectionCommandInvoker(JmxConnect connect)
-        {
-            this.connect = connect;
-        }
-
-        @Override
-        public int execute(ParseResult parseResult) throws ExecutionException, ParameterException
-        {
-            CommandSpec lastParent = lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
-            if (lastParent.userObject() instanceof AbstractCommand)
-            {
-                AbstractCommand command = (AbstractCommand) lastParent.userObject();
-                if (command.shouldConnect())
-                    connect.run();
-                command.probe(connect.probe());
-            }
-            return new RunLast().execute(parseResult);
-        }
-
-        @Override
-        public void close() throws CloseException
-        {
-            try
-            {
-                if (connect.probe() != null)
-                    ((AutoCloseable) connect.probe()).close();
-            }
-            catch (Exception e)
-            {
-                throw new CloseException("Failed to close JMX connection", e);
-            }
-        }
-
-        private static CommandLine.Model.CommandSpec lastExecutableSubcommandWithSameParent(List<CommandLine> parsedCommands)
-        {
-            int start = parsedCommands.size() - 1;
-            for (int i = parsedCommands.size() - 2; i >= 0; i--)
-            {
-                if (parsedCommands.get(i).getParent() != parsedCommands.get(i + 1).getParent())
-                    break;
-                start = i;
-            }
-            return parsedCommands.get(start).getCommandSpec();
-        }
-
-        private static class CloseException extends RuntimeException
-        {
-            public CloseException(String message, Throwable cause)
-            {
-                super(message, cause);
-            }
-        }
+    public String getPort()
+    {
+        return port;
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/JmxConnect.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/JmxConnect.java
@@ -22,7 +22,6 @@ import java.io.Console;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Scanner;
 
 import javax.inject.Inject;
@@ -33,20 +32,14 @@ import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.tools.INodeProbeFactory;
 import org.apache.cassandra.tools.NodeProbe;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ExecutionException;
-import picocli.CommandLine.IExecutionStrategy;
 import picocli.CommandLine.InitializationException;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParameterException;
-import picocli.CommandLine.ParseResult;
-import picocli.CommandLine.RunLast;
 import picocli.CommandLine.Spec;
 
 import static java.lang.Integer.parseInt;
-import static org.apache.cassandra.tools.NodeProbe.defaultPort;
+import static org.apache.cassandra.tools.RemoteJmxMBeanAccessor.defaultPort;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -57,8 +50,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 @Command(name = "connect", description = "Connect to a Cassandra node via JMX")
 public class JmxConnect extends AbstractCommand implements AutoCloseable
 {
-    public static final String MIXIN_KEY = "jmx";
-
     /** The command specification, used to access command-specific properties. */
     @Spec
     protected CommandSpec spec; // injected by picocli
@@ -80,30 +71,6 @@ public class JmxConnect extends AbstractCommand implements AutoCloseable
 
     @Inject
     private INodeProbeFactory nodeProbeFactory;
-
-    /**
-     * This method is called by picocli and used depending on the execution strategy.
-     * @param parseResult The parsed command line.
-     * @return The exit code.
-     */
-    public static int executionStrategy(ParseResult parseResult)
-    {
-        CommandSpec jmx = parseResult.commandSpec().mixins().get(MIXIN_KEY);
-        if (jmx == null)
-            throw new InitializationException("No JmxConnect command found in the top-level hierarchy");
-
-        try (JmxConnectionCommandInvoker invoker = new JmxConnectionCommandInvoker((JmxConnect) jmx.userObject()))
-        {
-            return invoker.execute(parseResult);
-        }
-        catch (JmxConnectionCommandInvoker.CloseException e)
-        {
-            jmx.commandLine()
-               .getErr()
-               .println("Failed to connect to JMX: " + e.getMessage());
-            return jmx.commandLine().getExitCodeExceptionMapper().getExitCode(e);
-        }
-    }
 
     /**
      * Initialize the JMX connection to the Cassandra node using the provided options.
@@ -183,61 +150,13 @@ public class JmxConnect extends AbstractCommand implements AutoCloseable
         return password;
     }
 
-    private static class JmxConnectionCommandInvoker implements IExecutionStrategy, AutoCloseable
+    public String getHost()
     {
-        private final JmxConnect connect;
+        return host;
+    }
 
-        public JmxConnectionCommandInvoker(JmxConnect connect)
-        {
-            this.connect = connect;
-        }
-
-        @Override
-        public int execute(ParseResult parseResult) throws ExecutionException, ParameterException
-        {
-            CommandSpec lastParent = lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
-            if (lastParent.userObject() instanceof AbstractCommand)
-            {
-                AbstractCommand command = (AbstractCommand) lastParent.userObject();
-                if (command.shouldConnect())
-                    connect.run();
-                command.probe(connect.probe());
-            }
-            return new RunLast().execute(parseResult);
-        }
-
-        @Override
-        public void close() throws CloseException
-        {
-            try
-            {
-                if (connect.probe() != null)
-                    ((AutoCloseable) connect.probe()).close();
-            }
-            catch (Exception e)
-            {
-                throw new CloseException("Failed to close JMX connection", e);
-            }
-        }
-
-        private static CommandLine.Model.CommandSpec lastExecutableSubcommandWithSameParent(List<CommandLine> parsedCommands)
-        {
-            int start = parsedCommands.size() - 1;
-            for (int i = parsedCommands.size() - 2; i >= 0; i--)
-            {
-                if (parsedCommands.get(i).getParent() != parsedCommands.get(i + 1).getParent())
-                    break;
-                start = i;
-            }
-            return parsedCommands.get(start).getCommandSpec();
-        }
-
-        private static class CloseException extends RuntimeException
-        {
-            public CloseException(String message, Throwable cause)
-            {
-                super(message, cause);
-            }
-        }
+    public String getPort()
+    {
+        return port;
     }
 }

--- a/src/java/org/apache/cassandra/tools/nodetool/Sjk.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Sjk.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.tools.nodetool;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -47,6 +48,7 @@ import org.gridkit.jvmtool.cli.CommandLauncher;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.Output;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -64,7 +66,7 @@ public class Sjk extends AbstractCommand
     private final Wrapper wrapper = new Wrapper();
 
     @Override
-    protected boolean shouldConnect() throws ExecutionException
+    public boolean shouldConnect() throws ExecutionException
     {
         // We want to parse the given arguments in advance to determine if the SJK command requires an MBeanServerConnection or not.
         wrapper.prepare(args.isEmpty() ? new String[]{ "--help" } : args.toArray(new String[0]), output.out, output.err);
@@ -243,7 +245,9 @@ public class Sjk extends AbstractCommand
                 {
                     public MBeanServerConnection getMServer()
                     {
-                        return probe.getMbeanServerConn();
+                        return probe.getMBeanAccessor() instanceof RemoteJmxMBeanAccessor ?
+                               ((RemoteJmxMBeanAccessor) probe.getMBeanAccessor()).getMBeanServerConnection() :
+                               ManagementFactory.getPlatformMBeanServer();
                     }
                 });
             }

--- a/src/java/org/apache/cassandra/tools/nodetool/StopDaemon.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/StopDaemon.java
@@ -18,8 +18,11 @@
 package org.apache.cassandra.tools.nodetool;
 
 
+import com.google.common.base.Throwables;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.nodetool.strategy.NodetoolConnectionException;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 
 import picocli.CommandLine.Command;
@@ -37,6 +40,12 @@ public class StopDaemon extends AbstractCommand
         } catch (Exception e)
         {
             JVMStabilityInspector.inspectThrowable(e);
+            // The connection dropping while the daemon stops is expected and ignored.
+            if (Throwables.getCausalChain(e).stream().anyMatch(NodetoolConnectionException.class::isInstance))
+            {
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
+            }
             // ignored
         }
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/stats/TableStatsHolder.java
@@ -33,6 +33,7 @@ import java.util.TimeZone;
 
 import javax.management.InstanceNotFoundException;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 
 import org.apache.commons.lang3.time.DurationFormatUtils;
@@ -341,7 +342,7 @@ public class TableStatsHolder implements StatsHolder
                 catch (RuntimeException e)
                 {
                     // offheap-metrics introduced in 2.1.3 - older versions do not have the appropriate mbeans
-                    if (!(e.getCause() instanceof InstanceNotFoundException))
+                    if (!(Throwables.getRootCause(e) instanceof InstanceNotFoundException))
                         throw e;
                 }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandExecutionStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import picocli.CommandLine;
+
+public interface CommandExecutionStrategy extends CommandLine.IExecutionStrategy, AutoCloseable
+{
+    @Override
+    default void close() throws ExecutionStrategyCloseException {}
+
+    class ExecutionStrategyCloseException extends RuntimeException
+    {
+        public ExecutionStrategyCloseException(String message, Throwable cause)
+        {
+            super(message, cause);
+        }
+    }
+
+    enum Type
+    {
+        CQL,
+        STATIC_MBEAN,
+        COMMAND_MBEAN,
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
@@ -106,8 +106,8 @@ public class CommandMBeanExecutionStrategy implements CommandExecutionStrategy
                 throw new RuntimeException("Invalid command result schema received from CommandMBeanAdapter: " + rawResult);
 
             probe.output().printInfo(output);
-            // The output needs to be consistent for the tests we already have and for thouse which heavily rely on
-            // asserting command output, so we use this property to control whether the execution id is printed or not.
+            // Existing tests assert on exact command output, so this property controls whether the
+            // execution id is printed.
             if (CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean() ||
                 CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean())
                 probe.output().printInfo("Command execution id: " + executionId);

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.management.MBeanException;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.RuntimeMBeanException;
+
+import com.google.common.base.Strings;
+
+import org.apache.cassandra.config.CassandraRelevantEnv;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+import org.apache.cassandra.management.CommandExecutionArgsSerde;
+import org.apache.cassandra.management.CommandMBeanAdapter;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.JmxConnect;
+import org.apache.cassandra.tools.nodetool.StopDaemon;
+
+import picocli.CommandLine;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID;
+import static org.apache.cassandra.management.ManagementUtils.fullCommandName;
+import static org.apache.cassandra.utils.JsonUtils.fromJsonMap;
+
+public class CommandMBeanExecutionStrategy implements CommandExecutionStrategy
+{
+    private static final String MBEAN_DOMAIN = "org.apache.cassandra.management";
+    private static final String MBEAN_TYPE_COMMAND = "Command";
+
+    private final JmxConnect connect;
+
+    public CommandMBeanExecutionStrategy(JmxConnect connect)
+    {
+        this.connect = connect;
+    }
+
+    @Override
+    public int execute(CommandLine.ParseResult parseResult) throws CommandLine.ExecutionException, CommandLine.ParameterException
+    {
+        CommandLine.Model.CommandSpec lastParent = StaticMBeanExecutionStrategy.lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
+
+        NodeProbe probe = null;
+        Object userObject = lastParent.userObject();
+
+        if (userObject instanceof AbstractCommand)
+        {
+            AbstractCommand command = (AbstractCommand) userObject;
+            if (command.shouldConnect())
+                connect.run();
+            probe = connect.probe();
+        }
+
+        // Local command execution with no JMX connection.
+        if (probe == null || parseResult.isUsageHelpRequested() || parseResult.isVersionHelpRequested())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        String commandName = extractCommandName(parseResult);
+        if (commandName == null || commandName.isEmpty())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        // Command is already populated with args from CommandLine.parseArgs(), convert to CommandExecutionArgs
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(userObject);
+        String jsonParams = CommandExecutionArgsSerde.toJson(args);
+
+        try
+        {
+            MBeanServerConnection mbs = ((RemoteJmxMBeanAccessor) probe.getMBeanAccessor()).getMBeanServerConnection();
+
+            if (!mbs.isRegistered(constructCommandMBeanName(commandName)))
+                return new CommandLine.RunLast().execute(parseResult);
+
+            String rawResult = executeViaRemoteMBean(mbs, commandName, jsonParams);
+
+            Map<String, String> commandResult = fromJsonMap(rawResult);
+
+            String executionId = commandResult.get(ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_EXECUTION_ID);
+            String output = commandResult.get(ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_OUTPUT);
+
+            if (Strings.isNullOrEmpty(executionId) || output == null)
+                throw new RuntimeException("Invalid command result schema received from CommandMBeanAdapter: " + rawResult);
+
+            probe.output().printInfo(output);
+            // The output needs to be consistent for the tests we already have and for thouse which heavily rely on
+            // asserting command output, so we use this property to control whether the execution id is printed or not.
+            if (CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean() ||
+                CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean())
+                probe.output().printInfo("Command execution id: " + executionId);
+            return 0;
+        }
+        catch (NodetoolConnectionException e)
+        {
+            throw e;
+        }
+        catch (RuntimeMBeanException e)
+        {
+            Throwable cause = e.getCause();
+            if (cause instanceof IllegalArgumentException || cause instanceof IllegalStateException)
+            {
+                throw new CommandLine.ParameterException(parseResult.commandSpec().commandLine(),
+                                                        "Invalid command parameters: " + cause.getMessage(), cause);
+            }
+            else
+            {
+                // Include security exception, instance not found, invocation target exceptions.
+                throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                         "Failed to execute command via MBean: " + cause.getMessage(), cause);
+            }
+        }
+        catch (IOException e)
+        {
+            if (userObject instanceof StopDaemon)
+            {
+                probe.output().printInfo("Cassandra has shutdown.");
+                return 0;
+            }
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     String.format("JMX connection to the node was lost while executing command '%s'. " +
+                                                                   "The command may still be running on the server.",
+                                                                   commandName),
+                                                     e);
+        }
+        catch (Exception e)
+        {
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     "Unexpected error during command execution: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws ExecutionStrategyCloseException
+    {
+        if (connect.probe() == null)
+            return;
+        try
+        {
+            connect.probe().close();
+        }
+        catch (Exception e)
+        {
+            throw new ExecutionStrategyCloseException("Failed to close JMX connection", e);
+        }
+    }
+
+    /** Handles nested commands (e.g. compressiondictionary.train). */
+    public static String extractCommandName(CommandLine.ParseResult parseResult)
+    {
+        List<CommandLine> commandLineList = parseResult.asCommandLineList();
+        if (commandLineList.size() <= 1) // Only root "nodetool"
+            return null;
+
+        // Skip the root command ("nodetool") and concatenate the rest to form the full command name.
+        return fullCommandName(commandLineList.subList(1, commandLineList.size()), CommandLine::getCommandName);
+    }
+
+    private String executeViaRemoteMBean(MBeanServerConnection mbs, String commandName, String jsonParams) throws Exception
+    {
+        ObjectName mbeanName = constructCommandMBeanName(commandName);
+
+        try
+        {
+            Object result = mbs.invoke(mbeanName, CommandMBeanAdapter.INVOKE_METHOD,
+                                       new Object[]{ jsonParams },
+                                       new String[]{ String.class.getName() });
+
+            return result == null ? "" : result.toString();
+        }
+        catch (MBeanException | ReflectionException e)
+        {
+            throw new RuntimeMBeanException(new RuntimeException(e), "Failed to invoke CommandMBeanAdapter: " + commandName);
+        }
+    }
+
+    private ObjectName constructCommandMBeanName(String commandName) throws Exception
+    {
+        String escapedName = ObjectName.quote(commandName);
+        String objectNameStr = String.format("%s:type=%s,name=%s", MBEAN_DOMAIN, MBEAN_TYPE_COMMAND, escapedName);
+        return new ObjectName(objectNameStr);
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
@@ -74,6 +74,7 @@ public class CommandMBeanExecutionStrategy implements CommandExecutionStrategy
             if (command.shouldConnect())
                 connect.run();
             probe = connect.probe();
+            command.probe(probe);
         }
 
         // Local command execution with no JMX connection.

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CommandMBeanExecutionStrategy.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.RuntimeMBeanException;
+
+import com.google.common.base.Strings;
+
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+import org.apache.cassandra.management.CommandExecutionArgsSerde;
+import org.apache.cassandra.management.CommandMBeanAdapter;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.JmxConnect;
+
+import picocli.CommandLine;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID;
+import static org.apache.cassandra.management.ManagementUtils.fullCommandName;
+import static org.apache.cassandra.utils.JsonUtils.fromJsonMap;
+
+public class CommandMBeanExecutionStrategy implements CommandExecutionStrategy
+{
+    private static final String MBEAN_DOMAIN = "org.apache.cassandra.management";
+    private static final String MBEAN_TYPE_COMMAND = "Command";
+
+    private final JmxConnect connect;
+
+    public CommandMBeanExecutionStrategy(JmxConnect connect)
+    {
+        this.connect = connect;
+    }
+
+    @Override
+    public int execute(CommandLine.ParseResult parseResult) throws CommandLine.ExecutionException, CommandLine.ParameterException
+    {
+        CommandLine.Model.CommandSpec lastParent = StaticMBeanExecutionStrategy.lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
+
+        NodeProbe probe = null;
+        Object userObject = lastParent.userObject();
+
+        if (userObject instanceof AbstractCommand)
+        {
+            AbstractCommand command = (AbstractCommand) userObject;
+            if (command.shouldConnect())
+                connect.run();
+            probe = connect.probe();
+        }
+
+        // Local command execution with no JMX connection.
+        if (probe == null || parseResult.isUsageHelpRequested() || parseResult.isVersionHelpRequested())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        String commandName = extractCommandName(parseResult);
+        if (commandName == null || commandName.isEmpty())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        // Command is already populated with args from CommandLine.parseArgs(), convert to CommandExecutionArgs
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(userObject);
+        String jsonParams = CommandExecutionArgsSerde.toJson(args);
+
+        try
+        {
+            String rawResult = executeViaRemoteMBean(((RemoteJmxMBeanAccessor) probe.getMBeanAccessor()).getMBeanServerConnection(),
+                                                  commandName, jsonParams);
+
+            Map<String, String> commandResult = fromJsonMap(rawResult);
+
+            String executionId = commandResult.get(ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_EXECUTION_ID);
+            String output = commandResult.get(ExecuteCommandStatement.COMMAND_RESULT_SCHEMA_OUTPUT);
+
+            if (Strings.isNullOrEmpty(executionId) || output == null)
+                throw new RuntimeException("Invalid command result schema received from CommandMBeanAdapter: " + rawResult);
+
+            probe.output().printInfo(output);
+            if (CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean() ||
+                CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean(false))
+                probe.output().printInfo("Command execution id: " + executionId);
+            return 0;
+        }
+        catch (RuntimeMBeanException e)
+        {
+            Throwable cause = e.getCause();
+            if (cause instanceof IllegalArgumentException || cause instanceof IllegalStateException)
+            {
+                throw new CommandLine.ParameterException(parseResult.commandSpec().commandLine(),
+                                                        "Invalid command parameters: " + cause.getMessage(), cause);
+            }
+            else
+            {
+                // Include security exception, instance not found, invocation target exceptions.
+                throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                         "Failed to execute command via MBean: " + cause.getMessage(), cause);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     "Unexpected error during command execution: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws ExecutionStrategyCloseException
+    {
+        if (connect.probe() == null)
+            return;
+        try
+        {
+            connect.probe().close();
+        }
+        catch (Exception e)
+        {
+            throw new ExecutionStrategyCloseException("Failed to close JMX connection", e);
+        }
+    }
+
+    /** Handles nested commands (e.g. compressiondictionary.train). */
+    public static String extractCommandName(CommandLine.ParseResult parseResult)
+    {
+        List<CommandLine> commandLineList = parseResult.asCommandLineList();
+        if (commandLineList.size() <= 1) // Only root "nodetool"
+            return null;
+
+        // Skip the root command ("nodetool") and concatenate the rest to form the full command name.
+        return fullCommandName(commandLineList.subList(1, commandLineList.size()), CommandLine::getCommandName);
+    }
+
+    private String executeViaRemoteMBean(MBeanServerConnection mbs, String commandName, String jsonParams) throws Exception
+    {
+        ObjectName mbeanName = constructCommandMBeanName(commandName);
+
+        if (!mbs.isRegistered(mbeanName))
+            throw new InstanceNotFoundException("Command MBean not found: " + mbeanName);
+
+        try
+        {
+            Object result = mbs.invoke(mbeanName, CommandMBeanAdapter.INVOKE_METHOD,
+                                       new Object[]{ jsonParams },
+                                       new String[]{ String.class.getName() });
+
+            return result == null ? "" : result.toString();
+        }
+        catch (MBeanException | ReflectionException e)
+        {
+            throw new RuntimeMBeanException(new RuntimeException(e), "Failed to invoke CommandMBeanAdapter: " + commandName);
+        }
+    }
+
+    private ObjectName constructCommandMBeanName(String commandName) throws Exception
+    {
+        String escapedName = ObjectName.quote(commandName);
+        String objectNameStr = String.format("%s:type=%s,name=%s", MBEAN_DOMAIN, MBEAN_TYPE_COMMAND, escapedName);
+        return new ObjectName(objectNameStr);
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategy.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import java.lang.reflect.Array;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.cassandra.config.CassandraRelevantEnv;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.marshal.ByteArrayAccessor;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.CqlConnect;
+import org.apache.cassandra.tools.nodetool.StopDaemon;
+import org.apache.cassandra.transport.SimpleClient;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import picocli.CommandLine;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID;
+import static org.apache.cassandra.management.ManagementUtils.normalizeOptionName;
+import static org.apache.cassandra.management.api.ParameterMetadata.COMMAND_POSITIONAL_PARAM_PREFIX;
+import static org.apache.cassandra.tools.nodetool.strategy.CommandMBeanExecutionStrategy.extractCommandName;
+
+public class CqlCommandExecutionStrategy implements CommandExecutionStrategy
+{
+    private final CqlConnect connect;
+
+    public CqlCommandExecutionStrategy(CqlConnect connect)
+    {
+        this.connect = connect;
+    }
+
+    @Override
+    public int execute(CommandLine.ParseResult parseResult) throws CommandLine.ExecutionException, CommandLine.ParameterException
+    {
+        CommandLine.Model.CommandSpec lastParent = StaticMBeanExecutionStrategy.lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
+
+        Object userObject = lastParent.userObject();
+
+        if (userObject instanceof AbstractCommand)
+        {
+            AbstractCommand command = (AbstractCommand) userObject;
+            if (command.shouldConnect())
+                connect.run();
+        }
+
+        // Local command execution with no CQL connection.
+        if (connect.client() == null || parseResult.isUsageHelpRequested() || parseResult.isVersionHelpRequested())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        String commandName = extractCommandName(parseResult);
+        if (commandName == null || commandName.isEmpty())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        // Command is already populated with args from CommandLine.parseArgs(), converting it to CommandExecutionArgs
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(userObject);
+
+        try
+        {
+            String cqlCommand = buildCqlCommandString(commandName, args);
+            ResultMessage result = connect.client().execute(cqlCommand, ConsistencyLevel.ONE);
+
+            if (result instanceof ResultMessage.Rows)
+            {
+                ResultMessage.Rows rows = (ResultMessage.Rows) result;
+                assert rows.result.size() == 1 : "Command execution result should have exactly 1 row, got " + rows.result.size();
+                assert rows.result.metadata.getColumnCount() == 2 : "Command execution result schema has been changed. " +
+                                                               "Expected 2 columns in result, got " + rows.result.metadata.getColumnCount();
+
+                if (!rows.result.isEmpty() && rows.result.metadata.names.size() >= 2)
+                {
+                    List<byte[]> firstRow = rows.result.rows.get(0);
+                    if (firstRow.size() >= 2)
+                    {
+                        UUID executionId = UUIDType.instance.getSerializer().deserialize(firstRow.get(0), ByteArrayAccessor.instance);
+                        String output = UTF8Type.instance.getSerializer().deserialize(firstRow.get(1), ByteArrayAccessor.instance);
+                        // NodeProbe instance is not available here, so print directly to the command output.
+                        parseResult.commandSpec().commandLine().getOut().println(output);
+                        if (CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean()
+                            || CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean())
+                            parseResult.commandSpec().commandLine().getOut().println("Command execution id: " + executionId.toString());
+                    }
+                }
+            }
+
+            return 0;
+        }
+        catch (SimpleClient.ConnectionClosedException e)
+        {
+            if (userObject instanceof StopDaemon)
+            {
+                parseResult.commandSpec().commandLine().getOut().println("Cassandra has shutdown.");
+                return 0;
+            }
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     String.format("Connection to the node was closed before a response " +
+                                                                   "was received for command '%s'. " +
+                                                                   "The command may still be running on the server.",
+                                                                   commandName),
+                                                     e);
+        }
+        catch (SimpleClient.TimeoutException e)
+        {
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     String.format("No response received for command '%s' within the client timeout. " +
+                                                                   "The command may still be running on the server. " +
+                                                                   "Increase the timeout via the %s environment variable " +
+                                                                   "or the %s system property (0 waits indefinitely). %s",
+                                                                   commandName,
+                                                                   CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS.getKey(),
+                                                                   CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_TIMEOUT_SECONDS.getKey(),
+                                                                   e.getMessage()),
+                                                     e);
+        }
+        catch (RuntimeException e)
+        {
+            Throwable cause = e.getCause();
+            if (cause instanceof UnauthorizedException)
+            {
+                throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                         "Unauthorized: " + cause.getMessage());
+            }
+            else if (cause instanceof InvalidRequestException)
+            {
+                // CQL invalid request (e.g. validating params and/or param values) translates into picocli param exection.
+                throw new CommandLine.ParameterException(parseResult.commandSpec().commandLine(),
+                                                         "Invalid request: " + cause.getMessage());
+            }
+            else if (cause instanceof CommandRequestExecutionException)
+            {
+                CommandRequestExecutionException cree = (CommandRequestExecutionException) cause;
+                String msg = String.format("Command execution failed (executionId: %s): %s",
+                                           cree.getCommandExecutionId(), cree.getMessage());
+                throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(), msg);
+            }
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     "Unknown command execution exception via CQL: " + e.getMessage(), e);
+        }
+        catch (Exception e) {
+            // Catch-all for checked exceptions thrown during command execution.
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     "Unknown command execution exception via CQL: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws ExecutionStrategyCloseException
+    {
+        if (connect == null)
+            return;
+        try
+        {
+            connect.close();
+        }
+        catch (Exception e)
+        {
+            throw new ExecutionStrategyCloseException("Failed to close CQL connection", e);
+        }
+    }
+
+    /**
+     * Build a CQL INVOKE COMMAND statement string from command name and CommandExecutionArgs.
+     * The format is: INVOKE COMMAND commandName WITH "key1" = 'value1' AND "key2" = 'value2';
+     */
+    @VisibleForTesting
+    static String buildCqlCommandString(String commandName, CommandExecutionArgs args)
+    {
+        CqlBuilder builder = new CqlBuilder();
+        builder.append("INVOKE COMMAND ");
+        builder.appendQuotingIfNeeded(commandName);
+
+        Map<String, Object> paramsMap = new LinkedHashMap<>();
+        for (Map.Entry<OptionMetadata, Object> entry : args.options().entrySet())
+        {
+            OptionMetadata optionMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            String key = normalizeOptionName(optionMetadata.paramLabel());
+            paramsMap.put(key, value);
+        }
+
+        for (Map.Entry<ParameterMetadata, Object> entry : args.parameters().entrySet())
+        {
+            ParameterMetadata paramMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            String key = COMMAND_POSITIONAL_PARAM_PREFIX + paramMetadata.index();
+            paramsMap.put(key, value);
+        }
+
+        if (!paramsMap.isEmpty())
+        {
+            builder.append(" WITH");
+            boolean first = true;
+            for (Map.Entry<String, Object> entry : paramsMap.entrySet())
+            {
+                if (first)
+                    builder.append(" ");
+                else
+                    builder.append(" AND ");
+
+                // Using ColumnIdentifier.maybeQuote as some of the keys
+                // may be reserved words in CQL (e.g., "keyspace", "table").
+                builder.append(ColumnIdentifier.maybeQuote(entry.getKey()));
+                builder.append(" = ");
+                appendCqlValue(builder, entry.getValue());
+
+                first = false;
+            }
+        }
+
+        builder.append(";");
+        return builder.toString();
+    }
+
+    /** Append a value to CqlBuilder with proper type handling and escaping. */
+    private static void appendCqlValue(CqlBuilder builder, Object value)
+    {
+        if (value == null)
+        {
+            builder.append("NULL");
+            return;
+        }
+
+        if (value instanceof String)
+            builder.appendWithSingleQuotes((String) value);
+        else if (value instanceof Enum)
+            builder.appendWithSingleQuotes(((Enum<?>) value).name());
+        else if (value instanceof Number)
+            builder.append(value);
+        else if (value instanceof Boolean)
+            builder.append(value);
+        else if (value instanceof List)
+        {
+            List<?> list = (List<?>) value;
+            builder.append("[");
+            for (int i = 0; i < list.size(); i++)
+            {
+                if (i > 0)
+                    builder.append(", ");
+                appendCqlValue(builder, list.get(i));
+            }
+            builder.append("]");
+        }
+        else if (value instanceof Map)
+        {
+            Map<String, Object> map = (Map<String, Object>) value;
+            builder.append("{");
+            boolean first = true;
+            for (Map.Entry<String, Object> entry : map.entrySet())
+            {
+                if (!first)
+                    builder.append(", ");
+                builder.appendWithSingleQuotes(entry.getKey());
+                builder.append(": ");
+                appendCqlValue(builder, entry.getValue());
+                first = false;
+            }
+            builder.append("}");
+        }
+        else if (value instanceof Set)
+        {
+            Set<?> set = (Set<?>) value;
+            builder.append("{");
+            boolean first = true;
+            for (Object item : set)
+            {
+                if (!first)
+                    builder.append(", ");
+                appendCqlValue(builder, item);
+                first = false;
+            }
+            builder.append("}");
+        }
+        else if (value.getClass().isArray())
+        {
+            int length = Array.getLength(value);
+            builder.append("[");
+            for (int i = 0; i < length; i++)
+            {
+                if (i > 0)
+                    builder.append(", ");
+                appendCqlValue(builder, Array.get(value, i));
+            }
+            builder.append("]");
+        }
+        else
+            builder.appendWithSingleQuotes(value.toString());
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategy.java
@@ -156,7 +156,7 @@ public class CqlCommandExecutionStrategy implements CommandExecutionStrategy
             }
             else if (cause instanceof InvalidRequestException)
             {
-                // CQL invalid request (e.g. validating params and/or param values) translates into picocli param exection.
+                // A CQL invalid request (e.g. bad param name or value) becomes a picocli ParameterException.
                 throw new CommandLine.ParameterException(parseResult.commandSpec().commandLine(),
                                                          "Invalid request: " + cause.getMessage());
             }

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategy.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.cassandra.cql3.ColumnIdentifier;
+import org.apache.cassandra.cql3.CqlBuilder;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.api.ParameterMetadata;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.CqlConnect;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import picocli.CommandLine;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID;
+import static org.apache.cassandra.management.ManagementUtils.normalizeOptionName;
+import static org.apache.cassandra.management.api.ParameterMetadata.COMMAND_POSITIONAL_PARAM_PREFIX;
+import static org.apache.cassandra.tools.nodetool.strategy.CommandMBeanExecutionStrategy.extractCommandName;
+
+public class CqlCommandExecutionStrategy implements CommandExecutionStrategy
+{
+    private final CqlConnect connect;
+
+    public CqlCommandExecutionStrategy(CqlConnect connect)
+    {
+        this.connect = connect;
+    }
+
+    @Override
+    public int execute(CommandLine.ParseResult parseResult) throws CommandLine.ExecutionException, CommandLine.ParameterException
+    {
+        CommandLine.Model.CommandSpec lastParent = StaticMBeanExecutionStrategy.lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
+
+        Object userObject = lastParent.userObject();
+
+        if (userObject instanceof AbstractCommand)
+        {
+            AbstractCommand command = (AbstractCommand) userObject;
+            if (command.shouldConnect())
+                connect.run();
+        }
+
+        // Local command execution with no CQL connection.
+        if (connect.client() == null || parseResult.isUsageHelpRequested() || parseResult.isVersionHelpRequested())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        String commandName = extractCommandName(parseResult);
+        if (commandName == null || commandName.isEmpty())
+            return new CommandLine.RunLast().execute(parseResult);
+
+        // Command is already populated with args from CommandLine.parseArgs(), converting it to CommandExecutionArgs
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(userObject);
+
+        try
+        {
+            String cqlCommand = buildCqlCommandString(commandName, args);
+            ResultMessage result = connect.client().execute(cqlCommand, ConsistencyLevel.ONE);
+
+            if (result instanceof ResultMessage.Rows)
+            {
+                ResultMessage.Rows rows = (ResultMessage.Rows) result;
+                assert rows.result.size() == 1 : "Command execution result should have exactly 1 row, got " + rows.result.size();
+                assert rows.result.metadata.getColumnCount() == 2 : "Command execution result schema has been changed. " +
+                                                               "Expected 2 columns in result, got " + rows.result.metadata.getColumnCount();
+
+                if (!rows.result.isEmpty() && rows.result.metadata.names.size() >= 2)
+                {
+                    List<ByteBuffer> firstRow = rows.result.rows.get(0);
+                    if (firstRow.size() >= 2)
+                    {
+                        UUID executionId = UUIDType.instance.getSerializer().deserialize(firstRow.get(0));
+                        String output = UTF8Type.instance.getSerializer().deserialize(firstRow.get(1));
+                        // NodeProbe instance is not available here, so print directly to the command output.
+                        parseResult.commandSpec().commandLine().getOut().println(output);
+                        if (CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean()
+                            || CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID.getBoolean(false))
+                            parseResult.commandSpec().commandLine().getOut().println("Command execution id: " + executionId.toString());
+                    }
+                }
+            }
+
+            return 0;
+        }
+        catch (RuntimeException e)
+        {
+            Throwable cause = e.getCause();
+            if (cause instanceof UnauthorizedException)
+            {
+                throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                         "Unauthorized: " + cause.getMessage());
+            }
+            else if (cause instanceof InvalidRequestException)
+            {
+                // CQL invalid request (e.g. validating params and/or param values) translates into picocli param exection.
+                throw new CommandLine.ParameterException(parseResult.commandSpec().commandLine(),
+                                                         "Invalid request: " + cause.getMessage());
+            }
+            else if (cause instanceof CommandRequestExecutionException)
+            {
+                CommandRequestExecutionException cree = (CommandRequestExecutionException) cause;
+                String msg = String.format("Command execution failed (executionId: %s): %s",
+                                           cree.getCommandExecutionId(), cree.getMessage());
+                throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(), msg);
+            }
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     "Unknown command execution exception via CQL: " + e.getMessage(), e);
+        }
+        catch (Exception e) {
+            // Catch-all for checked exceptions thrown during command execution.
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(),
+                                                     "Unknown command execution exception via CQL: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws ExecutionStrategyCloseException
+    {
+        if (connect == null)
+            return;
+        try
+        {
+            connect.close();
+        }
+        catch (Exception e)
+        {
+            throw new ExecutionStrategyCloseException("Failed to close CQL connection", e);
+        }
+    }
+
+    /**
+     * Build a CQL INVOKE COMMAND statement string from command name and CommandExecutionArgs.
+     * The format is: INVOKE COMMAND commandName WITH "key1" = 'value1' AND "key2" = 'value2';
+     */
+    private static String buildCqlCommandString(String commandName, CommandExecutionArgs args)
+    {
+        CqlBuilder builder = new CqlBuilder();
+        builder.append("INVOKE COMMAND ");
+        builder.appendQuotingIfNeeded(commandName);
+
+        Map<String, Object> paramsMap = new LinkedHashMap<>();
+        for (Map.Entry<OptionMetadata, Object> entry : args.options().entrySet())
+        {
+            OptionMetadata optionMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            String key = normalizeOptionName(optionMetadata.paramLabel());
+            paramsMap.put(key, value);
+        }
+
+        for (Map.Entry<ParameterMetadata, Object> entry : args.parameters().entrySet())
+        {
+            ParameterMetadata paramMetadata = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value == null)
+                continue;
+
+            String key = COMMAND_POSITIONAL_PARAM_PREFIX + paramMetadata.index();
+            paramsMap.put(key, value);
+        }
+
+        if (!paramsMap.isEmpty())
+        {
+            builder.append(" WITH");
+            boolean first = true;
+            for (Map.Entry<String, Object> entry : paramsMap.entrySet())
+            {
+                if (first)
+                    builder.append(" ");
+                else
+                    builder.append(" AND ");
+
+                // Using ColumnIdentifier.maybeQuote as some of the keys
+                // may be reserved words in CQL (e.g., "keyspace", "table").
+                builder.append(ColumnIdentifier.maybeQuote(entry.getKey()));
+                builder.append(" = ");
+                appendCqlValue(builder, entry.getValue());
+
+                first = false;
+            }
+        }
+
+        builder.append(";");
+        return builder.toString();
+    }
+
+    /** Append a value to CqlBuilder with proper type handling and escaping. */
+    private static void appendCqlValue(CqlBuilder builder, Object value)
+    {
+        if (value == null)
+        {
+            builder.append("NULL");
+            return;
+        }
+
+        if (value instanceof String)
+            builder.appendWithSingleQuotes((String) value);
+        else if (value instanceof Number)
+            builder.append(value);
+        else if (value instanceof Boolean)
+            builder.append(value);
+        else if (value instanceof List)
+        {
+            List<?> list = (List<?>) value;
+            builder.append("[");
+            for (int i = 0; i < list.size(); i++)
+            {
+                if (i > 0)
+                    builder.append(", ");
+                appendCqlValue(builder, list.get(i));
+            }
+            builder.append("]");
+        }
+        else if (value instanceof Map)
+        {
+            Map<String, Object> map = (Map<String, Object>) value;
+            builder.append("{");
+            boolean first = true;
+            for (Map.Entry<String, Object> entry : map.entrySet())
+            {
+                if (!first)
+                    builder.append(", ");
+                builder.appendWithSingleQuotes(entry.getKey());
+                builder.append(": ");
+                appendCqlValue(builder, entry.getValue());
+                first = false;
+            }
+            builder.append("}");
+        }
+        else if (value instanceof Set)
+        {
+            Set<?> set = (Set<?>) value;
+            builder.append("{");
+            boolean first = true;
+            for (Object item : set)
+            {
+                if (!first)
+                    builder.append(", ");
+                appendCqlValue(builder, item);
+                first = false;
+            }
+            builder.append("}");
+        }
+        else if (value.getClass().isArray())
+        {
+            int length = Array.getLength(value);
+            builder.append("[");
+            for (int i = 0; i < length; i++)
+            {
+                if (i > 0)
+                    builder.append(", ");
+                appendCqlValue(builder, Array.get(value, i));
+            }
+            builder.append("]");
+        }
+        else
+            builder.appendWithSingleQuotes(value.toString());
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/NodetoolConnectionException.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/NodetoolConnectionException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+/**
+ * Thrown when nodetool fails to establish its connection to the target node, over either JMX or CQL.
+ */
+public class NodetoolConnectionException extends RuntimeException
+{
+    public NodetoolConnectionException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/ProtocolAwareExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/ProtocolAwareExecutionStrategy.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import org.apache.cassandra.config.CassandraRelevantEnv;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.tools.nodetool.CqlConnect;
+import org.apache.cassandra.tools.nodetool.JmxConnect;
+
+import picocli.CommandLine;
+
+import static org.apache.cassandra.utils.LocalizeString.toUpperCaseLocalized;
+
+public class ProtocolAwareExecutionStrategy implements CommandExecutionStrategy
+{
+    public static int executionStrategy(CommandLine.ParseResult parseResult)
+    {
+        try (ProtocolAwareExecutionStrategy strategy = new ProtocolAwareExecutionStrategy())
+        {
+            return strategy.execute(parseResult);
+        }
+    }
+
+    /**
+     * This method is called by picocli and used depending on the execution strategy.
+     * @param parseResult The parsed command line.
+     * @return The exit code.
+     */
+    @Override
+    public int execute(CommandLine.ParseResult parseResult)
+    {
+        CommandLine.Model.CommandSpec connectCmd = parseResult.commandSpec()
+                                                       .mixins()
+                                                       .get(getExecutionStrategyTypeFromEnvAndSys().toString());
+        if (connectCmd == null)
+            throw new CommandLine.InitializationException("No 'connection' command found in the top-level hierarchy");
+
+        try (CommandExecutionStrategy invoker = createInvoker(connectCmd.userObject()))
+        {
+            return invoker.execute(parseResult);
+        }
+        catch (NodetoolConnectionException e)
+        {
+            throw new CommandLine.ExecutionException(parseResult.commandSpec().commandLine(), e.getMessage(), e);
+        }
+        catch (ExecutionStrategyCloseException e)
+        {
+            CommandLine commandLine = parseResult.commandSpec().commandLine();
+            commandLine.getErr().println("Failed to close connection: " + e.getMessage());
+            CommandLine.IExitCodeExceptionMapper mapper = commandLine.getExitCodeExceptionMapper();
+            return mapper != null ? mapper.getExitCode(e) : commandLine.getCommandSpec().exitCodeOnExecutionException();
+        }
+    }
+
+    public static Type getExecutionStrategyTypeFromEnvAndSys()
+    {
+        Type defaultStrategy = Type.valueOf(toUpperCaseLocalized(CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL.getDefaultValue()));
+        Type strategyEnv = CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_PROTOCOL.getEnum(true, Type.class, defaultStrategy.name());
+        Type strategySys = CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL.getEnum(true, Type.class);
+        return strategyEnv != defaultStrategy ? strategyEnv : strategySys;
+    }
+
+    protected CommandExecutionStrategy createInvoker(Object connectCmd)
+    {
+        Type strategy = getExecutionStrategyTypeFromEnvAndSys();
+        switch (strategy)
+        {
+            case CQL:
+                return new CqlCommandExecutionStrategy((CqlConnect) connectCmd);
+            case COMMAND_MBEAN:
+                return new CommandMBeanExecutionStrategy((JmxConnect) connectCmd);
+            case STATIC_MBEAN:
+                return new StaticMBeanExecutionStrategy((JmxConnect) connectCmd);
+            default:
+                throw new IllegalStateException("Unknown execution strategy: " + strategy);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/ProtocolAwareExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/ProtocolAwareExecutionStrategy.java
@@ -38,7 +38,8 @@ public class ProtocolAwareExecutionStrategy implements CommandExecutionStrategy
     }
 
     /**
-     * This method is called by picocli and used depending on the execution strategy.
+     * Picks the strategy named by {@link #getExecutionStrategyTypeFromEnvAndSys()}, finds its connection
+     * mixin on the top-level command and runs the parsed command through it.
      * @param parseResult The parsed command line.
      * @return The exit code.
      */

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/ProtocolAwareExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/ProtocolAwareExecutionStrategy.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import org.apache.cassandra.config.CassandraRelevantEnv;
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.tools.nodetool.CqlConnect;
+import org.apache.cassandra.tools.nodetool.JmxConnect;
+
+import picocli.CommandLine;
+
+import static org.apache.cassandra.utils.LocalizeString.toUpperCaseLocalized;
+
+public class ProtocolAwareExecutionStrategy implements CommandExecutionStrategy
+{
+    public static int executionStrategy(CommandLine.ParseResult parseResult)
+    {
+        try (ProtocolAwareExecutionStrategy strategy = new ProtocolAwareExecutionStrategy())
+        {
+            return strategy.execute(parseResult);
+        }
+    }
+
+    /**
+     * This method is called by picocli and used depending on the execution strategy.
+     * @param parseResult The parsed command line.
+     * @return The exit code.
+     */
+    @Override
+    public int execute(CommandLine.ParseResult parseResult)
+    {
+        CommandLine.Model.CommandSpec connectCmd = parseResult.commandSpec()
+                                                       .mixins()
+                                                       .get(getExecutionStrategyTypeFromEnvAndSys().toString());
+        if (connectCmd == null)
+            throw new CommandLine.InitializationException("No 'connection' command found in the top-level hierarchy");
+
+        try (CommandExecutionStrategy invoker = createInvoker(connectCmd.userObject()))
+        {
+            return invoker.execute(parseResult);
+        }
+        catch (ExecutionStrategyCloseException e)
+        {
+            connectCmd.commandLine()
+               .getErr()
+               .println("Failed to connect: " + e.getMessage());
+            return connectCmd.commandLine().getExitCodeExceptionMapper().getExitCode(e);
+        }
+    }
+
+    public static Type getExecutionStrategyTypeFromEnvAndSys()
+    {
+        Type defaultStrategy = Type.valueOf(toUpperCaseLocalized(CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL.getDefaultValue()));
+        Type strategyEnv = CassandraRelevantEnv.CASSANDRA_CLI_EXECUTION_PROTOCOL.getEnum(true, Type.class, defaultStrategy.name());
+        Type strategySys = CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL.getEnum(true, Type.class);
+        return strategyEnv != defaultStrategy ? strategyEnv : strategySys;
+    }
+
+    protected CommandExecutionStrategy createInvoker(Object connectCmd)
+    {
+        Type strategy = getExecutionStrategyTypeFromEnvAndSys();
+        switch (strategy)
+        {
+            case CQL:
+                return new CqlCommandExecutionStrategy((CqlConnect) connectCmd);
+            case COMMAND_MBEAN:
+                return new CommandMBeanExecutionStrategy((JmxConnect) connectCmd);
+            case STATIC_MBEAN:
+                return new StaticMBeanExecutionStrategy((JmxConnect) connectCmd);
+            default:
+                throw new IllegalStateException("Unknown execution strategy: " + strategy);
+        }
+    }
+}

--- a/src/java/org/apache/cassandra/tools/nodetool/strategy/StaticMBeanExecutionStrategy.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/strategy/StaticMBeanExecutionStrategy.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import java.util.List;
+
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.JmxConnect;
+
+import picocli.CommandLine;
+
+public class StaticMBeanExecutionStrategy implements CommandExecutionStrategy
+{
+    private final JmxConnect connect;
+
+    public StaticMBeanExecutionStrategy(JmxConnect connect)
+    {
+        this.connect = connect;
+    }
+
+    @Override
+    public int execute(CommandLine.ParseResult parseResult) throws CommandLine.ExecutionException, CommandLine.ParameterException
+    {
+        CommandLine.Model.CommandSpec lastParent = lastExecutableSubcommandWithSameParent(parseResult.asCommandLineList());
+        if (lastParent.userObject() instanceof AbstractCommand)
+        {
+            AbstractCommand command = (AbstractCommand) lastParent.userObject();
+            if (command.shouldConnect())
+                connect.run();
+            command.probe(connect.probe());
+        }
+        return new CommandLine.RunLast().execute(parseResult);
+    }
+
+    @Override
+    public void close() throws ExecutionStrategyCloseException
+    {
+        if (connect.probe() == null)
+            return;
+        try
+        {
+            connect.probe().close();
+        }
+        catch (Exception e)
+        {
+            throw new ExecutionStrategyCloseException("Failed to close JMX connection", e);
+        }
+    }
+
+    static CommandLine.Model.CommandSpec lastExecutableSubcommandWithSameParent(List<CommandLine> parsedCommands)
+    {
+        int start = parsedCommands.size() - 1;
+        for (int i = parsedCommands.size() - 2; i >= 0; i--)
+        {
+            if (parsedCommands.get(i).getParent() != parsedCommands.get(i + 1).getParent())
+                break;
+            start = i;
+        }
+        return parsedCommands.get(start).getCommandSpec();
+    }
+}

--- a/src/java/org/apache/cassandra/transport/Connection.java
+++ b/src/java/org/apache/cassandra/transport/Connection.java
@@ -23,6 +23,7 @@ import io.netty.util.AttributeKey;
 public class Connection
 {
     static final AttributeKey<Connection> attributeKey = AttributeKey.valueOf("CONN");
+    static final AttributeKey<Boolean> managementKey = AttributeKey.valueOf("IS_MANAGEMENT_CONN");
 
     private final Channel channel;
     private final ProtocolVersion version;

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -33,9 +33,16 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.concurrent.DebuggableTask;
 import org.apache.cassandra.concurrent.LocalAwareExecutorPlus;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.UseStatement;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.FrameEncoder;
+import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
@@ -44,6 +51,7 @@ import org.apache.cassandra.transport.ClientResourceLimits.Overload;
 import org.apache.cassandra.transport.Flusher.FlushItem;
 import org.apache.cassandra.transport.messages.ErrorMessage;
 import org.apache.cassandra.transport.messages.EventMessage;
+import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.NoSpamLogger;
@@ -53,6 +61,7 @@ import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
 
 import static org.apache.cassandra.concurrent.SharedExecutorPool.SHARED;
+import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
 
 public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Request>
 {
@@ -83,8 +92,43 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
                                                                           "transport",
                                                                           "Native-Transport-Auth-Requests");
 
+    /**
+     * Executor for handling requests from management connections (part of CEP-38).
+     *
+     * <p>Management connections are identified via Connection's flag set by the management
+     * transport server at initial connection setup. Request then are routed to a dedicated
+     * executor instead of the standard {@link #requestExecutor}. This provides isolation and
+     * prioritization of management operations, ensuring they can proceed even under
+     * a high load of regular client requests.
+     *
+     * <p>The executor is configured separately via
+     * {@link DatabaseDescriptor#getNativeTransportManagementMaxThreads()} to allow
+     * independent tuning of management operation throughput.
+     *
+     * <p>Management connections are established through the management transport server
+     * (see {@link org.apache.cassandra.service.NativeTransportManagementService}), which listens
+     * on a separate port from the regular native transport.
+     *
+     * <p>Unlike auth requests, management requests have no fallback executor, so values
+     * less than 1 are treated as 1: a zero-sized pool would queue management requests forever.
+     */
+    @VisibleForTesting
+    static final LocalAwareExecutorPlus managementExecutor = SHARED.newExecutor(Math.max(1, DatabaseDescriptor.getNativeTransportManagementMaxThreads()),
+                                                                                 DatabaseDescriptor::setNativeTransportManagementMaxThreads,
+                                                                                 "transport",
+                                                                                 "Native-Transport-Management-Tasks");
+
     private static final ConcurrentMap<EventLoop, Flusher> flusherLookup = new ConcurrentHashMap<>();
+
+    /**
+     * Set while a management request is executing on the current thread. A management command may itself
+     * initiate the management server's stop (e.g. INVOKE COMMAND stopdaemon), in which case the drain-wait
+     * in {@link Server#close} runs on this very thread and must not wait for its own task to complete.
+     */
+    private static final ThreadLocal<Boolean> IN_MANAGEMENT_TASK = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     private final boolean useLegacyFlusher;
+    private final boolean isManagementDispatcher;
 
     /**
      * Takes a Channel, Request and the Response produced by processRequest and outputs a FlushItem
@@ -98,9 +142,10 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         FlushItem<?> toFlushItem(P param, Channel channel, Message.Request request, Message.Response response);
     }
 
-    public Dispatcher(boolean useLegacyFlusher)
+    public Dispatcher(boolean useLegacyFlusher, boolean isManagementDispatcher)
     {
         this.useLegacyFlusher = useLegacyFlusher;
+        this.isManagementDispatcher = isManagementDispatcher;
     }
 
     @Override
@@ -126,10 +171,32 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         boolean isAuthQuery = DatabaseDescriptor.getNativeTransportMaxAuthThreads() > 0 &&
                               (request.type == Message.Type.AUTH_RESPONSE || request.type == Message.Type.CREDENTIALS);
 
-        // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
-        LocalAwareExecutorPlus executor = isAuthQuery ? authExecutor : requestExecutor;
+        if (isAuthQuery)
+        {
+            // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
+            authExecutor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
+            ClientMetrics.instance.markRequestDispatched();
+            return;
+        }
 
-        executor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
+        // Use connection object to check for management connections, this could be faster than checking
+        // channel attributies directly every time. For management connections, we route requests to
+        // the management executor.
+        Connection connection = request.connection();
+        if (connection instanceof ServerConnection)
+        {
+            ServerConnection serverConnection = (ServerConnection) connection;
+            if (serverConnection.isManagementConnection())
+            {
+                // Intentionally skipping ClientMetrics calls here: that meter tracks regular client request
+                // dispatch, and management API requests are accounted for separately dedicated metrics rather
+                // than mixing them into the client requests rate.
+                managementExecutor.submit(new ManagementRequestProcessor<>(channel, request, forFlusher, param, backpressure));
+                return;
+            }
+        }
+
+        requestExecutor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
         ClientMetrics.instance.markRequestDispatched();
     }
 
@@ -296,13 +363,13 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
      */
     public class RequestProcessor<P> implements DebuggableTask.RunnableDebuggableTask
     {
-        private final Channel channel;
-        private final Message.Request request;
-        private final FlushItemConverter<P> forFlusher;
-        private final P flusherParam;
-        private final Overload backpressure;
+        protected final Channel channel;
+        protected final Message.Request request;
+        protected final FlushItemConverter<P> forFlusher;
+        protected final P flusherParam;
+        protected final Overload backpressure;
 
-        private volatile long startTimeNanos;
+        protected volatile long startTimeNanos;
 
         public RequestProcessor(Channel channel, Message.Request request, FlushItemConverter<P> forFlusher, P flusherParam, Overload backpressure)
         {
@@ -348,6 +415,124 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         }
     }
 
+    /** RequestProcessor for management connections that validates before executing. */
+    private class ManagementRequestProcessor<P> extends RequestProcessor<P> {
+
+        public ManagementRequestProcessor(Channel channel,
+                                          Message.Request request,
+                                          FlushItemConverter<P> forFlusher,
+                                          P flusherParam,
+                                          Overload backpressure) {
+            super(channel, request, forFlusher, flusherParam, backpressure);
+        }
+
+        @Override
+        public void run() {
+            startTimeNanos = MonotonicClock.Global.preciseTime.now();
+            RequestTime requestTime = new RequestTime(request.createdAtNanos, startTimeNanos);
+
+            // Validate management request BEFORE executing
+            Connection connection = request.connection();
+            if (connection instanceof ServerConnection) {
+                ServerConnection serverConnection = (ServerConnection) connection;
+                if (serverConnection.isManagementConnection()) {
+                    if (!isManagementRequestAllowed(request)) {
+                        // The flush pipeline takes the stream id from the request envelope, so the
+                        // response must not carry one of its own.
+                        Message.Response response = ErrorMessage.fromExceptionNoStreamId(
+                        new InvalidRequestException(
+                            "Only executions of the INVOKE COMMAND statements are allowed on the management port."));
+                        response.attach(connection);
+                        FlushItem<?> toFlush = forFlusher.toFlushItem(flusherParam, channel, request, response);
+                        flush(toFlush);
+                        return;
+                    }
+                }
+            }
+
+            IN_MANAGEMENT_TASK.set(Boolean.TRUE);
+            try {
+                // If validation passes, call the normal processRequest to execute
+                // This calls the instance method processRequest() which does all the work
+                processRequest(channel, request, forFlusher, flusherParam, backpressure, requestTime);
+            } finally {
+                IN_MANAGEMENT_TASK.set(Boolean.FALSE);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isManagementRequestAllowed(Message.Request request)
+    {
+        switch (request.type)
+        {
+            case QUERY:
+                try
+                {
+                    // Early parse the query to check if it's an INVOKE COMMAND statement.
+                    // For management non-intensive operations double parsing is probably acceptable.
+                    CQLStatement.Raw rawStatement = QueryProcessor.parseStatement(((QueryMessage) request).query);
+                    if (rawStatement instanceof ExecuteCommandStatement.Raw)
+                        return true;
+
+                    // Allow read-only SELECT queries on system keyspaces (needed for driver metadata
+                    // discovery), except system_auth (see isManagementReadableSystemKeyspace).
+                    if (rawStatement instanceof SelectStatement.RawStatement)
+                    {
+                        SelectStatement.RawStatement selectRaw = (SelectStatement.RawStatement) rawStatement;
+                        return selectRaw.isFullyQualified()
+                               && isManagementReadableSystemKeyspace(selectRaw.keyspace());
+                    }
+
+                    // This is also a corner case for the driver's behavior on the management port.
+                    // When connecting, the driver sends a USE statement for the keyspace provided
+                    // in driver.connect("system_schema").
+                    if (rawStatement instanceof UseStatement)
+                    {
+                        UseStatement useStatement = (UseStatement) rawStatement;
+                        return isManagementReadableSystemKeyspace(useStatement.keyspace());
+                    }
+
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    logger.warn("The command request parsing failed. The command will not be executed: {}", e.getMessage());
+                    // If parsing fails (syntax error, etc.), it's not a valid command statement;
+                    // this is expected for non-command queries.
+                    return false;
+                }
+            case STARTUP:
+            case CREDENTIALS:
+            case AUTH_RESPONSE:
+            case OPTIONS:
+            case REGISTER:
+                return true; // Protocol messages are always allowed.
+            case EXECUTE:
+            case PREPARE:
+            case BATCH:
+            default:
+                return false; // Not supported and not allowed on management connections.
+        }
+    }
+
+    /**
+     * System keyspaces a CQL driver may read/USE on the management port for metadata discovery. This is
+     * {@link SchemaConstants#isSystemKeyspace(String)} (which also covers virtual system keyspaces) minus
+     * {@code system_auth}: that keyspace is the credential store (bcrypt {@code salted_hash}, superuser
+     * flags) and must never be readable over the management port, which is reachable without authorization
+     * (if AllowAllAuthorizer is enabled).
+     */
+    private static boolean isManagementReadableSystemKeyspace(String keyspace)
+    {
+        if (keyspace == null)
+            return false;
+        if (SchemaConstants.AUTH_KEYSPACE_NAME.equals(toLowerCaseLocalized(keyspace)))
+            return false;
+        return SchemaConstants.isSystemKeyspace(keyspace)
+               || SchemaConstants.isVirtualSystemKeyspace(keyspace);
+    }
+
     /**
      * Checks if the item in the head of the queue has spent more than allowed time in the queue.
      */
@@ -358,7 +543,8 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         if (threshold <= 0)
             return true;
 
-        return requestExecutor.oldestTaskQueueTime() < (DatabaseDescriptor.getNativeTransportTimeout(TimeUnit.NANOSECONDS) * threshold);
+        LocalAwareExecutorPlus executor = isManagementDispatcher ? managementExecutor : requestExecutor;
+        return executor.oldestTaskQueueTime() < (DatabaseDescriptor.getNativeTransportTimeout(TimeUnit.NANOSECONDS) * threshold);
     }
 
     /**
@@ -502,15 +688,23 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         flusher.start();
     }
 
+    /**
+     * @return true once the executor serving this dispatcher's server has drained: {@link #managementExecutor}
+     * for the management transport, {@link #requestExecutor} otherwise. A management task running on the
+     * calling thread is excluded — it is the task that initiated the stop and cannot drain before it.
+     */
     public boolean isDone()
     {
-        return requestExecutor.getPendingTaskCount() == 0 && requestExecutor.getActiveTaskCount() == 0;
+        LocalAwareExecutorPlus executor = isManagementDispatcher ? managementExecutor : requestExecutor;
+        int self = isManagementDispatcher && IN_MANAGEMENT_TASK.get() ? 1 : 0;
+        return executor.getPendingTaskCount() == 0 && executor.getActiveTaskCount() - self <= 0;
     }
 
     public static void shutdown()
     {
         requestExecutor.shutdown();
         authExecutor.shutdown();
+        managementExecutor.shutdown();
     }
 
     /**

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -96,14 +96,12 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
      * Executor for handling requests from management connections (part of CEP-38).
      *
      * <p>Management connections are identified via Connection's flag set by the management
-     * transport server at initial connection setup. Request then are routed to a dedicated
-     * executor instead of the standard {@link #requestExecutor}. This provides isolation and
-     * prioritization of management operations, ensuring they can proceed even under
-     * a high load of regular client requests.
+     * transport server at initial connection setup. Their requests are then routed to a dedicated
+     * executor instead of the standard {@link #requestExecutor}, so management operations keep
+     * making progress while the client pool is saturated.
      *
-     * <p>The executor is configured separately via
-     * {@link DatabaseDescriptor#getNativeTransportManagementMaxThreads()} to allow
-     * independent tuning of management operation throughput.
+     * <p>The executor is sized separately via
+     * {@link DatabaseDescriptor#getNativeTransportManagementMaxThreads()}.
      *
      * <p>Management connections are established through the management transport server
      * (see {@link org.apache.cassandra.service.NativeTransportManagementService}), which listens
@@ -179,9 +177,8 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
             return;
         }
 
-        // Use connection object to check for management connections, this could be faster than checking
-        // channel attributies directly every time. For management connections, we route requests to
-        // the management executor.
+        // Check the connection object rather than the channel attributes, which should be cheaper on every
+        // request. Management connections are routed to the management executor.
         Connection connection = request.connection();
         if (connection instanceof ServerConnection)
         {
@@ -189,8 +186,8 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
             if (serverConnection.isManagementConnection())
             {
                 // Intentionally skipping ClientMetrics calls here: that meter tracks regular client request
-                // dispatch, and management API requests are accounted for separately dedicated metrics rather
-                // than mixing them into the client requests rate.
+                // dispatch, and management API requests have their own metrics rather than being mixed
+                // into the client request rate.
                 managementExecutor.submit(new ManagementRequestProcessor<>(channel, request, forFlusher, param, backpressure));
                 return;
             }
@@ -431,7 +428,7 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
             startTimeNanos = MonotonicClock.Global.preciseTime.now();
             RequestTime requestTime = new RequestTime(request.createdAtNanos, startTimeNanos);
 
-            // Validate management request BEFORE executing
+            // Validate the management request before executing it
             Connection connection = request.connection();
             if (connection instanceof ServerConnection) {
                 ServerConnection serverConnection = (ServerConnection) connection;
@@ -452,8 +449,6 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
 
             IN_MANAGEMENT_TASK.set(Boolean.TRUE);
             try {
-                // If validation passes, call the normal processRequest to execute
-                // This calls the instance method processRequest() which does all the work
                 processRequest(channel, request, forFlusher, flusherParam, backpressure, requestTime);
             } finally {
                 IN_MANAGEMENT_TASK.set(Boolean.FALSE);
@@ -691,7 +686,7 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
     /**
      * @return true once the executor serving this dispatcher's server has drained: {@link #managementExecutor}
      * for the management transport, {@link #requestExecutor} otherwise. A management task running on the
-     * calling thread is excluded — it is the task that initiated the stop and cannot drain before it.
+     * calling thread is excluded, since it is the task that initiated the stop and cannot drain before it.
      */
     public boolean isDone()
     {

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -40,6 +40,8 @@ import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.cql3.statements.UseStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.OverloadedException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.FrameEncoder;
 import org.apache.cassandra.schema.SchemaConstants;
@@ -433,12 +435,11 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
             if (connection instanceof ServerConnection) {
                 ServerConnection serverConnection = (ServerConnection) connection;
                 if (serverConnection.isManagementConnection()) {
-                    if (!isManagementRequestAllowed(request)) {
+                    RequestValidationException rejection = checkManagementRequest(request);
+                    if (rejection != null) {
                         // The flush pipeline takes the stream id from the request envelope, so the
                         // response must not carry one of its own.
-                        Message.Response response = ErrorMessage.fromExceptionNoStreamId(
-                        new InvalidRequestException(
-                            "Only executions of the INVOKE COMMAND statements are allowed on the management port."));
+                        Message.Response response = ErrorMessage.fromExceptionNoStreamId(rejection);
                         response.attach(connection);
                         FlushItem<?> toFlush = forFlusher.toFlushItem(flusherParam, channel, request, response);
                         flush(toFlush);
@@ -459,56 +460,84 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
     @VisibleForTesting
     static boolean isManagementRequestAllowed(Message.Request request)
     {
+        return checkManagementRequest(request) == null;
+    }
+
+    /**
+     * {@code null} if the request may run on the management port; otherwise the exception to return to the client.
+     * Syntax errors stay {@link SyntaxException} so a mistyped {@code INVOKE COMMAND} is not reported as a
+     * statement-type rejection.
+     */
+    @VisibleForTesting
+    static RequestValidationException checkManagementRequest(Message.Request request)
+    {
         switch (request.type)
         {
             case QUERY:
+            {
+                if (!(request instanceof QueryMessage))
+                    return managementRequestNotAllowed();
+
+                CQLStatement.Raw rawStatement;
                 try
                 {
                     // Early parse the query to check if it's an INVOKE COMMAND statement.
                     // For management non-intensive operations double parsing is probably acceptable.
-                    CQLStatement.Raw rawStatement = QueryProcessor.parseStatement(((QueryMessage) request).query);
-                    if (rawStatement instanceof ExecuteCommandStatement.Raw)
-                        return true;
-
-                    // Allow read-only SELECT queries on system keyspaces (needed for driver metadata
-                    // discovery), except system_auth (see isManagementReadableSystemKeyspace).
-                    if (rawStatement instanceof SelectStatement.RawStatement)
-                    {
-                        SelectStatement.RawStatement selectRaw = (SelectStatement.RawStatement) rawStatement;
-                        return selectRaw.isFullyQualified()
-                               && isManagementReadableSystemKeyspace(selectRaw.keyspace());
-                    }
-
-                    // This is also a corner case for the driver's behavior on the management port.
-                    // When connecting, the driver sends a USE statement for the keyspace provided
-                    // in driver.connect("system_schema").
-                    if (rawStatement instanceof UseStatement)
-                    {
-                        UseStatement useStatement = (UseStatement) rawStatement;
-                        return isManagementReadableSystemKeyspace(useStatement.keyspace());
-                    }
-
-                    return false;
+                    rawStatement = QueryProcessor.parseStatement(((QueryMessage) request).query);
+                }
+                catch (SyntaxException e)
+                {
+                    return e;
                 }
                 catch (Exception e)
                 {
                     logger.warn("The command request parsing failed. The command will not be executed: {}", e.getMessage());
-                    // If parsing fails (syntax error, etc.), it's not a valid command statement;
-                    // this is expected for non-command queries.
-                    return false;
+                    return new InvalidRequestException("Failed to parse query on the management port: " + e.getMessage(), e);
                 }
+
+                if (rawStatement instanceof ExecuteCommandStatement.Raw)
+                    return null;
+
+                // Allow read-only SELECT queries on system keyspaces (needed for driver metadata
+                // discovery), except system_auth (see isManagementReadableSystemKeyspace).
+                if (rawStatement instanceof SelectStatement.RawStatement)
+                {
+                    SelectStatement.RawStatement selectRaw = (SelectStatement.RawStatement) rawStatement;
+                    return selectRaw.isFullyQualified()
+                           && isManagementReadableSystemKeyspace(selectRaw.keyspace())
+                           ? null : managementRequestNotAllowed();
+                }
+
+                // This is also a corner case for the driver's behavior on the management port.
+                // When connecting, the driver sends a USE statement for the keyspace provided
+                // in driver.connect("system_schema").
+                if (rawStatement instanceof UseStatement)
+                {
+                    UseStatement useStatement = (UseStatement) rawStatement;
+                    return isManagementReadableSystemKeyspace(useStatement.keyspace())
+                           ? null : managementRequestNotAllowed();
+                }
+
+                return managementRequestNotAllowed();
+            }
             case STARTUP:
             case CREDENTIALS:
             case AUTH_RESPONSE:
             case OPTIONS:
             case REGISTER:
-                return true; // Protocol messages are always allowed.
+                return null; // Protocol messages are always allowed.
             case EXECUTE:
             case PREPARE:
             case BATCH:
             default:
-                return false; // Not supported and not allowed on management connections.
+                return managementRequestNotAllowed();
         }
+    }
+
+    private static InvalidRequestException managementRequestNotAllowed()
+    {
+        return new InvalidRequestException(
+            "Only executions of the INVOKE COMMAND statements are allowed on the management port.");
     }
 
     /**

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -164,35 +164,25 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
             return;
         }
 
-        // Count every request accepted for dispatch. This runs on the connection's Netty event loop.
-        ((ServerConnection) request.connection()).incrementRequests();
+        Connection connection = request.connection();
+        if (connection instanceof ServerConnection)
+            ((ServerConnection) connection).incrementRequests();
 
-        // if native_transport_max_auth_threads is < 1, don't delegate to new pool on auth messages
         boolean isAuthQuery = DatabaseDescriptor.getNativeTransportMaxAuthThreads() > 0 &&
                               (request.type == Message.Type.AUTH_RESPONSE || request.type == Message.Type.CREDENTIALS);
 
         if (isAuthQuery)
         {
-            // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
             authExecutor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
             ClientMetrics.instance.markRequestDispatched();
             return;
         }
 
-        // Check the connection object rather than the channel attributes, which should be cheaper on every
-        // request. Management connections are routed to the management executor.
-        Connection connection = request.connection();
-        if (connection instanceof ServerConnection)
+        if (connection instanceof ServerConnection && ((ServerConnection) connection).isManagementConnection())
         {
-            ServerConnection serverConnection = (ServerConnection) connection;
-            if (serverConnection.isManagementConnection())
-            {
-                // Intentionally skipping ClientMetrics calls here: that meter tracks regular client request
-                // dispatch, and management API requests have their own metrics rather than being mixed
-                // into the client request rate.
-                managementExecutor.submit(new ManagementRequestProcessor<>(channel, request, forFlusher, param, backpressure));
-                return;
-            }
+            // Intentionally skipping ClientMetrics calls here
+            managementExecutor.submit(new ManagementRequestProcessor<>(channel, request, forFlusher, param, backpressure));
+            return;
         }
 
         requestExecutor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -33,9 +33,16 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.concurrent.DebuggableTask;
 import org.apache.cassandra.concurrent.LocalAwareExecutorPlus;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.UseStatement;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.FrameEncoder;
+import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
@@ -44,6 +51,7 @@ import org.apache.cassandra.transport.ClientResourceLimits.Overload;
 import org.apache.cassandra.transport.Flusher.FlushItem;
 import org.apache.cassandra.transport.messages.ErrorMessage;
 import org.apache.cassandra.transport.messages.EventMessage;
+import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.NoSpamLogger;
@@ -82,6 +90,29 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
                                                                           DatabaseDescriptor::setNativeTransportMaxAuthThreads,
                                                                           "transport",
                                                                           "Native-Transport-Auth-Requests");
+
+    /**
+     * Executor for handling requests from management connections (part of CEP-38).
+     *
+     * <p>Management connections are identified via Connection's flag set by the management
+     * transport server at initial connection setup. Request then are routed to a dedicated
+     * executor instead of the standard {@link #requestExecutor}. This provides isolation and
+     * prioritization of management operations, ensuring they can proceed even under
+     * a high load of regular client requests.
+     *
+     * <p>The executor is configured separately via
+     * {@link DatabaseDescriptor#getNativeTransportManagementMaxThreads()} to allow
+     * independent tuning of management operation throughput.
+     *
+     * <p>Management connections are established through the management transport server
+     * (see {@link org.apache.cassandra.service.NativeTransportManagementService}), which listens
+     * on a separate port from the regular native transport.
+     */
+    @VisibleForTesting
+    static final LocalAwareExecutorPlus managementExecutor = SHARED.newExecutor(DatabaseDescriptor.getNativeTransportManagementMaxThreads(),
+                                                                                 DatabaseDescriptor::setNativeTransportManagementMaxThreads,
+                                                                                 "transport",
+                                                                                 "Native-Transport-Management-Tasks");
 
     private static final ConcurrentMap<EventLoop, Flusher> flusherLookup = new ConcurrentHashMap<>();
     private final boolean useLegacyFlusher;
@@ -125,10 +156,29 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         boolean isAuthQuery = DatabaseDescriptor.getNativeTransportMaxAuthThreads() > 0 &&
                               (request.type == Message.Type.AUTH_RESPONSE || request.type == Message.Type.CREDENTIALS);
 
-        // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
-        LocalAwareExecutorPlus executor = isAuthQuery ? authExecutor : requestExecutor;
+        if (isAuthQuery)
+        {
+            // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
+            authExecutor.submit(new RequestProcessor(channel, request, forFlusher, backpressure));
+            ClientMetrics.instance.markRequestDispatched();
+            return;
+        }
 
-        executor.submit(new RequestProcessor(channel, request, forFlusher, backpressure));
+        // Use connection object to check for management connections, this could be faster than checking
+        // channel attributies directly every time. For management connections, we route requests to
+        // the management executor.
+        Connection connection = request.connection();
+        if (connection instanceof ServerConnection)
+        {
+            ServerConnection serverConnection = (ServerConnection) connection;
+            if (serverConnection.isManagementConnection())
+            {
+                managementExecutor.submit(new ManagementRequestProcessor(channel, request, forFlusher, backpressure));
+                return;
+            }
+        }
+
+        requestExecutor.submit(new RequestProcessor(channel, request, forFlusher, backpressure));
         ClientMetrics.instance.markRequestDispatched();
     }
 
@@ -295,12 +345,12 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
      */
     public class RequestProcessor implements DebuggableTask.RunnableDebuggableTask
     {
-        private final Channel channel;
-        private final Message.Request request;
-        private final FlushItemConverter forFlusher;
-        private final Overload backpressure;
+        protected final Channel channel;
+        protected final Message.Request request;
+        protected final FlushItemConverter forFlusher;
+        protected final Overload backpressure;
 
-        private volatile long startTimeNanos;
+        protected volatile long startTimeNanos;
 
         public RequestProcessor(Channel channel, Message.Request request, FlushItemConverter forFlusher, Overload backpressure)
         {
@@ -342,6 +392,101 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
                    "request=" + request +
                    ", approxStartTimeNanos=" + startTimeNanos +
                    '}';
+        }
+    }
+
+    /** RequestProcessor for management connections that validates before executing. */
+    private class ManagementRequestProcessor extends RequestProcessor {
+
+        public ManagementRequestProcessor(Channel channel,
+                                          Message.Request request,
+                                          FlushItemConverter forFlusher,
+                                          Overload backpressure) {
+            super(channel, request, forFlusher, backpressure);
+        }
+
+        @Override
+        public void run() {
+            startTimeNanos = MonotonicClock.Global.preciseTime.now();
+            RequestTime requestTime = new RequestTime(request.createdAtNanos, startTimeNanos);
+
+            // Validate management request BEFORE executing
+            Connection connection = request.connection();
+            if (connection instanceof ServerConnection) {
+                ServerConnection serverConnection = (ServerConnection) connection;
+                if (serverConnection.isManagementConnection()) {
+                    if (!isManagementRequestAllowed(request)) {
+                        Message.Response response = ErrorMessage.fromException(
+                        new InvalidRequestException(
+                            "Only executions of the INVOKE COMMAND statements are allowed on the management port."));
+                        response.setStreamId(request.getStreamId());
+                        response.attach(connection);
+                        FlushItem<?> toFlush = forFlusher.toFlushItem(channel, request, response);
+                        flush(toFlush);
+                        return;
+                    }
+                }
+            }
+
+            // If validation passes, call the normal processRequest to execute
+            // This calls the instance method processRequest() which does all the work
+            processRequest(channel, request, forFlusher, backpressure, requestTime);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isManagementRequestAllowed(Message.Request request)
+    {
+        switch (request.type)
+        {
+            case QUERY:
+                try
+                {
+                    // Early parse the query to check if it's an INVOKE COMMAND statement.
+                    // For management non-intensive operations double parsing is probably acceptable.
+                    CQLStatement.Raw rawStatement = QueryProcessor.parseStatement(((QueryMessage) request).query);
+                    if (rawStatement instanceof ExecuteCommandStatement.Raw)
+                        return true;
+
+                    // Allow read-only SELECT queries on system keyspaces (needed for driver metadata discovery).
+                    if (rawStatement instanceof SelectStatement.RawStatement)
+                    {
+                        SelectStatement.RawStatement selectRaw = (SelectStatement.RawStatement) rawStatement;
+                        return selectRaw.isFullyQualified()
+                               && (SchemaConstants.isSystemKeyspace(selectRaw.keyspace())
+                                   || SchemaConstants.isVirtualSystemKeyspace(selectRaw.keyspace()));
+                    }
+
+                    // This is also a corner case for the driver's behavior on the management port.
+                    // When connecting, the driver sends a USE statement for the keyspace provided
+                    // in driver.connect("system_schema").
+                    if (rawStatement instanceof UseStatement)
+                    {
+                        UseStatement useStatement = (UseStatement) rawStatement;
+                        return SchemaConstants.isSystemKeyspace(useStatement.keyspace())
+                               || SchemaConstants.isVirtualSystemKeyspace(useStatement.keyspace());
+                    }
+
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    logger.warn("The command request parsing failed. The command will not be executed: {}", e.getMessage());
+                    // If parsing fails (syntax error, etc.), it's not a valid command statement;
+                    // this is expected for non-command queries.
+                    return false;
+                }
+            case STARTUP:
+            case CREDENTIALS:
+            case AUTH_RESPONSE:
+            case OPTIONS:
+            case REGISTER:
+                return true; // Protocol messages are always allowed.
+            case EXECUTE:
+            case PREPARE:
+            case BATCH:
+            default:
+                return false; // Not supported and not allowed on management connections.
         }
     }
 
@@ -510,6 +655,7 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
     {
         requestExecutor.shutdown();
         authExecutor.shutdown();
+        managementExecutor.shutdown();
     }
 
     /**

--- a/src/java/org/apache/cassandra/transport/Dispatcher.java
+++ b/src/java/org/apache/cassandra/transport/Dispatcher.java
@@ -33,9 +33,16 @@ import org.slf4j.LoggerFactory;
 import org.apache.cassandra.concurrent.DebuggableTask;
 import org.apache.cassandra.concurrent.LocalAwareExecutorPlus;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.cql3.statements.UseStatement;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.exceptions.OverloadedException;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.FrameEncoder;
+import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.ClientWarn;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.reads.thresholds.CoordinatorWarnings;
@@ -44,6 +51,7 @@ import org.apache.cassandra.transport.ClientResourceLimits.Overload;
 import org.apache.cassandra.transport.Flusher.FlushItem;
 import org.apache.cassandra.transport.messages.ErrorMessage;
 import org.apache.cassandra.transport.messages.EventMessage;
+import org.apache.cassandra.transport.messages.QueryMessage;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.MonotonicClock;
 import org.apache.cassandra.utils.NoSpamLogger;
@@ -53,6 +61,7 @@ import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
 
 import static org.apache.cassandra.concurrent.SharedExecutorPool.SHARED;
+import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
 
 public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Request>
 {
@@ -83,8 +92,43 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
                                                                           "transport",
                                                                           "Native-Transport-Auth-Requests");
 
+    /**
+     * Executor for handling requests from management connections (part of CEP-38).
+     *
+     * <p>Management connections are identified via Connection's flag set by the management
+     * transport server at initial connection setup. Request then are routed to a dedicated
+     * executor instead of the standard {@link #requestExecutor}. This provides isolation and
+     * prioritization of management operations, ensuring they can proceed even under
+     * a high load of regular client requests.
+     *
+     * <p>The executor is configured separately via
+     * {@link DatabaseDescriptor#getNativeTransportManagementMaxThreads()} to allow
+     * independent tuning of management operation throughput.
+     *
+     * <p>Management connections are established through the management transport server
+     * (see {@link org.apache.cassandra.service.NativeTransportManagementService}), which listens
+     * on a separate port from the regular native transport.
+     *
+     * <p>Unlike auth requests, management requests have no fallback executor, so values
+     * less than 1 are treated as 1: a zero-sized pool would queue management requests forever.
+     */
+    @VisibleForTesting
+    static final LocalAwareExecutorPlus managementExecutor = SHARED.newExecutor(Math.max(1, DatabaseDescriptor.getNativeTransportManagementMaxThreads()),
+                                                                                 DatabaseDescriptor::setNativeTransportManagementMaxThreads,
+                                                                                 "transport",
+                                                                                 "Native-Transport-Management-Tasks");
+
     private static final ConcurrentMap<EventLoop, Flusher> flusherLookup = new ConcurrentHashMap<>();
+
+    /**
+     * Set while a management request is executing on the current thread. A management command may itself
+     * initiate the management server's stop (e.g. INVOKE COMMAND stopdaemon), in which case the drain-wait
+     * in {@link Server#close} runs on this very thread and must not wait for its own task to complete.
+     */
+    private static final ThreadLocal<Boolean> IN_MANAGEMENT_TASK = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     private final boolean useLegacyFlusher;
+    private final boolean isManagementDispatcher;
 
     /**
      * Takes a Channel, Request and the Response produced by processRequest and outputs a FlushItem
@@ -98,9 +142,10 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         FlushItem<?> toFlushItem(P param, Channel channel, Message.Request request, Message.Response response);
     }
 
-    public Dispatcher(boolean useLegacyFlusher)
+    public Dispatcher(boolean useLegacyFlusher, boolean isManagementDispatcher)
     {
         this.useLegacyFlusher = useLegacyFlusher;
+        this.isManagementDispatcher = isManagementDispatcher;
     }
 
     @Override
@@ -123,10 +168,32 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         boolean isAuthQuery = DatabaseDescriptor.getNativeTransportMaxAuthThreads() > 0 &&
                               (request.type == Message.Type.AUTH_RESPONSE || request.type == Message.Type.CREDENTIALS);
 
-        // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
-        LocalAwareExecutorPlus executor = isAuthQuery ? authExecutor : requestExecutor;
+        if (isAuthQuery)
+        {
+            // Importantly, the authExecutor will handle the AUTHENTICATE message which may be CPU intensive.
+            authExecutor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
+            ClientMetrics.instance.markRequestDispatched();
+            return;
+        }
 
-        executor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
+        // Use connection object to check for management connections, this could be faster than checking
+        // channel attributies directly every time. For management connections, we route requests to
+        // the management executor.
+        Connection connection = request.connection();
+        if (connection instanceof ServerConnection)
+        {
+            ServerConnection serverConnection = (ServerConnection) connection;
+            if (serverConnection.isManagementConnection())
+            {
+                // Intentionally skipping ClientMetrics calls here: that meter tracks regular client request
+                // dispatch, and management API requests are accounted for separately dedicated metrics rather
+                // than mixing them into the client requests rate.
+                managementExecutor.submit(new ManagementRequestProcessor<>(channel, request, forFlusher, param, backpressure));
+                return;
+            }
+        }
+
+        requestExecutor.submit(new RequestProcessor<>(channel, request, forFlusher, param, backpressure));
         ClientMetrics.instance.markRequestDispatched();
     }
 
@@ -293,13 +360,13 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
      */
     public class RequestProcessor<P> implements DebuggableTask.RunnableDebuggableTask
     {
-        private final Channel channel;
-        private final Message.Request request;
-        private final FlushItemConverter<P> forFlusher;
-        private final P flusherParam;
-        private final Overload backpressure;
+        protected final Channel channel;
+        protected final Message.Request request;
+        protected final FlushItemConverter<P> forFlusher;
+        protected final P flusherParam;
+        protected final Overload backpressure;
 
-        private volatile long startTimeNanos;
+        protected volatile long startTimeNanos;
 
         public RequestProcessor(Channel channel, Message.Request request, FlushItemConverter<P> forFlusher, P flusherParam, Overload backpressure)
         {
@@ -345,6 +412,124 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         }
     }
 
+    /** RequestProcessor for management connections that validates before executing. */
+    private class ManagementRequestProcessor<P> extends RequestProcessor<P> {
+
+        public ManagementRequestProcessor(Channel channel,
+                                          Message.Request request,
+                                          FlushItemConverter<P> forFlusher,
+                                          P flusherParam,
+                                          Overload backpressure) {
+            super(channel, request, forFlusher, flusherParam, backpressure);
+        }
+
+        @Override
+        public void run() {
+            startTimeNanos = MonotonicClock.Global.preciseTime.now();
+            RequestTime requestTime = new RequestTime(request.createdAtNanos, startTimeNanos);
+
+            // Validate management request BEFORE executing
+            Connection connection = request.connection();
+            if (connection instanceof ServerConnection) {
+                ServerConnection serverConnection = (ServerConnection) connection;
+                if (serverConnection.isManagementConnection()) {
+                    if (!isManagementRequestAllowed(request)) {
+                        // The flush pipeline takes the stream id from the request envelope, so the
+                        // response must not carry one of its own.
+                        Message.Response response = ErrorMessage.fromExceptionNoStreamId(
+                        new InvalidRequestException(
+                            "Only executions of the INVOKE COMMAND statements are allowed on the management port."));
+                        response.attach(connection);
+                        FlushItem<?> toFlush = forFlusher.toFlushItem(flusherParam, channel, request, response);
+                        flush(toFlush);
+                        return;
+                    }
+                }
+            }
+
+            IN_MANAGEMENT_TASK.set(Boolean.TRUE);
+            try {
+                // If validation passes, call the normal processRequest to execute
+                // This calls the instance method processRequest() which does all the work
+                processRequest(channel, request, forFlusher, flusherParam, backpressure, requestTime);
+            } finally {
+                IN_MANAGEMENT_TASK.set(Boolean.FALSE);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isManagementRequestAllowed(Message.Request request)
+    {
+        switch (request.type)
+        {
+            case QUERY:
+                try
+                {
+                    // Early parse the query to check if it's an INVOKE COMMAND statement.
+                    // For management non-intensive operations double parsing is probably acceptable.
+                    CQLStatement.Raw rawStatement = QueryProcessor.parseStatement(((QueryMessage) request).query);
+                    if (rawStatement instanceof ExecuteCommandStatement.Raw)
+                        return true;
+
+                    // Allow read-only SELECT queries on system keyspaces (needed for driver metadata
+                    // discovery), except system_auth (see isManagementReadableSystemKeyspace).
+                    if (rawStatement instanceof SelectStatement.RawStatement)
+                    {
+                        SelectStatement.RawStatement selectRaw = (SelectStatement.RawStatement) rawStatement;
+                        return selectRaw.isFullyQualified()
+                               && isManagementReadableSystemKeyspace(selectRaw.keyspace());
+                    }
+
+                    // This is also a corner case for the driver's behavior on the management port.
+                    // When connecting, the driver sends a USE statement for the keyspace provided
+                    // in driver.connect("system_schema").
+                    if (rawStatement instanceof UseStatement)
+                    {
+                        UseStatement useStatement = (UseStatement) rawStatement;
+                        return isManagementReadableSystemKeyspace(useStatement.keyspace());
+                    }
+
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    logger.warn("The command request parsing failed. The command will not be executed: {}", e.getMessage());
+                    // If parsing fails (syntax error, etc.), it's not a valid command statement;
+                    // this is expected for non-command queries.
+                    return false;
+                }
+            case STARTUP:
+            case CREDENTIALS:
+            case AUTH_RESPONSE:
+            case OPTIONS:
+            case REGISTER:
+                return true; // Protocol messages are always allowed.
+            case EXECUTE:
+            case PREPARE:
+            case BATCH:
+            default:
+                return false; // Not supported and not allowed on management connections.
+        }
+    }
+
+    /**
+     * System keyspaces a CQL driver may read/USE on the management port for metadata discovery. This is
+     * {@link SchemaConstants#isSystemKeyspace(String)} (which also covers virtual system keyspaces) minus
+     * {@code system_auth}: that keyspace is the credential store (bcrypt {@code salted_hash}, superuser
+     * flags) and must never be readable over the management port, which is reachable without authorization
+     * (if AllowAllAuthorizer is enabled).
+     */
+    private static boolean isManagementReadableSystemKeyspace(String keyspace)
+    {
+        if (keyspace == null)
+            return false;
+        if (SchemaConstants.AUTH_KEYSPACE_NAME.equals(toLowerCaseLocalized(keyspace)))
+            return false;
+        return SchemaConstants.isSystemKeyspace(keyspace)
+               || SchemaConstants.isVirtualSystemKeyspace(keyspace);
+    }
+
     /**
      * Checks if the item in the head of the queue has spent more than allowed time in the queue.
      */
@@ -355,7 +540,8 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         if (threshold <= 0)
             return true;
 
-        return requestExecutor.oldestTaskQueueTime() < (DatabaseDescriptor.getNativeTransportTimeout(TimeUnit.NANOSECONDS) * threshold);
+        LocalAwareExecutorPlus executor = isManagementDispatcher ? managementExecutor : requestExecutor;
+        return executor.oldestTaskQueueTime() < (DatabaseDescriptor.getNativeTransportTimeout(TimeUnit.NANOSECONDS) * threshold);
     }
 
     /**
@@ -500,15 +686,23 @@ public class Dispatcher implements CQLMessageHandler.MessageConsumer<Message.Req
         flusher.start();
     }
 
+    /**
+     * @return true once the executor serving this dispatcher's server has drained: {@link #managementExecutor}
+     * for the management transport, {@link #requestExecutor} otherwise. A management task running on the
+     * calling thread is excluded — it is the task that initiated the stop and cannot drain before it.
+     */
     public boolean isDone()
     {
-        return requestExecutor.getPendingTaskCount() == 0 && requestExecutor.getActiveTaskCount() == 0;
+        LocalAwareExecutorPlus executor = isManagementDispatcher ? managementExecutor : requestExecutor;
+        int self = isManagementDispatcher && IN_MANAGEMENT_TASK.get() ? 1 : 0;
+        return executor.getPendingTaskCount() == 0 && executor.getActiveTaskCount() - self <= 0;
     }
 
     public static void shutdown()
     {
         requestExecutor.shutdown();
         authExecutor.shutdown();
+        managementExecutor.shutdown();
     }
 
     /**

--- a/src/java/org/apache/cassandra/transport/PipelineConfigurator.java
+++ b/src/java/org/apache/cassandra/transport/PipelineConfigurator.java
@@ -117,17 +117,20 @@ public class PipelineConfigurator
     private final Dispatcher dispatcher;
     // Shared between pre-v5 and CQLMessage handlers
     private final QueueBackpressure queueBackpressure;
+    private final boolean isManagementConnection;
 
     public PipelineConfigurator(boolean epoll,
                                 boolean keepAlive,
                                 EncryptionOptions.TlsEncryptionPolicy encryptionPolicy,
-                                Dispatcher dispatcher)
+                                Dispatcher dispatcher,
+                                boolean isManagementConnection)
     {
         this.epoll               = epoll;
         this.keepAlive           = keepAlive;
         this.tlsEncryptionPolicy = encryptionPolicy;
         this.dispatcher          = dispatcher;
-        this.queueBackpressure   = QueueBackpressure.DEFAULT;
+        this.queueBackpressure   = isManagementConnection ? QueueBackpressure.MANAGEMENT_DEFAULT : QueueBackpressure.DEFAULT;
+        this.isManagementConnection = isManagementConnection;
     }
 
     @VisibleForTesting
@@ -139,8 +142,9 @@ public class PipelineConfigurator
         this.epoll               = epoll;
         this.keepAlive           = keepAlive;
         this.tlsEncryptionPolicy = encryptionPolicy;
-        this.dispatcher          = new Dispatcher(useLegacyFlusher);
+        this.dispatcher          = new Dispatcher(useLegacyFlusher, false);
         this.queueBackpressure   = QueueBackpressure.DEFAULT;
+        this.isManagementConnection = false;
     }
 
     public ChannelFuture initializeChannel(final EventLoopGroup workerGroup,
@@ -261,6 +265,9 @@ public class PipelineConfigurator
             pipeline.addFirst(CONNECTION_LIMIT_HANDLER, connectionLimitHandler);
         }
 
+        if (isManagementConnection)
+            channel.attr(Connection.managementKey).set(Boolean.TRUE);
+
         long idleTimeout = DatabaseDescriptor.nativeTransportIdleTimeout();
         if (idleTimeout > 0)
         {
@@ -367,11 +374,6 @@ public class PipelineConfigurator
     protected ClientResourceLimits.ResourceProvider resourceProvider(ClientResourceLimits.Allocator allocator)
     {
         return new ClientResourceLimits.ResourceProvider.Default(allocator);
-    }
-
-    protected Dispatcher dispatcher(boolean useLegacyFlusher)
-    {
-        return new Dispatcher(useLegacyFlusher);
     }
 
     protected CQLMessageHandler.MessageConsumer<Message.Request> messageConsumer()

--- a/src/java/org/apache/cassandra/transport/PipelineConfigurator.java
+++ b/src/java/org/apache/cassandra/transport/PipelineConfigurator.java
@@ -117,17 +117,20 @@ public class PipelineConfigurator
     private final Dispatcher dispatcher;
     // Shared between pre-v5 and CQLMessage handlers
     private final QueueBackpressure queueBackpressure;
+    private final boolean isManagementConnection;
 
     public PipelineConfigurator(boolean epoll,
                                 boolean keepAlive,
                                 EncryptionOptions.TlsEncryptionPolicy encryptionPolicy,
-                                Dispatcher dispatcher)
+                                Dispatcher dispatcher,
+                                boolean isManagementConnection)
     {
         this.epoll               = epoll;
         this.keepAlive           = keepAlive;
         this.tlsEncryptionPolicy = encryptionPolicy;
         this.dispatcher          = dispatcher;
         this.queueBackpressure   = QueueBackpressure.DEFAULT;
+        this.isManagementConnection = isManagementConnection;
     }
 
     @VisibleForTesting
@@ -141,6 +144,7 @@ public class PipelineConfigurator
         this.tlsEncryptionPolicy = encryptionPolicy;
         this.dispatcher          = new Dispatcher(useLegacyFlusher);
         this.queueBackpressure   = QueueBackpressure.DEFAULT;
+        this.isManagementConnection = false;
     }
 
     public ChannelFuture initializeChannel(final EventLoopGroup workerGroup,
@@ -261,6 +265,9 @@ public class PipelineConfigurator
             pipeline.addFirst(CONNECTION_LIMIT_HANDLER, connectionLimitHandler);
         }
 
+        if (isManagementConnection)
+            channel.attr(Connection.managementKey).set(Boolean.TRUE);
+
         long idleTimeout = DatabaseDescriptor.nativeTransportIdleTimeout();
         if (idleTimeout > 0)
         {
@@ -367,11 +374,6 @@ public class PipelineConfigurator
     protected ClientResourceLimits.ResourceProvider resourceProvider(ClientResourceLimits.Allocator allocator)
     {
         return new ClientResourceLimits.ResourceProvider.Default(allocator);
-    }
-
-    protected Dispatcher dispatcher(boolean useLegacyFlusher)
-    {
-        return new Dispatcher(useLegacyFlusher);
     }
 
     protected CQLMessageHandler.MessageConsumer<Message.Request> messageConsumer()

--- a/src/java/org/apache/cassandra/transport/QueueBackpressure.java
+++ b/src/java/org/apache/cassandra/transport/QueueBackpressure.java
@@ -48,16 +48,35 @@ public interface QueueBackpressure
 {
     QueueBackpressure NO_OP = timeUnit -> 0;
 
-    QueueBackpressure DEFAULT = new QueueBackpressure()
-    {
-        private final AtomicReference<Incident> state = new AtomicReference<>(noBackpressure(() -> DatabaseDescriptor.getNativeTransportMinBackoffOnQueueOverload(TimeUnit.NANOSECONDS),
-                                                                                             () -> DatabaseDescriptor.getNativeTransportMaxBackoffOnQueueOverload(TimeUnit.NANOSECONDS)));
+    /** Shared incident state for connections served by {@link Dispatcher#requestExecutor}. */
+    QueueBackpressure DEFAULT = newDefault();
 
-        public long markAndGetDelay(TimeUnit timeUnit)
+    /**
+     * Shared incident state for management connections ({@link Dispatcher#managementExecutor}). Kept separate
+     * from {@link #DEFAULT} because incident severity describes a single executor's queue: an overload streak
+     * on the client transport must not inflate delays applied to management connections, and vice versa.
+     */
+    QueueBackpressure MANAGEMENT_DEFAULT = newDefault();
+
+    static QueueBackpressure newDefault()
+    {
+        return newDefault(() -> DatabaseDescriptor.getNativeTransportMinBackoffOnQueueOverload(TimeUnit.NANOSECONDS),
+                          () -> DatabaseDescriptor.getNativeTransportMaxBackoffOnQueueOverload(TimeUnit.NANOSECONDS));
+    }
+
+    @VisibleForTesting
+    static QueueBackpressure newDefault(LongSupplier minDelayNanos, LongSupplier maxDelayNanos)
+    {
+        return new QueueBackpressure()
         {
-            return state.updateAndGet(Incident::mark).delay(timeUnit);
-        }
-    };
+            private final AtomicReference<Incident> state = new AtomicReference<>(noBackpressure(minDelayNanos, maxDelayNanos));
+
+            public long markAndGetDelay(TimeUnit timeUnit)
+            {
+                return state.updateAndGet(Incident::mark).delay(timeUnit);
+            }
+        };
+    }
 
     long markAndGetDelay(TimeUnit timeUnit);
 

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -85,7 +85,8 @@ public class Server implements CassandraDaemon.Server
     {
         public Connection newConnection(Channel channel, ProtocolVersion version)
         {
-            return new ServerConnection(channel, version, connectionTracker);
+            boolean isManagementConnection = Boolean.TRUE.equals(channel.attr(Connection.managementKey).get());
+            return new ServerConnection(channel, version, connectionTracker, isManagementConnection);
         }
     };
 
@@ -111,13 +112,14 @@ public class Server implements CassandraDaemon.Server
                 workerGroup = new NioEventLoopGroup();
         }
 
-        dispatcher = new Dispatcher(DatabaseDescriptor.useNativeTransportLegacyFlusher());
+        dispatcher = new Dispatcher(DatabaseDescriptor.useNativeTransportLegacyFlusher(), builder.isManagementConnection);
         pipelineConfigurator = builder.pipelineConfigurator != null
                                ? builder.pipelineConfigurator
                                : new PipelineConfigurator(useEpoll,
                                                           DatabaseDescriptor.getRpcKeepAlive(),
                                                           builder.tlsEncryptionPolicy,
-                                                          dispatcher);
+                                                          dispatcher,
+                                                          builder.isManagementConnection);
 
         EventNotifier notifier = builder.eventNotifier != null ? builder.eventNotifier : new EventNotifier();
         connectionTracker = new ConnectionTracker(isRunning::get);
@@ -234,6 +236,7 @@ public class Server implements CassandraDaemon.Server
         private InetSocketAddress socket;
         private PipelineConfigurator pipelineConfigurator;
         private EventNotifier eventNotifier;
+        private boolean isManagementConnection = false;
 
         public Builder withTlsEncryptionPolicy(EncryptionOptions.TlsEncryptionPolicy tlsEncryptionPolicy)
         {
@@ -270,6 +273,12 @@ public class Server implements CassandraDaemon.Server
         public Builder withEventNotifier(EventNotifier eventNotifier)
         {
             this.eventNotifier = eventNotifier;
+            return this;
+        }
+
+        public Builder withManagementConnectionFlag(boolean management)
+        {
+            this.isManagementConnection = management;
             return this;
         }
 

--- a/src/java/org/apache/cassandra/transport/Server.java
+++ b/src/java/org/apache/cassandra/transport/Server.java
@@ -85,7 +85,8 @@ public class Server implements CassandraDaemon.Server
     {
         public Connection newConnection(Channel channel, ProtocolVersion version)
         {
-            return new ServerConnection(channel, version, connectionTracker);
+            boolean isManagementConnection = Boolean.TRUE.equals(channel.attr(Connection.managementKey).get());
+            return new ServerConnection(channel, version, connectionTracker, isManagementConnection);
         }
     };
 
@@ -117,7 +118,8 @@ public class Server implements CassandraDaemon.Server
                                : new PipelineConfigurator(useEpoll,
                                                           DatabaseDescriptor.getRpcKeepAlive(),
                                                           builder.tlsEncryptionPolicy,
-                                                          dispatcher);
+                                                          dispatcher,
+                                                          builder.isManagementConnection);
 
         EventNotifier notifier = builder.eventNotifier != null ? builder.eventNotifier : new EventNotifier();
         connectionTracker = new ConnectionTracker(isRunning::get);
@@ -234,6 +236,7 @@ public class Server implements CassandraDaemon.Server
         private InetSocketAddress socket;
         private PipelineConfigurator pipelineConfigurator;
         private EventNotifier eventNotifier;
+        private boolean isManagementConnection = false;
 
         public Builder withTlsEncryptionPolicy(EncryptionOptions.TlsEncryptionPolicy tlsEncryptionPolicy)
         {
@@ -270,6 +273,12 @@ public class Server implements CassandraDaemon.Server
         public Builder withEventNotifier(EventNotifier eventNotifier)
         {
             this.eventNotifier = eventNotifier;
+            return this;
+        }
+
+        public Builder withManagementConnectionFlag(boolean management)
+        {
+            this.isManagementConnection = management;
             return this;
         }
 

--- a/src/java/org/apache/cassandra/transport/ServerConnection.java
+++ b/src/java/org/apache/cassandra/transport/ServerConnection.java
@@ -46,13 +46,20 @@ public class ServerConnection extends Connection
     private volatile long requests;
     private static final AtomicLongFieldUpdater<ServerConnection> requestsUpdater =
     AtomicLongFieldUpdater.newUpdater(ServerConnection.class, "requests");
+    private final boolean isManagementConnection;
 
     ServerConnection(Channel channel, ProtocolVersion version, Connection.Tracker tracker)
+    {
+        this(channel, version, tracker, false);
+    }
+
+    ServerConnection(Channel channel, ProtocolVersion version, Connection.Tracker tracker, boolean isManagementConnection)
     {
         super(channel, version, tracker);
 
         clientState = ClientState.forExternalCalls(channel.remoteAddress());
         stage = ConnectionStage.ESTABLISHED;
+        this.isManagementConnection = isManagementConnection;
     }
 
     public ClientState getClientState()
@@ -171,5 +178,10 @@ public class ServerConnection extends Connection
         SslHandler sslHandler = (SslHandler) channel().pipeline()
                                                       .get("ssl");
         return sslHandler != null;
+    }
+
+    public boolean isManagementConnection()
+    {
+        return isManagementConnection;
     }
 }

--- a/src/java/org/apache/cassandra/transport/ServerConnection.java
+++ b/src/java/org/apache/cassandra/transport/ServerConnection.java
@@ -42,13 +42,20 @@ public class ServerConnection extends Connection
     private final ClientState clientState;
     private volatile ConnectionStage stage;
     public final Counter requests = new Counter();
+    private final boolean isManagementConnection;
 
     ServerConnection(Channel channel, ProtocolVersion version, Connection.Tracker tracker)
+    {
+        this(channel, version, tracker, false);
+    }
+
+    ServerConnection(Channel channel, ProtocolVersion version, Connection.Tracker tracker, boolean isManagementConnection)
     {
         super(channel, version, tracker);
 
         clientState = ClientState.forExternalCalls(channel.remoteAddress());
         stage = ConnectionStage.ESTABLISHED;
+        this.isManagementConnection = isManagementConnection;
     }
 
     public ClientState getClientState()
@@ -156,5 +163,10 @@ public class ServerConnection extends Connection
         SslHandler sslHandler = (SslHandler) channel().pipeline()
                                                       .get("ssl");
         return sslHandler != null;
+    }
+
+    public boolean isManagementConnection()
+    {
+        return isManagementConnection;
     }
 }

--- a/src/java/org/apache/cassandra/transport/ServerConnection.java
+++ b/src/java/org/apache/cassandra/transport/ServerConnection.java
@@ -43,13 +43,20 @@ public class ServerConnection extends Connection
     private final ClientState clientState;
     private volatile ConnectionStage stage;
     public final Counter requests = new ThreadLocalCounter();
+    private final boolean isManagementConnection;
 
     ServerConnection(Channel channel, ProtocolVersion version, Connection.Tracker tracker)
+    {
+        this(channel, version, tracker, false);
+    }
+
+    ServerConnection(Channel channel, ProtocolVersion version, Connection.Tracker tracker, boolean isManagementConnection)
     {
         super(channel, version, tracker);
 
         clientState = ClientState.forExternalCalls(channel.remoteAddress());
         stage = ConnectionStage.ESTABLISHED;
+        this.isManagementConnection = isManagementConnection;
     }
 
     public ClientState getClientState()
@@ -157,5 +164,10 @@ public class ServerConnection extends Connection
         SslHandler sslHandler = (SslHandler) channel().pipeline()
                                                       .get("ssl");
         return sslHandler != null;
+    }
+
+    public boolean isManagementConnection()
+    {
+        return isManagementConnection;
     }
 }

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -91,7 +91,7 @@ import static org.apache.cassandra.net.SocketFactory.newSslHandler;
 import static org.apache.cassandra.transport.CQLMessageHandler.envelopeSize;
 import static org.apache.cassandra.transport.Flusher.MAX_FRAMED_PAYLOAD_SIZE;
 import static org.apache.cassandra.transport.PipelineConfigurator.SSL_FACTORY_CONTEXT_DESCRIPTION;
-import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
+import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 import static org.apache.cassandra.utils.concurrent.BlockingQueues.newBlockingQueue;
 import static org.apache.cassandra.utils.concurrent.NonBlockingRateLimiter.NO_OP_LIMITER;
 
@@ -99,6 +99,23 @@ public class SimpleClient implements Closeable
 {
 
     public static final int TIMEOUT_SECONDS = 10;
+
+    public static class TimeoutException extends RuntimeException
+    {
+        TimeoutException(long seconds)
+        {
+            super("Timed out after waiting " + seconds + " seconds for a server response. " +
+                  "The request may still be executing on the server.");
+        }
+    }
+
+    public static class ConnectionClosedException extends RuntimeException
+    {
+        ConnectionClosedException()
+        {
+            super("Connection was closed by the server before a response was received.");
+        }
+    }
 
     static
     {
@@ -111,6 +128,8 @@ public class SimpleClient implements Closeable
     public final int port;
     private final EncryptionOptions.ClientEncryptionOptions encryptionOptions;
     private final int largeMessageThreshold;
+    /** How long {@link #execute(Message.Request)} waits for a server response; {@code <= 0} means wait indefinitely. */
+    private final long requestTimeoutSeconds;
 
     protected final ResponseHandler responseHandler = new ResponseHandler();
     protected final Connection.Tracker tracker = new ConnectionTracker();
@@ -131,6 +150,7 @@ public class SimpleClient implements Closeable
         private ProtocolVersion version = ProtocolVersion.CURRENT;
         private boolean useBeta = false;
         private int largeMessageThreshold = FrameEncoder.Payload.MAX_SIZE;
+        private long requestTimeoutSeconds = TIMEOUT_SECONDS;
 
         private Builder(String host, int port)
         {
@@ -162,6 +182,13 @@ public class SimpleClient implements Closeable
             return this;
         }
 
+        /** @param seconds response wait limit for each request; {@code <= 0} waits indefinitely */
+        public Builder requestTimeoutSeconds(long seconds)
+        {
+            requestTimeoutSeconds = seconds;
+            return this;
+        }
+
         public SimpleClient build()
         {
             if (version.isBeta() && !useBeta)
@@ -182,6 +209,7 @@ public class SimpleClient implements Closeable
         this.version = builder.version;
         this.encryptionOptions = builder.encryptionOptions.applyConfig();
         this.largeMessageThreshold = builder.largeMessageThreshold;
+        this.requestTimeoutSeconds = builder.requestTimeoutSeconds;
     }
 
     public SimpleClient(String host, int port, ProtocolVersion version, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
@@ -211,6 +239,7 @@ public class SimpleClient implements Closeable
         this.largeMessageThreshold = FrameEncoder.Payload.MAX_SIZE -
                                         Math.max(FrameEncoderCrc.HEADER_AND_TRAILER_LENGTH,
                                                  FrameEncoderLZ4.HEADER_AND_TRAILER_LENGTH);
+        this.requestTimeoutSeconds = TIMEOUT_SECONDS;
     }
 
     public SimpleClient(String host, int port)
@@ -328,9 +357,9 @@ public class SimpleClient implements Closeable
         {
             request.attach(connection);
             lastWriteFuture = channel.writeAndFlush(Collections.singletonList(request));
-            Message.Response msg = responseHandler.responses.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Message.Response msg = awaitResponse(responseDeadlineNanos());
             if (msg == null)
-                throw new RuntimeException("timeout");
+                throw new TimeoutException(requestTimeoutSeconds);
             if (throwOnErrorResponse && msg instanceof ErrorMessage)
                 throw new RuntimeException((Throwable)((ErrorMessage)msg).error);
             return msg;
@@ -357,12 +386,12 @@ public class SimpleClient implements Closeable
                 }
                 lastWriteFuture = channel.writeAndFlush(requests);
 
-                long deadline = currentTimeMillis() + TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+                long deadlineNanos = responseDeadlineNanos();
                 for (int i = 0; i < requests.size(); i++)
                 {
-                    Message.Response msg = responseHandler.responses.poll(deadline - currentTimeMillis(), TimeUnit.MILLISECONDS);
+                    Message.Response msg = awaitResponse(deadlineNanos);
                     if (msg == null)
-                        throw new RuntimeException("timeout");
+                        throw new TimeoutException(requestTimeoutSeconds);
                     if (msg instanceof ErrorMessage)
                         throw new RuntimeException((Throwable) ((ErrorMessage) msg).error);
                     rrMap.put(requests.get(msg.getSource().header.streamId), msg);
@@ -393,6 +422,26 @@ public class SimpleClient implements Closeable
     {
         Envelope source = message.getSource();
         return source == null ? 0 : source.header.streamId;
+    }
+
+    private long responseDeadlineNanos()
+    {
+        return requestTimeoutSeconds > 0 ? nanoTime() + TimeUnit.SECONDS.toNanos(requestTimeoutSeconds) : Long.MAX_VALUE;
+    }
+
+    private Message.Response awaitResponse(long deadlineNanos) throws InterruptedException
+    {
+        while (true)
+        {
+            long waitNanos = Math.min(TimeUnit.SECONDS.toNanos(1), deadlineNanos - nanoTime());
+            Message.Response msg = waitNanos > 0 ? responseHandler.responses.poll(waitNanos, TimeUnit.NANOSECONDS) : null;
+            if (msg != null)
+                return msg;
+            if (responseHandler.connectionClosed)
+                throw new ConnectionClosedException();
+            if (nanoTime() - deadlineNanos >= 0)
+                return null;
+        }
     }
 
     public interface EventHandler
@@ -702,6 +751,14 @@ public class SimpleClient implements Closeable
     {
         public final BlockingQueue<Message.Response> responses = new SynchronousQueue<>(true);
         public EventHandler eventHandler;
+        volatile boolean connectionClosed;
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception
+        {
+            connectionClosed = true;
+            ctx.fireChannelInactive();
+        }
 
         @Override
         public void channelRead0(ChannelHandlerContext ctx, Message.Response r)

--- a/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/ErrorMessage.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
@@ -37,6 +38,7 @@ import org.apache.cassandra.exceptions.AuthenticationException;
 import org.apache.cassandra.exceptions.CDCWriteException;
 import org.apache.cassandra.exceptions.CasWriteTimeoutException;
 import org.apache.cassandra.exceptions.CasWriteUnknownResultException;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.ExceptionCode;
 import org.apache.cassandra.exceptions.FunctionExecutionException;
@@ -217,6 +219,18 @@ public class ErrorMessage extends Message.Response
                     int blockFor = body.readInt();
                     te = new CasWriteUnknownResultException(cl, received, blockFor);
                     break;
+                case COMMAND_FAILED:
+                    if (version.isSmallerThan(ProtocolVersion.V5))
+                    {
+                        // Fallback for older clients - they'll get SERVER_ERROR instead
+                        te = new ServerError(msg);
+                    }
+                    else
+                    {
+                        UUID executionId = CBUtil.readUUID(body);
+                        te = new CommandRequestExecutionException(executionId, msg, null);
+                    }
+                    break;
             }
             return new ErrorMessage(te);
         }
@@ -302,6 +316,11 @@ public class ErrorMessage extends Message.Response
                     CBUtil.writeConsistencyLevel(cwue.consistency, dest);
                     dest.writeInt(cwue.received);
                     dest.writeInt(cwue.blockFor);
+                    break;
+                case COMMAND_FAILED:
+                    CommandRequestExecutionException cree = (CommandRequestExecutionException)err;
+                    CBUtil.writeUUID(cree.getCommandExecutionId(), dest);
+                    break;
             }
         }
 
@@ -371,6 +390,10 @@ public class ErrorMessage extends Message.Response
                     CasWriteUnknownResultException cwue = (CasWriteUnknownResultException)err;
                     size += CBUtil.sizeOfConsistencyLevel(cwue.consistency) + 4 + 4; // receivedFor: 4, blockFor: 4
                     break;
+                case COMMAND_FAILED:
+                    CommandRequestExecutionException cree = (CommandRequestExecutionException)err;
+                    size += CBUtil.sizeOfUUID(cree.getCommandExecutionId()); // 16 bytes
+                    break;
             }
             return size;
         }
@@ -408,6 +431,13 @@ public class ErrorMessage extends Message.Response
                 case CAS_WRITE_UNKNOWN:
                     CasWriteUnknownResultException cwue = (CasWriteUnknownResultException) msg.error;
                     return new WriteTimeoutException(WriteType.CAS, cwue.consistency, cwue.received, cwue.blockFor);
+                case COMMAND_FAILED:
+                    // For older clients, the executionId is lost, but the message should contain it.
+                    CommandRequestExecutionException cree = (CommandRequestExecutionException) msg.error;
+                    String msgWithId = String.format("Command execution failed (executionId: %s): %s",
+                                                     cree.getCommandExecutionId(),
+                                                     cree.getMessage());
+                    return new ServerError(msgWithId);
             }
         }
 

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -134,6 +134,12 @@ public class StartupMessage extends Message.Request
 
         Guardrails.minimumClientDriverVersion.guard(driverName, driverVersion, clientState);
 
+        if (connection instanceof ServerConnection)
+        {
+            ServerConnection serverConnection = (ServerConnection) connection;
+            clientState.setManagement(serverConnection.isManagementConnection());
+        }
+
         IAuthenticator authenticator = DatabaseDescriptor.getAuthenticator();
         if (authenticator.requireAuthentication())
         {

--- a/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
+++ b/src/java/org/apache/cassandra/transport/messages/StartupMessage.java
@@ -130,6 +130,12 @@ public class StartupMessage extends Message.Request
             clientState.setDriverVersion(options.get(DRIVER_VERSION));
         }
 
+        if (connection instanceof ServerConnection)
+        {
+            ServerConnection serverConnection = (ServerConnection) connection;
+            clientState.setManagement(serverConnection.isManagementConnection());
+        }
+
         IAuthenticator authenticator = DatabaseDescriptor.getAuthenticator();
         if (authenticator.requireAuthentication())
         {

--- a/src/java/org/apache/cassandra/utils/JsonUtils.java
+++ b/src/java/org/apache/cassandra/utils/JsonUtils.java
@@ -259,4 +259,51 @@ public final class JsonUtils
                 valueMap.put(lowered, valueMap.remove(mapKey));
         }
     }
+
+    public static String getJsonType(Class<?> type)
+    {
+        if (type == String.class)
+            return "string";
+        else if (type == int.class || type == Integer.class)
+            return "integer";
+        else if (type == long.class || type == Long.class)
+            return "integer";
+        else if (type == boolean.class || type == Boolean.class)
+            return "boolean";
+        else if (type == double.class || type == Double.class ||
+                 type == float.class || type == Float.class)
+            return "number";
+        else if (type.isArray() || List.class.isAssignableFrom(type))
+            return "array";
+        else if (Map.class.isAssignableFrom(type))
+            return "object";
+        else if (type.isEnum())
+            return "string";
+        else
+            return "string";
+    }
+
+    public static Object convertDefaultValue(String defaultValue, Class<?> type)
+    {
+        try
+        {
+            if (type == boolean.class || type == Boolean.class)
+                return Boolean.parseBoolean(defaultValue);
+            else if (type == int.class || type == Integer.class)
+                return Integer.parseInt(defaultValue);
+            else if (type == long.class || type == Long.class)
+                return Long.parseLong(defaultValue);
+            else if (type == double.class || type == Double.class)
+                return Double.parseDouble(defaultValue);
+            else if (type == float.class || type == Float.class)
+                return Float.parseFloat(defaultValue);
+            else
+                return defaultValue;
+        }
+        catch (Exception e)
+        {
+            // Fall back to string default value if parsing fails.
+            return defaultValue;
+        }
+    }
 }

--- a/src/java/org/apache/cassandra/utils/JsonUtils.java
+++ b/src/java/org/apache/cassandra/utils/JsonUtils.java
@@ -142,7 +142,10 @@ public final class JsonUtils
     {
         try
         {
-            return JSON_OBJECT_MAPPER.readValue(json, Map.class);
+            Map<String, T> result = JSON_OBJECT_MAPPER.readValue(json, Map.class);
+            if (result == null)
+                throw new MarshalException("Error decoding JSON string: expected an object, got null");
+            return result;
         }
         catch (IOException ex)
         {
@@ -154,7 +157,10 @@ public final class JsonUtils
     {
         try
         {
-            return JSON_OBJECT_MAPPER.readValue(bytes, Map.class);
+            Map<String, T> result = JSON_OBJECT_MAPPER.readValue(bytes, Map.class);
+            if (result == null)
+                throw new MarshalException("Error decoding JSON: expected an object, got null");
+            return result;
         }
         catch (IOException ex)
         {

--- a/src/java/org/apache/cassandra/utils/JsonUtils.java
+++ b/src/java/org/apache/cassandra/utils/JsonUtils.java
@@ -222,4 +222,51 @@ public final class JsonUtils
                 valueMap.put(lowered, valueMap.remove(mapKey));
         }
     }
+
+    public static String getJsonType(Class<?> type)
+    {
+        if (type == String.class)
+            return "string";
+        else if (type == int.class || type == Integer.class)
+            return "integer";
+        else if (type == long.class || type == Long.class)
+            return "integer";
+        else if (type == boolean.class || type == Boolean.class)
+            return "boolean";
+        else if (type == double.class || type == Double.class ||
+                 type == float.class || type == Float.class)
+            return "number";
+        else if (type.isArray() || List.class.isAssignableFrom(type))
+            return "array";
+        else if (Map.class.isAssignableFrom(type))
+            return "object";
+        else if (type.isEnum())
+            return "string";
+        else
+            return "string";
+    }
+
+    public static Object convertDefaultValue(String defaultValue, Class<?> type)
+    {
+        try
+        {
+            if (type == boolean.class || type == Boolean.class)
+                return Boolean.parseBoolean(defaultValue);
+            else if (type == int.class || type == Integer.class)
+                return Integer.parseInt(defaultValue);
+            else if (type == long.class || type == Long.class)
+                return Long.parseLong(defaultValue);
+            else if (type == double.class || type == Double.class)
+                return Double.parseDouble(defaultValue);
+            else if (type == float.class || type == Float.class)
+                return Float.parseFloat(defaultValue);
+            else
+                return defaultValue;
+        }
+        catch (Exception e)
+        {
+            // Fall back to string default value if parsing fails.
+            return defaultValue;
+        }
+    }
 }

--- a/src/resources/META-INF/services/org.apache.cassandra.management.api.CommandsProvider
+++ b/src/resources/META-INF/services/org.apache.cassandra.management.api.CommandsProvider
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+org.apache.cassandra.management.picocli.PicocliCommandsProvider
+

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -118,6 +118,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.Sampler;
 import org.apache.cassandra.metrics.ThreadLocalMetrics;
@@ -1044,6 +1045,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                                 SnapshotManager.instance::close,
                                 () -> IndexStatusManager.instance.shutdownAndWait(1L, MINUTES),
                                 DiskErrorsHandlerService::close,
+                                CommandInvokerService::shutdown,
                                 () -> ThreadLocalMetrics.shutdownCleaner(1L, MINUTES)
             );
 

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -122,6 +122,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.Sampler;
 import org.apache.cassandra.metrics.ThreadLocalMetrics;
@@ -1051,6 +1052,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                                 SnapshotManager.instance::close,
                                 () -> IndexStatusManager.instance.shutdownAndWait(1L, MINUTES),
                                 DiskErrorsHandlerService::close,
+                                CommandInvokerService::shutdown,
                                 () -> ThreadLocalMetrics.shutdownCleaner(1L, MINUTES),
                                 () -> JavaBasedUDFunction.shutdownAndWait(1L, MINUTES),
                                 () -> PerSSTableIndexWriter.shutdownAndWait(1L, MINUTES)

--- a/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/Instance.java
@@ -118,6 +118,7 @@ import org.apache.cassandra.io.util.DataOutputPlus;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.PathUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.Sampler;
 import org.apache.cassandra.metrics.ThreadLocalMetrics;
@@ -1028,6 +1029,7 @@ public class Instance extends IsolatedExecutor implements IInvokableInstance
                                 SnapshotManager.instance::close,
                                 () -> IndexStatusManager.instance.shutdownAndWait(1L, MINUTES),
                                 DiskErrorsHandlerService::close,
+                                CommandInvokerService::shutdown,
                                 () -> ThreadLocalMetrics.shutdownCleaner(1L, MINUTES)
             );
 

--- a/test/distributed/org/apache/cassandra/distributed/mock/nodetool/InternalNodeProbe.java
+++ b/test/distributed/org/apache/cassandra/distributed/mock/nodetool/InternalNodeProbe.java
@@ -19,79 +19,69 @@
 package org.apache.cassandra.distributed.mock.nodetool;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Multimap;
 
 import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.batchlog.BatchlogManagerMBean;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
 import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.gms.FailureDetectorMBean;
 import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.GossiperMBean;
 import org.apache.cassandra.hints.HintsService;
+import org.apache.cassandra.hints.HintsServiceMBean;
 import org.apache.cassandra.locator.DynamicEndpointSnitch;
 import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfo;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.locator.SnitchAdapter;
+import org.apache.cassandra.management.MBeanAccessor;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.MessagingServiceMBean;
+import org.apache.cassandra.profiler.AsyncProfilerMBean;
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.ActiveRepairServiceMBean;
 import org.apache.cassandra.service.AsyncProfilerService;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.service.CacheServiceMBean;
 import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.service.GCInspectorMXBean;
 import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.StorageProxyMBean;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.StorageServiceMBean;
 import org.apache.cassandra.service.accord.AccordOperations;
+import org.apache.cassandra.service.accord.AccordOperationsMBean;
 import org.apache.cassandra.service.snapshot.SnapshotManager;
+import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
 import org.apache.cassandra.streaming.StreamManager;
+import org.apache.cassandra.streaming.StreamManagerMBean;
 import org.apache.cassandra.tcm.CMSOperations;
+import org.apache.cassandra.tcm.CMSOperationsMBean;
 import org.apache.cassandra.tools.NodeProbe;
 
 public class InternalNodeProbe extends NodeProbe
 {
-    private final boolean withNotifications;
     private boolean previousSkipNotificationListeners = false;
 
     public InternalNodeProbe(boolean withNotifications)
     {
-        this.withNotifications = withNotifications;
-        connect();
-    }
-
-    protected void connect()
-    {
-        // note that we are not connecting via JMX for testing
-        mbeanServerConn = null;
-        jmxc = null;
-
+        super(new TestMockMBeanAccessor()); // host/port are unused in InternalNodeProbe
         previousSkipNotificationListeners = StorageService.instance.skipNotificationListeners;
         StorageService.instance.skipNotificationListeners = !withNotifications;
-
-        ssProxy = StorageService.instance;
-        snapshotProxy = SnapshotManager.instance;
-        cmsProxy = CMSOperations.instance;
-        accordProxy = AccordOperations.instance;
-        msProxy = MessagingService.instance();
-        streamProxy = StreamManager.instance;
-        compactionProxy = CompactionManager.instance;
-        fdProxy = (FailureDetectorMBean) FailureDetector.instance;
-        cacheService = CacheService.instance;
-        spProxy = StorageProxy.instance;
-        hsProxy = HintsService.instance;
-
-        gcProxy = new GCInspector();
-        gossProxy = Gossiper.instance;
-        bmProxy = BatchlogManager.instance;
-        arsProxy = ActiveRepairService.instance();
-        memProxy = ManagementFactory.getMemoryMXBean();
-        runtimeProxy = ManagementFactory.getRuntimeMXBean();
-        asyncProfilerProxy = AsyncProfilerService.instance();
     }
 
     @Override
@@ -190,5 +180,79 @@ public class InternalNodeProbe extends NodeProbe
     public long getStorageMetric(String metricName)
     {
         throw new UnsupportedOperationException();
+    }
+
+    private static class TestMockMBeanAccessor implements MBeanAccessor
+    {
+        private final Map<Class<?>, Object> mbeanRegistry = new HashMap<>();
+
+        public TestMockMBeanAccessor()
+        {
+            registerMBean(StorageServiceMBean.class, StorageService.instance);
+            registerMBean(SnapshotManagerMBean.class, SnapshotManager.instance);
+            registerMBean(CMSOperationsMBean.class, CMSOperations.instance);
+            registerMBean(AccordOperationsMBean.class, AccordOperations.instance);
+            registerMBean(MessagingServiceMBean.class, MessagingService.instance());
+            registerMBean(StreamManagerMBean.class, StreamManager.instance);
+            registerMBean(CompactionManagerMBean.class, CompactionManager.instance);
+            registerMBean(FailureDetectorMBean.class, (FailureDetectorMBean) FailureDetector.instance);
+            registerMBean(CacheServiceMBean.class, CacheService.instance);
+            registerMBean(StorageProxyMBean.class, StorageProxy.instance);
+            registerMBean(HintsServiceMBean.class, HintsService.instance);
+            registerMBean(GCInspectorMXBean.class, new GCInspector());
+            registerMBean(GossiperMBean.class, Gossiper.instance);
+            registerMBean(BatchlogManagerMBean.class, BatchlogManager.instance);
+            registerMBean(ActiveRepairServiceMBean.class, ActiveRepairService.instance());
+            registerMBean(MemoryMXBean.class, ManagementFactory.getMemoryMXBean());
+            registerMBean(RuntimeMXBean.class, ManagementFactory.getRuntimeMXBean());
+            registerMBean(AsyncProfilerMBean.class, AsyncProfilerService.instance());
+        }
+
+        protected <T> void registerMBean(Class<T> clazz, T mbean)
+        {
+            mbeanRegistry.put(clazz, mbean);
+        }
+
+        @Override
+        public <T> T findMBean(Class<T> clazz)
+        {
+            return mbeanRegistry.get(clazz) == null ? null : clazz.cast(mbeanRegistry.get(clazz));
+        }
+
+        @Override
+        public <T> T findMBeanMetric(Class<T> clazz, Props props)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isMBeanMetricRegistered(Props props)
+        {
+            return false;
+        }
+
+        @Override
+        public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+        {
+            return null;
+        }
+
+        @Override
+        public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+        {
+            return null;
+        }
+
+        @Override
+        public List<ThreadPoolInfo> threadPoolInfos()
+        {
+            return List.of();
+        }
+
+        @Override
+        public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+        {
+            return List.of();
+        }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/mock/nodetool/InternalNodeProbe.java
+++ b/test/distributed/org/apache/cassandra/distributed/mock/nodetool/InternalNodeProbe.java
@@ -19,79 +19,68 @@
 package org.apache.cassandra.distributed.mock.nodetool;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Multimap;
 
 import org.apache.cassandra.batchlog.BatchlogManager;
+import org.apache.cassandra.batchlog.BatchlogManagerMBean;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
 import org.apache.cassandra.gms.FailureDetector;
 import org.apache.cassandra.gms.FailureDetectorMBean;
 import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.GossiperMBean;
 import org.apache.cassandra.hints.HintsService;
+import org.apache.cassandra.hints.HintsServiceMBean;
 import org.apache.cassandra.locator.DynamicEndpointSnitch;
 import org.apache.cassandra.locator.DynamicEndpointSnitchMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfo;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.locator.SnitchAdapter;
+import org.apache.cassandra.management.MBeanAccessor;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.net.MessagingService;
+import org.apache.cassandra.net.MessagingServiceMBean;
+import org.apache.cassandra.profiler.AsyncProfilerMBean;
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.ActiveRepairServiceMBean;
 import org.apache.cassandra.service.AsyncProfilerService;
 import org.apache.cassandra.service.CacheService;
 import org.apache.cassandra.service.CacheServiceMBean;
 import org.apache.cassandra.service.GCInspector;
+import org.apache.cassandra.service.GCInspectorMXBean;
 import org.apache.cassandra.service.StorageProxy;
+import org.apache.cassandra.service.StorageProxyMBean;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.service.StorageServiceMBean;
 import org.apache.cassandra.service.accord.AccordOperations;
+import org.apache.cassandra.service.accord.AccordOperationsMBean;
 import org.apache.cassandra.service.snapshot.SnapshotManager;
+import org.apache.cassandra.service.snapshot.SnapshotManagerMBean;
 import org.apache.cassandra.streaming.StreamManager;
+import org.apache.cassandra.streaming.StreamManagerMBean;
 import org.apache.cassandra.tcm.CMSOperations;
+import org.apache.cassandra.tcm.CMSOperationsMBean;
 import org.apache.cassandra.tools.NodeProbe;
 
 public class InternalNodeProbe extends NodeProbe
 {
-    private final boolean withNotifications;
     private boolean previousSkipNotificationListeners = false;
 
     public InternalNodeProbe(boolean withNotifications)
     {
-        this.withNotifications = withNotifications;
-        connect();
-    }
-
-    protected void connect()
-    {
-        // note that we are not connecting via JMX for testing
-        mbeanServerConn = null;
-        jmxc = null;
-
+        super(new TestMockMBeanAccessor()); // host/port are unused in InternalNodeProbe
         previousSkipNotificationListeners = StorageService.instance.skipNotificationListeners;
         StorageService.instance.skipNotificationListeners = !withNotifications;
-
-        ssProxy = StorageService.instance;
-        snapshotProxy = SnapshotManager.instance;
-        cmsProxy = CMSOperations.instance;
-        accordProxy = AccordOperations.instance;
-        msProxy = MessagingService.instance();
-        streamProxy = StreamManager.instance;
-        compactionProxy = CompactionManager.instance;
-        fdProxy = (FailureDetectorMBean) FailureDetector.instance;
-        cacheService = CacheService.instance;
-        spProxy = StorageProxy.instance;
-        hsProxy = HintsService.instance;
-
-        gcProxy = new GCInspector();
-        gossProxy = Gossiper.instance;
-        bmProxy = BatchlogManager.instance;
-        arsProxy = ActiveRepairService.instance();
-        memProxy = ManagementFactory.getMemoryMXBean();
-        runtimeProxy = ManagementFactory.getRuntimeMXBean();
-        asyncProfilerProxy = AsyncProfilerService.instance();
     }
 
     @Override
@@ -184,5 +173,79 @@ public class InternalNodeProbe extends NodeProbe
     public long getStorageMetric(String metricName)
     {
         throw new UnsupportedOperationException();
+    }
+
+    private static class TestMockMBeanAccessor implements MBeanAccessor
+    {
+        private final Map<Class<?>, Object> mbeanRegistry = new HashMap<>();
+
+        public TestMockMBeanAccessor()
+        {
+            registerMBean(StorageServiceMBean.class, StorageService.instance);
+            registerMBean(SnapshotManagerMBean.class, SnapshotManager.instance);
+            registerMBean(CMSOperationsMBean.class, CMSOperations.instance);
+            registerMBean(AccordOperationsMBean.class, AccordOperations.instance);
+            registerMBean(MessagingServiceMBean.class, MessagingService.instance());
+            registerMBean(StreamManagerMBean.class, StreamManager.instance);
+            registerMBean(CompactionManager.class, CompactionManager.instance);
+            registerMBean(FailureDetectorMBean.class, (FailureDetectorMBean) FailureDetector.instance);
+            registerMBean(CacheServiceMBean.class, CacheService.instance);
+            registerMBean(StorageProxyMBean.class, StorageProxy.instance);
+            registerMBean(HintsServiceMBean.class, HintsService.instance);
+            registerMBean(GCInspectorMXBean.class, new GCInspector());
+            registerMBean(GossiperMBean.class, Gossiper.instance);
+            registerMBean(BatchlogManagerMBean.class, BatchlogManager.instance);
+            registerMBean(ActiveRepairServiceMBean.class, ActiveRepairService.instance());
+            registerMBean(MemoryMXBean.class, ManagementFactory.getMemoryMXBean());
+            registerMBean(RuntimeMXBean.class, ManagementFactory.getRuntimeMXBean());
+            registerMBean(AsyncProfilerMBean.class, AsyncProfilerService.instance());
+        }
+
+        protected <T> void registerMBean(Class<T> clazz, T mbean)
+        {
+            mbeanRegistry.put(clazz, mbean);
+        }
+
+        @Override
+        public <T> T findMBean(Class<T> clazz)
+        {
+            return mbeanRegistry.get(clazz) == null ? null : clazz.cast(mbeanRegistry.get(clazz));
+        }
+
+        @Override
+        public <T> T findMBeanMetric(Class<T> clazz, Props props)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isMBeanMetricRegistered(Props props)
+        {
+            return false;
+        }
+
+        @Override
+        public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+        {
+            return null;
+        }
+
+        @Override
+        public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+        {
+            return null;
+        }
+
+        @Override
+        public List<ThreadPoolInfo> threadPoolInfos()
+        {
+            return List.of();
+        }
+
+        @Override
+        public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+        {
+            return List.of();
+        }
     }
 }

--- a/test/distributed/org/apache/cassandra/distributed/test/ManagementRequestServingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ManagementRequestServingTest.java
@@ -56,9 +56,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * This test verifyes that management requests are served even when native transport is under a heavy
- * load by driver's SELECT requests. We block these requests and verify that management requests are
- * still processed.
+ * Verifies that management requests are served while the native transport is saturated with SELECT
+ * requests from the driver. The test blocks those SELECTs and checks that management requests still
+ * get processed.
  */
 public class ManagementRequestServingTest extends TestBaseImpl
 {

--- a/test/distributed/org/apache/cassandra/distributed/test/ManagementRequestServingTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ManagementRequestServingTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+
+import org.junit.Test;
+
+import org.apache.cassandra.concurrent.SEPExecutor;
+import org.apache.cassandra.concurrent.SharedExecutorPool;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.Dispatcher;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This test verifyes that management requests are served even when native transport is under a heavy
+ * load by driver's SELECT requests. We block these requests and verify that management requests are
+ * still processed.
+ */
+public class ManagementRequestServingTest extends TestBaseImpl
+{
+    private static final int MANAGEMENT_PORT = 11211;
+    private static final int NATIVE_PORT = 9042;
+    private static final int SELECT_REQUESTS_NUM = 10;
+
+    @Test
+    public void testManagementRequestsServedUnderRegularPortLoad() throws Exception
+    {
+        ExecutorService executor = Executors.newFixedThreadPool(SELECT_REQUESTS_NUM);
+        try (Cluster cluster = init(Cluster.build(1)
+                                           .withInstanceInitializer(BlockingSelectByteBuddy::install)
+                                           .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL)
+                                                                       .set("start_native_transport_management", true)
+                                                                       .set("native_transport_management_port", MANAGEMENT_PORT))
+                                           .start());
+             com.datastax.driver.core.Cluster driver = com.datastax.driver.core.Cluster.builder()
+                                                                                       .addContactPoint("127.0.0.1")
+                                                                                       .withPort(NATIVE_PORT)
+                                                                                       .build();
+             Session session = driver.connect())
+        {
+            cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int PRIMARY KEY, v int)"));
+
+            long mgmtBefore = cluster.get(1).callOnInstance(() -> getCompletedTaskCountByExecutor("Native-Transport-Management-Tasks"));
+            long reqBefore = cluster.get(1).callOnInstance(() -> getCompletedTaskCountByExecutor("Native-Transport-Requests"));
+
+            cluster.get(1).runOnInstance(() -> assertTrue(BlockingSelectByteBuddy.enabled.compareAndSet(false, true)));
+
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < SELECT_REQUESTS_NUM; i++)
+                futures.add(CompletableFuture.supplyAsync(() -> session.execute("SELECT * FROM " + KEYSPACE + ".tbl"), executor));
+
+            cluster.get(1).runOnInstance(() -> {
+                try
+                {
+                    BlockingSelectByteBuddy.latch.await();
+                }
+                catch (InterruptedException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            try (com.datastax.driver.core.Cluster mgmt = com.datastax.driver.core.Cluster.builder()
+                                                                                         .addContactPoint("127.0.0.1")
+                                                                                         .withPort(MANAGEMENT_PORT)
+                                                                                         .build();
+                 Session mgmtSession = mgmt.connect("system"))
+            {
+                ResultSet rs = mgmtSession.execute("SELECT * FROM system.local");
+                assertFalse("Management query should return data", rs.all().isEmpty());
+            }
+
+            long mgmtAfter = cluster.get(1).callOnInstance(() -> getCompletedTaskCountByExecutor("Native-Transport-Management-Tasks"));
+            assertTrue("Management executor should have processed requests", mgmtAfter > mgmtBefore);
+
+            cluster.get(1).runOnInstance(() -> BlockingSelectByteBuddy.signal.countDown());
+
+            for (Future<?> f : futures)
+                f.get();
+
+            long reqAfter = cluster.get(1).callOnInstance(() -> getCompletedTaskCountByExecutor("Native-Transport-Requests"));
+            assertTrue("Request executor should have processed requests", reqAfter > reqBefore);
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+    }
+
+    private static long getCompletedTaskCountByExecutor(String name)
+    {
+        return SharedExecutorPool.SHARED.executors.stream()
+                                                  .filter(e -> e.name.endsWith(name))
+                                                  .findFirst()
+                                                  .map(SEPExecutor::getCompletedTaskCount)
+                                                  .orElse(0L);
+    }
+
+    public static class BlockingSelectByteBuddy
+    {
+        static CountDownLatch latch = new CountDownLatch(SELECT_REQUESTS_NUM);
+        static CountDownLatch signal = new CountDownLatch(1);
+        static AtomicBoolean enabled = new AtomicBoolean(false);
+
+        static void install(ClassLoader cl, int ignored)
+        {
+            new ByteBuddy().rebase(SelectStatement.class)
+                           .method(named("execute")
+                                   .and(takesArguments(QueryState.class, QueryOptions.class, Dispatcher.RequestTime.class)))
+                           .intercept(MethodDelegation.to(BlockingSelectByteBuddy.class))
+                           .make()
+                           .load(cl, ClassLoadingStrategy.Default.INJECTION);
+        }
+
+        public static ResultMessage.Rows execute(QueryState state,
+                                                 QueryOptions options,
+                                                 Dispatcher.RequestTime requestTime,
+                                                 @SuperCall Callable<ResultMessage.Rows> r) throws Exception
+        {
+            if (enabled.get() && !state.getClientState().isInternal && !state.getClientState().isManagement())
+            {
+                latch.countDown();
+                signal.await();
+            }
+            return r.call();
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ManagementTransportMultiNodeTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ManagementTransportMultiNodeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import com.datastax.driver.core.Session;
+
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ManagementTransportMultiNodeTest extends TestBaseImpl
+{
+    private static final int MANAGEMENT_PORT = 11211;
+
+    @Test
+    public void testMultiNodeManagementPort() throws Exception
+    {
+        int nodes = 3;
+        try (Cluster cluster = init(Cluster.build(nodes)
+                                           .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL)
+                                                                       .set("start_native_transport_management", true)
+                                                                       .set("native_transport_management_port", MANAGEMENT_PORT))
+                                           .start()))
+        {
+            for (int i = 1; i <= nodes; i++)
+            {
+                String host = cluster.get(i).config().broadcastAddress().getAddress().getHostAddress();
+                try (com.datastax.driver.core.Cluster c = com.datastax.driver.core.Cluster.builder()
+                                                                                          .addContactPoint(host)
+                                                                                          .withPort(MANAGEMENT_PORT)
+                                                                                          .build();
+                     Session s = c.connect())
+                {
+                    assertFalse("Management port on node " + i + " should respond",
+                                s.execute("SELECT * FROM system.local").all().isEmpty());
+                }
+            }
+
+            String node1Host = cluster.get(1).config().broadcastAddress().getAddress().getHostAddress();
+            try (com.datastax.driver.core.Cluster c = com.datastax.driver.core.Cluster.builder()
+                                                                                      .addContactPoint(node1Host)
+                                                                                      .withPort(MANAGEMENT_PORT)
+                                                                                      .build();
+                 Session s = c.connect())
+            {
+                int peerCount = s.execute("SELECT * FROM system.peers").all().size();
+                assertEquals("Node 1 should see other peers via management port",
+                             nodes - 1, peerCount);
+
+                assertFalse("Keyspaces should be visible via management port",
+                            s.execute("SELECT * FROM system_schema.keyspaces").all().isEmpty());
+            }
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ManagementTransportProtocolTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ManagementTransportProtocolTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.tools.ToolRunner;
+import org.apache.cassandra.tools.ToolRunner.ToolResult;
+
+import static org.apache.cassandra.distributed.api.Feature.GOSSIP;
+import static org.apache.cassandra.distributed.api.Feature.NATIVE_PROTOCOL;
+import static org.apache.cassandra.distributed.api.Feature.NETWORK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * End-to-end tests for the management native transport protocol (CEP-38).
+ *
+ *  @see org.apache.cassandra.service.NativeTransportManagementService
+ */
+public class ManagementTransportProtocolTest extends TestBaseImpl
+{
+    private static final Logger logger = LoggerFactory.getLogger(ManagementTransportProtocolTest.class);
+
+    private static final int MANAGEMENT_PORT = 11211;
+    private static final int NATIVE_PORT = 9042;
+    private static Cluster CLUSTER;
+
+    @BeforeClass
+    public static void setupCluster() throws Exception
+    {
+        CLUSTER = init(Cluster.build(1)
+                              .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL)
+                                                          .set("start_native_transport_management", true)
+                                                          .set("native_transport_management_port", MANAGEMENT_PORT))
+                              .start());
+    }
+
+    @AfterClass
+    public static void teardownCluster()
+    {
+        if  (CLUSTER == null)
+            return;
+        CLUSTER.close();
+    }
+
+    @Test
+    public void testManagementPortRemainsUpWhenBinaryDisabled() throws Throwable
+    {
+        assertTrue("Regular port accessible", isAlive(NATIVE_PORT));
+        assertTrue("Management port accessible", isAlive(MANAGEMENT_PORT));
+
+        ToolResult tool = ToolRunner.invokeNodetoolJvmDtest(CLUSTER.get(1), "disablebinary");
+        assertEquals(0, tool.getExitCode());
+        assertFalse("Regular port NOT accessible after disable", isAlive(NATIVE_PORT));
+        assertTrue("Management port still accessible after disable", isAlive(MANAGEMENT_PORT));
+
+        tool = ToolRunner.invokeNodetoolJvmDtest(CLUSTER.get(1), "enablebinary");
+        assertEquals(0, tool.getExitCode());
+        assertTrue("Regular port accessible after re-enable", isAlive(NATIVE_PORT));
+    }
+
+    @Test
+    public void testSelectOnSystemKeyspacesAllowed()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect())
+        {
+            assertFalse(s.execute("SELECT * FROM system.local").all().isEmpty());
+            // system.peers is empty on single-node
+            assertTrue(s.execute("SELECT * FROM system.peers").all().isEmpty());
+            assertFalse(s.execute("SELECT * FROM system_schema.keyspaces").all().isEmpty());
+            assertFalse(s.execute("SELECT * FROM system_schema.tables").all().isEmpty());
+            assertFalse(s.execute("SELECT * FROM system_schema.columns").all().isEmpty());
+        }
+    }
+
+    @Test
+    public void testSelectOnVirtualKeyspacesAllowed()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect())
+        {
+            s.execute("SELECT * FROM system_virtual_schema.keyspaces");
+            s.execute("SELECT * FROM system_virtual_schema.tables");
+        }
+    }
+
+    @Test(expected = InvalidQueryException.class)
+    public void testSelectOnUserKeyspaceRejected()
+    {
+        CLUSTER.schemaChange("CREATE TABLE IF NOT EXISTS " + KEYSPACE + ".mgmt_test (pk int PRIMARY KEY, v int)");
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect())
+        {
+            s.execute("SELECT * FROM " + KEYSPACE + ".mgmt_test");
+        }
+    }
+
+    @Test(expected = InvalidQueryException.class)
+    public void testInsertRejectedOnManagementPort()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect())
+        {
+            s.execute("INSERT INTO system.local (key) VALUES ('test')");
+        }
+    }
+
+    @Test(expected = InvalidQueryException.class)
+    public void testDDLRejectedOnManagementPort()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect())
+        {
+            s.execute("CREATE TABLE " + KEYSPACE + ".should_fail (pk int PRIMARY KEY)");
+        }
+    }
+
+    @Test(expected = InvalidQueryException.class)
+    public void testUnqualifiedSelectRejected()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect())
+        {
+            s.execute("SELECT * FROM local");
+        }
+    }
+
+    /**
+     * This is also a corner case for the driver's behavior on the management port.
+     * When connecting, the driver sends a USE statement for the keyspace provided in connect().
+     * If that keyspace is a system keyspace, the USE msut succeeds, and subsequent queries without
+     * keyspace qualification are allowed. If that keyspace is a user keyspace, the USE should fail.
+     */
+    @Test
+    public void testConnectWithSystemKeyspaceAllowed()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect("system_schema"))
+        {
+            // Driver sends USE system_schema, then we query a table without qualification
+            assertFalse(s.execute("SELECT * FROM system_schema.keyspaces").all().isEmpty());
+        }
+    }
+
+    @Test
+    public void testConnectWithUserKeyspaceRejected()
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(MANAGEMENT_PORT);
+             Session s = c.connect(KEYSPACE))
+        {
+            fail("Should not be able to USE a user keyspace on management port");
+        }
+        catch (Exception e)
+        {
+            logger.debug("Expected failure when connecting with user keyspace: {}", e.getMessage());
+        }
+    }
+
+    private static com.datastax.driver.core.Cluster driverOnPort(int port)
+    {
+        return com.datastax.driver.core.Cluster.builder()
+                                               .addContactPoint("127.0.0.1")
+                                               .withPort(port)
+                                               .build();
+    }
+
+    private static boolean isAlive(int port)
+    {
+        try (com.datastax.driver.core.Cluster c = driverOnPort(port);
+             Session s = c.connect())
+        {
+            s.execute("SELECT * FROM system.local");
+            return true;
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/ManagementTransportProtocolTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/ManagementTransportProtocolTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
 /**
  * End-to-end tests for the management native transport protocol (CEP-38).
  *
- *  @see org.apache.cassandra.service.NativeTransportManagementService
+ * @see org.apache.cassandra.service.NativeTransportManagementService
  */
 public class ManagementTransportProtocolTest extends TestBaseImpl
 {
@@ -154,10 +154,9 @@ public class ManagementTransportProtocolTest extends TestBaseImpl
     }
 
     /**
-     * This is also a corner case for the driver's behavior on the management port.
-     * When connecting, the driver sends a USE statement for the keyspace provided in connect().
-     * If that keyspace is a system keyspace, the USE msut succeeds, and subsequent queries without
-     * keyspace qualification are allowed. If that keyspace is a user keyspace, the USE should fail.
+     * A corner case of the driver's behaviour on the management port: on connect it sends a USE statement
+     * for the keyspace passed to connect(). For a system keyspace the USE must succeed, and later queries
+     * may then omit the keyspace qualifier. For a user keyspace the USE must fail.
      */
     @Test
     public void testConnectWithSystemKeyspaceAllowed()

--- a/test/distributed/org/apache/cassandra/distributed/test/NodeToolEnableDisableBinaryTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NodeToolEnableDisableBinaryTest.java
@@ -72,12 +72,9 @@ public class NodeToolEnableDisableBinaryTest extends TestBaseImpl
     }
 
     /**
-     * This is an important corner case to verify that when binary protocol is disabled,
-     * we can still connect to the management port and query system tables. This case
-     * must be explicitly tested because the management port is used by ops and other
-     * monitoring tools to control the cluster.
-     *
-     * @throws Throwable If any exception occurs during the test.
+     * With the binary protocol disabled, the management port must still accept connections and serve
+     * queries against system tables. Operators and monitoring tools drive the cluster through that port,
+     * so disabling the client transport must not take it down with it.
      */
     @Test
     public void testSystemQueriesViaManagementPortWhenBinaryDisabled() throws Throwable

--- a/test/distributed/org/apache/cassandra/distributed/test/NodeToolEnableDisableBinaryTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NodeToolEnableDisableBinaryTest.java
@@ -18,13 +18,10 @@
 
 package org.apache.cassandra.distributed.test;
 
-import java.io.IOException;
-
+import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.cassandra.distributed.api.ICluster;
@@ -46,52 +43,96 @@ import static org.junit.Assert.assertTrue;
  */
 public class NodeToolEnableDisableBinaryTest extends TestBaseImpl
 {
-    private static ICluster cluster;
-
-    @Before
-    public void setupEnv() throws IOException
-    {
-        if (cluster == null)
-        {
-            cluster = init(builder().withNodes(1)
-                                    .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL))
-                                    .start());
-            cluster.get(1).nodetool("disableautocompaction");
-        }
-    }
-
-    @AfterClass
-    public static void teardownEnv() throws Exception
-    {
-        cluster.close();
-    }
-
     @Test
     public void testEnableDisableBinary() throws Throwable
     {
-        // We can connect
-        assertTrue(canConnect());
+        try (ICluster<?> nodeCluster = init(builder().withNodes(1)
+                                                        .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL))
+                                                        .start()))
+        {
+            nodeCluster.get(1).nodetool("disableautocompaction");
 
-        // We can't connect after disabling
-        ToolResult tool = ToolRunner.invokeNodetoolJvmDtest(cluster.get(1), "disablebinary");
-        Assertions.assertThat(tool.getStdout()).containsIgnoringCase("Stop listening for CQL clients");
-        assertTrue(tool.getCleanedStderr().isEmpty());
-        assertEquals(0, tool.getExitCode());
-        assertFalse(canConnect());
+            // We can connect
+            assertTrue(canConnect());
 
-        // We can connect after re-enabling
-        tool = ToolRunner.invokeNodetoolJvmDtest(cluster.get(1), "enablebinary");
-        Assertions.assertThat(tool.getStdout()).containsIgnoringCase("Starting listening for CQL clients");
-        assertTrue(tool.getCleanedStderr().isEmpty());
-        assertEquals(0, tool.getExitCode());
-        assertTrue(canConnect());
+            // We can't connect after disabling
+            ToolResult tool = ToolRunner.invokeNodetoolJvmDtest(nodeCluster.get(1), "disablebinary");
+            Assertions.assertThat(tool.getStdout()).containsIgnoringCase("Stop listening for CQL clients");
+            assertTrue(tool.getCleanedStderr().isEmpty());
+            assertEquals(0, tool.getExitCode());
+            assertFalse(canConnect());
+
+            // We can connect after re-enabling
+            tool = ToolRunner.invokeNodetoolJvmDtest(nodeCluster.get(1), "enablebinary");
+            Assertions.assertThat(tool.getStdout()).containsIgnoringCase("Starting listening for CQL clients");
+            assertTrue(tool.getCleanedStderr().isEmpty());
+            assertEquals(0, tool.getExitCode());
+            assertTrue(canConnect());
+        }
+    }
+
+    /**
+     * This is an important corner case to verify that when binary protocol is disabled,
+     * we can still connect to the management port and query system tables. This case
+     * must be explicitly tested because the management port is used by ops and other
+     * monitoring tools to control the cluster.
+     *
+     * @throws Throwable If any exception occurs during the test.
+     */
+    @Test
+    public void testSystemQueriesViaManagementPortWhenBinaryDisabled() throws Throwable
+    {
+        int managementPort = 11211;
+        int numberOfNodes = 1;
+        try (ICluster<?> managementCluster = init(builder().withNodes(numberOfNodes)
+                                                        .withConfig(config -> config.with(NETWORK, GOSSIP, NATIVE_PROTOCOL)
+                                                                                    .set("start_native_transport_management", true)
+                                                                                    .set("native_transport_management_port", managementPort))
+                                                        .start()))
+        {
+            managementCluster.get(1).nodetool("disableautocompaction");
+            assertTrue("Regular native CQL port should is accessible", canConnect());
+            assertTrue("Management port should is accessible", canConnect(managementPort));
+
+            ToolResult tool = ToolRunner.invokeNodetoolJvmDtest(managementCluster.get(1), "disablebinary");
+            Assertions.assertThat(tool.getStdout()).containsIgnoringCase("Stop listening for CQL clients");
+            assertEquals(0, tool.getExitCode());
+            assertFalse("Regular native CQL port should NOT be accessible", canConnect());
+            assertTrue("Management port should is accessible", canConnect(managementPort));
+
+            try (Cluster c = Cluster.builder()
+                                    .addContactPoint("127.0.0.1")
+                                    .withPort(managementPort)
+                                    .build();
+                 Session s = c.connect())
+            {
+                assertFalse("system.local should return data",
+                            s.execute("SELECT * FROM system.local").all().isEmpty());
+                assertTrue("system.peers is NOT empty, howeverwe only have one node in the cluster",
+                           s.execute("SELECT * FROM system.peers").all().isEmpty());
+                assertFalse("system_schema.keyspaces should return data",
+                            s.execute("SELECT * FROM system_schema.keyspaces").all().isEmpty());
+                assertFalse("system_schema.tables should return data",
+                            s.execute("SELECT * FROM system_schema.tables").all().isEmpty());
+            }
+
+            tool = ToolRunner.invokeNodetoolJvmDtest(managementCluster.get(1), "enablebinary");
+            assertEquals(0, tool.getExitCode());
+            assertTrue("Should connect to regular binary after re-enabling", canConnect());
+        }
     }
 
     private boolean canConnect()
     {
+        return canConnect(9042);
+    }
+
+    private boolean canConnect(int port)
+    {
         boolean canConnect = false;
         try(com.datastax.driver.core.Cluster c = com.datastax.driver.core.Cluster.builder()
                                                                                  .addContactPoint("127.0.0.1")
+                                                                                 .withPort(port)
                                                                                  .build();
             Session s = c.connect("system_schema"))
         {

--- a/test/distributed/org/apache/cassandra/distributed/test/NodeToolTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/NodeToolTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.ICluster;
 import org.apache.cassandra.distributed.api.IInvokableInstance;
 import org.apache.cassandra.distributed.api.NodeToolResult;
@@ -139,6 +140,24 @@ public class NodeToolTest extends TestBaseImpl
             ringResult.asserts().stdoutContains("Uptime");
             ringResult.asserts().stdoutContains("Heap Memory");
         }
+    }
+
+    @Test
+    public void testCompactionCommandsThroughMockProbe()
+    {
+        String table = "compaction_history_tbl";
+        CLUSTER.schemaChange("CREATE TABLE " + KEYSPACE + '.' + table + " (k int PRIMARY KEY, v int)");
+        assertEquals(0, NODE.nodetool("disableautocompaction", KEYSPACE));
+        for (int i = 0; i < 2; i++)
+        {
+            CLUSTER.coordinator(1).execute("INSERT INTO " + KEYSPACE + '.' + table + " (k, v) VALUES (?, ?)",
+                                           ConsistencyLevel.ONE, i, i);
+            NODE.flush(KEYSPACE);
+        }
+        NODE.forceCompact(KEYSPACE, table);
+
+        NODE.nodetoolResult("compactionhistory").asserts().success().stdoutContains(table);
+        NODE.nodetoolResult("stop", "COMPACTION").asserts().success();
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/cql3/CQLNodetoolProtocolTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLNodetoolProtocolTester.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.cql3;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.tools.NodeTool;
+import org.apache.cassandra.tools.ToolRunner;
+import org.apache.cassandra.tools.nodetool.strategy.CommandExecutionStrategy;
+
+@RunWith(Parameterized.class)
+public abstract class CQLNodetoolProtocolTester extends CQLTester
+{
+    protected static final Pattern EXECUTION_ID_UUID_PATTERN =
+        Pattern.compile("Command execution id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\s*");
+
+    @Parameterized.Parameter
+    public CommandExecutionStrategy.Type strategy;
+
+    @Parameterized.Parameters(name = "strategy={0}")
+    public static Collection<Object[]> data()
+    {
+        List<Object[]> params = new ArrayList<>();
+        for (CommandExecutionStrategy.Type type : CommandExecutionStrategy.Type.values())
+            params.add(new Object[]{type});
+        return params;
+    }
+
+    public ToolRunner.ToolResult invokeNodetool(List<String> args)
+    {
+        return invokeNodetool(args.toArray(new String[0]));
+    }
+
+    public ToolRunner.ToolResult invokeNodetool(String... args)
+    {
+        // Use invokeNodetoolInJvm for faster execution of the command operations and
+        // enabling easier debugging when running in debug mode from IDE. There is also
+        // no need to run 'ant jars' to run nodetool commands in this test after code changes.
+        try (WithProperties with = new WithProperties().set(CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL,
+                                                            strategy.name().toLowerCase()))
+        {
+            return ToolRunner.invokeNodetoolInJvm(NodeTool::new,
+                                                  strategy == CommandExecutionStrategy.Type.CQL ?
+                                                  CQLTester::buildNodetoolCqlArgs :
+                                                  CQLTester::buildNodetoolArgs,
+                                                  args);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -174,6 +174,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileSystems;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.MessagingService;
@@ -277,12 +278,14 @@ public abstract class CQLTester
      */
     private static boolean coordinatorExecution = false;
 
+    private static org.apache.cassandra.transport.Server managementServer;
     private static org.apache.cassandra.transport.Server server;
     private static JMXConnectorServer jmxServer;
     protected static String jmxHost;
     protected static int jmxPort;
     protected static MBeanServerConnection jmxConnection;
 
+    protected static int managementPort;
     protected static int nativePort;
     protected static final InetAddress nativeAddr;
     private static final Map<ClusterSettings, Cluster> clusters = new HashMap<>();
@@ -328,6 +331,7 @@ public abstract class CQLTester
 
         nativeAddr = InetAddress.getLoopbackAddress();
         nativePort = getAutomaticallyAllocatedPort(nativeAddr);
+        managementPort = getAutomaticallyAllocatedPort(nativeAddr);
     }
 
     private List<String> keyspaces = new ArrayList<>();
@@ -486,6 +490,7 @@ public abstract class CQLTester
         StorageService.instance.setPartitionerUnsafe(Murmur3Partitioner.instance);
         SnapshotManager.instance.registerMBean();
         SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
+        CommandInvokerService.instance.start();
     }
 
     // So derived classes can get enough intialization to start setting DatabaseDescriptor options
@@ -505,6 +510,9 @@ public abstract class CQLTester
         if (server != null)
             server.stop();
 
+        if (managementServer != null)
+            managementServer.stop();
+
         // We use queryInternal for CQLTester so prepared statement will populate our internal cache (if reusePrepared is used; otherwise prepared
         // statements are not cached but re-prepared every time). So we clear the cache between test files to avoid accumulating too much.
         if (reusePrepared)
@@ -520,6 +528,8 @@ public abstract class CQLTester
             {
                 logger.warn("Error shutting down jmx", e);
             }
+
+            CommandInvokerService.instance.stop();
         }
     }
 
@@ -598,6 +608,29 @@ public abstract class CQLTester
         allArgs.add(String.valueOf(port));
         allArgs.add("-h");
         allArgs.add(host);
+        allArgs.addAll(args);
+        return allArgs;
+    }
+
+    public static List<String> buildNodetoolCqlArgs(List<String> args)
+    {
+        List<String> allArgs = new ArrayList<>();
+        allArgs.add("bin/nodetool");
+        allArgs.add("-p");
+        allArgs.add(Integer.toString(managementPort));
+        allArgs.add("-h");
+        allArgs.add(nativeAddr.getHostAddress());
+        allArgs.addAll(args);
+        return allArgs;
+    }
+
+    public static List<String> buildCqlshManagementArgs(List<String> args)
+    {
+        List<String> allArgs = new ArrayList<>();
+        allArgs.add("bin/cqlsh");
+        allArgs.add(nativeAddr.getHostAddress());
+        allArgs.add(Integer.toString(managementPort));
+        allArgs.add("-e");
         allArgs.addAll(args);
         return allArgs;
     }
@@ -722,6 +755,7 @@ public abstract class CQLTester
 
         startServices();
         startServer(serverConfigurator);
+        startManagementServer(server -> {});
     }
 
     protected static void requireNetworkWithoutDriver()
@@ -731,6 +765,7 @@ public abstract class CQLTester
 
         startServices();
         startServer(server -> {});
+        startManagementServer(server -> {});
     }
 
     private static void startServices()
@@ -766,6 +801,13 @@ public abstract class CQLTester
         clusterBuilderConfigurator = clusterConfigurator;
 
         startServer(serverConfigurator);
+
+        if (managementServer != null && managementServer.isRunning())
+        {
+            managementServer.stop();
+            managementServer = null;
+        }
+        startManagementServer(serverConfigurator);
     }
 
     private static void startServer(Consumer<Server.Builder> decorator)
@@ -776,6 +818,17 @@ public abstract class CQLTester
         server = serverBuilder.build();
         ClientMetrics.instance.init(server);
         server.start();
+    }
+
+    private static void startManagementServer(Consumer<Server.Builder> decorator)
+    {
+        managementPort = getAutomaticallyAllocatedPort(nativeAddr);
+        Server.Builder serverBuilder = new Server.Builder().withHost(nativeAddr)
+                                                           .withPort(managementPort)
+                                                           .withManagementConnectionFlag(true);
+        decorator.accept(serverBuilder);
+        managementServer = serverBuilder.build();
+        managementServer.start();
     }
 
     private static Cluster initClientCluster(User user, ProtocolVersion version, boolean useEncryption, boolean useClientCert)

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -173,6 +173,7 @@ import org.apache.cassandra.io.sstable.Descriptor;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileSystems;
 import org.apache.cassandra.io.util.FileUtils;
+import org.apache.cassandra.management.CommandInvokerService;
 import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.net.MessagingService;
@@ -276,12 +277,14 @@ public abstract class CQLTester
      */
     private static boolean coordinatorExecution = false;
 
+    private static org.apache.cassandra.transport.Server managementServer;
     private static org.apache.cassandra.transport.Server server;
     private static JMXConnectorServer jmxServer;
     protected static String jmxHost;
     protected static int jmxPort;
     protected static MBeanServerConnection jmxConnection;
 
+    protected static int managementPort;
     protected static int nativePort;
     protected static final InetAddress nativeAddr;
     private static final Map<ClusterSettings, Cluster> clusters = new HashMap<>();
@@ -327,6 +330,7 @@ public abstract class CQLTester
 
         nativeAddr = InetAddress.getLoopbackAddress();
         nativePort = getAutomaticallyAllocatedPort(nativeAddr);
+        managementPort = getAutomaticallyAllocatedPort(nativeAddr);
     }
 
     private List<String> keyspaces = new ArrayList<>();
@@ -485,6 +489,7 @@ public abstract class CQLTester
         StorageService.instance.setPartitionerUnsafe(Murmur3Partitioner.instance);
         SnapshotManager.instance.registerMBean();
         SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
+        CommandInvokerService.instance.start();
     }
 
     // So derived classes can get enough intialization to start setting DatabaseDescriptor options
@@ -504,6 +509,9 @@ public abstract class CQLTester
         if (server != null)
             server.stop();
 
+        if (managementServer != null)
+            managementServer.stop();
+
         // We use queryInternal for CQLTester so prepared statement will populate our internal cache (if reusePrepared is used; otherwise prepared
         // statements are not cached but re-prepared every time). So we clear the cache between test files to avoid accumulating too much.
         if (reusePrepared)
@@ -519,6 +527,8 @@ public abstract class CQLTester
             {
                 logger.warn("Error shutting down jmx", e);
             }
+
+            CommandInvokerService.instance.stop();
         }
     }
 
@@ -597,6 +607,29 @@ public abstract class CQLTester
         allArgs.add(String.valueOf(port));
         allArgs.add("-h");
         allArgs.add(host);
+        allArgs.addAll(args);
+        return allArgs;
+    }
+
+    public static List<String> buildNodetoolCqlArgs(List<String> args)
+    {
+        List<String> allArgs = new ArrayList<>();
+        allArgs.add("bin/nodetool");
+        allArgs.add("-p");
+        allArgs.add(Integer.toString(managementPort));
+        allArgs.add("-h");
+        allArgs.add(nativeAddr.getHostAddress());
+        allArgs.addAll(args);
+        return allArgs;
+    }
+
+    public static List<String> buildCqlshManagementArgs(List<String> args)
+    {
+        List<String> allArgs = new ArrayList<>();
+        allArgs.add("bin/cqlsh");
+        allArgs.add(nativeAddr.getHostAddress());
+        allArgs.add(Integer.toString(managementPort));
+        allArgs.add("-e");
         allArgs.addAll(args);
         return allArgs;
     }
@@ -721,6 +754,7 @@ public abstract class CQLTester
 
         startServices();
         startServer(serverConfigurator);
+        startManagementServer(server -> {});
     }
 
     protected static void requireNetworkWithoutDriver()
@@ -730,6 +764,7 @@ public abstract class CQLTester
 
         startServices();
         startServer(server -> {});
+        startManagementServer(server -> {});
     }
 
     private static void startServices()
@@ -765,6 +800,13 @@ public abstract class CQLTester
         clusterBuilderConfigurator = clusterConfigurator;
 
         startServer(serverConfigurator);
+
+        if (managementServer != null && managementServer.isRunning())
+        {
+            managementServer.stop();
+            managementServer = null;
+        }
+        startManagementServer(serverConfigurator);
     }
 
     private static void startServer(Consumer<Server.Builder> decorator)
@@ -775,6 +817,17 @@ public abstract class CQLTester
         server = serverBuilder.build();
         ClientMetrics.instance.init(server);
         server.start();
+    }
+
+    private static void startManagementServer(Consumer<Server.Builder> decorator)
+    {
+        managementPort = getAutomaticallyAllocatedPort(nativeAddr);
+        Server.Builder serverBuilder = new Server.Builder().withHost(nativeAddr)
+                                                           .withPort(managementPort)
+                                                           .withManagementConnectionFlag(true);
+        decorator.accept(serverBuilder);
+        managementServer = serverBuilder.build();
+        managementServer.start();
     }
 
     private static Cluster initClientCluster(User user, ProtocolVersion version, boolean useEncryption, boolean useClientCert)

--- a/test/unit/org/apache/cassandra/cql3/statements/ExecuteCommandStatementAuthTest.java
+++ b/test/unit/org/apache/cassandra/cql3/statements/ExecuteCommandStatementAuthTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.statements;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.CommandResource;
+import org.apache.cassandra.auth.IAuthorizer;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.auth.RoleResource;
+import org.apache.cassandra.auth.StubAuthorizer;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.exceptions.UnauthorizedException;
+import org.apache.cassandra.service.ClientState;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ExecuteCommandStatementAuthTest extends CQLTester
+{
+    private static final String ROLE_NAME = "test_command_auth_role";
+
+    private ClientState clientState;
+    private RoleResource role;
+
+    @BeforeClass
+    public static void setupAuthorizer() throws Exception
+    {
+        IAuthorizer authorizer = new StubAuthorizer();
+        Field authorizerField = DatabaseDescriptor.class.getDeclaredField("authorizer");
+        authorizerField.setAccessible(true);
+        authorizerField.set(null, authorizer);
+        DatabaseDescriptor.setPermissionsValidity(0);
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        ((StubAuthorizer) DatabaseDescriptor.getAuthorizer()).clear();
+
+        role = RoleResource.role(ROLE_NAME);
+        AuthenticatedUser user = new AuthenticatedUser(ROLE_NAME);
+        clientState = ClientState.forInternalCalls();
+        Field userField = ClientState.class.getDeclaredField("user");
+        userField.setAccessible(true);
+        userField.set(clientState, user);
+    }
+
+    @Test
+    public void deniesCommandExecutionForOrdinaryRoleWithNoGrant()
+    {
+        ExecuteCommandStatement.Raw statement = new ExecuteCommandStatement.Raw("version", Collections.emptyMap());
+
+        assertThatThrownBy(() -> statement.authorize(clientState))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessageContaining("EXECUTE");
+    }
+
+    @Test
+    public void allowsCommandExecutionForRoleGrantedExecuteOnCommandResource()
+    {
+        DatabaseDescriptor.getAuthorizer().grant(AuthenticatedUser.SYSTEM_USER,
+                                                 ImmutableSet.of(Permission.EXECUTE),
+                                                 CommandResource.command("version"),
+                                                 role);
+
+        ExecuteCommandStatement.Raw statement = new ExecuteCommandStatement.Raw("version", Collections.emptyMap());
+        statement.authorize(clientState);
+    }
+}

--- a/test/unit/org/apache/cassandra/db/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/db/SnapshotTest.java
@@ -23,13 +23,13 @@ import java.nio.file.StandardOpenOption;
 
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.io.sstable.format.SSTableFormat.Components;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.service.snapshot.SnapshotManager;
 
-public class SnapshotTest extends CQLTester
+public class SnapshotTest extends CQLNodetoolProtocolTester
 {
     @Test
     public void testEmptyTOC() throws Throwable

--- a/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryIntegrationTest.java
+++ b/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryIntegrationTest.java
@@ -87,8 +87,8 @@ public class CompressionDictionaryIntegrationTest extends CQLTester
                                                Map.of(TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME, TRAINING_MAX_DICTIONARY_SIZE,
                                                       TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME, TRAINING_MAX_TOTAL_SAMPLE_SIZE)))
         .as("Should disallow manual training when using lz4")
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("does not support dictionary compression");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not enabled or SSTable compressor is not a dictionary compressor");
 
         // Re-enable dictionary compression
         CompressionParams dictParams = CompressionParams.zstd(CompressionParams.DEFAULT_CHUNK_LENGTH, true,

--- a/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryManagerTest.java
+++ b/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryManagerTest.java
@@ -176,8 +176,8 @@ public class CompressionDictionaryManagerTest
     public void testTrainManualWithNonDictionaryTable()
     {
         assertThatThrownBy(() -> managerWithoutDict.train(false))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("does not support dictionary compression");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not enabled or SSTable compressor is not a dictionary compressor");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryTrainingFrequencyTest.java
+++ b/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryTrainingFrequencyTest.java
@@ -25,11 +25,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DurationSpec;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.compression.CompressionDictionary.LightweightCompressionDictionary;
 import org.apache.cassandra.db.compression.CompressionDictionaryDetailsTabularData.CompressionDictionaryDataObject;
@@ -43,10 +44,9 @@ import org.apache.cassandra.utils.JsonUtils;
 import org.apache.cassandra.utils.Pair;
 
 import static java.lang.String.format;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CompressionDictionaryTrainingFrequencyTest extends CQLTester
+public class CompressionDictionaryTrainingFrequencyTest extends CQLNodetoolProtocolTester
 {
     private static final String tableName = "mytable";
 
@@ -55,6 +55,14 @@ public class CompressionDictionaryTrainingFrequencyTest extends CQLTester
     {
         requireNetwork();
         startJMXServer();
+    }
+
+    @After
+    public void afterCompressionDictionaryTest() throws Throwable
+    {
+        execute(format("TRUNCATE %s.%s",
+                       SchemaConstants.DISTRIBUTED_KEYSPACE_NAME,
+                       SystemDistributedKeyspace.COMPRESSION_DICTIONARIES));
     }
 
     @Test
@@ -169,7 +177,7 @@ public class CompressionDictionaryTrainingFrequencyTest extends CQLTester
 
         // Test training command with --force since we have limited test data
         ToolRunner.ToolResult result = invokeNodetool("compressiondictionary", "train", "--force", keyspace(), tableName);
-        assertThat(result.getExitCode()).isEqualTo(1);
+        assertThat(result.getExitCode()).isEqualTo(2);
 
         assertThat(result.getStderr())
         .as("Should indicate training can not be triggered")
@@ -181,12 +189,12 @@ public class CompressionDictionaryTrainingFrequencyTest extends CQLTester
                                       .findFirst()
                                       .orElseThrow(() -> new RuntimeException("Unable to find failing message"));
 
-        String pattern = "Failed to trigger training: The next training or importing can occur only at least after " +
+        String pattern = "The next training or importing can occur only at least after " +
                          "(.*) from the last training which happened at (.*). " +
                          "You can train again no earlier than at (.*).";
         Matcher matcher = Pattern.compile(pattern).matcher(failingMessage);
 
-        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.find()).isTrue();
 
         DurationSpec.IntMinutesBound frequencySpec = new DurationSpec.IntMinutesBound(matcher.group(1));
         Instant lastTraining = Instant.parse(matcher.group(2));
@@ -199,7 +207,7 @@ public class CompressionDictionaryTrainingFrequencyTest extends CQLTester
     private void assertFailingImport(File file)
     {
         ToolRunner.ToolResult result = invokeNodetool("compressiondictionary", "import", file.absolutePath());
-        assertThat(result.getExitCode()).isEqualTo(1);
+        assertThat(result.getExitCode()).isEqualTo(2);
     }
 
     private void assertSuccessfulImport(File file)

--- a/test/unit/org/apache/cassandra/db/guardrails/GuardrailTablePropertiesTest.java
+++ b/test/unit/org/apache/cassandra/db/guardrails/GuardrailTablePropertiesTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.cassandra.db.guardrails;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,6 +37,7 @@ import org.apache.cassandra.config.GuardrailsOptions;
 import org.apache.cassandra.cql3.statements.schema.TableAttributes;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -94,6 +97,18 @@ public class GuardrailTablePropertiesTest extends GuardrailTester
         assertInvalidPropertyCSV("comment,invalid1,invalid2", "[invalid1, invalid2]");
         assertInvalidPropertyCSV("invalid1,invalid2,comment", "[invalid1, invalid2]");
         assertInvalidPropertyCSV("invalid1,comment,invalid2", "[invalid1, invalid2]");
+    }
+
+    @Test
+    public void testInsertionOrderPreservedOnSet()
+    {
+        LinkedHashSet<String> properties = new LinkedHashSet<>(Arrays.asList("comment", "cdc", "gc_grace_seconds"));
+        guardrails().setTablePropertiesWarned(properties);
+
+        Set<String> result = guardrails().getTablePropertiesWarned();
+        assertThat(result).isInstanceOf(LinkedHashSet.class);
+        assertEquals(Arrays.asList("comment", "cdc", "gc_grace_seconds"),
+                     new ArrayList<>(result));
     }
 
     private void assertValidProperty(Set<String> properties)

--- a/test/unit/org/apache/cassandra/management/CommandMBeanAdapterTest.java
+++ b/test/unit/org/apache/cassandra/management/CommandMBeanAdapterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandMetadata;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CommandMBeanAdapterTest
+{
+    private static CommandMBeanAdapter newAdapter()
+    {
+        @SuppressWarnings("unchecked")
+        Command<Void> command = Mockito.mock(Command.class);
+        Mockito.when(command.metadata()).thenReturn(Mockito.mock(CommandMetadata.class));
+        // Executor must never be reached for the invalid-argument cases below.
+        CommandInvokerService.Executor executor = (name, args) -> {
+            throw new AssertionError("Executor should not be invoked for invalid arguments");
+        };
+        return new CommandMBeanAdapter("version", command, executor);
+    }
+
+    @Test
+    public void invokeRejectsNonStringArgument()
+    {
+        assertThatThrownBy(() -> newAdapter().invoke("invoke", new Object[]{ 42 }, new String[]{ "int" }))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("exactly one parameter");
+    }
+
+    @Test
+    public void invokeRejectsWrongArgumentCount()
+    {
+        assertThatThrownBy(() -> newAdapter().invoke("invoke", new Object[]{ "a", "b" }, new String[]{ "String", "String" }))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("exactly one parameter");
+    }
+
+    @Test
+    public void invokeRejectsNullParams()
+    {
+        assertThatThrownBy(() -> newAdapter().invoke("invoke", null, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("exactly one parameter");
+    }
+
+    @Test
+    public void invokeRejectsUnknownAction()
+    {
+        assertThatThrownBy(() -> newAdapter().invoke("bogus", new Object[]{ "{}" }, new String[]{ "String" }))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("Unknown operation");
+    }
+}

--- a/test/unit/org/apache/cassandra/management/CommandServiceTest.java
+++ b/test/unit/org/apache/cassandra/management/CommandServiceTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertNotNull;
+
+public class CommandServiceTest extends CQLTester
+{
+    private static final String COMMAND_MBEAN_PATTERN = "org.apache.cassandra.management:type=Command,name=*";
+
+    @Test
+    public void testCommandServiceMBeanRegistered()
+    {
+        try
+        {
+            ObjectName serviceName = new ObjectName(CommandInvokerServiceMBean.MBEAN_NAME);
+            assertThat(MBeanWrapper.instance.isRegistered(serviceName)).as("CommandInvokerService MBean should be registered after start()").isTrue();
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Failed to check MBean registration", e);
+        }
+    }
+
+    @Test
+    public void testCommandMBeansRegistered()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        try
+        {
+            ObjectName pattern = new ObjectName(COMMAND_MBEAN_PATTERN);
+            Set<ObjectName> commandMBeans = MBeanWrapper.instance.queryNames(pattern, null);
+
+            assertThat(commandMBeans).as("At least one Command MBean should be registered").isNotEmpty();
+
+            String[] commandNames = service.getCommandNames();
+            assertThat(commandNames).as("Service should return command names").isNotEmpty();
+
+            for (String commandName : commandNames)
+            {
+                String mbeanName = service.getCommandMBeanName(commandName);
+                assertNotNull("MBean name should not be null for command: " + commandName, mbeanName);
+
+                ObjectName objectName = new ObjectName(mbeanName);
+                assertThat(MBeanWrapper.instance.isRegistered(objectName)).as("Command MBean should be registered for: " + commandName).isTrue();
+            }
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Failed to verify Command MBeans", e);
+        }
+    }
+
+    @Test
+    public void testUnsupportedCommandsNotRegistered()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        String[] commandNames = service.getCommandNames();
+
+        for (String unsupported : CassandraCommandRegistry.UNSUPPORTED_COMMANDS)
+        {
+            Command<?> cmd = service.getRegistry().command(unsupported);
+            assertThat(cmd).as("Unsupported command '%s' should not be in the registry", unsupported).isNull();
+
+            assertThat(Arrays.asList(commandNames))
+                .as("Unsupported command '%s' should not appear in getCommandNames()", unsupported)
+                .noneMatch(name -> name.equals(unsupported) || name.startsWith(unsupported + "."));
+        }
+    }
+
+    @Test
+    public void testCommandMBeanInvoke()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+
+        try
+        {
+            for (String testCommand : service.getCommandNames())
+            {
+                String mbeanName = service.getCommandMBeanName(testCommand);
+                ObjectName commandObjectName = new ObjectName(mbeanName);
+                assertThat(MBeanWrapper.instance.isRegistered(commandObjectName)).as("Command MBean should be registered").isTrue();
+
+                MBeanServer mbs = MBeanWrapper.instance.getMBeanServer();
+                String schema = (String) mbs.invoke(commandObjectName, "getJsonSchema", null, null);
+                assertThat(schema).as("getJsonSchema() should return non-null JSON string").isNotNull().isNotEmpty();
+
+                assertThat(schema.trim()).as("Schema should start with '{'").startsWith("{");
+            }
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Failed to test CommandMBeanAdapter invoke", e);
+        }
+    }
+
+    /**
+     * A successful execution is recorded in the bounded execution history as a success.
+     */
+    @Test
+    public void testSuccessfulExecutionRecordedInHistory() throws Exception
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        UUID executionId = service.invokeCommand("version", CommandServiceTest::emptyArgs).getExecutionId();
+
+        CommandInvokerService.ExecutionHistory record = findInHistory(service, executionId);
+        assertThat(record).as("Successful 'version' execution should be recorded in history").isNotNull();
+        assertThat(record.isSuccess()).as("Record should be marked successful").isTrue();
+        assertThat(record.commandName()).isEqualTo("version");
+    }
+
+    @Test
+    public void testValidationFailureRecordedInHistory()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+
+        int before = service.executionHistory().size();
+        assertThatThrownBy(() -> service.invokeCommand("getauthcacheconfig", CommandServiceTest::emptyArgs))
+            .isInstanceOf(CommandValidationException.class);
+
+        List<CommandInvokerService.ExecutionHistory> history = service.executionHistory();
+        assertThat(history.size()).as("Failed execution should still be recorded").isGreaterThan(before);
+
+        CommandInvokerService.ExecutionHistory last = history.get(history.size() - 1);
+        assertThat(last.commandName()).isEqualTo("getauthcacheconfig");
+        assertThat(last.isSuccess()).as("Validation failure should be recorded as not successful").isFalse();
+        assertThat(last.error()).as("Failure record should retain the error").isNotNull();
+    }
+
+    @Test
+    public void testMalformedJsonMappedToValidationException()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        CommandMetadata metadata = service.getRegistry().command("version").metadata();
+
+        assertThatThrownBy(() -> service.invokeCommand("version", () -> CommandExecutionArgsSerde.fromJson("{not valid json", metadata)))
+            .isInstanceOf(CommandValidationException.class)
+            .hasMessageContaining("Bad usage");
+    }
+
+    @Test
+    public void testMalformedJsonReportedAsValidationErrorViaMBean()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        Command<?> command = service.getRegistry().command("version");
+        CommandMBeanAdapter adapter = new CommandMBeanAdapter("version", command, service::invokeCommand);
+
+        assertThatThrownBy(() -> adapter.invoke(CommandMBeanAdapter.INVOKE_METHOD,
+                                                new Object[]{ "{not valid json" },
+                                                new String[]{ String.class.getName() }))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Error decoding JSON string");
+    }
+
+    private static CommandExecutionArgs emptyArgs()
+    {
+        return new SimpleCommandExecutionArgs(Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    private static CommandInvokerService.ExecutionHistory findInHistory(CommandInvokerService service, UUID executionId)
+    {
+        return service.executionHistory().stream()
+                      .filter(r -> executionId.equals(r.executionId()))
+                      .reduce((first, second) -> second) // last match
+                      .orElse(null);
+    }
+}

--- a/test/unit/org/apache/cassandra/management/CommandServiceTest.java
+++ b/test/unit/org/apache/cassandra/management/CommandServiceTest.java
@@ -187,6 +187,20 @@ public class CommandServiceTest extends CQLTester
             .hasMessageContaining("Error decoding JSON string");
     }
 
+    @Test
+    public void testCommandNotFoundReportedAsIllegalArgumentViaMBean()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        Command<?> command = service.getRegistry().command("version");
+        CommandMBeanAdapter adapter = new CommandMBeanAdapter("nonexistentcommand", command, service::invokeCommand);
+
+        assertThatThrownBy(() -> adapter.invoke(CommandMBeanAdapter.INVOKE_METHOD,
+                                                new Object[]{ "{}" },
+                                                new String[]{ String.class.getName() }))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Command not found");
+    }
+
     private static CommandExecutionArgs emptyArgs()
     {
         return new SimpleCommandExecutionArgs(Collections.emptyMap(), Collections.emptyMap());

--- a/test/unit/org/apache/cassandra/management/CommandServiceTest.java
+++ b/test/unit/org/apache/cassandra/management/CommandServiceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.management.api.Command;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+public class CommandServiceTest extends CQLTester
+{
+    private static final String COMMAND_MBEAN_PATTERN = "org.apache.cassandra.management:type=Command,name=*";
+
+    @Test
+    public void testCommandServiceMBeanRegistered()
+    {
+        try
+        {
+            ObjectName serviceName = new ObjectName(CommandInvokerServiceMBean.MBEAN_NAME);
+            assertThat(MBeanWrapper.instance.isRegistered(serviceName)).as("CommandInvokerService MBean should be registered after start()").isTrue();
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Failed to check MBean registration", e);
+        }
+    }
+
+    @Test
+    public void testCommandMBeansRegistered()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        try
+        {
+            ObjectName pattern = new ObjectName(COMMAND_MBEAN_PATTERN);
+            Set<ObjectName> commandMBeans = MBeanWrapper.instance.queryNames(pattern, null);
+
+            assertThat(commandMBeans).as("At least one Command MBean should be registered").isNotEmpty();
+
+            String[] commandNames = service.getCommandNames();
+            assertThat(commandNames).as("Service should return command names").isNotEmpty();
+
+            for (String commandName : commandNames)
+            {
+                String mbeanName = service.getCommandMBeanName(commandName);
+                assertNotNull("MBean name should not be null for command: " + commandName, mbeanName);
+
+                ObjectName objectName = new ObjectName(mbeanName);
+                assertThat(MBeanWrapper.instance.isRegistered(objectName)).as("Command MBean should be registered for: " + commandName).isTrue();
+            }
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Failed to verify Command MBeans", e);
+        }
+    }
+
+    @Test
+    public void testUnsupportedCommandsNotRegistered()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+        String[] commandNames = service.getCommandNames();
+
+        for (String unsupported : CassandraCommandRegistry.UNSUPPORTED_COMMANDS)
+        {
+            Command<?> cmd = service.getRegistry().command(unsupported);
+            assertThat(cmd).as("Unsupported command '%s' should not be in the registry", unsupported).isNull();
+
+            assertThat(Arrays.asList(commandNames))
+                .as("Unsupported command '%s' should not appear in getCommandNames()", unsupported)
+                .noneMatch(name -> name.equals(unsupported) || name.startsWith(unsupported + "."));
+        }
+    }
+
+    @Test
+    public void testCommandMBeanInvoke()
+    {
+        CommandInvokerService service = CommandInvokerService.instance;
+
+        try
+        {
+            for (String testCommand : service.getCommandNames())
+            {
+                String mbeanName = service.getCommandMBeanName(testCommand);
+                ObjectName commandObjectName = new ObjectName(mbeanName);
+                assertThat(MBeanWrapper.instance.isRegistered(commandObjectName)).as("Command MBean should be registered").isTrue();
+
+                MBeanServer mbs = MBeanWrapper.instance.getMBeanServer();
+                String schema = (String) mbs.invoke(commandObjectName, "getJsonSchema", null, null);
+                assertThat(schema).as("getJsonSchema() should return non-null JSON string").isNotNull().isNotEmpty();
+
+                assertThat(schema.trim()).as("Schema should start with '{'").startsWith("{");
+            }
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Failed to test CommandMBeanAdapter invoke", e);
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/management/CqlExecuteCommandTest.java
+++ b/test/unit/org/apache/cassandra/management/CqlExecuteCommandTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.management;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CqlExecuteCommandTest extends CQLTester
+{
+    @Test
+    public void testExecuteCommandForcecompact() throws Throwable
+    {
+        String keyspaceName = createKeyspace("CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
+        String tableName = createTable(keyspaceName, "CREATE TABLE %s (k text PRIMARY KEY, v int)");
+
+        execute(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", keyspaceName, tableName), "k1", 1);
+        execute(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", keyspaceName, tableName), "k2", 2);
+        execute(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", keyspaceName, tableName), "k4", 4);
+        execute(String.format("INSERT INTO %s.%s (k, v) VALUES (?, ?)", keyspaceName, tableName), "k7", 7);
+
+        flush(keyspaceName, tableName);
+
+        // Execute the INVOKE COMMAND statement using CQL-style syntax.
+        String command = String.format("INVOKE COMMAND forcecompact WITH \"keyspace\" = '%s' AND \"table\" = '%s' AND keys = ['k4', 'k2', 'k7'];",
+                                       keyspaceName, tableName);
+
+        UntypedResultSet result = execute(command);
+
+        assertNotNull("Result should not be null", result);
+        assertEquals("Result should have one row", 1, result.size());
+        
+        UntypedResultSet.Row row = result.one();
+        assertNotNull("Row should not be null", row);
+        
+        assertTrue("Result should have 'output' column", row.has("output"));
+        String output = row.getString("output");
+        assertNotNull("Output should not be null", output);
+        assertFalse("Output should not be empty", output.trim().isEmpty());
+    }
+
+    @Test
+    public void testExecuteCommandWithInvalidCommand() throws Throwable
+    {
+        String command = "INVOKE COMMAND nonexistentcommand WITH key = 'value';";
+        assertInvalidThrow(InvalidRequestException.class, command);
+    }
+
+    @Test
+    public void testExecuteCommandWithoutParameters() throws Throwable
+    {
+        // Test that INVOKE COMMAND statements without WITH clause parse correctly
+        String command = "INVOKE COMMAND status;";
+        
+        UntypedResultSet result = execute(command);
+        
+        assertNotNull("Result should not be null", result);
+        assertEquals("Result should have one row", 1, result.size());
+        
+        UntypedResultSet.Row row = result.one();
+        assertNotNull("Row should not be null", row);
+        assertTrue("Result should have 'output' column", row.has("output"));
+        String output = row.getString("output");
+        assertNotNull("Output should not be null", output);
+    }
+}

--- a/test/unit/org/apache/cassandra/management/ExecuteCommandStatementParseTest.java
+++ b/test/unit/org/apache/cassandra/management/ExecuteCommandStatementParseTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that INVOKE COMMAND CQL statements are parsed correctly into {@link ExecuteCommandStatement.Raw},
+ * using real nodetool command names and realistic argument patterns.
+ */
+public class ExecuteCommandStatementParseTest
+{
+    @Test
+    public void testParseVersionWithoutArgs()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND version;");
+        assertEquals("version", stmt.commandName());
+        assertTrue(stmt.args().isEmpty());
+    }
+
+    @Test
+    public void testParseStatusWithKeyspace()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND status WITH param0 = 'system';");
+        assertEquals("status", stmt.commandName());
+        assertEquals(Map.of("param0", "system"), stmt.args());
+    }
+
+    @Test
+    public void testParseSnapshotWithEscapedQuoteInTag()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND snapshot WITH tag = 'pre-upgrade''s_backup';");
+        assertEquals("snapshot", stmt.commandName());
+        assertEquals(Map.of("tag", "pre-upgrade's_backup"), stmt.args());
+    }
+
+    @Test
+    public void testParseCleanupWithJobs()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND cleanup WITH jobs = 2;");
+        assertEquals("cleanup", stmt.commandName());
+        assertEquals(Map.of("jobs", "2"), stmt.args());
+    }
+
+    @Test
+    public void testParseDecommissionWithForce()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND decommission WITH force = true;");
+        assertEquals("decommission", stmt.commandName());
+        assertEquals(Map.of("force", "true"), stmt.args());
+    }
+
+    @Test
+    public void testParseSetTraceProbabilityWithFloat()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND settraceprobability WITH param0 = 0.2;");
+        assertEquals("settraceprobability", stmt.commandName());
+        assertEquals(Map.of("param0", "0.2"), stmt.args());
+    }
+
+    @Test
+    public void testParseSetTraceProbabilityWithExponentAndNegativeFloats()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND foo WITH a = 1.5e3 AND b = -0.75 AND c = 100.0;"
+        );
+        assertEquals("foo", stmt.commandName());
+        Map<String, Object> args = stmt.args();
+        assertEquals(3, args.size());
+        assertEquals("1.5e3", args.get("a"));
+        assertEquals("-0.75", args.get("b"));
+        assertEquals("100.0", args.get("c"));
+    }
+
+    @Test
+    public void testParseRepairWithDatacenters()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND repair WITH specific_dc = ['dc1', 'dc2', 'dc3'];");
+        assertEquals("repair", stmt.commandName());
+        Object dcs = stmt.args().get("specific_dc");
+        assertTrue("Expected List but got " + dcs.getClass().getName(), dcs instanceof List);
+        assertEquals(List.of("dc1", "dc2", "dc3"), dcs);
+    }
+
+    @Test
+    public void testParseRepairWithEmptyHostList()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND repair WITH specific_host = [];");
+        assertEquals("repair", stmt.commandName());
+        Object hosts = stmt.args().get("specific_host");
+        assertTrue("Expected List but got " + hosts.getClass().getName(), hosts instanceof List);
+        assertEquals(List.of(), hosts);
+    }
+
+    @Test
+    public void testParseRepairWithHostsContainingEscapedQuotes()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND repair WITH specific_host = ['node-1''s.example.com', 'node-2''s.example.com'];"
+        );
+        assertEquals(List.of("node-1's.example.com", "node-2's.example.com"),
+                     stmt.args().get("specific_host"));
+    }
+
+    @Test
+    public void testParseRepairWithSingleDatacenter()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND repair WITH specific_dc = ['us-east-1'];");
+        assertEquals(List.of("us-east-1"), stmt.args().get("specific_dc"));
+    }
+
+    @Test
+    public void testParseForcecompactWithMixedArgs()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND forcecompact WITH \"keyspace\" = 'my_ks' AND \"table\" = 'my_table' AND keys = ['k1', 'k2'];"
+        );
+
+        assertEquals("forcecompact", stmt.commandName());
+        Map<String, Object> args = stmt.args();
+        assertEquals(3, args.size());
+        assertEquals("my_ks", args.get("keyspace"));
+        assertEquals("my_table", args.get("table"));
+        assertEquals(List.of("k1", "k2"), args.get("keys"));
+    }
+
+    @Test
+    public void testParseSetLoggingLevelWithNamedParams()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND setlogginglevel WITH component = 'org.apache.cassandra.db' AND level = 'DEBUG';"
+        );
+
+        assertEquals("setlogginglevel", stmt.commandName());
+        Map<String, Object> args = stmt.args();
+        assertEquals(2, args.size());
+        assertEquals("org.apache.cassandra.db", args.get("component"));
+        assertEquals("DEBUG", args.get("level"));
+    }
+
+    private static ExecuteCommandStatement.Raw parse(String cql)
+    {
+        CQLStatement.Raw stmt = QueryProcessor.parseStatement(cql);
+        assertTrue("Expected ExecuteCommandStatement.Raw but got: " + stmt.getClass().getName(),
+                   stmt instanceof ExecuteCommandStatement.Raw);
+        return (ExecuteCommandStatement.Raw) stmt;
+    }
+}

--- a/test/unit/org/apache/cassandra/management/ExecuteCommandStatementParseTest.java
+++ b/test/unit/org/apache/cassandra/management/ExecuteCommandStatementParseTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that INVOKE COMMAND CQL statements are parsed correctly into {@link ExecuteCommandStatement.Raw},
+ * using real nodetool command names and realistic argument patterns.
+ */
+public class ExecuteCommandStatementParseTest
+{
+    @Test
+    public void testParseVersionWithoutArgs()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND version;");
+        assertEquals("version", stmt.commandName());
+        assertTrue(stmt.args().isEmpty());
+    }
+
+    @Test
+    public void testParseStatusWithKeyspace()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND status WITH param0 = 'system';");
+        assertEquals("status", stmt.commandName());
+        assertEquals(Map.of("param0", "system"), stmt.args());
+    }
+
+    @Test
+    public void testParseSnapshotWithEscapedQuoteInTag()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND snapshot WITH tag = 'pre-upgrade''s_backup';");
+        assertEquals("snapshot", stmt.commandName());
+        assertEquals(Map.of("tag", "pre-upgrade's_backup"), stmt.args());
+    }
+
+    @Test
+    public void testParseCleanupWithJobs()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND cleanup WITH jobs = 2;");
+        assertEquals("cleanup", stmt.commandName());
+        assertEquals(Map.of("jobs", "2"), stmt.args());
+    }
+
+    @Test
+    public void testParseDecommissionWithForce()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND decommission WITH force = true;");
+        assertEquals("decommission", stmt.commandName());
+        assertEquals(Map.of("force", "true"), stmt.args());
+    }
+
+    @Test
+    public void testParseRepairWithDatacenters()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND repair WITH specific_dc = ['dc1', 'dc2', 'dc3'];");
+        assertEquals("repair", stmt.commandName());
+        Object dcs = stmt.args().get("specific_dc");
+        assertTrue("Expected List but got " + dcs.getClass().getName(), dcs instanceof List);
+        assertEquals(List.of("dc1", "dc2", "dc3"), dcs);
+    }
+
+    @Test
+    public void testParseRepairWithEmptyHostList()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND repair WITH specific_host = [];");
+        assertEquals("repair", stmt.commandName());
+        Object hosts = stmt.args().get("specific_host");
+        assertTrue("Expected List but got " + hosts.getClass().getName(), hosts instanceof List);
+        assertEquals(List.of(), hosts);
+    }
+
+    @Test
+    public void testParseRepairWithHostsContainingEscapedQuotes()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND repair WITH specific_host = ['node-1''s.example.com', 'node-2''s.example.com'];"
+        );
+        assertEquals(List.of("node-1's.example.com", "node-2's.example.com"),
+                     stmt.args().get("specific_host"));
+    }
+
+    @Test
+    public void testParseRepairWithSingleDatacenter()
+    {
+        ExecuteCommandStatement.Raw stmt = parse("INVOKE COMMAND repair WITH specific_dc = ['us-east-1'];");
+        assertEquals(List.of("us-east-1"), stmt.args().get("specific_dc"));
+    }
+
+    @Test
+    public void testParseForcecompactWithMixedArgs()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND forcecompact WITH \"keyspace\" = 'my_ks' AND \"table\" = 'my_table' AND keys = ['k1', 'k2'];"
+        );
+
+        assertEquals("forcecompact", stmt.commandName());
+        Map<String, Object> args = stmt.args();
+        assertEquals(3, args.size());
+        assertEquals("my_ks", args.get("keyspace"));
+        assertEquals("my_table", args.get("table"));
+        assertEquals(List.of("k1", "k2"), args.get("keys"));
+    }
+
+    @Test
+    public void testParseSetLoggingLevelWithNamedParams()
+    {
+        ExecuteCommandStatement.Raw stmt = parse(
+            "INVOKE COMMAND setlogginglevel WITH component = 'org.apache.cassandra.db' AND level = 'DEBUG';"
+        );
+
+        assertEquals("setlogginglevel", stmt.commandName());
+        Map<String, Object> args = stmt.args();
+        assertEquals(2, args.size());
+        assertEquals("org.apache.cassandra.db", args.get("component"));
+        assertEquals("DEBUG", args.get("level"));
+    }
+
+    private static ExecuteCommandStatement.Raw parse(String cql)
+    {
+        CQLStatement.Raw stmt = QueryProcessor.parseStatement(cql);
+        assertTrue("Expected ExecuteCommandStatement.Raw but got: " + stmt.getClass().getName(),
+                   stmt instanceof ExecuteCommandStatement.Raw);
+        return (ExecuteCommandStatement.Raw) stmt;
+    }
+}

--- a/test/unit/org/apache/cassandra/management/InternalNodeMBeanAccessorTest.java
+++ b/test/unit/org/apache/cassandra/management/InternalNodeMBeanAccessorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import org.junit.Test;
+
+import org.apache.cassandra.auth.jmx.AuthorizationProxy;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class InternalNodeMBeanAccessorTest extends CQLTester
+{
+    private final InternalNodeMBeanAccessor accessor = new InternalNodeMBeanAccessor();
+
+    @Test
+    public void testFindColumnFamilyResolvesSecondaryIndexStores()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        String index = createIndex("CREATE INDEX ON %s(v) USING 'legacy_local_table'");
+        String indexStoreName = currentTable() + '.' + index;
+
+        assertThat(accessor.findColumnFamily("ColumnFamilies", KEYSPACE, currentTable())).isNotNull();
+
+        ColumnFamilyStoreMBean indexStore = accessor.findColumnFamily("IndexColumnFamilies", KEYSPACE, indexStoreName);
+        assertThat(indexStore).isNotNull();
+        assertThat(indexStore.getTableName()).isEqualTo(indexStoreName);
+
+        assertThatThrownBy(() -> accessor.findColumnFamily("IndexColumnFamilies", KEYSPACE, currentTable() + ".missing_idx"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Index not found");
+    }
+
+    @Test
+    public void testFindColumnFamiliesListsSecondaryIndexStores()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v int)");
+        String index = createIndex("CREATE INDEX ON %s(v) USING 'legacy_local_table'");
+        String indexStoreName = currentTable() + '.' + index;
+
+        assertThat(accessor.findColumnFamilies("IndexColumnFamilies"))
+        .anySatisfy(e -> {
+            assertThat(e.getKey()).isEqualTo(KEYSPACE);
+            assertThat(e.getValue().getTableName()).isEqualTo(indexStoreName);
+        });
+
+        assertThat(accessor.findColumnFamilies("ColumnFamilies"))
+        .anySatisfy(e -> {
+            assertThat(e.getKey()).isEqualTo(KEYSPACE);
+            assertThat(e.getValue().getTableName()).isEqualTo(currentTable());
+        })
+        .noneSatisfy(e -> assertThat(e.getValue().getTableName()).isEqualTo(indexStoreName));
+    }
+
+    @Test
+    public void testFindMBeanResolvesJmxPermissionsCache()
+    {
+        AuthorizationProxy.JmxPermissionsCache expected = AuthorizationProxy.jmxPermissionsCache;
+        assertThat(accessor.findMBean(AuthorizationProxy.JmxPermissionsCacheMBean.class)).isSameAs(expected);
+    }
+
+    @Test
+    public void testFindCompressionDictionaryContract()
+    {
+        createTable("CREATE TABLE %s (k int PRIMARY KEY, v text)");
+        assertThatThrownBy(() -> accessor.findCompressionDictionary(KEYSPACE, currentTable()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not enabled or SSTable compressor is not a dictionary compressor");
+
+        assertThatThrownBy(() -> accessor.findCompressionDictionary(KEYSPACE, "table_does_not_exist"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not exist");
+
+        assertThatThrownBy(() -> accessor.findCompressionDictionary("keyspace_does_not_exist", currentTable()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not exist");
+    }
+}

--- a/test/unit/org/apache/cassandra/management/PicocliCommandArgsConverterTest.java
+++ b/test/unit/org/apache/cassandra/management/PicocliCommandArgsConverterTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.CommandMetadata;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.management.picocli.PicocliCommandMetadata;
+import org.apache.cassandra.service.AsyncProfilerService.AsyncProfilerEvent;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.AsyncProfileCommandGroup.AsyncProfileStartCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PicocliCommandArgsConverterTest
+{
+    @Test
+    public void testFromCommandDefaultValueHandling()
+    {
+        CommandExecutionArgs annotationDefaultArgs = PicocliCommandArgsConverter.fromCommand(new CommandWithAnnotationDefaults());
+        assertThat(findOptionValue(annotationDefaultArgs, "--name")).isEqualTo("default-name");
+        assertThat(findOptionValue(annotationDefaultArgs, "--count")).isEqualTo(1);
+        assertThat(findOptionValue(annotationDefaultArgs, "--items")).isEqualTo(List.of());
+        assertThat(findOptionValue(annotationDefaultArgs, "--flag")).isNull();
+        assertThat(annotationDefaultArgs.parameters()).isEmpty();
+
+        CommandWithAnnotationDefaults overridden = new CommandWithAnnotationDefaults();
+        overridden.flag = true;
+        overridden.name = "cassandra-node-1";
+        overridden.count = 42;
+        overridden.items = List.of("a", "b", "c");
+        overridden.target = "node1";
+
+        CommandExecutionArgs overriddenArgs = PicocliCommandArgsConverter.fromCommand(overridden);
+        assertThat(findOptionValue(overriddenArgs, "--flag")).isEqualTo(Boolean.TRUE);
+        assertThat(findOptionValue(overriddenArgs, "--name")).isEqualTo("cassandra-node-1");
+        assertThat(findOptionValue(overriddenArgs, "--count")).isEqualTo(42);
+        assertThat(findOptionValue(overriddenArgs, "--items")).isEqualTo(List.of("a", "b", "c"));
+        assertThat(overriddenArgs.parameters()).hasSize(1);
+        assertThat(overriddenArgs.parameters().values().iterator().next()).isEqualTo("node1");
+
+        CommandExecutionArgs javaDefaultArgs = PicocliCommandArgsConverter.fromCommand(new CommandWithJavaDefaults());
+        assertThat(findOptionValue(javaDefaultArgs, "--name")).isEqualTo("default-name");
+        assertThat(findOptionValue(javaDefaultArgs, "--count")).isEqualTo(0);
+        assertThat(findOptionValue(javaDefaultArgs, "--flag")).isNull();
+        assertThat(javaDefaultArgs.parameters()).isEmpty();
+    }
+
+    @Test
+    public void testRoundTripSimpleCommand()
+    {
+        CommandWithJavaDefaults source = new CommandWithJavaDefaults();
+        source.flag = true;
+        source.name = "round-trip";
+        source.count = 7;
+        source.items = List.of("p", "q");
+        source.target = "node42";
+
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(source);
+
+        CommandWithJavaDefaults target = new CommandWithJavaDefaults();
+        PicocliCommandArgsConverter.toCommand(args, target);
+
+        assertThat(target.flag).isTrue();
+        assertThat(target.name).isEqualTo("round-trip");
+        assertThat(target.count).isEqualTo(7);
+        assertThat(target.items).containsExactly("p", "q");
+        assertThat(target.target).isEqualTo("node42");
+    }
+
+    @Test
+    public void testRoundTripMixinCommand()
+    {
+        CommandExecutionArgs defaultArgs = PicocliCommandArgsConverter.fromCommand(new CommandWithMixin());
+        assertThat(findOptionValue(defaultArgs, "--verbose")).isNull();
+
+        CommandWithMixin source = new CommandWithMixin();
+        source.verboseMixin.verbose = true;
+        source.host = "node-dc2";
+
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(source);
+
+        CommandWithMixin target = new CommandWithMixin();
+        PicocliCommandArgsConverter.toCommand(args, target);
+
+        assertThat(target.verboseMixin.verbose).isTrue();
+        assertThat(target.host).isEqualTo("node-dc2");
+    }
+
+    @Test
+    public void testSetOfEnumElementsAreConverted()
+    {
+        CollectionElementCommand command = new CollectionElementCommand();
+        CommandMetadata metadata = PicocliCommandMetadata.from(command);
+
+        Map<String, Object> raw = Map.of("colorSet", List.of("green", "red"));
+        CommandExecutionArgs args = CommandExecutionArgsSerde.fromMap(raw, metadata);
+
+        PicocliCommandArgsConverter.toCommand(args, command);
+
+        String joined = command.colorSet.stream().map(Enum::name).collect(Collectors.joining(","));
+        assertThat(joined).contains("green").contains("red");
+        assertThat(command.colorSet).containsExactlyInAnyOrder(Color.green, Color.red);
+    }
+
+    @Test
+    public void testArrayOfEnumElementsAreConverted()
+    {
+        CollectionElementCommand command = new CollectionElementCommand();
+        CommandMetadata metadata = PicocliCommandMetadata.from(command);
+
+        Map<String, Object> raw = Map.of("colorArray", List.of("red", "green"));
+        CommandExecutionArgs args = CommandExecutionArgsSerde.fromMap(raw, metadata);
+
+        PicocliCommandArgsConverter.toCommand(args, command);
+
+        assertThat(command.colorArray).containsExactly(Color.red, Color.green);
+    }
+
+    @Test
+    public void testAsyncProfilerStartEventListIsConverted()
+    {
+        AsyncProfileStartCommand command = new AsyncProfileStartCommand();
+        CommandMetadata metadata = PicocliCommandMetadata.from(command);
+
+        // The grammar parses "cpu,alloc" into a list of String literals.
+        Map<String, Object> raw = Map.of("event", List.of("cpu", "alloc"));
+        CommandExecutionArgs args = CommandExecutionArgsSerde.fromMap(raw, metadata);
+
+        PicocliCommandArgsConverter.toCommand(args, command);
+
+        assertThat(command.event).containsExactly(AsyncProfilerEvent.cpu, AsyncProfilerEvent.alloc);
+
+        String joined = command.event.stream().map(Enum::name).collect(Collectors.joining(","));
+        assertThat(joined).isEqualTo("cpu,alloc");
+    }
+
+    private static Object findOptionValue(CommandExecutionArgs args, String optionName)
+    {
+        for (java.util.Map.Entry<OptionMetadata, Object> entry : args.options().entrySet())
+        {
+            if (List.of(entry.getKey().names()).contains(optionName))
+                return entry.getValue();
+        }
+        return null;
+    }
+
+    @Command(name = "command-with-annotation-defaults")
+    static class CommandWithAnnotationDefaults extends AbstractCommand
+    {
+        @Option(names = { "--flag", "-f" }, description = "A boolean flag")
+        boolean flag = false;
+
+        @Option(names = { "--name", "-n" }, description = "A string option", paramLabel = "name", defaultValue = "default-name")
+        String name = "default-name";
+
+        @Option(names = { "--count", "-c" }, description = "An integer option", paramLabel = "count", defaultValue = "1")
+        int count = 1;
+
+        @Option(names = { "--items" }, description = "A list option", paramLabel = "items")
+        List<String> items = List.of();
+
+        @Parameters(index = "0", paramLabel = "target", description = "A positional parameter", arity = "0..1")
+        String target = null;
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+
+    @Command(name = "command-with-java-defaults")
+    static class CommandWithJavaDefaults extends AbstractCommand
+    {
+        @Option(names = { "--flag", "-f" }, description = "A boolean flag")
+        boolean flag = false;
+
+        @Option(names = { "--name", "-n" }, description = "A string option", paramLabel = "name")
+        String name = "default-name";
+
+        @Option(names = { "--count", "-c" }, description = "An integer option", paramLabel = "count")
+        int count = 0;
+
+        @Option(names = { "--items" }, description = "A list option", paramLabel = "items")
+        List<String> items = List.of();
+
+        @Parameters(index = "0", paramLabel = "target", description = "A positional parameter", arity = "0..1")
+        String target = null;
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+
+    static class VerboseMixin
+    {
+        @Option(names = { "--verbose", "-v" }, description = "Enable verbose output")
+        boolean verbose = false;
+    }
+
+    @Command(name = "mixin-command")
+    static class CommandWithMixin extends AbstractCommand
+    {
+        @Mixin
+        VerboseMixin verboseMixin = new VerboseMixin();
+
+        @Option(names = { "--host" }, description = "Target host",
+        paramLabel = "host", defaultValue = "localhost")
+        String host = "localhost";
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+
+    enum Color
+    {
+        red, green, blue
+    }
+
+    @Command(name = "collection-element-command")
+    static class CollectionElementCommand extends AbstractCommand
+    {
+        @Option(names = { "--colorSet", "-s" }, paramLabel = "colorSet", description = "A set of enum values")
+        public Set<Color> colorSet = Set.of();
+
+        @Option(names = { "--colorArray", "-a" }, paramLabel = "colorArray", description = "An array of enum values")
+        public Color[] colorArray = new Color[0];
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/management/PicocliCommandArgsConverterTest.java
+++ b/test/unit/org/apache/cassandra/management/PicocliCommandArgsConverterTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.management;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.api.OptionMetadata;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PicocliCommandArgsConverterTest
+{
+    @Test
+    public void testFromCommandDefaultValueHandling()
+    {
+        CommandExecutionArgs annotationDefaultArgs = PicocliCommandArgsConverter.fromCommand(new CommandWithAnnotationDefaults());
+        assertThat(findOptionValue(annotationDefaultArgs, "--name")).isEqualTo("default-name");
+        assertThat(findOptionValue(annotationDefaultArgs, "--count")).isEqualTo(1);
+        assertThat(findOptionValue(annotationDefaultArgs, "--items")).isEqualTo(List.of());
+        assertThat(findOptionValue(annotationDefaultArgs, "--flag")).isNull();
+        assertThat(annotationDefaultArgs.parameters()).isEmpty();
+
+        CommandWithAnnotationDefaults overridden = new CommandWithAnnotationDefaults();
+        overridden.flag = true;
+        overridden.name = "cassandra-node-1";
+        overridden.count = 42;
+        overridden.items = List.of("a", "b", "c");
+        overridden.target = "node1";
+
+        CommandExecutionArgs overriddenArgs = PicocliCommandArgsConverter.fromCommand(overridden);
+        assertThat(findOptionValue(overriddenArgs, "--flag")).isEqualTo(Boolean.TRUE);
+        assertThat(findOptionValue(overriddenArgs, "--name")).isEqualTo("cassandra-node-1");
+        assertThat(findOptionValue(overriddenArgs, "--count")).isEqualTo(42);
+        assertThat(findOptionValue(overriddenArgs, "--items")).isEqualTo(List.of("a", "b", "c"));
+        assertThat(overriddenArgs.parameters()).hasSize(1);
+        assertThat(overriddenArgs.parameters().values().iterator().next()).isEqualTo("node1");
+
+        CommandExecutionArgs javaDefaultArgs = PicocliCommandArgsConverter.fromCommand(new CommandWithJavaDefaults());
+        assertThat(findOptionValue(javaDefaultArgs, "--name")).isEqualTo("default-name");
+        assertThat(findOptionValue(javaDefaultArgs, "--count")).isEqualTo(0);
+        assertThat(findOptionValue(javaDefaultArgs, "--flag")).isNull();
+        assertThat(javaDefaultArgs.parameters()).isEmpty();
+    }
+
+    @Test
+    public void testRoundTripSimpleCommand()
+    {
+        CommandWithJavaDefaults source = new CommandWithJavaDefaults();
+        source.flag = true;
+        source.name = "round-trip";
+        source.count = 7;
+        source.items = List.of("p", "q");
+        source.target = "node42";
+
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(source);
+
+        CommandWithJavaDefaults target = new CommandWithJavaDefaults();
+        PicocliCommandArgsConverter.toCommand(args, target);
+
+        assertThat(target.flag).isTrue();
+        assertThat(target.name).isEqualTo("round-trip");
+        assertThat(target.count).isEqualTo(7);
+        assertThat(target.items).containsExactly("p", "q");
+        assertThat(target.target).isEqualTo("node42");
+    }
+
+    @Test
+    public void testRoundTripMixinCommand()
+    {
+        CommandExecutionArgs defaultArgs = PicocliCommandArgsConverter.fromCommand(new CommandWithMixin());
+        assertThat(findOptionValue(defaultArgs, "--verbose")).isNull();
+
+        CommandWithMixin source = new CommandWithMixin();
+        source.verboseMixin.verbose = true;
+        source.host = "node-dc2";
+
+        CommandExecutionArgs args = PicocliCommandArgsConverter.fromCommand(source);
+
+        CommandWithMixin target = new CommandWithMixin();
+        PicocliCommandArgsConverter.toCommand(args, target);
+
+        assertThat(target.verboseMixin.verbose).isTrue();
+        assertThat(target.host).isEqualTo("node-dc2");
+    }
+
+    private static Object findOptionValue(CommandExecutionArgs args, String optionName)
+    {
+        for (java.util.Map.Entry<OptionMetadata, Object> entry : args.options().entrySet())
+        {
+            if (List.of(entry.getKey().names()).contains(optionName))
+                return entry.getValue();
+        }
+        return null;
+    }
+
+    @Command(name = "command-with-annotation-defaults")
+    static class CommandWithAnnotationDefaults extends AbstractCommand
+    {
+        @Option(names = { "--flag", "-f" }, description = "A boolean flag")
+        boolean flag = false;
+
+        @Option(names = { "--name", "-n" }, description = "A string option", paramLabel = "name", defaultValue = "default-name")
+        String name = "default-name";
+
+        @Option(names = { "--count", "-c" }, description = "An integer option", paramLabel = "count", defaultValue = "1")
+        int count = 1;
+
+        @Option(names = { "--items" }, description = "A list option", paramLabel = "items")
+        List<String> items = List.of();
+
+        @Parameters(index = "0", paramLabel = "target", description = "A positional parameter", arity = "0..1")
+        String target = null;
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+
+    @Command(name = "command-with-java-defaults")
+    static class CommandWithJavaDefaults extends AbstractCommand
+    {
+        @Option(names = { "--flag", "-f" }, description = "A boolean flag")
+        boolean flag = false;
+
+        @Option(names = { "--name", "-n" }, description = "A string option", paramLabel = "name")
+        String name = "default-name";
+
+        @Option(names = { "--count", "-c" }, description = "An integer option", paramLabel = "count")
+        int count = 0;
+
+        @Option(names = { "--items" }, description = "A list option", paramLabel = "items")
+        List<String> items = List.of();
+
+        @Parameters(index = "0", paramLabel = "target", description = "A positional parameter", arity = "0..1")
+        String target = null;
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+
+    static class VerboseMixin
+    {
+        @Option(names = { "--verbose", "-v" }, description = "Enable verbose output")
+        boolean verbose = false;
+    }
+
+    @Command(name = "mixin-command")
+    static class CommandWithMixin extends AbstractCommand
+    {
+        @Mixin
+        VerboseMixin verboseMixin = new VerboseMixin();
+
+        @Option(names = { "--host" }, description = "Target host",
+        paramLabel = "host", defaultValue = "localhost")
+        String host = "localhost";
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/service/NativeTransportManagementServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/NativeTransportManagementServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.service;
+
+import java.util.function.BooleanSupplier;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import io.netty.channel.EventLoopGroup;
+
+import static org.apache.cassandra.service.NativeTransportServiceTest.withService;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NativeTransportManagementServiceTest
+{
+    @BeforeClass
+    public static void setupTransport()
+    {
+        DatabaseDescriptor.daemonInitialization();
+        DatabaseDescriptor.setStartNativeTransportManagement(true);
+    }
+
+    @AfterClass
+    public static void cleanupManagementConfig()
+    {
+        DatabaseDescriptor.setStartNativeTransportManagement(false);
+    }
+
+    @Test
+    public void testStart()
+    {
+        withService((CassandraDaemon.Server service) -> assertTrue(service.isRunning()),
+                    NativeTransportManagementService::new, true, 1);
+    }
+
+    @Test
+    public void testDestroy()
+    {
+        withService((CassandraDaemon.Server srv) -> {
+            NativeTransportManagementService service = (NativeTransportManagementService) srv;
+            EventLoopGroup workerGroup = service.getWorkerGroup();
+            BooleanSupplier allTerminated = () -> workerGroup != null
+                                                  && workerGroup.isShutdown()
+                                                  && workerGroup.isTerminated();
+
+            assertFalse(allTerminated.getAsBoolean());
+            service.destroy();
+            assertTrue(allTerminated.getAsBoolean());
+        }, NativeTransportManagementService::new, true, 1);
+    }
+
+    @Test
+    public void testConcurrentDestroys()
+    {
+        withService(srv -> ((NativeTransportManagementService) srv).destroy(),
+                    NativeTransportManagementService::new, true, 20);
+    }
+}

--- a/test/unit/org/apache/cassandra/service/NativeTransportServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/NativeTransportServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.service;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import org.junit.After;
@@ -170,7 +171,16 @@ public class NativeTransportServiceTest
 
     private static void withService(Consumer<NativeTransportService> f, boolean start, int concurrently)
     {
-        NativeTransportService service = new NativeTransportService();
+        withService(srv -> f.accept((NativeTransportService) srv),
+                    NativeTransportService::new, start, concurrently);
+    }
+
+    static void withService(Consumer<CassandraDaemon.Server> f,
+                            Supplier<CassandraDaemon.Server> provider,
+                            boolean start,
+                            int concurrently)
+    {
+        CassandraDaemon.Server service = provider.get();
         assertFalse(service.isRunning());
         if (start)
         {

--- a/test/unit/org/apache/cassandra/tools/JMXStandardsTest.java
+++ b/test/unit/org/apache/cassandra/tools/JMXStandardsTest.java
@@ -125,6 +125,7 @@ public class JMXStandardsTest
         Pattern mbeanPattern = Pattern.compile(".*MBean$");
         Set<String> matches = reflections.getAll(Scanners.SubTypes).stream()
                                          .filter(s -> mbeanPattern.matcher(s).find())
+                                         .filter(s -> s.startsWith("org.apache.cassandra."))
                                          .collect(Collectors.toSet());
 
         List<String> warnings = new ArrayList<>();

--- a/test/unit/org/apache/cassandra/tools/NodeProbeMBeanProxyTest.java
+++ b/test/unit/org/apache/cassandra/tools/NodeProbeMBeanProxyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.management.InstanceNotFoundException;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ColumnFamilyStoreMBean;
+import org.apache.cassandra.db.compression.CompressionDictionaryManagerMBean;
+import org.apache.cassandra.management.MBeanAccessor;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class NodeProbeMBeanProxyTest
+{
+    @Test
+    public void testMissingMBeanSurfacesAsInstanceNotFound()
+    {
+        NodeProbe probe = new NodeProbe(new NullMBeanAccessor());
+
+        assertThatThrownBy(probe::stopCassandraDaemon)
+        .isInstanceOf(RuntimeException.class)
+        .hasRootCauseInstanceOf(InstanceNotFoundException.class)
+        .hasRootCauseMessage("StorageServiceMBean is not available on this node");
+    }
+
+    private static class NullMBeanAccessor implements MBeanAccessor
+    {
+        @Override
+        public <T> T findMBean(Class<T> clazz)
+        {
+            return null;
+        }
+
+        @Override
+        public <T> T findMBeanMetric(Class<T> clazz, Props props)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isMBeanMetricRegistered(Props props)
+        {
+            return false;
+        }
+
+        @Override
+        public ColumnFamilyStoreMBean findColumnFamily(String type, String keyspace, String columnFamily)
+        {
+            return null;
+        }
+
+        @Override
+        public CompressionDictionaryManagerMBean findCompressionDictionary(String keyspace, String table)
+        {
+            return null;
+        }
+
+        @Override
+        public List<ThreadPoolInfo> threadPoolInfos()
+        {
+            return List.of();
+        }
+
+        @Override
+        public List<Map.Entry<String, ColumnFamilyStoreMBean>> findColumnFamilies(String type)
+        {
+            return List.of();
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/NodeProbeTest.java
+++ b/test/unit/org/apache/cassandra/tools/NodeProbeTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.cassandra.tools;
 
-import java.io.IOException;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,11 +37,11 @@ public class NodeProbeTest extends CQLTester
     {
         requireNetwork();
         startJMXServer();
-        probe = new NodeProbe(jmxHost, jmxPort);
+        probe = new NodeProbe(new RemoteJmxMBeanAccessor(jmxHost, jmxPort));
     }
 
     @AfterClass
-    public static void teardown() throws IOException
+    public static void teardown() throws Exception
     {
         probe.close();
     }

--- a/test/unit/org/apache/cassandra/tools/ToolRunner.java
+++ b/test/unit/org/apache/cassandra/tools/ToolRunner.java
@@ -182,6 +182,11 @@ public class ToolRunner
         return invoke(CQLTester.buildCqlshArgs(args));
     }
 
+    public static ToolResult invokeCqlshManagement(List<String> args)
+    {
+        return invoke(CQLTester.buildCqlshManagementArgs(args));
+    }
+
     public static ToolResult invokeCassandraStress(String... args)
     {
         return invokeCassandraStress(Arrays.asList(args));
@@ -210,6 +215,11 @@ public class ToolRunner
     public static ToolResult invokeNodetool(Map<String, String> env, List<String> args)
     {
         return invoke(env, CQLTester.buildNodetoolArgs(args));
+    }
+
+    public static ToolResult invokeCqlNodetool(Map<String, String> env, List<String> args)
+    {
+        return invoke(env, CQLTester.buildNodetoolCqlArgs(args));
     }
 
     public static ToolRunner.ToolResult invokeNodetoolInJvm(String... args)
@@ -358,6 +368,13 @@ public class ToolRunner
 
     public static ToolRunner.ToolResult invokeNodetoolInJvm(BiFunction<INodeProbeFactory, Output, Object> nodeTool, String... args)
     {
+        return invokeNodetoolInJvm(nodeTool, CQLTester::buildNodetoolArgs, args);
+    }
+
+    public static ToolRunner.ToolResult invokeNodetoolInJvm(BiFunction<INodeProbeFactory, Output, Object> nodeTool,
+                                                            Function<List<String>, List<String>> argsBuilder,
+                                                            String... args)
+    {
         PrintStream originalSysOut = System.out;
         PrintStream originalSysErr = System.err;
         LinesOutputStream out = new LinesOutputStream(logger::info);
@@ -365,7 +382,7 @@ public class ToolRunner
         PrintStream printOut = new PrintStream(out);
         PrintStream printErr = new PrintStream(err);
         Output output = new Output(printOut, printErr);
-        List<String> clearedArgs = CQLTester.buildNodetoolArgs(isEmpty(args) ? new ArrayList<>() : List.of(args));
+        List<String> clearedArgs = argsBuilder.apply(isEmpty(args) ? new ArrayList<>() : List.of(args));
         clearedArgs.remove("bin/nodetool");
         try
         {
@@ -927,7 +944,10 @@ public class ToolRunner
         public String getOutput()
         {
             flush();
-            return String.join("\n", outputLines);
+            String joined = String.join("\n", outputLines);
+            if (!joined.isEmpty() && !joined.endsWith("\n"))
+                joined += "\n";
+            return joined;
         }
     }
 }

--- a/test/unit/org/apache/cassandra/tools/cqlsh/CqlshTest.java
+++ b/test/unit/org/apache/cassandra/tools/cqlsh/CqlshTest.java
@@ -23,6 +23,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,6 +46,7 @@ public class CqlshTest extends CQLTester
     public static void setUp()
     {
         requireNetwork();
+        addVirtualKeyspace();
     }
 
     @Test
@@ -146,6 +148,84 @@ public class CqlshTest extends CQLTester
         UntypedResultSet importedRows = execute("SELECT * FROM %s");
         assertRowsIgnoringOrder(importedRows, row(1, vector(1, 2, 3, 4, 5, 6)),
                                 row(3, vector(1, 2, 3, 4, 6, 7)));
+    }
+
+    @Test
+    public void testManagementPortCommandStatus()
+    {
+        ToolResult tool = ToolRunner.invokeCqlshManagement(Collections.singletonList("INVOKE COMMAND status;"));
+        tool.asserts().success();
+        assertThat(tool.getStdout()).contains("execution_id");
+        assertThat(tool.getStdout()).contains("output");
+    }
+
+    @Test
+    public void testManagementPortSelectSystemLocal()
+    {
+        ToolResult tool = ToolRunner.invokeCqlshManagement(
+            Collections.singletonList("SELECT cluster_name, release_version FROM system.local;"));
+        tool.asserts().success();
+        assertThat(tool.getStdout()).contains("cluster_name");
+        assertThat(tool.getStdout()).contains("release_version");
+    }
+
+    @Test
+    public void testManagementPortSelectSystemPeers()
+    {
+        ToolResult tool = ToolRunner.invokeCqlshManagement(Collections.singletonList("SELECT * FROM system.peers;"));
+        tool.asserts().success();
+        assertThat(tool.getStdout()).contains("peer");
+    }
+
+    @Test
+    public void testManagementPortSelectSystemSchemaKeyspaces()
+    {
+        ToolResult tool = ToolRunner.invokeCqlshManagement(
+            Collections.singletonList("SELECT keyspace_name FROM system_schema.keyspaces;"));
+        tool.asserts().success();
+        assertThat(tool.getStdout()).contains("keyspace_name");
+        assertThat(tool.getStdout()).contains("system");
+    }
+
+    @Test
+    public void testManagementPortSelectVirtualTableSettings()
+    {
+        ToolResult tool = ToolRunner.invokeCqlshManagement(
+            Collections.singletonList("SELECT name FROM system_views.settings LIMIT 1;"));
+        tool.asserts().success();
+        assertThat(tool.getStdout()).contains("name");
+    }
+
+    @Test
+    public void testManagementPortSelectVirtualTableClients()
+    {
+        ToolResult tool = ToolRunner.invokeCqlshManagement(
+            Collections.singletonList("SELECT * FROM system_views.clients;"));
+        tool.asserts().success();
+        assertThat(tool.getStdout()).contains("address");
+    }
+
+    @Test
+    public void testManagementPortRejectsNonSystemSelect()
+    {
+        String keyspaceName = createKeyspace(
+            "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
+        String tableName = createTable(keyspaceName, "CREATE TABLE %s (k text PRIMARY KEY, v int)");
+        ToolResult tool = ToolRunner.invokeCqlshManagement(
+            Collections.singletonList(format("SELECT * FROM %s.%s;", keyspaceName, tableName)));
+        tool.asserts().failure();
+    }
+
+    @Test
+    public void testManagementPortRejectsInsert()
+    {
+        String keyspaceName = createKeyspace(
+            "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
+        String tableName = createTable(keyspaceName, "CREATE TABLE %s (k text PRIMARY KEY, v int)");
+
+        ToolResult tool = ToolRunner.invokeCqlshManagement(
+            Collections.singletonList(format("INSERT INTO %s.%s (k, v) VALUES ('a', 1);", keyspaceName, tableName)));
+        tool.asserts().failure();
     }
 
     private static Path prepareCSVFile(Object[][] rows) throws IOException

--- a/test/unit/org/apache/cassandra/tools/nodetool/CIDRFilteringStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CIDRFilteringStatsTest.java
@@ -39,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class CIDRFilteringStatsTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/ClearSnapshotTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ClearSnapshotTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.tools.nodetool;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,13 +34,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.snapshot.SnapshotManager;
 import org.apache.cassandra.service.snapshot.SnapshotManifest;
 import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 
 import static java.lang.String.format;
@@ -49,13 +49,12 @@ import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Collections.emptyMap;
 import static org.apache.cassandra.config.DatabaseDescriptor.getAllDataFileLocations;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 
-public class ClearSnapshotTest extends CQLTester
+public class ClearSnapshotTest extends CQLNodetoolProtocolTester
 {
     private static final Pattern DASH_PATTERN = Pattern.compile("-");
     private static NodeProbe probe;
@@ -65,7 +64,7 @@ public class ClearSnapshotTest extends CQLTester
     {
         startJMXServer();
         requireNetwork();
-        probe = new NodeProbe(jmxHost, jmxPort);
+        probe = new NodeProbe(new RemoteJmxMBeanAccessor(jmxHost, jmxPort));
     }
 
     @Before
@@ -75,7 +74,7 @@ public class ClearSnapshotTest extends CQLTester
     }
 
     @AfterClass
-    public static void teardown() throws IOException
+    public static void teardown() throws Exception
     {
         probe.close();
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactTest.java
@@ -23,13 +23,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
-
-public class CompactTest extends CQLTester
+public class CompactTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Throwable
@@ -88,7 +86,7 @@ public class CompactTest extends CQLTester
         invokeNodetool("compact", "--partition", Long.toString(42), keyspace(), "doesnotexist")
         .asserts()
         .failure()
-        .errorContains(String.format("java.lang.IllegalArgumentException: Unknown keyspace/cf pair (%s.doesnotexist)", keyspace()));
+        .errorContains(String.format("Unknown keyspace/cf pair (%s.doesnotexist)", keyspace()));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactTest.java
@@ -23,13 +23,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
-
-public class CompactTest extends CQLTester
+public class CompactTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Throwable

--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactionHistoryTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactionHistoryTest.java
@@ -31,19 +31,17 @@ import com.google.common.collect.Lists;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
+import org.apache.cassandra.tools.nodetool.strategy.CommandExecutionStrategy;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -53,25 +51,27 @@ import static org.junit.Assert.assertTrue;
  * @see Compact
  * @see GarbageCollect
  */
-@RunWith(Parameterized.class)
-public class CompactionHistoryTest extends CQLTester
+public class CompactionHistoryTest extends CQLNodetoolProtocolTester
 {
-    @Parameter
+    @Parameter(1)
     public List<String> cmd;
 
-    @Parameter(1)
+    @Parameter(2)
     public String compactionType;
 
-    @Parameter(2)
+    @Parameter(3)
     public int systemTableRecord;
 
-    @Parameters(name = "{index}: cmd={0} compactionType={1} systemTableRecord={2}")
+    @Parameters(name = "{index}: strategy={0} cmd={1} compactionType={2} systemTableRecord={3}")
     public static Collection<Object[]> data()
     {
         List<Object[]> result = new ArrayList<>();
-        result.add(new Object[]{ Lists.newArrayList("compact"), OperationType.MAJOR_COMPACTION.type, 1 });
-        result.add(new Object[]{ Lists.newArrayList("garbagecollect"), OperationType.GARBAGE_COLLECT.type, 10 });
-        result.add(new Object[]{ Lists.newArrayList("upgradesstables", "-a"), OperationType.UPGRADE_SSTABLES.type, 10 });
+        for (CommandExecutionStrategy.Type strategy : CommandExecutionStrategy.Type.values())
+        {
+            result.add(new Object[]{ strategy, Lists.newArrayList("compact"), OperationType.MAJOR_COMPACTION.type, 1 });
+            result.add(new Object[]{ strategy, Lists.newArrayList("garbagecollect"), OperationType.GARBAGE_COLLECT.type, 10 });
+            result.add(new Object[]{ strategy, Lists.newArrayList("upgradesstables", "-a"), OperationType.UPGRADE_SSTABLES.type, 10 });
+        }
         return result;
     }
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactionStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactionStatsTest.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.compaction.CompactionInfo;
@@ -40,7 +41,7 @@ import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-public class CompactionStatsTest extends CQLTester
+public class CompactionStatsTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -264,7 +265,7 @@ public class CompactionStatsTest extends CQLTester
     {
         AtomicReference<String> stdout = new AtomicReference<>();
         await().until(() -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(args);
+            ToolRunner.ToolResult tool = invokeNodetool(args);
             tool.assertOnCleanExit();
             String output = tool.getStdout();
             stdout.set(output);

--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactionStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactionStatsTest.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.compaction.CompactionInfo;
@@ -40,7 +41,7 @@ import static org.apache.cassandra.utils.TimeUUID.Generator.nextTimeUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-public class CompactionStatsTest extends CQLTester
+public class CompactionStatsTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -259,7 +260,7 @@ public class CompactionStatsTest extends CQLTester
     {
         AtomicReference<String> stdout = new AtomicReference<>();
         await().until(() -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(args);
+            ToolRunner.ToolResult tool = invokeNodetool(args);
             tool.assertOnCleanExit();
             String output = tool.getStdout();
             stdout.set(output);

--- a/test/unit/org/apache/cassandra/tools/nodetool/DataPathsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/DataPathsTest.java
@@ -21,12 +21,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DataPathsTest extends CQLTester
+public class DataPathsTest extends CQLNodetoolProtocolTester
 {
     private static final String SUBCOMMAND = "datapaths";
     
@@ -40,7 +40,7 @@ public class DataPathsTest extends CQLTester
     @Test
     public void testAllOutput()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND);
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND);
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_schema");
         assertThat(StringUtils.countMatches(tool.getStdout(), "Keyspace:")).isGreaterThan(1);
@@ -51,7 +51,7 @@ public class DataPathsTest extends CQLTester
     @Test
     public void testSelectedKeyspace()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "system_traces");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "system_traces");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_traces");
         assertThat(StringUtils.countMatches(tool.getStdout(), "Keyspace:")).isEqualTo(1);
@@ -62,7 +62,7 @@ public class DataPathsTest extends CQLTester
     @Test
     public void testSelectedMultipleKeyspaces()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "system_traces", "system_auth");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "system_traces", "system_auth");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_traces");
         assertThat(tool.getStdout()).contains("Keyspace: system_auth");
@@ -74,7 +74,7 @@ public class DataPathsTest extends CQLTester
     @Test
     public void testSelectedTable()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "system_auth.roles");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "system_auth.roles");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_auth");
         assertThat(StringUtils.countMatches(tool.getStdout(), "Keyspace:")).isEqualTo(1);
@@ -86,7 +86,7 @@ public class DataPathsTest extends CQLTester
     @Test
     public void testSelectedMultipleTables()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "system_auth.roles", "system_auth.role_members");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "system_auth.roles", "system_auth.role_members");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_auth");
         assertThat(StringUtils.countMatches(tool.getStdout(), "Keyspace:")).isEqualTo(1);
@@ -99,21 +99,21 @@ public class DataPathsTest extends CQLTester
     @Test
     public void testFormatArgJson()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "--format", "json");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "--format", "json");
         tool.assertOnCleanExit();
     }
 
     @Test
     public void testFormatArgYaml()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "--format", "yaml");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "--format", "yaml");
         tool.assertOnCleanExit();
     }
 
     @Test
     public void testFormatArgBad()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(SUBCOMMAND, "--format", "bad");
+        ToolRunner.ToolResult tool = invokeNodetool(SUBCOMMAND, "--format", "bad");
         assertThat(tool.getStdout()).contains("arguments for -F are yaml and json only.");
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/DropCIDRGroupTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/DropCIDRGroupTest.java
@@ -34,6 +34,8 @@ import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class DropCIDRGroupTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/ExportImportListCompressionDictionaryTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ExportImportListCompressionDictionaryTest.java
@@ -20,15 +20,18 @@ package org.apache.cassandra.tools.nodetool;
 
 import java.nio.file.Files;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.compression.CompressionDictionaryDetailsTabularData.CompressionDictionaryDataObject;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.io.util.FileUtils;
@@ -37,18 +40,28 @@ import org.apache.cassandra.utils.JsonUtils;
 import org.apache.cassandra.utils.Pair;
 
 import static java.lang.String.format;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.apache.cassandra.utils.JsonUtils.serializeToJsonFile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class ExportImportListCompressionDictionaryTest extends CQLTester
+public class ExportImportListCompressionDictionaryTest extends CQLNodetoolProtocolTester
 {
+    private final Set<String> createdTables = new HashSet<>();
+
     @BeforeClass
     public static void setup() throws Throwable
     {
         requireNetwork();
         startJMXServer();
+    }
+
+    @After
+    public void afterTest() throws Throwable
+    {
+        for (String table : createdTables)
+            execute(String.format("DROP TABLE IF EXISTS %s.%s", keyspace(), table));
+        createdTables.clear();
+        super.afterTest();
     }
 
     @Test
@@ -97,7 +110,7 @@ public class ExportImportListCompressionDictionaryTest extends CQLTester
                                                                 Instant.now()), pair.right);
 
         ToolResult result = invokeNodetool("compressiondictionary", "import", pair.right.absolutePath());
-        assertTrue(result.getStderr().contains("Unable to import dictionary JSON: Table abc.def does not exist or does not support dictionary compression"));
+        assertTrue(result.getStdout().contains("Table abc.def does not exist"));
     }
 
     @Test
@@ -117,7 +130,7 @@ public class ExportImportListCompressionDictionaryTest extends CQLTester
         JsonUtils.JSON_OBJECT_MAPPER.writeValue(jsonWithoutTable.toJavaIOFile(), node);
 
         ToolResult result = invokeNodetool("compressiondictionary", "import", jsonWithoutTable.absolutePath());
-        assertTrue(result.getStderr().contains("Unable to import dictionary JSON: Table not specified."));
+        assertTrue(result.getStderr().contains("Table not specified."));
     }
 
     @Test
@@ -136,7 +149,7 @@ public class ExportImportListCompressionDictionaryTest extends CQLTester
         result.assertOnCleanExit();
         // older will not be possible to import
         result = invokeNodetool("compressiondictionary", "import", pair.right.absolutePath());
-        assertTrue(result.getStderr().contains(format("Unable to import dictionary JSON: Dictionary to import has older dictionary id " +
+        assertTrue(result.getStdout().contains(format("Dictionary to import has older dictionary id " +
                                                       "(%s) than the latest compression dictionary (%s) " +
                                                       "for table %s.%s",
                                                       pair.left.dictId,
@@ -154,9 +167,16 @@ public class ExportImportListCompressionDictionaryTest extends CQLTester
 
         ToolResult result = invokeNodetool("compressiondictionary", "import", pair.right.absolutePath());
         Assert.assertEquals(1, result.getExitCode());
-        assertTrue(result.getStderr().contains(format("Unable to import dictionary JSON: Table %s.%s does not exist or does not support dictionary compression",
+        assertTrue(result.getStdout().contains(format("The compression on table %s.%s is not enabled or SSTable compressor is not a dictionary compressor",
                                                       keyspace(),
                                                       table)));
+    }
+
+    protected String createTable(String query)
+    {
+        String table = createTable(KEYSPACE, query);
+        createdTables.add(table);
+        return table;
     }
 
     private void importDictionary(File dictFile)
@@ -193,8 +213,11 @@ public class ExportImportListCompressionDictionaryTest extends CQLTester
 
     private Pair<CompressionDictionaryDataObject, File> trainAndExport(String table) throws Throwable
     {
+        disableCompaction();
         trainDictionary(table);
-        return export(table, null);
+        Pair<CompressionDictionaryDataObject, File> pair = export(table, null);
+        enableCompaction();
+        return pair;
     }
 
     private Pair<CompressionDictionaryDataObject, File> export(String table, Long id) throws Throwable

--- a/test/unit/org/apache/cassandra/tools/nodetool/ForceCompactionTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ForceCompactionTest.java
@@ -29,7 +29,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.Util;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.rows.Cell;
@@ -38,13 +39,12 @@ import org.apache.cassandra.db.rows.Unfiltered;
 import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
-import org.apache.cassandra.tools.ToolRunner;
 
 import static org.apache.commons.lang3.ArrayUtils.addAll;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class ForceCompactionTest extends CQLTester
+public class ForceCompactionTest extends CQLNodetoolProtocolTester
 {
     private final static int NUM_PARTITIONS = 10;
     private final static int NUM_ROWS = 100;
@@ -54,6 +54,11 @@ public class ForceCompactionTest extends CQLTester
     {
         requireNetwork();
         startJMXServer();
+
+        // This ensures initialization happens before any transport classes (like Envelope.Decoder)
+        // are loaded, as they have static initializers that depend on DatabaseDescriptor.
+        if (!DatabaseDescriptor.isClientOrToolInitialized())
+            DatabaseDescriptor.clientInitialization(false);
     }
 
     @Before
@@ -251,7 +256,7 @@ public class ForceCompactionTest extends CQLTester
         if (cfs != null)
         {
             cfs.forceMajorCompaction();
-            ToolRunner.invokeNodetool(addAll(new String[]{ "forcecompact", cfs.keyspace.getName(), cfs.getTableName() },
+            invokeNodetool(addAll(new String[]{ "forcecompact", cfs.keyspace.getName(), cfs.getTableName() },
                                              partitionKeysIgnoreGcGrace)).assertOnCleanExit();
         }
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/GcStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GcStatsTest.java
@@ -23,9 +23,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.service.GCInspector;
-import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 import org.apache.cassandra.tools.nodetool.stats.GcStatsHolder;
 import org.apache.cassandra.utils.JsonUtils;
@@ -38,7 +37,7 @@ import static org.apache.cassandra.tools.nodetool.stats.GcStatsHolder.RESERVED_D
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-public class GcStatsTest extends CQLTester
+public class GcStatsTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setUp() throws Exception
@@ -51,7 +50,7 @@ public class GcStatsTest extends CQLTester
     @Test
     public void testDefaultGcStatsOutput()
     {
-        ToolResult tool = ToolRunner.invokeNodetool("gcstats");
+        ToolResult tool = invokeNodetool("gcstats");
         tool.assertOnCleanExit();
         String output = tool.getStdout();
         for (String value : GcStatsHolder.columnDescriptionMap.values())
@@ -62,7 +61,7 @@ public class GcStatsTest extends CQLTester
     public void testJsonGcStatsOutput()
     {
         asList("-F", "--format").forEach(arg -> {
-            ToolResult tool = ToolRunner.invokeNodetool("gcstats", arg, "json");
+            ToolResult tool = invokeNodetool("gcstats", arg, "json");
             tool.assertOnCleanExit();
             String json = tool.getStdout();
             assertThatCode(() -> JsonUtils.JSON_OBJECT_MAPPER.readTree(json)).doesNotThrowAnyException();
@@ -76,7 +75,7 @@ public class GcStatsTest extends CQLTester
     public void testYamlGcStatsOutput()
     {
         asList("-F", "--format").forEach(arg -> {
-            ToolResult tool = ToolRunner.invokeNodetool("gcstats", arg, "yaml");
+            ToolResult tool = invokeNodetool("gcstats", arg, "yaml");
             tool.assertOnCleanExit();
             String yamlOutput = tool.getStdout();
             Yaml yaml = new Yaml();
@@ -90,7 +89,7 @@ public class GcStatsTest extends CQLTester
     @Test
     public void testInvalidFormatOption()
     {
-        ToolResult tool = ToolRunner.invokeNodetool("gcstats", "-F", "invalid_format");
+        ToolResult tool = invokeNodetool("gcstats", "-F", "invalid_format");
         assertThat(tool.getExitCode()).isEqualTo(1);
         assertThat(tool.getStdout()).contains("arguments for -F are json, yaml, table only.");
     }
@@ -98,7 +97,7 @@ public class GcStatsTest extends CQLTester
     @Test
     public void testWithoutNoOption()
     {
-        ToolResult tool = ToolRunner.invokeNodetool("gcstats");
+        ToolResult tool = invokeNodetool("gcstats");
         tool.assertOnCleanExit();
 
         for (String value : GcStatsHolder.columnDescriptionMap.values())
@@ -108,7 +107,7 @@ public class GcStatsTest extends CQLTester
     @Test
     public void testWithHumanReadableOption()
     {
-        ToolResult tool = ToolRunner.invokeNodetool("gcstats", "--human-readable", "-F", "table");
+        ToolResult tool = invokeNodetool("gcstats", "--human-readable", "-F", "table");
         tool.assertOnCleanExit();
         String gcStatsOutput = tool.getStdout();
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetAuditLogTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetAuditLogTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for the {@code GetAuditLog} nodetool command.
  * @see GetAuditLog
  */
-public class GetAuditLogTest extends CQLTester
+public class GetAuditLogTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -84,24 +84,24 @@ public class GetAuditLogTest extends CQLTester
 
     private String getAuditLog()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("getauditlog");
+        ToolRunner.ToolResult tool = invokeNodetool("getauditlog");
         tool.assertOnCleanExit();
         return tool.getStdout();
     }
 
     private void disableAuditLog()
     {
-        ToolRunner.invokeNodetool("disableauditlog").assertOnCleanExit();
+        invokeNodetool("disableauditlog").assertOnCleanExit();
     }
 
     private void enableAuditLogSimple()
     {
-        ToolRunner.invokeNodetool("enableauditlog").assertOnCleanExit();
+        invokeNodetool("enableauditlog").assertOnCleanExit();
     }
 
     private void enableAuditLogComplex()
     {
-        ToolRunner.invokeNodetool("enableauditlog",
+        invokeNodetool("enableauditlog",
                                   "--included-keyspaces", "ks1,ks2,ks3",
                                   "--excluded-categories", "ddl,dcl").assertOnCleanExit();
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetAuthCacheConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetAuthCacheConfigTest.java
@@ -35,6 +35,10 @@ import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+ *   once nodetool supports passing authentication credentials.
+ */
 public class GetAuthCacheConfigTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetCIDRGroupsOfIPTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetCIDRGroupsOfIPTest.java
@@ -34,6 +34,10 @@ import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+ *   once nodetool supports passing authentication credentials.
+ */
 public class GetCIDRGroupsOfIPTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetDefaultKeyspaceRFTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetDefaultKeyspaceRFTest.java
@@ -22,12 +22,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GetDefaultKeyspaceRFTest extends CQLTester
+public class GetDefaultKeyspaceRFTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -39,7 +39,7 @@ public class GetDefaultKeyspaceRFTest extends CQLTester
     @Test
     public void testGetDefaultRF()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("getdefaultrf");
+        ToolRunner.ToolResult tool = invokeNodetool("getdefaultrf");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout().trim()).isEqualTo(Integer.toString(DatabaseDescriptor.getDefaultKeyspaceRF()));
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/GetFullQueryLogTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GetFullQueryLogTest.java
@@ -24,7 +24,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.fql.FullQueryLoggerOptions;
 import org.apache.cassandra.tools.ToolRunner;
 
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @see ResetFullQueryLog
  * @see DisableFullQueryLog
  */
-public class GetFullQueryLogTest extends CQLTester
+public class GetFullQueryLogTest extends CQLNodetoolProtocolTester
 {
     @ClassRule
     public static TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -83,24 +83,24 @@ public class GetFullQueryLogTest extends CQLTester
 
     private String getFullQueryLog()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("getfullquerylog");
+        ToolRunner.ToolResult tool = invokeNodetool("getfullquerylog");
         tool.assertOnCleanExit();
         return tool.getStdout();
     }
 
     private void resetFullQueryLog()
     {
-        ToolRunner.invokeNodetool("resetfullquerylog").assertOnCleanExit();
+        invokeNodetool("resetfullquerylog").assertOnCleanExit();
     }
 
     private void disableFullQueryLog()
     {
-        ToolRunner.invokeNodetool("disablefullquerylog").assertOnCleanExit();
+        invokeNodetool("disablefullquerylog").assertOnCleanExit();
     }
 
     private void enableFullQueryLog()
     {
-        ToolRunner.invokeNodetool("enablefullquerylog",
+        invokeNodetool("enablefullquerylog",
                                   "--path",
                                   temporaryFolder.getRoot().toString(),
                                   "--blocking",

--- a/test/unit/org/apache/cassandra/tools/nodetool/GossipInfoTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GossipInfoTest.java
@@ -23,7 +23,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.NoPayload;
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @see GossipInfo
  */
-public class GossipInfoTest extends CQLTester
+public class GossipInfoTest extends CQLNodetoolProtocolTester
 {
     private static String token;
 
@@ -52,7 +52,7 @@ public class GossipInfoTest extends CQLTester
     @Test
     public void testGossipInfo()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("gossipinfo");
+        ToolRunner.ToolResult tool = invokeNodetool("gossipinfo");
         tool.assertOnCleanExit();
         String stdout = tool.getStdout();
         Assertions.assertThat(stdout).contains("/127.0.0.1");
@@ -75,7 +75,7 @@ public class GossipInfoTest extends CQLTester
         MessagingService.instance().send(echoMessageOut, FBUtilities.getBroadcastAddressAndPort());
 
         String origHeartbeatCount = StringUtils.substringBetween(stdout, "heartbeat:", "\n");
-        tool = ToolRunner.invokeNodetool("gossipinfo");
+        tool = invokeNodetool("gossipinfo");
         tool.assertOnCleanExit();
         String newHeartbeatCount = StringUtils.substringBetween(stdout, "heartbeat:", "\n");
         assertThat(Integer.parseInt(origHeartbeatCount)).isLessThanOrEqualTo(Integer.parseInt(newHeartbeatCount));
@@ -84,7 +84,7 @@ public class GossipInfoTest extends CQLTester
     @Test
     public void testGossipInfoWithPortPrint()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("-pp", "gossipinfo");
+        ToolRunner.ToolResult tool = invokeNodetool("-pp", "gossipinfo");
         tool.assertOnCleanExit();
         String stdout = tool.getStdout();
         Assertions.assertThat(stdout).containsPattern("/127.0.0.1\\:[0-9]+\\s+generation");
@@ -93,7 +93,7 @@ public class GossipInfoTest extends CQLTester
     @Test
     public void testGossipInfoWithResolveIp()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("gossipinfo", "--resolve-ip");
+        ToolRunner.ToolResult tool = invokeNodetool("gossipinfo", "--resolve-ip");
         tool.assertOnCleanExit();
         String stdout = tool.getStdout();
         Assertions.assertThat(stdout).containsPattern("^localhost\\s+generation");
@@ -102,7 +102,7 @@ public class GossipInfoTest extends CQLTester
     @Test
     public void testGossipInfoWithPortPrintAndResolveIp()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("-pp", "gossipinfo", "--resolve-ip");
+        ToolRunner.ToolResult tool = invokeNodetool("-pp", "gossipinfo", "--resolve-ip");
         tool.assertOnCleanExit();
         String stdout = tool.getStdout();
         Assertions.assertThat(stdout).containsPattern("^localhost\\:[0-9]+\\s+generation");

--- a/test/unit/org/apache/cassandra/tools/nodetool/GuardrailsConfigCommandsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/GuardrailsConfigCommandsTest.java
@@ -27,28 +27,36 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.Config;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.guardrails.GuardrailsMBean;
 import org.apache.cassandra.tools.ToolRunner.ToolResult;
 import org.apache.cassandra.tools.nodetool.GuardrailsConfigCommand.GetGuardrailsConfig;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class GuardrailsConfigCommandsTest extends CQLTester
+public class GuardrailsConfigCommandsTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
     {
         requireNetwork();
         startJMXServer();
+    }
+
+    @After
+    public void tearDown()
+    {
+        setFlag("allow_filtering_enabled", true);
+        setValues("table_properties_warned", "null");
+        setThresholds("keyspaces_threshold", "-1", "-1");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/InfoTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InfoTest.java
@@ -15,22 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.cassandra.tools.nodetool;
 
+import java.lang.management.ManagementFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.management.ObjectName;
 
 import com.datastax.driver.core.PreparedStatement;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
 import org.apache.cassandra.tools.ToolRunner;
+import org.apache.cassandra.utils.MBeanWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InfoTest extends CQLTester
+/**
+ * @see Info
+ */
+public class InfoTest extends CQLNodetoolProtocolTester
 {
     private static final Pattern PREPARED_STATEMENT_CACHE_PATTERN =
     Pattern.compile("Prepared Stmt Cache\\s+: entries (\\d+), size ([^,]+), capacity ([^,]+), (\\d+) executions, (\\d+) evictions");
@@ -43,13 +53,39 @@ public class InfoTest extends CQLTester
     }
 
     @Test
+    public void testInfoOutput()
+    {
+        ToolRunner.ToolResult tool = invokeNodetool("info");
+        tool.assertOnCleanExit();
+        String stdout = tool.getStdout();
+
+        assertThat(stdout).contains("ID");
+        assertThat(stdout).contains("Gossip active");
+        assertThat(stdout).contains("Native Transport active");
+        assertThat(stdout).contains("Load");
+        assertThat(stdout).contains("Uncompressed load");
+        assertThat(stdout).contains("Generation No");
+        assertThat(stdout).contains("Uptime (seconds)");
+        assertThat(stdout).contains("Heap Memory (MB)");
+        assertThat(stdout).contains("Data Center");
+        assertThat(stdout).contains("Rack");
+        assertThat(stdout).contains("Exceptions");
+        assertThat(stdout).contains("Key Cache");
+        assertThat(stdout).contains("Row Cache");
+        assertThat(stdout).contains("Counter Cache");
+        assertThat(stdout).contains("Percent Repaired");
+        assertThat(stdout).contains("Token");
+        assertThat(stdout).contains("Bootstrap state");
+    }
+
+    @Test
     public void testInfoContainsPreparedStatementCache()
     {
         createTable("CREATE TABLE %s (id int PRIMARY KEY, val text)");
         PreparedStatement preparedStatement = sessionNet().prepare("INSERT INTO " + KEYSPACE + '.' + currentTable() + " (id, val) VALUES (?, ?)");
         sessionNet().execute(preparedStatement.bind(1, "value1"));
 
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("info");
+        ToolRunner.ToolResult tool = invokeNodetool("info");
         tool.assertOnCleanExit();
         String stdout = tool.getStdout();
         assertThat(stdout).contains("Prepared Stmt Cache");
@@ -58,5 +94,34 @@ public class InfoTest extends CQLTester
         assertThat(Integer.parseInt(matcher.group(1))).isGreaterThan(0);
         assertThat(matcher.group(2)).isNotEqualTo("0 bytes");
         assertThat(Integer.parseInt(matcher.group(4))).isGreaterThan(0);
+    }
+
+    @Test
+    public void testInfoWithMissingCacheMBean() throws Exception
+    {
+        javax.management.MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName chunkCacheEntries = new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=ChunkCache,name=Entries");
+
+        boolean wasRegistered = mbs.isRegistered(chunkCacheEntries);
+        if (wasRegistered)
+            mbs.unregisterMBean(chunkCacheEntries);
+        try
+        {
+            ToolRunner.ToolResult tool = invokeNodetool("info");
+            tool.assertOnCleanExit();
+            String stdout = tool.getStdout();
+
+            assertThat(stdout).doesNotContain("Chunk Cache");
+            assertThat(stdout).contains("Percent Repaired");
+            assertThat(stdout).contains("Bootstrap state");
+        }
+        finally
+        {
+            if (wasRegistered && !mbs.isRegistered(chunkCacheEntries))
+            {
+                CassandraMetricsRegistry.Metrics.registerMBean(
+                    ChunkCache.instance.metrics.entries, chunkCacheEntries, MBeanWrapper.instance, false);
+            }
+        }
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/InfoTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InfoTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.ObjectName;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cache.ChunkCache;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.apache.cassandra.tools.ToolRunner;
+import org.apache.cassandra.utils.MBeanWrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @see Info
+ */
+public class InfoTest extends CQLNodetoolProtocolTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        requireNetwork();
+        startJMXServer();
+    }
+
+    @Test
+    public void testInfoOutput()
+    {
+        ToolRunner.ToolResult tool = invokeNodetool("info");
+        tool.assertOnCleanExit();
+        String stdout = tool.getStdout();
+
+        assertThat(stdout).contains("ID");
+        assertThat(stdout).contains("Gossip active");
+        assertThat(stdout).contains("Native Transport active");
+        assertThat(stdout).contains("Load");
+        assertThat(stdout).contains("Uncompressed load");
+        assertThat(stdout).contains("Generation No");
+        assertThat(stdout).contains("Uptime (seconds)");
+        assertThat(stdout).contains("Heap Memory (MB)");
+        assertThat(stdout).contains("Data Center");
+        assertThat(stdout).contains("Rack");
+        assertThat(stdout).contains("Exceptions");
+        assertThat(stdout).contains("Key Cache");
+        assertThat(stdout).contains("Row Cache");
+        assertThat(stdout).contains("Counter Cache");
+        assertThat(stdout).contains("Percent Repaired");
+        assertThat(stdout).contains("Token");
+        assertThat(stdout).contains("Bootstrap state");
+    }
+
+    @Test
+    public void testInfoWithMissingCacheMBean() throws Exception
+    {
+        javax.management.MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName chunkCacheEntries = new ObjectName("org.apache.cassandra.metrics:type=Cache,scope=ChunkCache,name=Entries");
+
+        boolean wasRegistered = mbs.isRegistered(chunkCacheEntries);
+        if (wasRegistered)
+            mbs.unregisterMBean(chunkCacheEntries);
+        try
+        {
+            ToolRunner.ToolResult tool = invokeNodetool("info");
+            tool.assertOnCleanExit();
+            String stdout = tool.getStdout();
+
+            assertThat(stdout).doesNotContain("Chunk Cache");
+            assertThat(stdout).contains("Percent Repaired");
+            assertThat(stdout).contains("Bootstrap state");
+        }
+        finally
+        {
+            if (wasRegistered && !mbs.isRegistered(chunkCacheEntries))
+            {
+                CassandraMetricsRegistry.Metrics.registerMBean(
+                    ChunkCache.instance.metrics.entries, chunkCacheEntries, MBeanWrapper.instance, false);
+            }
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCIDRPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCIDRPermissionsCacheTest.java
@@ -35,6 +35,8 @@ import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getCidrPermissionsReadCount;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class InvalidateCIDRPermissionsCacheTest extends CQLTester
 {
     static InetSocketAddress ipAddr;

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateCredentialsCacheTest.java
@@ -40,6 +40,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @see InvalidateCredentialsCache
+ *
+ * TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+ *   once nodetool supports passing authentication credentials.
  */
 public class InvalidateCredentialsCacheTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateJmxPermissionsCacheTest.java
@@ -46,6 +46,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @see InvalidateJmxPermissionsCache
+ *
+ * TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+ *   once nodetool supports passing authentication credentials.
  */
 public class InvalidateJmxPermissionsCacheTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateNetworkPermissionsCacheTest.java
@@ -34,6 +34,8 @@ import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getNetworkPermissionsReadCount;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class InvalidateNetworkPermissionsCacheTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidatePermissionsCacheTest.java
@@ -50,6 +50,8 @@ import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getRolePermissionsReadCount;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class InvalidatePermissionsCacheTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/InvalidateRolesCacheTest.java
@@ -34,6 +34,8 @@ import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.auth.AuthTestUtils.getRolesReadCount;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class InvalidateRolesCacheTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/ListCIDRGroupTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ListCIDRGroupTest.java
@@ -35,6 +35,8 @@ import org.apache.cassandra.tools.ToolRunner;
 import static org.apache.cassandra.auth.AuthTestUtils.insertCidrsMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class ListCIDRGroupTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/NetStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NetStatsTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
@@ -44,7 +44,7 @@ import static java.util.Collections.emptyList;
 import static org.apache.cassandra.net.Verb.ECHO_REQ;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NetStatsTest extends CQLTester
+public class NetStatsTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -59,9 +59,9 @@ public class NetStatsTest extends CQLTester
         Message<NoPayload> echoMessageOut = Message.out(ECHO_REQ, NoPayload.noPayload);
         MessagingService.instance().send(echoMessageOut, FBUtilities.getBroadcastAddressAndPort());
 
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("netstats");
+        ToolRunner.ToolResult tool = invokeNodetool("netstats");
         tool.assertOnCleanExit();
-        assertThat(tool.getStdout()).contains("Gossip messages                 n/a         0              2         0");
+        assertThat(tool.getStdout()).containsPattern("Gossip messages\\s+n/a\\s+0\\s+\\d+\\s+0");
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
@@ -224,15 +224,13 @@ public class NodetoolClassHierarchyTest extends CQLTester
     }
 
     /**
-     * Previously, in the Airline implementation of nodetool, the defaul values for command
-     * parameters were declared as values in the java field of the command class. We left this
-     * as-is, but with picocli we have to make sure that this is consistend with annotations
-     * such as {@code @Option(defaultValue = "...")}.
+     * In the Airline implementation of nodetool, default values for command parameters were declared as
+     * Java field initializers on the command class. We left them there, so under picocli they have to
+     * stay consistent with annotations such as {@code @Option(defaultValue = "...")}.
      * <p>
-     * When {@code @Option(defaultValue = "...")} is declared on a field, the Java field
-     * initializer must produce the same value. This is required because picocli only applies
-     * {@code defaultValue} during {@code parseArgs()}, any code that reads the field before
-     * parsing sees only the Java initializer, not the annotations default.
+     * When {@code @Option(defaultValue = "...")} is declared on a field, the Java field initializer must
+     * produce the same value. Picocli applies {@code defaultValue} only during {@code parseArgs()}, so any
+     * code that reads the field before parsing sees the Java initializer, not the annotation's default.
      */
     @Test
     public void testOptionAnnotationDefaultMatchesJavaInitializer()

--- a/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.tools.nodetool;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -220,6 +221,213 @@ public class NodetoolClassHierarchyTest extends CQLTester
         else if (name.startsWith("-"))
             return name.substring(1);
         return name;
+    }
+
+    /**
+     * Previously, in the Airline implementation of nodetool, the defaul values for command
+     * parameters were declared as values in the java field of the command class. We left this
+     * as-is, but with picocli we have to make sure that this is consistend with annotations
+     * such as {@code @Option(defaultValue = "...")}.
+     * <p>
+     * When {@code @Option(defaultValue = "...")} is declared on a field, the Java field
+     * initializer must produce the same value. This is required because picocli only applies
+     * {@code defaultValue} during {@code parseArgs()}, any code that reads the field before
+     * parsing sees only the Java initializer, not the annotations default.
+     */
+    @Test
+    public void testOptionAnnotationDefaultMatchesJavaInitializer()
+    {
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> violations = new TreeMap<>();
+
+        commandTreeWalker(root, cmd -> {
+            List<String> cmdViolations = collectDefaultValueMismatches(cmd);
+            if (!cmdViolations.isEmpty())
+                violations.put(fullCommandName(cmd), cmdViolations);
+        });
+
+        assertTrue("The following commands have @Option(defaultValue) that does not match " +
+                   "the Java field initializer. Either remove defaultValue from the annotation " +
+                   "or align the Java field initializer with it:\n" +
+                   buildAffectedCommandMessage(violations),
+                   violations.isEmpty());
+    }
+
+    /**
+     * Commands must not declare aliases. Alias MBean registration is not supported,
+     * so allowing aliases would create a mismatch between the CLI (which would honor them)
+     * and the JMX/CQL transports (which would not). If alias support is added in the future,
+     * this test should be replaced with proper alias-aware registration and lookup logic.
+     */
+    @Test
+    public void testNoCommandDeclaresAliases()
+    {
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> affected = new TreeMap<>();
+
+        commandTreeWalker(root, cmd -> {
+            String[] aliases = cmd.getCommandSpec().aliases();
+            if (aliases.length > 0)
+                affected.put(fullCommandName(cmd), Arrays.asList(aliases));
+        });
+
+        assertTrue("The following commands declare aliases, but alias registration " +
+                   "is not yet supported across all transports (JMX, CQL):\n" +
+                   buildAffectedCommandMessage(affected),
+                   affected.isEmpty());
+    }
+
+    /**
+     * Commands must not declare custom picocli {@code converters} on options or parameters.
+     * <p>
+     * Instead, options and parameters must use plain strings, lists of strings, or the built-in Java
+     * types supported by {@code TypeConverterRegistry} (primitives, enums, and collections/arrays of
+     * those). Commands that need a richer domain type should accept one of these simple types and
+     * perform the conversion in the command body, as several existing commands already do.
+     */
+    @Test
+    public void testNoCommandDeclaresCustomConverter()
+    {
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> affected = new TreeMap<>();
+
+        commandTreeWalker(root, cmd -> {
+            List<String> converters = collectCustomConverters(cmd);
+            if (!converters.isEmpty())
+                affected.put(fullCommandName(cmd), converters);
+        });
+
+        assertTrue("The following commands declare custom picocli converters, which are not supported " +
+                   "by the remote argument-conversion path (it would feed the whole collection's toString() " +
+                   "to a per-element converter). Make PicocliOptionMetadata/PicocliParameterMetadata.convertValue " +
+                   "element-aware before adding one:\n" +
+                   buildAffectedCommandMessage(affected),
+                   affected.isEmpty());
+    }
+
+    private static List<String> collectCustomConverters(CommandLine cmd)
+    {
+        List<String> converters = new ArrayList<>();
+
+        for (CommandLine.Model.OptionSpec option : cmd.getCommandSpec().options())
+        {
+            if (option.usageHelp() || option.versionHelp())
+                continue;
+            CommandLine.ITypeConverter<?>[] optionConverters = option.converters();
+            if (optionConverters != null && optionConverters.length > 0)
+                converters.add(String.format("option %s -> %s",
+                                             String.join("/", option.names()),
+                                             optionConverters[0].getClass().getName()));
+        }
+
+        for (CommandLine.Model.PositionalParamSpec param : cmd.getCommandSpec().positionalParameters())
+        {
+            CommandLine.ITypeConverter<?>[] paramConverters = param.converters();
+            if (paramConverters != null && paramConverters.length > 0)
+                converters.add(String.format("parameter index=%s (%s) -> %s",
+                                             param.index(),
+                                             param.paramLabel(),
+                                             paramConverters[0].getClass().getName()));
+        }
+
+        return converters;
+    }
+
+    /**
+     * Commands must not declare {@code @ArgGroup} fields.
+     * Declare the options directly on the command and validate the grouping in the command body.
+     */
+    @Test
+    public void testNoCommandDeclaresArgGroups()
+    {
+        Set<Class<?>> ignore = Set.of(CMSAdmin.DumpClusterMetadata.class);
+
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> affected = new TreeMap<>();
+        Set<Class<?>> staleExclusions = new LinkedHashSet<>(ignore);
+
+        commandTreeWalker(root, cmd -> {
+            List<String> groups = collectArgGroups(cmd);
+            if (groups.isEmpty())
+                return;
+
+            Object userObject = cmd.getCommandSpec().userObject();
+            if (userObject != null && ignore.contains(userObject.getClass()))
+                staleExclusions.remove(userObject.getClass());
+            else
+                affected.put(fullCommandName(cmd), groups);
+        });
+
+        assertTrue("The following commands declare @ArgGroup fields, which cannot be populated " +
+                   "by the remote execution path (picocli only instantiates group objects during " +
+                   "parseArgs(), which the server never runs). Declare the options directly on " +
+                   "the command and validate the grouping in the command body:\n" +
+                   buildAffectedCommandMessage(affected),
+                   affected.isEmpty());
+
+        assertTrue("Commands excluded as pending @ArgGroup refactoring no longer declare @ArgGroup, " +
+                   "remove them from the exclusion list: " + staleExclusions,
+                   staleExclusions.isEmpty());
+    }
+
+    private static List<String> collectArgGroups(CommandLine cmd)
+    {
+        List<String> groups = new ArrayList<>();
+        for (CommandLine.Model.ArgGroupSpec group : cmd.getCommandSpec().argGroups())
+        {
+            List<String> members = new ArrayList<>();
+            for (CommandLine.Model.OptionSpec option : group.allOptionsNested())
+                members.add(String.join("/", option.names()));
+            groups.add("group [" + String.join(", ", members) + "]");
+        }
+        return groups;
+    }
+
+    private static List<String> collectDefaultValueMismatches(CommandLine cmd)
+    {
+        List<String> violations = new ArrayList<>();
+
+        for (CommandLine.Model.OptionSpec optionSpec : cmd.getCommandSpec().options())
+        {
+            if (optionSpec.usageHelp() || optionSpec.versionHelp())
+                continue;
+
+            String annotationDefault = optionSpec.defaultValue();
+            if (annotationDefault == null)
+                continue;
+
+            Object javaValue = optionSpec.getValue();
+            String javaValueStr = javaValue == null ? "null" : String.valueOf(javaValue);
+
+            if (!annotationDefault.equals(javaValueStr))
+            {
+                violations.add(String.format("option %s: @Option(defaultValue=\"%s\") but Java initializer gives \"%s\"",
+                                             Arrays.toString(optionSpec.names()),
+                                             annotationDefault,
+                                             javaValueStr));
+            }
+        }
+
+        for (CommandLine.Model.PositionalParamSpec paramSpec : cmd.getCommandSpec().positionalParameters())
+        {
+            String annotationDefault = paramSpec.defaultValue();
+            if (annotationDefault == null)
+                continue;
+
+            Object javaValue = paramSpec.getValue();
+            String javaValueStr = javaValue == null ? "null" : String.valueOf(javaValue);
+
+            if (!annotationDefault.equals(javaValueStr))
+            {
+                violations.add(String.format("parameter index=%s (%s): @Parameters(defaultValue=\"%s\") but Java initializer gives \"%s\"",
+                                             paramSpec.index(),
+                                             paramSpec.paramLabel(),
+                                             annotationDefault,
+                                             javaValueStr));
+            }
+        }
+
+        return violations;
     }
 
     /**

--- a/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
@@ -276,6 +276,28 @@ public class NodetoolClassHierarchyTest extends CQLTester
     }
 
     /**
+     * Top-level commands must not declare aliases.
+     */
+    @Test
+    public void testNoTopLevelCommandDeclaresAlias()
+    {
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> affected = new TreeMap<>();
+
+        for (CommandLine cmd : root.getSubcommands().values())
+        {
+            String[] aliases = cmd.getCommandSpec().aliases();
+            if (aliases.length > 0)
+                affected.put(fullCommandName(cmd), Arrays.asList(aliases));
+        }
+
+        assertTrue("Top-level commands must not declare aliases, otherwise it should be explicitly " +
+                   "supported by  PicocliCommandsProvider.commands() " +
+                   buildAffectedCommandMessage(affected),
+                   affected.isEmpty());
+    }
+
+    /**
      * Commands must not declare custom picocli {@code converters} on options or parameters.
      * <p>
      * Instead, options and parameters must use plain strings, lists of strings, or the built-in Java

--- a/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NodetoolClassHierarchyTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.tools.nodetool;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -111,6 +112,107 @@ public class NodetoolClassHierarchyTest extends CQLTester
         assertTrue("The following commands declare @ParentCommand and consume " +
                    "options or parameters from a parent command: " + buildAffectedCommandMessage(affected),
                    affected.isEmpty());
+    }
+
+    /**
+     * Previously, in the Airline implementation of nodetool, the defaul values for command
+     * parameters were declared as values in the java field of the command class. We left this
+     * as-is, but with picocli we have to make sure that this is consistend with annotations
+     * such as {@code @Option(defaultValue = "...")}.
+     * <p>
+     * When {@code @Option(defaultValue = "...")} is declared on a field, the Java field
+     * initializer must produce the same value. This is required because picocli only applies
+     * {@code defaultValue} during {@code parseArgs()}, any code that reads the field before
+     * parsing sees only the Java initializer, not the annotations default.
+     */
+    @Test
+    public void testOptionAnnotationDefaultMatchesJavaInitializer()
+    {
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> violations = new TreeMap<>();
+
+        commandTreeWalker(root, cmd -> {
+            List<String> cmdViolations = collectDefaultValueMismatches(cmd);
+            if (!cmdViolations.isEmpty())
+                violations.put(fullCommandName(cmd), cmdViolations);
+        });
+
+        assertTrue("The following commands have @Option(defaultValue) that does not match " +
+                   "the Java field initializer. Either remove defaultValue from the annotation " +
+                   "or align the Java field initializer with it:\n" +
+                   buildAffectedCommandMessage(violations),
+                   violations.isEmpty());
+    }
+
+    /**
+     * Commands must not declare aliases. Alias MBean registration is not supported,
+     * so allowing aliases would create a mismatch between the CLI (which would honor them)
+     * and the JMX/CQL transports (which would not). If alias support is added in the future,
+     * this test should be replaced with proper alias-aware registration and lookup logic.
+     */
+    @Test
+    public void testNoCommandDeclaresAliases()
+    {
+        CommandLine root = new CommandLine(NodetoolCommand.class);
+        Map<String, List<String>> affected = new TreeMap<>();
+
+        commandTreeWalker(root, cmd -> {
+            String[] aliases = cmd.getCommandSpec().aliases();
+            if (aliases.length > 0)
+                affected.put(fullCommandName(cmd), Arrays.asList(aliases));
+        });
+
+        assertTrue("The following commands declare aliases, but alias registration " +
+                   "is not yet supported across all transports (JMX, CQL):\n" +
+                   buildAffectedCommandMessage(affected),
+                   affected.isEmpty());
+    }
+
+    private static List<String> collectDefaultValueMismatches(CommandLine cmd)
+    {
+        List<String> violations = new ArrayList<>();
+
+        for (CommandLine.Model.OptionSpec optionSpec : cmd.getCommandSpec().options())
+        {
+            if (optionSpec.usageHelp() || optionSpec.versionHelp())
+                continue;
+
+            String annotationDefault = optionSpec.defaultValue();
+            if (annotationDefault == null)
+                continue;
+
+            Object javaValue = optionSpec.getValue();
+            String javaValueStr = javaValue == null ? "null" : String.valueOf(javaValue);
+
+            if (!annotationDefault.equals(javaValueStr))
+            {
+                violations.add(String.format("option %s: @Option(defaultValue=\"%s\") but Java initializer gives \"%s\"",
+                                             Arrays.toString(optionSpec.names()),
+                                             annotationDefault,
+                                             javaValueStr));
+            }
+        }
+
+        for (CommandLine.Model.PositionalParamSpec paramSpec : cmd.getCommandSpec().positionalParameters())
+        {
+            String annotationDefault = paramSpec.defaultValue();
+            if (annotationDefault == null)
+                continue;
+
+            Object javaValue = paramSpec.getValue();
+            String javaValueStr = javaValue == null ? "null" : String.valueOf(javaValue);
+
+            if (!annotationDefault.equals(javaValueStr))
+            {
+                violations.add(String.format("parameter index=%s (%s): @Parameters(defaultValue=\"%s\") but Java initializer gives \"%s\"",
+                                             paramSpec.index(),
+                                             paramSpec.paramLabel(),
+                                             annotationDefault,
+                                             javaValueStr));
+            }
+        }
+
+        return violations;
     }
 
     /**

--- a/test/unit/org/apache/cassandra/tools/nodetool/NodetoolConnectFailureTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NodetoolConnectFailureTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.tools.NodeTool;
+import org.apache.cassandra.tools.ToolRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NodetoolConnectFailureTest extends CQLTester
+{
+    private static final String CLOSED_HOST = "127.0.0.1";
+    // A port that is essentially always closed; connecting to it fails fast.
+    private static final String CLOSED_PORT = "2";
+
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        requireNetwork();
+    }
+
+    @Test
+    public void cqlConnectFailurePrintsFriendlyMessageAndExits()
+    {
+        assertConnectFailure("cql", "nodetool: Failed to connect to '" + CLOSED_HOST + ':' + CLOSED_PORT + "' via CQL");
+    }
+
+    @Test
+    public void staticMBeanConnectFailurePrintsFriendlyMessageAndExits()
+    {
+        assertConnectFailure("static_mbean", "nodetool: Failed to connect to '" + CLOSED_HOST + ':' + CLOSED_PORT + '\'');
+    }
+
+    @Test
+    public void commandMBeanConnectFailurePrintsFriendlyMessageAndExits()
+    {
+        assertConnectFailure("command_mbean", "nodetool: Failed to connect to '" + CLOSED_HOST + ':' + CLOSED_PORT + '\'');
+    }
+
+    private static void assertConnectFailure(String protocol, String expectedMessage)
+    {
+        try (WithProperties ignored = new WithProperties()
+                                      .set(CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL, protocol))
+        {
+            ToolRunner.ToolResult result =
+                ToolRunner.invokeNodetoolInJvm(NodeTool::new, NodetoolConnectFailureTest::closedTargetArgs, "status");
+
+            assertThat(result.getExitCode()).as("connect failure should exit 1 (clean), not 2 (stack trace)")
+                                            .isEqualTo(1);
+            assertThat(result.getCleanedStderr()).contains(expectedMessage)
+                                                 .doesNotContain("-- StackTrace --");
+        }
+    }
+
+    /** Builds nodetool args with the closed host/port placed before the subcommand. */
+    private static List<String> closedTargetArgs(List<String> commandArgs)
+    {
+        List<String> all = new ArrayList<>();
+        all.add("bin/nodetool");
+        all.add("-h");
+        all.add(CLOSED_HOST);
+        all.add("-p");
+        all.add(CLOSED_PORT);
+        all.addAll(commandArgs);
+        return all;
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/NodetoolConnectFailureTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/NodetoolConnectFailureTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class NodetoolConnectFailureTest extends CQLTester
 {
     private static final String CLOSED_HOST = "127.0.0.1";
-    // A port that is essentially always closed; connecting to it fails fast.
+    // A privileged port nothing listens on, so connecting to it fails fast.
     private static final String CLOSED_PORT = "2";
 
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/ReloadCIDRGroupsCacheTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ReloadCIDRGroupsCacheTest.java
@@ -38,6 +38,8 @@ import static org.apache.cassandra.auth.AuthTestUtils.ROLE_B;
 import static org.apache.cassandra.schema.SchemaConstants.AUTH_KEYSPACE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class ReloadCIDRGroupsCacheTest extends CQLTester
 {
     static InetSocketAddress ipAddr;

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAuthCacheConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAuthCacheConfigTest.java
@@ -35,6 +35,8 @@ import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class SetAuthCacheConfigTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetDefaultKeyspaceRFTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetDefaultKeyspaceRFTest.java
@@ -22,12 +22,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SetDefaultKeyspaceRFTest extends CQLTester
+public class SetDefaultKeyspaceRFTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetColumnIndexSizeTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetColumnIndexSizeTest.java
@@ -21,17 +21,16 @@ package org.apache.cassandra.tools.nodetool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.service.StorageService;
 
 import static org.apache.cassandra.tools.ToolRunner.ToolResult;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@code nodetool setcolumnindexsize} and {@code nodetool getcolumnindexsize}.
  */
-public class SetGetColumnIndexSizeTest extends CQLTester
+public class SetGetColumnIndexSizeTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -83,7 +82,7 @@ public class SetGetColumnIndexSizeTest extends CQLTester
         assertSetInvalidColumnIndexSize("value", "Invalid value for positional parameter at index 0 (column_index_size): 'value' is not an int", 1);
     }
 
-    private static void assertSetGetValidColumnIndexSize(int columnIndexSizeInKB)
+    private void assertSetGetValidColumnIndexSize(int columnIndexSizeInKB)
     {
         ToolResult tool = invokeNodetool("setcolumnindexsize", String.valueOf(columnIndexSizeInKB));
         tool.assertOnCleanExit();
@@ -94,7 +93,7 @@ public class SetGetColumnIndexSizeTest extends CQLTester
         assertThat(StorageService.instance.getColumnIndexSizeInKiB()).isEqualTo(columnIndexSizeInKB);
     }
 
-    private static void assertSetInvalidColumnIndexSize(String columnIndexSizeInKB, String expectedErrorMessage, int expectedErrorCode)
+    private void assertSetInvalidColumnIndexSize(String columnIndexSizeInKB, String expectedErrorMessage, int expectedErrorCode)
     {
         ToolResult tool = columnIndexSizeInKB == null ? invokeNodetool("setcolumnindexsize")
                                              : invokeNodetool("setcolumnindexsize", columnIndexSizeInKB);
@@ -102,7 +101,7 @@ public class SetGetColumnIndexSizeTest extends CQLTester
         assertThat(expectedErrorCode == 1 ? tool.getStdout() : tool.getStderr()).contains(expectedErrorMessage);
     }
 
-    private static void assertGetThroughput(int expected)
+    private void assertGetThroughput(int expected)
     {
         ToolResult tool = invokeNodetool("getcolumnindexsize");
         tool.assertOnCleanExit();

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
@@ -22,16 +22,15 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 
 import static org.apache.cassandra.tools.ToolRunner.ToolResult;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@code nodetool setcompactionthroughput} and {@code nodetool getcompactionthroughput}.
  */
-public class SetGetCompactionThroughputTest extends CQLTester
+public class SetGetCompactionThroughputTest extends CQLNodetoolProtocolTester
 {
     private static final int MAX_INT_CONFIG_VALUE_IN_MBIT = Integer.MAX_VALUE - 1;
 
@@ -92,7 +91,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
         assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(15 minute\\): \\d+\\.\\d+ MiB/s");
     }
 
-    private static void assertSetGetValidThroughput(int throughput)
+    private void assertSetGetValidThroughput(int throughput)
     {
         ToolResult tool = invokeNodetool("setcompactionthroughput", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -102,7 +101,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
         assertGetThroughputDouble(throughput);
     }
 
-    private static void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
+    private void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
     {
         ToolResult tool = throughput == null ? invokeNodetool("setcompactionthroughput")
                                              : invokeNodetool("setcompactionthroughput", throughput);
@@ -110,7 +109,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains(expectedErrorMessage);
     }
 
-    private static void assertSetInvalidThroughput()
+    private void assertSetInvalidThroughput()
     {
         DatabaseDescriptor.setCompactionThroughputBytesPerSec(500);
         ToolResult tool = invokeNodetool("getstreamthroughput");
@@ -118,7 +117,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
         assertThat(tool.getStderr()).contains("Use the -d flag to quiet this error and get the exact throughput in megabits/s");
     }
 
-    private static void assertSetInvalidThroughputMib(String throughput)
+    private void assertSetInvalidThroughputMib(String throughput)
     {
         ToolResult tool = invokeNodetool("setcompactionthroughput", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -126,7 +125,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
                                               " 2147483647 in MiB/s");
     }
 
-    private static void assertPreciseMibFlagNeeded()
+    private void assertPreciseMibFlagNeeded()
     {
         DatabaseDescriptor.setCompactionThroughputBytesPerSec(15);
         ToolResult tool = invokeNodetool("getcompactionthroughput");
@@ -134,7 +133,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
         assertThat(tool.getStderr()).contains("Use the -d flag to quiet this error and get the exact throughput in MiB/s");
     }
 
-    private static void assertGetThroughput(int expected)
+    private void assertGetThroughput(int expected)
     {
         ToolResult tool = invokeNodetool("getcompactionthroughput");
         tool.assertOnCleanExit();
@@ -145,7 +144,7 @@ public class SetGetCompactionThroughputTest extends CQLTester
             assertThat(tool.getStdout()).contains("Current compaction throughput: 0 MiB/s");
     }
 
-    private static void assertGetThroughputDouble(double expected)
+    private void assertGetThroughputDouble(double expected)
     {
         ToolResult tool = invokeNodetool("getcompactionthroughput", "-d");
         tool.assertOnCleanExit();

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableInterDCStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableInterDCStreamThroughputTest.java
@@ -21,11 +21,10 @@ package org.apache.cassandra.tools.nodetool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 
 import static org.apache.cassandra.streaming.StreamManager.StreamRateLimiter;
 import static org.apache.cassandra.tools.ToolRunner.ToolResult;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withPrecision;
 
@@ -35,7 +34,7 @@ import static org.assertj.core.api.Assertions.withPrecision;
  * @see GetInterDCStreamThroughput
  * @see SetInterDCStreamThroughput
  */
-public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLTester
+public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLNodetoolProtocolTester
 {
     private static final int MAX_INT_CONFIG_VALUE_MIB = Integer.MAX_VALUE - 1;
 
@@ -83,7 +82,7 @@ public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLTester
         assertSetInvalidThroughput("value", "Invalid value for positional parameter at index 0 (inter_dc_stream_throughput): 'value' is not an int");
     }
 
-    private static void assertSetGetValidThroughput(int throughput, double rateInBytes)
+    private void assertSetGetValidThroughput(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", "-e", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -94,7 +93,7 @@ public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getEntireSSTableInterDCRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.01));
     }
 
-    private static void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
+    private void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
     {
         ToolResult tool = throughput == null ? invokeNodetool("setinterdcstreamthroughput", "-e")
                                              : invokeNodetool("setinterdcstreamthroughput", "-e", throughput);
@@ -102,7 +101,7 @@ public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains(expectedErrorMessage);
     }
 
-    private static void assertSetInvalidEntireSStableInterDCThroughputMib(String throughput)
+    private void assertSetInvalidEntireSStableInterDCThroughputMib(String throughput)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", "-e", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -110,7 +109,7 @@ public class SetGetEntireSSTableInterDCStreamThroughputTest extends CQLTester
                                               " it should be less than 2147483647 in MiB/s");
     }
 
-    private static void assertGetThroughput(double expected)
+    private void assertGetThroughput(double expected)
     {
         ToolResult tool = invokeNodetool("getinterdcstreamthroughput", "-e");
         tool.assertOnCleanExit();

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetEntireSSTableStreamThroughputTest.java
@@ -21,18 +21,17 @@ package org.apache.cassandra.tools.nodetool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 
 import static org.apache.cassandra.streaming.StreamManager.StreamRateLimiter;
 import static org.apache.cassandra.tools.ToolRunner.ToolResult;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withPrecision;
 
 /**
  * Tests for entire SSTable {@code nodetool setstreamthroughput} and {@code nodetool getstreamthroughput}.
  */
-public class SetGetEntireSSTableStreamThroughputTest extends CQLTester
+public class SetGetEntireSSTableStreamThroughputTest extends CQLNodetoolProtocolTester
 {
     private static final int MAX_INT_CONFIG_VALUE_MIB = Integer.MAX_VALUE - 1;
 
@@ -80,7 +79,7 @@ public class SetGetEntireSSTableStreamThroughputTest extends CQLTester
         assertSetInvalidThroughput("value", "Invalid value for positional parameter at index 0 (stream_throughput): 'value' is not an int");
     }
 
-    private static void assertSetGetValidThroughput(int throughput)
+    private void assertSetGetValidThroughput(int throughput)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-e", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -89,14 +88,14 @@ public class SetGetEntireSSTableStreamThroughputTest extends CQLTester
         assertGetThroughput(throughput);
     }
 
-    private static void assertSetGetValidThroughput(int throughput, double rateInBytes)
+    private void assertSetGetValidThroughput(int throughput, double rateInBytes)
     {
         assertSetGetValidThroughput(throughput);
 
         assertThat(StreamRateLimiter.getEntireSSTableRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.01));
     }
 
-    private static void assertSetInvalidEntireSStableThroughputMib(String throughput)
+    private void assertSetInvalidEntireSStableThroughputMib(String throughput)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-e", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -104,7 +103,7 @@ public class SetGetEntireSSTableStreamThroughputTest extends CQLTester
                                               "should be less than 2147483647 in MiB/s");
     }
 
-    private static void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
+    private void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
     {
         ToolResult tool = throughput == null ? invokeNodetool("setstreamthroughput", "-e")
                                              : invokeNodetool("setstreamthroughput", "-e", throughput);
@@ -112,7 +111,7 @@ public class SetGetEntireSSTableStreamThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains(expectedErrorMessage);
     }
 
-    private static void assertGetThroughput(double expected)
+    private void assertGetThroughput(double expected)
     {
         ToolResult tool = invokeNodetool("getstreamthroughput", "-e");
         tool.assertOnCleanExit();

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetInterDCStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetInterDCStreamThroughputTest.java
@@ -22,18 +22,17 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DataRateSpec;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 
 import static org.apache.cassandra.streaming.StreamManager.StreamRateLimiter;
 import static org.apache.cassandra.tools.ToolRunner.ToolResult;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withPrecision;
 
 /**
  * Tests for {@code nodetool setinterdcstreamthroughput} and {@code nodetool getinterdcstreamthroughput}.
  */
-public class SetGetInterDCStreamThroughputTest extends CQLTester
+public class SetGetInterDCStreamThroughputTest extends CQLNodetoolProtocolTester
 {
     private static final int MAX_INT_CONFIG_VALUE_IN_MBIT = Integer.MAX_VALUE - 1;
     private static final double BYTES_PER_MEGABIT = 125_000;
@@ -107,7 +106,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertDFlagNeeded();
     }
 
-    private static void assertSetGetValidThroughput(int throughput, double rateInBytes)
+    private void assertSetGetValidThroughput(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -118,7 +117,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getInterDCRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.04));
     }
 
-    private static void assertDFlagNeeded()
+    private void assertDFlagNeeded()
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-m", String.valueOf(1));
         tool.assertOnCleanExit();
@@ -129,7 +128,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertThat(tool.getStderr()).contains("Use the -d flag to quiet this error and get the exact throughput in megabits/s");
     }
 
-    private static void assertSetGetValidThroughputMiB(int throughput, double rateInBytes)
+    private void assertSetGetValidThroughputMiB(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", "-m", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -140,7 +139,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getInterDCRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.01));
     }
 
-    private static void assertSetMbitGetMibValidThroughput(int throughput, double rateInBytes)
+    private void assertSetMbitGetMibValidThroughput(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -151,7 +150,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getInterDCRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.01));
     }
 
-    private static void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
+    private void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
     {
         ToolResult tool = throughput == null ? invokeNodetool("setinterdcstreamthroughput")
                                              : invokeNodetool("setinterdcstreamthroughput", throughput);
@@ -159,7 +158,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains(expectedErrorMessage);
     }
 
-    private static void assertSetInvalidThroughputMib(String throughput)
+    private void assertSetInvalidThroughputMib(String throughput)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", "-m", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -167,7 +166,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
                                               " less than 2147483647 in megabits/s");
     }
 
-    private static void assertSetInvalidThroughputMbit(String throughput)
+    private void assertSetInvalidThroughputMbit(String throughput)
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -176,7 +175,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
                                               "megabits per second");
     }
 
-    private static void assertSetGetMoreFlagsIsInvalid()
+    private void assertSetGetMoreFlagsIsInvalid()
     {
         ToolResult tool = invokeNodetool("setinterdcstreamthroughput", "-m", "5", "-e", "6");
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -199,7 +198,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains("You cannot use more than one flag with this command");
     }
 
-    private static void assertGetThroughput(int expected)
+    private void assertGetThroughput(int expected)
     {
         ToolResult tool = invokeNodetool("getinterdcstreamthroughput");
         tool.assertOnCleanExit();
@@ -210,7 +209,7 @@ public class SetGetInterDCStreamThroughputTest extends CQLTester
             assertThat(tool.getStdout()).contains("Current inter-datacenter stream throughput: unlimited");
     }
 
-    private static void assertGetThroughputMiB(double expected)
+    private void assertGetThroughputMiB(double expected)
     {
         ToolResult tool = invokeNodetool("getinterdcstreamthroughput", "-m");
         tool.assertOnCleanExit();

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetStreamThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetStreamThroughputTest.java
@@ -22,11 +22,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.config.DataRateSpec;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 
 import static org.apache.cassandra.streaming.StreamManager.StreamRateLimiter;
 import static org.apache.cassandra.tools.ToolRunner.ToolResult;
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.withPrecision;
 
@@ -36,7 +35,7 @@ import static org.assertj.core.api.Assertions.withPrecision;
  * @see GetStreamThroughput
  * @see SetStreamThroughput
  */
-public class SetGetStreamThroughputTest extends CQLTester
+public class SetGetStreamThroughputTest extends CQLNodetoolProtocolTester
 {
     private static final int MAX_INT_CONFIG_VALUE_IN_MBIT = Integer.MAX_VALUE - 1;
     private static final double BYTES_PER_MEGABIT = 125_000;
@@ -111,7 +110,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertSetGetMoreFlagsIsInvalid();
     }
 
-    private static void assertSetGetValidThroughput(int throughput, double rateInBytes)
+    private void assertSetGetValidThroughput(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -122,7 +121,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.04));
     }
 
-    private static void assertSetGetValidThroughputMiB(int throughput, double rateInBytes)
+    private void assertSetGetValidThroughputMiB(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-m", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -133,7 +132,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.01));
     }
 
-    private static void assertDFlagNeeded()
+    private void assertDFlagNeeded()
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-m", String.valueOf(1));
         tool.assertOnCleanExit();
@@ -144,7 +143,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertThat(tool.getStderr()).contains("Use the -d flag to quiet this error and get the exact throughput in megabits/s");
     }
 
-    private static void assertSetMbitGetMibValidThroughput(int throughput, double rateInBytes)
+    private void assertSetMbitGetMibValidThroughput(int throughput, double rateInBytes)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", String.valueOf(throughput));
         tool.assertOnCleanExit();
@@ -155,7 +154,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertThat(StreamRateLimiter.getRateLimiterRateInBytes()).isEqualTo(rateInBytes, withPrecision(0.01));
     }
 
-    private static void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
+    private void assertSetInvalidThroughput(String throughput, String expectedErrorMessage)
     {
         ToolResult tool = throughput == null ? invokeNodetool("setstreamthroughput")
                                              : invokeNodetool("setstreamthroughput", throughput);
@@ -163,7 +162,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains(expectedErrorMessage);
     }
 
-    private static void assertSetInvalidThroughputMib(String throughput)
+    private void assertSetInvalidThroughputMib(String throughput)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-m", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -171,7 +170,7 @@ public class SetGetStreamThroughputTest extends CQLTester
                                               "than 2147483647 in megabits/s");
     }
 
-    private static void assertSetInvalidThroughputMbit(String throughput)
+    private void assertSetInvalidThroughputMbit(String throughput)
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", throughput);
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -179,7 +178,7 @@ public class SetGetStreamThroughputTest extends CQLTester
                                               "and inter_dc_stream_throughput_outbound should be between 0 and 2147483646 in megabits per second");
     }
 
-    private static void assertSetGetMoreFlagsIsInvalid()
+    private void assertSetGetMoreFlagsIsInvalid()
     {
         ToolResult tool = invokeNodetool("setstreamthroughput", "-m", "5", "-e", "6");
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -202,7 +201,7 @@ public class SetGetStreamThroughputTest extends CQLTester
         assertThat(tool.getStdout()).contains("You cannot use more than one flag with this command");
     }
 
-    private static void assertGetThroughput(int expected)
+    private void assertGetThroughput(int expected)
     {
         ToolResult tool = invokeNodetool("getstreamthroughput");
         tool.assertOnCleanExit();
@@ -213,7 +212,7 @@ public class SetGetStreamThroughputTest extends CQLTester
             assertThat(tool.getStdout()).contains("Current stream throughput: unlimited");
     }
 
-    private static void assertGetThroughputMiB(double expected)
+    private void assertGetThroughputMiB(double expected)
     {
         ToolResult tool = invokeNodetool("getstreamthroughput", "-m");
         tool.assertOnCleanExit();

--- a/test/unit/org/apache/cassandra/tools/nodetool/ShowExecutionIdOutputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/ShowExecutionIdOutputTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.distributed.shared.WithProperties;
+import org.apache.cassandra.tools.NodeTool;
+import org.apache.cassandra.tools.ToolRunner;
+import org.apache.cassandra.tools.nodetool.strategy.CommandExecutionStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ShowExecutionIdOutputTest extends CQLNodetoolProtocolTester
+{
+    @BeforeClass
+    public static void setup() throws Exception
+    {
+        requireNetwork();
+        startJMXServer();
+    }
+
+    @Override
+    public ToolRunner.ToolResult invokeNodetool(String... args)
+    {
+        try (WithProperties with = new WithProperties()
+                                   .set(CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_PROTOCOL, strategy.name().toLowerCase())
+                                   .set(CassandraRelevantProperties.CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID, true))
+        {
+            return ToolRunner.invokeNodetoolInJvm(NodeTool::new,
+                                                  strategy == CommandExecutionStrategy.Type.CQL ?
+                                                  CQLTester::buildNodetoolCqlArgs :
+                                                  CQLTester::buildNodetoolArgs,
+                                                  args);
+        }
+    }
+
+    @Test
+    public void testExecutionIdInOutputWhenShowExecutionIdEnabled()
+    {
+        Assume.assumeFalse("STATIC_MBEAN does not print execution ID",
+                           strategy == CommandExecutionStrategy.Type.STATIC_MBEAN);
+
+        ToolRunner.ToolResult tool = invokeNodetool("status");
+        tool.assertOnCleanExit();
+        assertThat(EXECUTION_ID_UUID_PATTERN.matcher(tool.getStdout()).find())
+        .as("When CASSANDRA_CLI_EXECUTION_SHOW_EXECUTION_ID is true, output should contain 'Command execution id: <uuid>'")
+        .isTrue();
+    }
+}

--- a/test/unit/org/apache/cassandra/tools/nodetool/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SnapshotTest.java
@@ -45,7 +45,7 @@ public class SnapshotTest extends CQLNodetoolProtocolTester
     @After
     public void tearDown()
     {
-        // Clear all named snaphsots created by tests.
+        // Clear all named snapshots created by tests.
         for (String tag : List.of("custom_snapshot_name", "skip_flush", "ttl", "table", "kt_option"))
             invokeNodetool("clearsnapshot", "-t", tag);
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/SnapshotTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SnapshotTest.java
@@ -18,26 +18,36 @@
 
 package org.apache.cassandra.tools.nodetool;
 
+import java.util.List;
+
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.tools.ToolRunner;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**o
  * Tests for the {@code nodetool snapshot} command
  */
-public class SnapshotTest extends CQLTester
+public class SnapshotTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
     {
         requireNetwork();
         startJMXServer();
+    }
+
+    @After
+    public void tearDown()
+    {
+        // Clear all named snaphsots created by tests.
+        for (String tag : List.of("custom_snapshot_name", "skip_flush", "ttl", "table", "kt_option"))
+            invokeNodetool("clearsnapshot", "-t", tag);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/StatusTest.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.locator.SimpleLocationProvider;
 import org.apache.cassandra.schema.SchemaConstants;
@@ -32,7 +33,7 @@ import org.apache.cassandra.utils.FBUtilities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StatusTest extends CQLTester
+public class StatusTest extends CQLNodetoolProtocolTester
 {
     private static final Pattern PATTERN = Pattern.compile("\\R");
     private static String localHostId;
@@ -76,7 +77,7 @@ public class StatusTest extends CQLTester
         schemaChange("DROP KEYSPACE " + CQLTester.KEYSPACE);
         schemaChange("DROP KEYSPACE " + CQLTester.KEYSPACE_PER_TEST);
 
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("status");
+        ToolRunner.ToolResult tool = invokeNodetool("status");
         tool.assertOnCleanExit();
         String[] lines = PATTERN.split(tool.getStdout());
 
@@ -135,7 +136,7 @@ public class StatusTest extends CQLTester
 
     private void validateStatusOutput(String hostForm, String... args)
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool(args);
+        ToolRunner.ToolResult tool = invokeNodetool(args);
         tool.assertOnCleanExit();
         /*
          Datacenter: datacenter1

--- a/test/unit/org/apache/cassandra/tools/nodetool/TableHistogramsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TableHistogramsTest.java
@@ -22,7 +22,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.apache.cassandra.auth.AuthKeyspace;
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.SystemKeyspace;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.SchemaKeyspace;
@@ -31,14 +31,13 @@ import org.apache.cassandra.service.accord.AccordKeyspace;
 import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.tracing.TraceKeyspace;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotEquals;
 
 /**
  * @see TableHistograms
  */
-public class TableHistogramsTest extends CQLTester
+public class TableHistogramsTest extends CQLNodetoolProtocolTester
 {
     private static final String INFO_ROW = "Percentile      Read Latency     Write Latency          SSTables    Partition Size        Cell Count";
     private final int ALL_TABLE_SIZE = SystemKeyspace.TABLE_NAMES.size() +
@@ -91,16 +90,16 @@ public class TableHistogramsTest extends CQLTester
         //format 1 : ks1.tb1 ks2.tb2
         ToolRunner.ToolResult tool = invokeNodetool("tablehistograms", "system.local", "system.paxos");
         assertNotEquals(0, tool.getExitCode());
-        assertThat(tool.getStdout()).contains("nodetool: tablehistograms requires <keyspace> <table> or <keyspace.table> format argument");
+        assertThat(tool.getStdout()).contains("tablehistograms requires <keyspace> <table> or <keyspace.table> format argument");
 
         // format 2 : ks1 tb1 ks2 tb2
         tool = invokeNodetool("tablehistograms", "system", "local", "system", "paxos");
         assertNotEquals(0, tool.getExitCode());
-        assertThat(tool.getStdout()).contains("nodetool: Unmatched arguments from index 7: 'system', 'paxos'");
+        assertThat(tool.getStdout()).contains("Unmatched arguments from index 7: 'system', 'paxos'");
 
         // format 3 : ks1.tb1 ks2
         tool = invokeNodetool("tablehistograms", "system.local", "system");
         assertNotEquals(0, tool.getExitCode());
-        assertThat(tool.getStdout()).contains("nodetool: tablehistograms requires <keyspace> <table> or <keyspace.table> format argument");
+        assertThat(tool.getStdout()).contains("tablehistograms requires <keyspace> <table> or <keyspace.table> format argument");
     }
 }

--- a/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TableStatsTest.java
@@ -29,7 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 import org.apache.cassandra.utils.JsonUtils;
 
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /**
  * @see TableStats
  */
-public class TableStatsTest extends CQLTester
+public class TableStatsTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -51,12 +51,12 @@ public class TableStatsTest extends CQLTester
     @Test
     public void testTableStats()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats");
+        ToolRunner.ToolResult tool = invokeNodetool("tablestats");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_schema");
         assertThat(StringUtils.countMatches(tool.getStdout(), "Table:")).isGreaterThan(1);
 
-        tool = ToolRunner.invokeNodetool("tablestats", "system_distributed");
+        tool = invokeNodetool("tablestats", "system_distributed");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_distributed");
         assertThat(tool.getStdout()).doesNotContain("Keyspace : system_schema");
@@ -66,7 +66,7 @@ public class TableStatsTest extends CQLTester
     @Test
     public void testTableIgnoreArg()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", "-i", "system_schema.aggregates");
+        ToolRunner.ToolResult tool = invokeNodetool("tablestats", "-i", "system_schema.aggregates");
         tool.assertOnCleanExit();
         assertThat(tool.getStdout()).contains("Keyspace: system_schema");
         assertThat(tool.getStdout()).doesNotContain("Table: system_schema.aggregates");
@@ -77,7 +77,7 @@ public class TableStatsTest extends CQLTester
     public void testHumanReadableArg()
     {
         Arrays.asList("-H", "--human-readable").forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", arg);
+            ToolRunner.ToolResult tool = invokeNodetool("tablestats", arg);
             tool.assertOnCleanExit();
             assertThat(tool.getStdout()).contains(" KiB");
         });
@@ -89,13 +89,13 @@ public class TableStatsTest extends CQLTester
         Pattern regExp = Pattern.compile("((?m)Table: .*$)");
 
         Arrays.asList("-s", "--sort").forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", arg, "table_name");
+            ToolRunner.ToolResult tool = invokeNodetool("tablestats", arg, "table_name");
             Matcher m = regExp.matcher(tool.getStdout());
             ArrayList<String> orig = new ArrayList<>();
             while (m.find())
                 orig.add(m.group(1));
 
-            tool = ToolRunner.invokeNodetool("tablestats", arg, "sstable_count");
+            tool = invokeNodetool("tablestats", arg, "sstable_count");
             tool.assertOnCleanExit();
             m = regExp.matcher(tool.getStdout());
             ArrayList<String> sorted = new ArrayList<>();
@@ -108,7 +108,7 @@ public class TableStatsTest extends CQLTester
             assertThat(sorted).isEqualTo(orig);
         });
 
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", "-s", "wrongSort");
+        ToolRunner.ToolResult tool = invokeNodetool("tablestats", "-s", "wrongSort");
         assertThat(tool.getStdout()).contains("argument for sort must be one of");
         tool.assertCleanStdErr();
         assertThat(tool.getExitCode()).isEqualTo(1);
@@ -118,12 +118,12 @@ public class TableStatsTest extends CQLTester
     public void testTopArg()
     {
         Arrays.asList("-t", "--top").forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", "-s", "table_name", arg, "1");
+            ToolRunner.ToolResult tool = invokeNodetool("tablestats", "-s", "table_name", arg, "1");
             tool.assertOnCleanExit();
             assertThat(StringUtils.countMatches(tool.getStdout(), "Table:")).isEqualTo(1);
         });
 
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", "-s", "table_name", "-t", "-1");
+        ToolRunner.ToolResult tool = invokeNodetool("tablestats", "-s", "table_name", "-t", "-1");
         tool.assertCleanStdErr();
         assertThat(tool.getExitCode()).isEqualTo(1);
         assertThat(tool.getStdout()).contains("argument for top must be a positive integer");
@@ -133,12 +133,12 @@ public class TableStatsTest extends CQLTester
     public void testSSTableLocationCheckArg()
     {
         Arrays.asList("-l", "--sstable-location-check").forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", arg, "system.local");
+            ToolRunner.ToolResult tool = invokeNodetool("tablestats", arg, "system.local");
             tool.assertOnCleanExit();
             assertThat(StringUtils.countMatches(tool.getStdout(), "SSTables in correct location: ")).isEqualTo(1);
         });
 
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", "system.local");
+        ToolRunner.ToolResult tool = invokeNodetool("tablestats", "system.local");
         tool.assertCleanStdErr();
         assertThat(tool.getStdout()).doesNotContain("SSTables in correct location: ");
     }
@@ -147,7 +147,7 @@ public class TableStatsTest extends CQLTester
     public void testFormatJson()
     {
         Arrays.asList("-F", "--format").forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", arg, "json");
+            ToolRunner.ToolResult tool = invokeNodetool("tablestats", arg, "json");
             tool.assertOnCleanExit();
             String json = tool.getStdout();
             assertThatCode(() -> JsonUtils.JSON_OBJECT_MAPPER.readTree(json)).doesNotThrowAnyException();
@@ -160,7 +160,7 @@ public class TableStatsTest extends CQLTester
     public void testFormatYaml()
     {
         Arrays.asList("-F", "--format").forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tablestats", arg, "yaml");
+            ToolRunner.ToolResult tool = invokeNodetool("tablestats", arg, "yaml");
             tool.assertOnCleanExit();
             String yaml = tool.getStdout();
             org.yaml.snakeyaml.LoaderOptions loaderOptions = new org.yaml.snakeyaml.LoaderOptions();

--- a/test/unit/org/apache/cassandra/tools/nodetool/TpStatsTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TpStatsTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,7 +32,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.MessagingService;
 import org.apache.cassandra.net.NoPayload;
@@ -40,8 +42,9 @@ import org.apache.cassandra.utils.JsonUtils;
 
 import static org.apache.cassandra.net.Verb.ECHO_REQ;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
-public class TpStatsTest extends CQLTester
+public class TpStatsTest extends CQLNodetoolProtocolTester
 {
 
     @BeforeClass
@@ -54,7 +57,7 @@ public class TpStatsTest extends CQLTester
     @Test
     public void testTpStats() throws Throwable
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tpstats");
+        ToolRunner.ToolResult tool = invokeNodetool("tpstats");
         tool.assertOnCleanExit();
         String stdout = tool.getStdout();
         assertThat(stdout).containsPattern("Pool Name \\s+ Active Pending Completed Blocked All time blocked");
@@ -69,7 +72,7 @@ public class TpStatsTest extends CQLTester
         execute("INSERT INTO %s (pk, c) VALUES (?, ?)", 1, 1);
         flush();
 
-        tool = ToolRunner.invokeNodetool("tpstats");
+        tool = invokeNodetool("tpstats");
         tool.assertOnCleanExit();
         stdout = tool.getStdout();
         ArrayList<String> newStats = getAllGroupMatches(nonZeroedThreadsRegExp, stdout);
@@ -77,29 +80,35 @@ public class TpStatsTest extends CQLTester
 
         assertThat(origStats).isNotEqualTo(newStats);
 
-        // Does sending a message alter Gossip & ECHO stats?
+        // Does sending a message alter GossipStage stats?
+        // Use relative comparison since stats are cumulative across parameterized runs.
         String origGossip = getAllGroupMatches("((?m)GossipStage.*)", stdout).get(0);
-        assertThat(stdout).doesNotContainPattern("ECHO_REQ\\D.*[1-9].*");
-        assertThat(stdout).doesNotContainPattern("ECHO_RSP\\D.*[1-9].*");
 
+        CountDownLatch latch = new CountDownLatch(1);
         Message<NoPayload> echoMessageOut = Message.out(ECHO_REQ, NoPayload.noPayload);
-        MessagingService.instance().send(echoMessageOut, FBUtilities.getBroadcastAddressAndPort());
+        MessagingService.instance().sendWithCallback(echoMessageOut, FBUtilities.getBroadcastAddressAndPort(),
+                                                     (msg) -> latch.countDown());
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
 
-        tool = ToolRunner.invokeNodetool("tpstats");
+        tool = invokeNodetool("tpstats");
         tool.assertOnCleanExit();
         stdout = tool.getStdout();
         String newGossip = getAllGroupMatches("((?m)GossipStage.*)", stdout).get(0);
 
+        // We intentionally do not assert on ECHO_REQ changes here. The ECHO_REQ line
+        // in tpstats reports histogram percentiles (DecayingEstimatedHistogramReservoir) which
+        // use fixed bucket boundaries. Adding samples that fall into the same buckets as existing
+        // ones does not change the reported percentile values, making string comparison unreliable.
+        // The GossipStage completed count (a monotonic counter) is enough to verify that
+        // ECHO_REQ messages were processed, since ECHO_REQ is handled on the GOSSIP stage.
         assertThat(origGossip).isNotEqualTo(newGossip);
-        assertThat(stdout).containsPattern("ECHO_REQ\\D.*[1-9].*");
-        assertThat(stdout).containsPattern("ECHO_RSP\\D.*[0-9].*");
     }
 
     @Test
     public void testFormatArg()
     {
         Arrays.asList(Pair.of("-F", "json"), Pair.of("--format", "json")).forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tpstats", arg.getLeft(), arg.getRight());
+            ToolRunner.ToolResult tool = invokeNodetool("tpstats", arg.getLeft(), arg.getRight());
             tool.assertOnCleanExit();
             String json = tool.getStdout();
             assertThat(isJSONString(json)).isTrue();
@@ -107,7 +116,7 @@ public class TpStatsTest extends CQLTester
         });
 
         Arrays.asList( Pair.of("-F", "yaml"), Pair.of("--format", "yaml")).forEach(arg -> {
-            ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("tpstats", arg.getLeft(), arg.getRight());
+            ToolRunner.ToolResult tool = invokeNodetool("tpstats", arg.getLeft(), arg.getRight());
             tool.assertOnCleanExit();
             String yaml = tool.getStdout();
             assertThat(isYAMLString(yaml)).isTrue();

--- a/test/unit/org/apache/cassandra/tools/nodetool/TrainCompressionDictionaryTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/TrainCompressionDictionaryTest.java
@@ -21,14 +21,13 @@ package org.apache.cassandra.tools.nodetool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.io.compress.IDictionaryCompressor;
 import org.apache.cassandra.tools.ToolRunner;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TrainCompressionDictionaryTest extends CQLTester
+public class TrainCompressionDictionaryTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Throwable
@@ -136,8 +135,7 @@ public class TrainCompressionDictionaryTest extends CQLTester
                                                       "train",
                                                       keyspace(),
                                                       table);
-        assertThat(result.getStderr())
-        .contains("Failed to trigger training: No SSTables available for training", "after flush");
+        assertThat(result.getStdout()).contains("No SSTables available for training", "after flush");
     }
 
     @Test
@@ -147,9 +145,7 @@ public class TrainCompressionDictionaryTest extends CQLTester
                                                       "train",
                                                       "nonexistent_keyspace",
                                                       "nonexistent_table");
-        result.asserts()
-              .failure()
-              .errorContains("Failed to trigger training");
+        assertThat(result.getStdout()).contains("Failed to trigger training");
     }
 
     @Test
@@ -159,10 +155,7 @@ public class TrainCompressionDictionaryTest extends CQLTester
                                                       "train",
                                                       keyspace(),
                                                       "nonexistent_table");
-        result.asserts()
-              .failure()
-              .errorContains("Failed to trigger training")
-              .errorContains("does not exist or does not support dictionary compression");
+        assertThat(result.getStdout()).contains("Failed to trigger training");
     }
 
     @Test
@@ -175,9 +168,9 @@ public class TrainCompressionDictionaryTest extends CQLTester
                                                       "train",
                                                       keyspace(),
                                                       table);
-        result.asserts()
-              .failure()
-              .errorContains("does not support dictionary compression");
+        result.asserts().failure();
+        assertThat(result.getStdout())
+              .contains("is not enabled or SSTable compressor is not a dictionary compressor");
     }
 
     @Test
@@ -190,9 +183,9 @@ public class TrainCompressionDictionaryTest extends CQLTester
                                                       "train",
                                                       keyspace(),
                                                       table);
-        result.asserts()
-              .failure()
-              .errorContains("does not support dictionary compression");
+        result.asserts().failure();
+        assertThat(result.getStdout())
+              .contains("is not enabled or SSTable compressor is not a dictionary compressor");
     }
 
 
@@ -204,18 +197,17 @@ public class TrainCompressionDictionaryTest extends CQLTester
 
         // Training should fail on LZ4 table
         ToolRunner.ToolResult result = invokeNodetool("compressiondictionary", "train", keyspace(), table);
-        result.asserts()
-              .failure()
-              .errorContains("Failed to trigger training")
-              .errorContains("does not exist or does not support dictionary compression");
+        result.asserts().failure();
+        assertThat(result.getStdout())
+              .contains("is not enabled or SSTable compressor is not a dictionary compressor");
 
         // Alter table to use ZstdDictionaryCompressor
         execute("ALTER TABLE %s WITH compression = {'class': 'ZstdDictionaryCompressor'}");
 
         // Training should fail with no sstables
         result = invokeNodetool("compressiondictionary", "train", keyspace(), table);
-        assertThat(result.getStderr())
-        .contains("Failed to trigger training: No SSTables available for training", "after flush");
+        assertThat(result.getStdout())
+        .contains("No SSTables available for training", "after flush");
 
         // Write sstables
         createSSTables(true);

--- a/test/unit/org/apache/cassandra/tools/nodetool/UninitializedServerTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/UninitializedServerTest.java
@@ -21,12 +21,12 @@ package org.apache.cassandra.tools.nodetool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class UninitializedServerTest extends CQLTester
+public class UninitializedServerTest extends CQLNodetoolProtocolTester
 {
     @BeforeClass
     public static void setup() throws Exception
@@ -39,7 +39,7 @@ public class UninitializedServerTest extends CQLTester
     {
         // CASSANDRA-11537
         // fails, not finished initializing node because test never calls requireNetwork()
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("status");
+        ToolRunner.ToolResult tool = invokeNodetool("status");
         assertThat(tool.getException() instanceof IllegalArgumentException);
         assertThat(tool.getStderr().contains("Server is not initialized yet, cannot run nodetool."));
     }

--- a/test/unit/org/apache/cassandra/tools/nodetool/UpdateCIDRGroupTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/UpdateCIDRGroupTest.java
@@ -30,6 +30,8 @@ import static org.apache.cassandra.auth.AuthKeyspace.CIDR_GROUPS;
 import static org.apache.cassandra.schema.SchemaConstants.AUTH_KEYSPACE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO: CASSANDRA-XXXXX Test needs to be migrated to CQLNodetoolProtocolTester
+//  once nodetool supports passing authentication credentials.
 public class UpdateCIDRGroupTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/VerifyTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/VerifyTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Iterables;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.index.sai.StorageAttachedIndex;
 import org.apache.cassandra.index.sai.StorageAttachedIndexGroup;
@@ -37,12 +37,11 @@ import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.tools.ToolRunner;
 
-import static org.apache.cassandra.tools.ToolRunner.invokeNodetool;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class VerifyTest extends CQLTester
+public class VerifyTest extends CQLNodetoolProtocolTester
 {
 
     @BeforeClass

--- a/test/unit/org/apache/cassandra/tools/nodetool/VersionTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/VersionTest.java
@@ -20,12 +20,12 @@ package org.apache.cassandra.tools.nodetool;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.CQLNodetoolProtocolTester;
 import org.apache.cassandra.tools.ToolRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class VersionTest extends CQLTester
+public class VersionTest extends CQLNodetoolProtocolTester
 {
 
     @BeforeClass
@@ -38,7 +38,7 @@ public class VersionTest extends CQLTester
     @Test
     public void testBasic()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("version");
+        ToolRunner.ToolResult tool = invokeNodetool("version");
         tool.assertOnExitCode();
         String stdout = tool.getStdout();
         assertThat(stdout).containsPattern("ReleaseVersion:\\s+\\S+");
@@ -47,7 +47,7 @@ public class VersionTest extends CQLTester
     @Test
     public void testVOption()
     {
-        ToolRunner.ToolResult tool = ToolRunner.invokeNodetool("version", "-v");
+        ToolRunner.ToolResult tool = invokeNodetool("version", "-v");
         tool.assertOnExitCode();
         String stdout = tool.getStdout();
         assertThat(stdout).containsPattern("ReleaseVersion:\\s+\\S+");

--- a/test/unit/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategyTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/strategy/CqlCommandExecutionStrategyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.tools.nodetool.strategy;
+
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.ExecuteCommandStatement;
+import org.apache.cassandra.db.compaction.OperationType;
+import org.apache.cassandra.management.CommandExecutionArgsSerde;
+import org.apache.cassandra.management.api.CommandExecutionArgs;
+import org.apache.cassandra.management.picocli.PicocliCommandArgsConverter;
+import org.apache.cassandra.management.picocli.PicocliCommandMetadata;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.nodetool.AbstractCommand;
+import org.apache.cassandra.tools.nodetool.Stop;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CqlCommandExecutionStrategyTest
+{
+    @Test
+    public void testStopDefaultOperationTypeSurvivesCqlRoundTrip()
+    {
+        String cql = CqlCommandExecutionStrategy.buildCqlCommandString("stop", PicocliCommandArgsConverter.fromCommand(new Stop()));
+
+        assertThat(cql).contains("'UNKNOWN'")
+                       .doesNotContain(OperationType.UNKNOWN.toString());
+
+        CommandExecutionArgs serverArgs = serverSideArgs(cql, new Stop());
+        assertThat(serverArgs.parameters().values()).contains(OperationType.UNKNOWN);
+    }
+
+    @Test
+    public void testAllOperationTypesSurviveCqlRoundTrip()
+    {
+        for (OperationType type : OperationType.values())
+        {
+            EnumParamCommand client = new EnumParamCommand();
+            client.compactionType = type;
+            String cql = CqlCommandExecutionStrategy.buildCqlCommandString("stop", PicocliCommandArgsConverter.fromCommand(client));
+
+            EnumParamCommand server = new EnumParamCommand();
+            PicocliCommandArgsConverter.toCommand(serverSideArgs(cql, server), server);
+            assertThat(server.compactionType).as("round trip of %s via: %s", type, cql).isEqualTo(type);
+        }
+    }
+
+    /**
+     * Parse the statement and convert its raw args the same way {@link ExecuteCommandStatement} does.
+     */
+    private static CommandExecutionArgs serverSideArgs(String cql, AbstractCommand command)
+    {
+        CQLStatement.Raw stmt = QueryProcessor.parseStatement(cql);
+        assertThat(stmt).isInstanceOf(ExecuteCommandStatement.Raw.class);
+        ExecuteCommandStatement.Raw raw = (ExecuteCommandStatement.Raw) stmt;
+        return CommandExecutionArgsSerde.fromMap(raw.args(), PicocliCommandMetadata.from(command));
+    }
+
+    @Command(name = "stop")
+    static class EnumParamCommand extends AbstractCommand
+    {
+        @Parameters(paramLabel = "compaction_type", arity = "0..1")
+        OperationType compactionType = OperationType.UNKNOWN;
+
+        @Override
+        protected void execute(NodeProbe probe)
+        {
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.transport;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.WriteType;
 import org.apache.cassandra.exceptions.CasWriteTimeoutException;
 import org.apache.cassandra.exceptions.CasWriteUnknownResultException;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.WriteFailureException;
@@ -39,6 +41,7 @@ import org.apache.cassandra.transport.messages.ErrorMessage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ErrorMessageTest extends EncodeAndDecodeTestBase<ErrorMessage>
@@ -189,6 +192,72 @@ public class ErrorMessageTest extends EncodeAndDecodeTestBase<ErrorMessage>
 
         assertEquals(failureReasonMap1, rfe.failureReasonByEndpoint);
         assertEquals(failureReasonMap1, wfe.failureReasonByEndpoint);
+    }
+
+    @Test
+    public void testV5CommandFailedSerDeser()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        Throwable cause = new RuntimeException("Underlying cause");
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage, cause);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromExceptionNoStreamId(ex), ProtocolVersion.V5);
+        assertTrue(deserialized.error instanceof CommandRequestExecutionException);
+        CommandRequestExecutionException deserializedEx = (CommandRequestExecutionException) deserialized.error;
+
+        assertEquals(executionId, deserializedEx.getCommandExecutionId());
+        assertEquals(errorMessage, deserializedEx.getMessage());
+        assertNull(deserializedEx.getCause());
+    }
+
+    @Test
+    public void testV4CommandFailedSerDeser()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        Throwable cause = new RuntimeException("Underlying cause");
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage, cause);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromExceptionNoStreamId(ex), ProtocolVersion.V4);
+        assertTrue(deserialized.error instanceof ServerError);
+        ServerError deserializedEx = (ServerError) deserialized.error;
+
+        // The executionId should be included in the message for backward compatibility.
+        assertTrue(deserializedEx.getMessage().contains(executionId.toString()));
+        assertTrue(deserializedEx.getMessage().contains(errorMessage));
+    }
+
+    @Test
+    public void testV5CommandFailedWithoutCause()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromExceptionNoStreamId(ex), ProtocolVersion.V5);
+        assertTrue(deserialized.error instanceof CommandRequestExecutionException);
+        CommandRequestExecutionException deserializedEx = (CommandRequestExecutionException) deserialized.error;
+
+        assertEquals(executionId, deserializedEx.getCommandExecutionId());
+        assertEquals(errorMessage, deserializedEx.getMessage());
+        assertNull(deserializedEx.getCause());
+    }
+
+    @Test
+    public void testV3CommandFailedSerDeser()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromExceptionNoStreamId(ex), ProtocolVersion.V3);
+        assertTrue(deserialized.error instanceof ServerError);
+        ServerError deserializedEx = (ServerError) deserialized.error;
+
+        // The executionId should be included in the message for backward compatibility.
+        assertTrue(deserializedEx.getMessage().contains(executionId.toString()));
+        assertTrue(deserializedEx.getMessage().contains(errorMessage));
     }
 
     protected Message.Codec<ErrorMessage> getCodec()

--- a/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
+++ b/test/unit/org/apache/cassandra/transport/ErrorMessageTest.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.transport;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.WriteType;
 import org.apache.cassandra.exceptions.CasWriteTimeoutException;
 import org.apache.cassandra.exceptions.CasWriteUnknownResultException;
+import org.apache.cassandra.exceptions.CommandRequestExecutionException;
 import org.apache.cassandra.exceptions.ReadFailureException;
 import org.apache.cassandra.exceptions.RequestFailureReason;
 import org.apache.cassandra.exceptions.WriteFailureException;
@@ -39,6 +41,7 @@ import org.apache.cassandra.transport.messages.ErrorMessage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ErrorMessageTest extends EncodeAndDecodeTestBase<ErrorMessage>
@@ -189,6 +192,72 @@ public class ErrorMessageTest extends EncodeAndDecodeTestBase<ErrorMessage>
 
         assertEquals(failureReasonMap1, rfe.failureReasonByEndpoint);
         assertEquals(failureReasonMap1, wfe.failureReasonByEndpoint);
+    }
+
+    @Test
+    public void testV5CommandFailedSerDeser()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        Throwable cause = new RuntimeException("Underlying cause");
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage, cause);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromException(ex), ProtocolVersion.V5);
+        assertTrue(deserialized.error instanceof CommandRequestExecutionException);
+        CommandRequestExecutionException deserializedEx = (CommandRequestExecutionException) deserialized.error;
+
+        assertEquals(executionId, deserializedEx.getCommandExecutionId());
+        assertEquals(errorMessage, deserializedEx.getMessage());
+        assertNull(deserializedEx.getCause());
+    }
+
+    @Test
+    public void testV4CommandFailedSerDeser()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        Throwable cause = new RuntimeException("Underlying cause");
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage, cause);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromException(ex), ProtocolVersion.V4);
+        assertTrue(deserialized.error instanceof ServerError);
+        ServerError deserializedEx = (ServerError) deserialized.error;
+
+        // The executionId should be included in the message for backward compatibility.
+        assertTrue(deserializedEx.getMessage().contains(executionId.toString()));
+        assertTrue(deserializedEx.getMessage().contains(errorMessage));
+    }
+
+    @Test
+    public void testV5CommandFailedWithoutCause()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromException(ex), ProtocolVersion.V5);
+        assertTrue(deserialized.error instanceof CommandRequestExecutionException);
+        CommandRequestExecutionException deserializedEx = (CommandRequestExecutionException) deserialized.error;
+
+        assertEquals(executionId, deserializedEx.getCommandExecutionId());
+        assertEquals(errorMessage, deserializedEx.getMessage());
+        assertNull(deserializedEx.getCause());
+    }
+
+    @Test
+    public void testV3CommandFailedSerDeser()
+    {
+        UUID executionId = UUID.randomUUID();
+        String errorMessage = "Command execution failed: test command";
+        CommandRequestExecutionException ex = new CommandRequestExecutionException(executionId, errorMessage);
+
+        ErrorMessage deserialized = encodeThenDecode(ErrorMessage.fromException(ex), ProtocolVersion.V3);
+        assertTrue(deserialized.error instanceof ServerError);
+        ServerError deserializedEx = (ServerError) deserialized.error;
+
+        // The executionId should be included in the message for backward compatibility.
+        assertTrue(deserializedEx.getMessage().contains(executionId.toString()));
+        assertTrue(deserializedEx.getMessage().contains(errorMessage));
     }
 
     protected Message.Codec<ErrorMessage> getCodec()

--- a/test/unit/org/apache/cassandra/transport/MessageDispatcherTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageDispatcherTest.java
@@ -172,7 +172,7 @@ public class MessageDispatcherTest
     {
         public AuthTestDispatcher()
         {
-            super(false);
+            super(false, false);
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/transport/MessageManagementDispatcherTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageManagementDispatcherTest.java
@@ -1,0 +1,621 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.metrics.ClientMetrics;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.utils.Clock;
+
+import io.netty.channel.Channel;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MessageManagementDispatcherTest
+{
+    private static ManagementTestDispatcher dispatch;
+    private static int maxManagementThreadsBeforeTests;
+
+    @BeforeClass
+    public static void init() throws Exception
+    {
+        DatabaseDescriptor.daemonInitialization();
+        ClientMetrics.instance.init(null);
+        maxManagementThreadsBeforeTests = DatabaseDescriptor.getNativeTransportManagementMaxThreads();
+        dispatch = new ManagementTestDispatcher();
+    }
+
+    @AfterClass
+    public static void restoreManagementSize()
+    {
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(maxManagementThreadsBeforeTests);
+    }
+
+    @Test
+    public void testManagementExecutorRouting() throws Exception
+    {
+        long startRequests = completedRequests();
+        long startAuth = completedAuth();
+
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        long managementTasks = tryRequest(this::completedManagement, queryMessage("INVOKE COMMAND status;"));
+        assertEquals("Management request should be routed to management executor",
+                     1, managementTasks);
+        assertEquals("No auth requests should be processed", startAuth, completedAuth());
+        assertEquals("Regular requests should not increase", startRequests, completedRequests());
+    }
+
+    @Test
+    public void testManagementExecutorIsolation() throws Exception
+    {
+        long startManagement = completedManagement();
+
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        // Test that regular (non-management) requests don't use management executor
+        for (Message.Type type : Message.Type.values())
+        {
+            if (type.direction != Message.Direction.REQUEST)
+                continue;
+
+            long requests = tryRequest(() -> Message.Type.CREDENTIALS == type || Message.Type.AUTH_RESPONSE == type
+                                             ? completedAuth()
+                                             : completedRequests(),
+                                       createRegularRequest(type));
+
+            assertEquals("No management tasks should be processed", startManagement, completedManagement());
+            assertEquals(format("Request should be processed for type: %s", type), 1, requests);
+        }
+    }
+
+    @Test
+    public void testManagementConnectionAllMessageTypes() throws Exception
+    {
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        for (Message.Type type : Message.Type.values())
+        {
+            if (type.direction != Message.Direction.REQUEST)
+                continue;
+
+            Message.Request request = createManagementRequest(type);
+            long managementTasks = tryRequest(() -> Message.Type.CREDENTIALS == type || Message.Type.AUTH_RESPONSE == type
+                                                    ? completedAuth()
+                                                    : completedManagement(),
+                                              request);
+            assertEquals(format("Management %s request should route to management executor", type),
+                         1, managementTasks);
+        }
+    }
+
+    @Test
+    public void testNonServerConnectionNotRoutedToManagement() throws Exception
+    {
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        // Create a connection that is not a ServerConnection
+        Connection nonServerConnection = connectionMock();
+
+        Message.Request request = new Message.Request(Message.Type.QUERY)
+        {
+            @Override
+            public Connection connection()
+            {
+                return nonServerConnection;
+            }
+
+            @Override
+            public Response execute(QueryState queryState, Dispatcher.RequestTime requestTime, boolean traceRequest)
+            {
+                return null;
+            }
+        };
+
+        long startManagement = completedManagement();
+        long regularTasks = tryRequest(this::completedRequests, request);
+
+        assertEquals("Non-server connection should use regular executor", 1, regularTasks);
+        assertEquals("Non-server connection should not use management executor",
+                            startManagement, completedManagement());
+    }
+
+    @Test
+    public void testCommandStatementAllowed()
+    {
+        assertTrue("INVOKE COMMAND statements should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("INVOKE COMMAND status;")));
+    }
+
+    @Test
+    public void testCommandWithParamsAllowed()
+    {
+        assertTrue("INVOKE COMMAND with params should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("INVOKE COMMAND forcecompact WITH \"keyspace\" = 'ks' AND \"table\" = 'tbl';")));
+    }
+
+    @Test
+    public void testSelectSystemLocalAllowed()
+    {
+        assertTrue("SELECT from system.local should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system.local WHERE key = 'local';")));
+    }
+
+    @Test
+    public void testSelectSystemPeersAllowed()
+    {
+        assertTrue("SELECT from system.peers should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system.peers;")));
+    }
+
+    @Test
+    public void testSelectSystemSchemaKeyspacesAllowed()
+    {
+        assertTrue("SELECT from system_schema.keyspaces should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_schema.keyspaces;")));
+    }
+
+    @Test
+    public void testSelectSystemSchemaTablesAllowed()
+    {
+        assertTrue("SELECT from system_schema.tables should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_schema.tables;")));
+    }
+
+    @Test
+    public void testSelectSystemSchemaColumnsAllowed()
+    {
+        assertTrue("SELECT from system_schema.columns should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_schema.columns;")));
+    }
+
+    @Test
+    public void testSelectUserKeyspaceRejected()
+    {
+        assertFalse("SELECT from user keyspace should be rejected",
+                    Dispatcher.isManagementRequestAllowed(
+                    queryMessage("SELECT * FROM my_keyspace.my_table;")));
+    }
+
+    @Test
+    public void testSelectSystemAuthRejected()
+    {
+        assertFalse("SELECT from system_auth.roles should be rejected",
+                    Dispatcher.isManagementRequestAllowed(
+                    queryMessage("SELECT * FROM system_auth.roles;")));
+        assertFalse("SELECT from system_auth.role_permissions should be rejected",
+                    Dispatcher.isManagementRequestAllowed(
+                    queryMessage("SELECT * FROM system_auth.role_permissions;")));
+    }
+
+    @Test
+    public void testUseSystemAuthRejected()
+    {
+        assertFalse("USE system_auth should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("USE system_auth;")));
+    }
+
+    @Test
+    public void testSelectSystemDistributedAllowed()
+    {
+        assertTrue("SELECT from system_distributed should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_distributed.repair_history;")));
+    }
+
+    @Test
+    public void testInsertRejected()
+    {
+        assertFalse("INSERT should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage(
+                    "INSERT INTO system.local (key) VALUES ('test');")));
+    }
+
+    @Test
+    public void testCreateTableRejected()
+    {
+        assertFalse("DDL should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage(
+                    "CREATE TABLE system.foo (k text PRIMARY KEY);")));
+    }
+
+    @Test
+    public void testUnqualifiedSelectRejected()
+    {
+        assertFalse("Unqualified SELECT should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("SELECT * FROM local;")));
+    }
+
+    @Test
+    public void testInvalidSyntaxRejected()
+    {
+        assertFalse("Invalid syntax should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("NOT VALID CQL AT ALL;")));
+    }
+
+    @Test
+    public void testProtocolMessagesAllowed()
+    {
+        Message.Request startup = createManagementRequest(Message.Type.STARTUP);
+        assertTrue("STARTUP should be allowed", Dispatcher.isManagementRequestAllowed(startup));
+
+        Message.Request options = createManagementRequest(Message.Type.OPTIONS);
+        assertTrue("OPTIONS should be allowed", Dispatcher.isManagementRequestAllowed(options));
+
+        Message.Request register = createManagementRequest(Message.Type.REGISTER);
+        assertTrue("REGISTER should be allowed", Dispatcher.isManagementRequestAllowed(register));
+    }
+
+    @Test
+    public void testPrepareRejected()
+    {
+        Message.Request prepare = createManagementRequest(Message.Type.PREPARE);
+        assertFalse("PREPARE should be rejected", Dispatcher.isManagementRequestAllowed(prepare));
+    }
+
+    @Test
+    public void testBatchRejected()
+    {
+        Message.Request batch = createManagementRequest(Message.Type.BATCH);
+        assertFalse("BATCH should be rejected", Dispatcher.isManagementRequestAllowed(batch));
+    }
+
+    @Test
+    public void testExecuteRejected()
+    {
+        Message.Request execute = createManagementRequest(Message.Type.EXECUTE);
+        assertFalse("EXECUTE should be rejected", Dispatcher.isManagementRequestAllowed(execute));
+    }
+
+    @Test
+    public void testUseSystemKeyspaceAllowed()
+    {
+        assertTrue("USE system should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("USE system;")));
+    }
+
+    @Test
+    public void testUseSystemSchemaAllowed()
+    {
+        assertTrue("USE system_schema should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("USE system_schema;")));
+    }
+
+    @Test
+    public void testUseVirtualKeyspaceAllowed()
+    {
+        assertTrue("USE system_views should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("USE system_views;")));
+    }
+
+    @Test
+    public void testUseUserKeyspaceRejected()
+    {
+        assertFalse("USE user keyspace should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("USE my_keyspace;")));
+    }
+
+    @Test
+    public void testIsDoneTracksManagementExecutor() throws Exception
+    {
+        Dispatcher managementDispatcher = new ManagementTestDispatcher(true);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Dispatcher.managementExecutor.submit(() -> {
+            started.countDown();
+            Uninterruptibles.awaitUninterruptibly(release);
+        });
+        try
+        {
+            assertTrue(started.await(10, TimeUnit.SECONDS));
+            assertFalse("An in-flight management task should block the management drain",
+                        managementDispatcher.isDone());
+            awaitTrue("The regular dispatcher drain should ignore the management executor",
+                      dispatch::isDone);
+        }
+        finally
+        {
+            release.countDown();
+        }
+        awaitTrue("The management drain should complete once its task finishes",
+                  managementDispatcher::isDone);
+    }
+
+    @Test
+    public void testIsDoneIgnoresRequestExecutorBacklog() throws Exception
+    {
+        Dispatcher managementDispatcher = new ManagementTestDispatcher(true);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Dispatcher.requestExecutor.submit(() -> {
+            started.countDown();
+            Uninterruptibles.awaitUninterruptibly(release);
+        });
+        try
+        {
+            assertTrue(started.await(10, TimeUnit.SECONDS));
+            assertFalse("An in-flight regular task should block the regular drain",
+                        dispatch.isDone());
+            assertTrue("The management drain should ignore the regular request executor",
+                       managementDispatcher.isDone());
+        }
+        finally
+        {
+            release.countDown();
+        }
+        awaitTrue("The regular drain should complete once its task finishes",
+                  dispatch::isDone);
+    }
+
+    /**
+     * A management command may itself initiate the server stop (e.g. INVOKE COMMAND stopdaemon), in which
+     * case the drain-wait runs on the very thread executing the command and must not wait for its own task.
+     */
+    @Test
+    public void testIsDoneExcludesStopInitiatingManagementTask() throws Exception
+    {
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicBoolean isDoneInsideTask = new AtomicBoolean();
+
+        Dispatcher managementDispatcher = new ManagementTestDispatcher(true)
+        {
+            @Override
+            <P> void processRequest(Channel channel,
+                                    Message.Request request,
+                                    FlushItemConverter<P> forFlusher,
+                                    P param,
+                                    ClientResourceLimits.Overload backpressure,
+                                    RequestTime requestTime)
+            {
+                isDoneInsideTask.set(isDone());
+                entered.countDown();
+                Uninterruptibles.awaitUninterruptibly(release);
+            }
+        };
+
+        Message.Request request = createManagementRequest(Message.Type.STARTUP);
+        managementDispatcher.dispatch(request.connection().channel(), request, (param, channel, req, response) -> null,
+                                      null, ClientResourceLimits.Overload.NONE);
+        try
+        {
+            assertTrue(entered.await(10, TimeUnit.SECONDS));
+            assertTrue("The drain must not wait for the management task that initiated it",
+                       isDoneInsideTask.get());
+            assertFalse("Other threads should still see the in-flight management task",
+                        managementDispatcher.isDone());
+        }
+        finally
+        {
+            release.countDown();
+        }
+        awaitTrue("The management drain should complete once its task finishes",
+                  managementDispatcher::isDone);
+    }
+
+    /**
+     * Queue-time backpressure must be keyed to the executor serving the connection: a backlog on the
+     * management pool should trigger backpressure for management connections only, and must stay
+     * invisible to regular client connections (and vice versa).
+     */
+    @Test
+    public void testHasQueueCapacityTracksOwnExecutor() throws Exception
+    {
+        Dispatcher managementDispatcher = new ManagementTestDispatcher(true);
+        double thresholdBefore = DatabaseDescriptor.getRawConfig().native_transport_queue_max_item_age_threshold;
+        DatabaseDescriptor.getRawConfig().native_transport_queue_max_item_age_threshold = 1e-9;
+
+        int poolSize = Dispatcher.managementExecutor.getMaximumPoolSize();
+        CountDownLatch saturated = new CountDownLatch(poolSize);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch processed = new CountDownLatch(1);
+        try
+        {
+            assertTrue("Both drains should report capacity while idle", managementDispatcher.hasQueueCapacity());
+            assertTrue(dispatch.hasQueueCapacity());
+
+            for (int i = 0; i < poolSize; i++)
+            {
+                Dispatcher.managementExecutor.submit(() -> {
+                    saturated.countDown();
+                    Uninterruptibles.awaitUninterruptibly(release);
+                });
+            }
+            assertTrue(saturated.await(10, TimeUnit.SECONDS));
+
+            Dispatcher queuedProcessor = new ManagementTestDispatcher(true)
+            {
+                @Override
+                <P> void processRequest(Channel channel,
+                                        Message.Request request,
+                                        FlushItemConverter<P> forFlusher,
+                                        P param,
+                                        ClientResourceLimits.Overload backpressure,
+                                        RequestTime requestTime)
+                {
+                    processed.countDown();
+                }
+            };
+            Message.Request request = createManagementRequest(Message.Type.STARTUP);
+            queuedProcessor.dispatch(request.connection().channel(), request, (param, channel, req, response) -> null,
+                                     null, ClientResourceLimits.Overload.NONE);
+
+            awaitTrue("A queued management request should trigger management backpressure",
+                      () -> !managementDispatcher.hasQueueCapacity());
+            assertTrue("A management backlog should be invisible to the regular drain",
+                       dispatch.hasQueueCapacity());
+        }
+        finally
+        {
+            release.countDown();
+            DatabaseDescriptor.getRawConfig().native_transport_queue_max_item_age_threshold = thresholdBefore;
+        }
+        assertTrue(processed.await(10, TimeUnit.SECONDS));
+        awaitTrue("The management pool should drain once its tasks finish",
+                  managementDispatcher::isDone);
+    }
+
+    private static void awaitTrue(String message, Callable<Boolean> condition) throws Exception
+    {
+        long timeout = Clock.Global.currentTimeMillis();
+        while (!condition.call() && Clock.Global.currentTimeMillis() - timeout < 10_000)
+            Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+        assertTrue(message, condition.call());
+    }
+
+    private long completedRequests()
+    {
+        return Dispatcher.requestExecutor.getCompletedTaskCount();
+    }
+
+    private long completedAuth()
+    {
+        return Dispatcher.authExecutor.getCompletedTaskCount();
+    }
+
+    private long completedManagement()
+    {
+        return Dispatcher.managementExecutor.getCompletedTaskCount();
+    }
+
+    private long tryRequest(Callable<Long> check, Message.Request request) throws Exception
+    {
+        long start = check.call();
+        dispatch.dispatch(request.connection().channel(), request, (param, channel, req, response) -> null,
+                          null, ClientResourceLimits.Overload.NONE);
+
+        long timeout = Clock.Global.currentTimeMillis();
+        while (start == check.call() && Clock.Global.currentTimeMillis() - timeout < 1000)
+            Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+        return check.call() - start;
+    }
+
+    private static ServerConnection managementConnectionMock()
+    {
+        Connection.Tracker tracker = Mockito.mock(Connection.Tracker.class);
+        Mockito.when(tracker.isRunning()).thenAnswer(invocation -> true);
+
+        Channel channel = Mockito.mock(Channel.class);
+        ServerConnection connection = Mockito.mock(ServerConnection.class);
+        Mockito.when(connection.getTracker()).thenAnswer(invocation -> tracker);
+        Mockito.when(connection.isManagementConnection()).thenReturn(true);
+        Mockito.when(connection.getVersion()).thenReturn(ProtocolVersion.CURRENT);
+        Mockito.when(connection.channel()).thenReturn(channel);
+
+        return connection;
+    }
+
+    private static Connection connectionMock()
+    {
+        Connection.Tracker tracker = Mockito.mock(Connection.Tracker.class);
+        Mockito.when(tracker.isRunning()).thenAnswer(invocation -> true);
+        Connection c = Mockito.mock(Connection.class);
+        Mockito.when(c.getTracker()).thenAnswer(invocation -> tracker);
+        return c;
+    }
+
+    private static Message.Request createManagementRequest(Message.Type type)
+    {
+        return createRequest(type, managementConnectionMock());
+    }
+
+    private static Message.Request createRegularRequest(Message.Type type)
+    {
+        return createRequest(type, connectionMock());
+    }
+
+    private static Message.Request createRequest(Message.Type type, Connection conn)
+    {
+        return new Message.Request(type)
+        {
+            @Override
+            public Connection connection()
+            {
+                return conn;
+            }
+
+            @Override
+            public Response execute(QueryState queryState, Dispatcher.RequestTime requestTime, boolean traceRequest)
+            {
+                return null;
+            }
+        };
+    }
+
+    private static QueryMessage queryMessage(String cql)
+    {
+        QueryMessage msg = new QueryMessage(cql, QueryOptions.DEFAULT)
+        {
+            @Override
+            public Connection connection()
+            {
+                return managementConnectionMock();
+            }
+        };
+        msg.setSource(new Envelope(Envelope.Header.dummy(1, msg.type), null));
+        return msg;
+    }
+
+    public static class ManagementTestDispatcher extends Dispatcher
+    {
+        public ManagementTestDispatcher()
+        {
+            this(false);
+        }
+
+        public ManagementTestDispatcher(boolean isManagementDispatcher)
+        {
+            super(false, isManagementDispatcher);
+        }
+
+        @Override
+        <P> void processRequest(Channel channel,
+                                Message.Request request,
+                                FlushItemConverter<P> forFlusher,
+                                P param,
+                                ClientResourceLimits.Overload backpressure,
+                                RequestTime requestTime)
+        {
+            // noop - just for testing routing
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/MessageManagementDispatcherTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageManagementDispatcherTest.java
@@ -32,6 +32,9 @@ import org.mockito.Mockito;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.exceptions.RequestValidationException;
+import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.metrics.ClientMetrics;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.transport.messages.QueryMessage;
@@ -42,6 +45,8 @@ import io.netty.channel.Channel;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class MessageManagementDispatcherTest
@@ -169,6 +174,14 @@ public class MessageManagementDispatcherTest
     }
 
     @Test
+    public void testQuotedDottedCommandNameAllowed()
+    {
+        assertNull("Quoted dotted command names should parse as INVOKE COMMAND",
+                   Dispatcher.checkManagementRequest(
+                   queryMessage("INVOKE COMMAND \"profile.start\" WITH event = ['alloc'] AND duration = '1m';")));
+    }
+
+    @Test
     public void testSelectSystemLocalAllowed()
     {
         assertTrue("SELECT from system.local should be allowed",
@@ -245,9 +258,12 @@ public class MessageManagementDispatcherTest
     @Test
     public void testInsertRejected()
     {
-        assertFalse("INSERT should be rejected",
-                    Dispatcher.isManagementRequestAllowed(queryMessage(
-                    "INSERT INTO system.local (key) VALUES ('test');")));
+        RequestValidationException rejection = Dispatcher.checkManagementRequest(queryMessage(
+                    "INSERT INTO system.local (key) VALUES ('test');"));
+        assertNotNull("INSERT should be rejected", rejection);
+        assertTrue(rejection instanceof InvalidRequestException);
+        assertEquals("Only executions of the INVOKE COMMAND statements are allowed on the management port.",
+                     rejection.getMessage());
     }
 
     @Test
@@ -268,8 +284,22 @@ public class MessageManagementDispatcherTest
     @Test
     public void testInvalidSyntaxRejected()
     {
-        assertFalse("Invalid syntax should be rejected",
-                    Dispatcher.isManagementRequestAllowed(queryMessage("NOT VALID CQL AT ALL;")));
+        RequestValidationException rejection = Dispatcher.checkManagementRequest(queryMessage("NOT VALID CQL AT ALL;"));
+        assertNotNull(rejection);
+        assertTrue("Invalid syntax should be reported as a syntax error, not a statement-type rejection",
+                   rejection instanceof SyntaxException);
+        assertFalse(rejection.getMessage().contains("INVOKE COMMAND"));
+    }
+
+    @Test
+    public void testMalformedInvokeCommandReturnsSyntaxError()
+    {
+        RequestValidationException rejection = Dispatcher.checkManagementRequest(
+            queryMessage("INVOKE COMMAND \"profile.start\" WITH event = ['alloc'] AND AND duration = '1m';"));
+        assertNotNull(rejection);
+        assertTrue("A mistyped INVOKE COMMAND should surface the parse error",
+                   rejection instanceof SyntaxException);
+        assertFalse(rejection.getMessage().contains("Only executions of the INVOKE COMMAND"));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/transport/MessageManagementDispatcherTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessageManagementDispatcherTest.java
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryOptions;
+import org.apache.cassandra.metrics.ClientMetrics;
+import org.apache.cassandra.service.QueryState;
+import org.apache.cassandra.transport.messages.QueryMessage;
+import org.apache.cassandra.utils.Clock;
+
+import io.netty.channel.Channel;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MessageManagementDispatcherTest
+{
+    private static ManagementTestDispatcher dispatch;
+    private static int maxManagementThreadsBeforeTests;
+
+    @BeforeClass
+    public static void init() throws Exception
+    {
+        DatabaseDescriptor.daemonInitialization();
+        ClientMetrics.instance.init(null);
+        maxManagementThreadsBeforeTests = DatabaseDescriptor.getNativeTransportManagementMaxThreads();
+        dispatch = new ManagementTestDispatcher();
+    }
+
+    @AfterClass
+    public static void restoreManagementSize()
+    {
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(maxManagementThreadsBeforeTests);
+    }
+
+    @Test
+    public void testManagementExecutorRouting() throws Exception
+    {
+        long startRequests = completedRequests();
+        long startAuth = completedAuth();
+
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        long managementTasks = tryRequest(this::completedManagement, queryMessage("INVOKE COMMAND status;"));
+        assertEquals("Management request should be routed to management executor",
+                     1, managementTasks);
+        assertEquals("No auth requests should be processed", startAuth, completedAuth());
+        assertEquals("Regular requests should not increase", startRequests, completedRequests());
+    }
+
+    @Test
+    public void testManagementExecutorIsolation() throws Exception
+    {
+        long startManagement = completedManagement();
+
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        // Test that regular (non-management) requests don't use management executor
+        for (Message.Type type : Message.Type.values())
+        {
+            if (type.direction != Message.Direction.REQUEST)
+                continue;
+
+            long requests = tryRequest(() -> Message.Type.CREDENTIALS == type || Message.Type.AUTH_RESPONSE == type
+                                             ? completedAuth()
+                                             : completedRequests(),
+                                       createRegularRequest(type));
+
+            assertEquals("No management tasks should be processed", startManagement, completedManagement());
+            assertEquals(format("Request should be processed for type: %s", type), 1, requests);
+        }
+    }
+
+    @Test
+    public void testManagementConnectionAllMessageTypes() throws Exception
+    {
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        for (Message.Type type : Message.Type.values())
+        {
+            if (type.direction != Message.Direction.REQUEST)
+                continue;
+
+            Message.Request request = createManagementRequest(type);
+            long managementTasks = tryRequest(() -> Message.Type.CREDENTIALS == type || Message.Type.AUTH_RESPONSE == type
+                                                    ? completedAuth()
+                                                    : completedManagement(),
+                                              request);
+            assertEquals(format("Management %s request should route to management executor", type),
+                         1, managementTasks);
+        }
+    }
+
+    @Test
+    public void testNonServerConnectionNotRoutedToManagement() throws Exception
+    {
+        DatabaseDescriptor.setNativeTransportManagementMaxThreads(1);
+
+        // Create a connection that is not a ServerConnection
+        Connection nonServerConnection = connectionMock();
+
+        Message.Request request = new Message.Request(Message.Type.QUERY)
+        {
+            @Override
+            public Connection connection()
+            {
+                return nonServerConnection;
+            }
+
+            @Override
+            public Response execute(QueryState queryState, Dispatcher.RequestTime requestTime, boolean traceRequest)
+            {
+                return null;
+            }
+        };
+
+        long startManagement = completedManagement();
+        long regularTasks = tryRequest(this::completedRequests, request);
+
+        assertEquals("Non-server connection should use regular executor", 1, regularTasks);
+        assertEquals("Non-server connection should not use management executor",
+                            startManagement, completedManagement());
+    }
+
+    @Test
+    public void testCommandStatementAllowed()
+    {
+        assertTrue("INVOKE COMMAND statements should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("INVOKE COMMAND status;")));
+    }
+
+    @Test
+    public void testCommandWithParamsAllowed()
+    {
+        assertTrue("INVOKE COMMAND with params should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("INVOKE COMMAND forcecompact WITH \"keyspace\" = 'ks' AND \"table\" = 'tbl';")));
+    }
+
+    @Test
+    public void testSelectSystemLocalAllowed()
+    {
+        assertTrue("SELECT from system.local should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system.local WHERE key = 'local';")));
+    }
+
+    @Test
+    public void testSelectSystemPeersAllowed()
+    {
+        assertTrue("SELECT from system.peers should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system.peers;")));
+    }
+
+    @Test
+    public void testSelectSystemSchemaKeyspacesAllowed()
+    {
+        assertTrue("SELECT from system_schema.keyspaces should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_schema.keyspaces;")));
+    }
+
+    @Test
+    public void testSelectSystemSchemaTablesAllowed()
+    {
+        assertTrue("SELECT from system_schema.tables should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_schema.tables;")));
+    }
+
+    @Test
+    public void testSelectSystemSchemaColumnsAllowed()
+    {
+        assertTrue("SELECT from system_schema.columns should be allowed",
+                   Dispatcher.isManagementRequestAllowed(
+                   queryMessage("SELECT * FROM system_schema.columns;")));
+    }
+
+    @Test
+    public void testSelectUserKeyspaceRejected()
+    {
+        assertFalse("SELECT from user keyspace should be rejected",
+                    Dispatcher.isManagementRequestAllowed(
+                    queryMessage("SELECT * FROM my_keyspace.my_table;")));
+    }
+
+    @Test
+    public void testInsertRejected()
+    {
+        assertFalse("INSERT should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage(
+                    "INSERT INTO system.local (key) VALUES ('test');")));
+    }
+
+    @Test
+    public void testCreateTableRejected()
+    {
+        assertFalse("DDL should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage(
+                    "CREATE TABLE system.foo (k text PRIMARY KEY);")));
+    }
+
+    @Test
+    public void testUnqualifiedSelectRejected()
+    {
+        assertFalse("Unqualified SELECT should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("SELECT * FROM local;")));
+    }
+
+    @Test
+    public void testInvalidSyntaxRejected()
+    {
+        assertFalse("Invalid syntax should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("NOT VALID CQL AT ALL;")));
+    }
+
+    @Test
+    public void testProtocolMessagesAllowed()
+    {
+        Message.Request startup = createManagementRequest(Message.Type.STARTUP);
+        assertTrue("STARTUP should be allowed", Dispatcher.isManagementRequestAllowed(startup));
+
+        Message.Request options = createManagementRequest(Message.Type.OPTIONS);
+        assertTrue("OPTIONS should be allowed", Dispatcher.isManagementRequestAllowed(options));
+
+        Message.Request register = createManagementRequest(Message.Type.REGISTER);
+        assertTrue("REGISTER should be allowed", Dispatcher.isManagementRequestAllowed(register));
+    }
+
+    @Test
+    public void testPrepareRejected()
+    {
+        Message.Request prepare = createManagementRequest(Message.Type.PREPARE);
+        assertFalse("PREPARE should be rejected", Dispatcher.isManagementRequestAllowed(prepare));
+    }
+
+    @Test
+    public void testBatchRejected()
+    {
+        Message.Request batch = createManagementRequest(Message.Type.BATCH);
+        assertFalse("BATCH should be rejected", Dispatcher.isManagementRequestAllowed(batch));
+    }
+
+    @Test
+    public void testExecuteRejected()
+    {
+        Message.Request execute = createManagementRequest(Message.Type.EXECUTE);
+        assertFalse("EXECUTE should be rejected", Dispatcher.isManagementRequestAllowed(execute));
+    }
+
+    @Test
+    public void testUseSystemKeyspaceAllowed()
+    {
+        assertTrue("USE system should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("USE system;")));
+    }
+
+    @Test
+    public void testUseSystemSchemaAllowed()
+    {
+        assertTrue("USE system_schema should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("USE system_schema;")));
+    }
+
+    @Test
+    public void testUseVirtualKeyspaceAllowed()
+    {
+        assertTrue("USE system_views should be allowed",
+                   Dispatcher.isManagementRequestAllowed(queryMessage("USE system_views;")));
+    }
+
+    @Test
+    public void testUseUserKeyspaceRejected()
+    {
+        assertFalse("USE user keyspace should be rejected",
+                    Dispatcher.isManagementRequestAllowed(queryMessage("USE my_keyspace;")));
+    }
+
+    private long completedRequests()
+    {
+        return Dispatcher.requestExecutor.getCompletedTaskCount();
+    }
+
+    private long completedAuth()
+    {
+        return Dispatcher.authExecutor.getCompletedTaskCount();
+    }
+
+    private long completedManagement()
+    {
+        return Dispatcher.managementExecutor.getCompletedTaskCount();
+    }
+
+    private long tryRequest(Callable<Long> check, Message.Request request) throws Exception
+    {
+        long start = check.call();
+        dispatch.dispatch(request.connection().channel(), request, (channel, req, response) -> null,
+                          ClientResourceLimits.Overload.NONE);
+
+        long timeout = Clock.Global.currentTimeMillis();
+        while (start == check.call() && Clock.Global.currentTimeMillis() - timeout < 1000)
+            Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+        return check.call() - start;
+    }
+
+    private static ServerConnection managementConnectionMock()
+    {
+        Connection.Tracker tracker = Mockito.mock(Connection.Tracker.class);
+        Mockito.when(tracker.isRunning()).thenAnswer(invocation -> true);
+
+        Channel channel = Mockito.mock(Channel.class);
+        ServerConnection connection = Mockito.mock(ServerConnection.class);
+        Mockito.when(connection.getTracker()).thenAnswer(invocation -> tracker);
+        Mockito.when(connection.isManagementConnection()).thenReturn(true);
+        Mockito.when(connection.getVersion()).thenReturn(ProtocolVersion.CURRENT);
+        Mockito.when(connection.channel()).thenReturn(channel);
+
+        return connection;
+    }
+
+    private static Connection connectionMock()
+    {
+        Connection.Tracker tracker = Mockito.mock(Connection.Tracker.class);
+        Mockito.when(tracker.isRunning()).thenAnswer(invocation -> true);
+        Connection c = Mockito.mock(Connection.class);
+        Mockito.when(c.getTracker()).thenAnswer(invocation -> tracker);
+        return c;
+    }
+
+    private static Message.Request createManagementRequest(Message.Type type)
+    {
+        return createRequest(type, managementConnectionMock());
+    }
+
+    private static Message.Request createRegularRequest(Message.Type type)
+    {
+        return createRequest(type, connectionMock());
+    }
+
+    private static Message.Request createRequest(Message.Type type, Connection conn)
+    {
+        return new Message.Request(type)
+        {
+            @Override
+            public Connection connection()
+            {
+                return conn;
+            }
+
+            @Override
+            public Response execute(QueryState queryState, Dispatcher.RequestTime requestTime, boolean traceRequest)
+            {
+                return null;
+            }
+        };
+    }
+
+    private static QueryMessage queryMessage(String cql)
+    {
+        QueryMessage msg = new QueryMessage(cql, QueryOptions.DEFAULT)
+        {
+            @Override
+            public Connection connection()
+            {
+                return managementConnectionMock();
+            }
+        };
+        msg.setStreamId(1);
+        return msg;
+    }
+
+    public static class ManagementTestDispatcher extends Dispatcher
+    {
+        public ManagementTestDispatcher()
+        {
+            super(false);
+        }
+
+        @Override
+        void processRequest(Channel channel,
+                            Message.Request request,
+                            FlushItemConverter forFlusher,
+                            ClientResourceLimits.Overload backpressure,
+                            RequestTime requestTime)
+        {
+            // noop - just for testing routing
+        }
+    }
+}

--- a/test/unit/org/apache/cassandra/transport/QueueBackpressureTest.java
+++ b/test/unit/org/apache/cassandra/transport/QueueBackpressureTest.java
@@ -57,4 +57,25 @@ public class QueueBackpressureTest
         backpressure = backpressure.mark(backpressure.appliedAt() + TimeUnit.MILLISECONDS.toNanos(1001));
         Assert.assertEquals(backpressure.minDelayNanos(), backpressure.delay(TimeUnit.NANOSECONDS));
     }
+
+    /**
+     * The client and management transports use separate {@link QueueBackpressure} instances, so an overload
+     * incident on one must not inflate the delay applied by the other.
+     */
+    @Test
+    public void testIncidentStateIsPerInstance()
+    {
+        long minDelayNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        long maxDelayNanos = TimeUnit.MILLISECONDS.toNanos(100);
+        QueueBackpressure client = QueueBackpressure.newDefault(() -> minDelayNanos, () -> maxDelayNanos);
+        QueueBackpressure management = QueueBackpressure.newDefault(() -> minDelayNanos, () -> maxDelayNanos);
+
+        long clientDelay = 0;
+        for (int i = 0; i < 50; i++)
+            clientDelay = client.markAndGetDelay(TimeUnit.NANOSECONDS);
+        Assert.assertTrue("Client incident should have ramped past the minimum delay", clientDelay > minDelayNanos);
+
+        Assert.assertEquals("A first management overload must start its own incident at the minimum delay",
+                            minDelayNanos, management.markAndGetDelay(TimeUnit.NANOSECONDS));
+    }
 }

--- a/test/unit/org/apache/cassandra/transport/SimpleClientTimeoutTest.java
+++ b/test/unit/org/apache/cassandra/transport/SimpleClientTimeoutTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.transport;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SimpleClientTimeoutTest
+{
+    @BeforeClass
+    public static void setup()
+    {
+        DatabaseDescriptor.toolInitialization();
+    }
+
+    @Test(timeout = 30000)
+    public void testConnectionClosedDetectedWithIndefiniteTimeout() throws Exception
+    {
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress()))
+        {
+            Thread closer = new Thread(() -> {
+                try
+                {
+                    server.accept().close();
+                }
+                catch (IOException e)
+                {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            closer.start();
+
+            try (SimpleClient client = SimpleClient.builder(server.getInetAddress().getHostAddress(), server.getLocalPort())
+                                                   .requestTimeoutSeconds(0)
+                                                   .build())
+            {
+                assertThatThrownBy(() -> client.connect(false))
+                .isInstanceOf(SimpleClient.ConnectionClosedException.class);
+            }
+            closer.join();
+        }
+    }
+
+    @Test
+    public void testConfigurableRequestTimeout() throws Exception
+    {
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getLoopbackAddress()))
+        {
+            try (SimpleClient client = SimpleClient.builder(server.getInetAddress().getHostAddress(), server.getLocalPort())
+                                                   .requestTimeoutSeconds(1)
+                                                   .build())
+            {
+                assertThatThrownBy(() -> client.connect(false))
+                .isInstanceOf(SimpleClient.TimeoutException.class)
+                .hasMessageContaining("1 seconds");
+            }
+        }
+    }
+}

--- a/tools/stress/src/org/apache/cassandra/stress/util/JmxCollector.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JmxCollector.java
@@ -18,7 +18,6 @@
 */
 package org.apache.cassandra.stress.util;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -30,6 +29,7 @@ import java.util.concurrent.Future;
 import org.apache.cassandra.concurrent.NamedThreadFactory;
 import org.apache.cassandra.stress.settings.SettingsJMX;
 import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.RemoteJmxMBeanAccessor;
 
 public class JmxCollector implements Callable<JmxCollector.GcStats>
 {
@@ -91,17 +91,10 @@ public class JmxCollector implements Callable<JmxCollector.GcStats>
 
     private static NodeProbe connect(String host, int port, SettingsJMX jmx)
     {
-        try
-        {
-            if (jmx.user != null && jmx.password != null)
-                return new NodeProbe(host, port, jmx.user, jmx.password);
-            else
-                return new NodeProbe(host, port);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
+        if (jmx.user != null && jmx.password != null)
+            return new NodeProbe(new RemoteJmxMBeanAccessor(host, port, jmx.user, jmx.password));
+        else
+            return new NodeProbe(new RemoteJmxMBeanAccessor(host, port));
     }
 
     public GcStats call() throws Exception


### PR DESCRIPTION
# CEP-38: Management API MVP Implementation

## Summary

This PR implements the mvp of CEP-38, enabling server-side execution of ops commands via a native management transport and CQL interface. This eliminates the need for external JMX connections.

See: https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-38%3A+CQL+Management+API

## Key Features

### 1. Management API Infrastructure

- **CommandInvokerService**: Central service managing command registry lifecycle and execution
- **Command Registry**: Hierarchical command registry supporting nested commands
- **Command Metadata**: Structured metadata for commands, options, and parameters
- **Execution Context**: Server-side execution context with `NodeProbe` integration for in-process MBean access

### 2. Native Management Transport

- **NativeTransportManagementService**: Separate native transport server on port 11211 (configurable via `native_transport_management_port`)
- **Dedicated Executor**: Management connections use a separate thread pool (`managementExecutor`) for isolation and prioritization
- **Connection Flagging**: Management connections are flagged at connection setup and routed to the management executor
- **Request Validation**: Only `COMMAND` statements are allowed on management connections; other CQL operations are rejected

### 3. CQL Command Execution

- **ExecuteCommandStatement**: New CQL statement syntax: `COMMAND <commandName> [WITH key1 = value1 AND key2 = value2]`
- **Result Format**: Commands return a result set with `execution_id` (UUID) and `output` (String) columns
- **Argument Parsing**: Supports CQL string literals, lists, and proper escaping
- **Error Handling**: Structured exceptions for validation, authorization, and execution errors

### 4. Picocli Integration

- **PicocliCommandsProvider**: Automatically discovers and registers all nodetool commands
- **Command Adapters**: `PicocliCommandAdapter` and `PicocliCommandRegistryAdapter` bridge picocli commands to the management API
- **Metadata Extraction**: Automatic extraction of command metadata from picocli annotations
- **Argument Conversion**: Bidirectional conversion between picocli command objects and `CommandExecutionArgs`

### 5. Server-Side Execution

- **InternalNodeMBeanAccessor**: In-process MBean accessor eliminating JMX/RMI overhead
- **Direct Instance Access**: Direct access to singleton instances
- **Performance Benefits**: No serialization/deserialization, no network overhead, better performance
- **NodeProbe Integration**: `NodeProbe` supports remote jmx and server-side in-process execution modes

### 6. JMX/Dynamic MBean Support

- **CommandMBean**: Each command is exposed as an dynamic MBean for JMX access and for auditing exections
- **MBean Registration**: Commands are automatically registered as MBeans under `org.apache.cassandra.management:type=Command,name=<commandName>`

### 7. Nodetool Integration

- **CqlCommandExecutionStrategy**: New execution strategy allowing nodetool to execute commands via CQL
- **Protocol-Aware Execution**: Nodetool can choose between JMX, CQL, or other protocols based on connection configuration
- **Seamless Integration**: Existing nodetool commands work without modification

## Configuration

- `start_native_management_transport`: Enable/disable management transport (default disabled - `false`)
- `native_transport_management_port`: Port for management transport (default: `11211`)
- `native_transport_management_max_threads`: Thread pool size for management operations

## Limitations

- **Authentication**: Currently only supported with `AllowAllAuthenticator` (authentication disabled). Full authentication and authorization support is planned for future releases.
- **CQL Commands**: `DESCRIBE COMMAND` will be introduces later
- **Virtual Tables**: Visibility will be introduced later

## Related

- CEP-38: https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-38%3A+CQL+Management+API
- Builds on existing nodetool command infrastructure
- Integrates with existing native transport and CQL infrastructure

## Example Usage

```
 > ./nodetool -Dcassandra.cli.execution.protocol=cql status
Connecting to 127.0.0.1:11211 via CQL...
Datacenter: datacenter1
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack 
UN  127.0.0.1  189,06 KiB  16      100,0%            6d194555-f6eb-41d0-c000-000000000001  rack1


Command execution id: 44bea459-d884-4433-9da3-ad14b42ca942
```

```
> ./cqlsh 127.0.0.1 11211
Connected to Test Cluster at 127.0.0.1:11211
[cqlsh 6.3.0 | Cassandra 5.1-SNAPSHOT | CQL spec 3.4.8 | Native protocol v5]
Use HELP for help.
cqlsh> COMMAND status;

 execution_id                         | output
--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 cf30c137-88d7-4422-8248-d571093872f3 | Datacenter: datacenter1\n=======================\nStatus=Up/Down\n|/ State=Normal/Leaving/Joining/Moving\n--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack \nUN  127.0.0.1  139,76 KiB  16      100,0%            6d194555-f6eb-41d0-c000-000000000001  rack1\n\n

cqlsh> 
```

```
-- Execute a command via CQL
INVOKE COMMAND status;

-- Execute a command with parameters
INVOKE COMMAND forcecompact WITH "keyspace" = 'mykeyspace' AND "table" = 'mytable' AND keys = ['key1', 'key2'];
```
