### PR TITLE
CASSANDRA-21136 Reject writes that modify same row more than once in a transaction

### DIFF
--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -1006,6 +1006,60 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         return fragments;
     }
 
+    public List<RowKey> getRowKeys(ClientState state, QueryOptions options)
+    {
+        List<RowKey> rowKeys = new ArrayList<>();
+        List<PartitionUpdate> updates = getTxnUpdate(state, options);
+        for (PartitionUpdate update : updates)
+        {
+            DecoratedKey key = update.partitionKey();
+            List<Clustering<?>> clusteringColumns = txnClusterings(options, state);
+            for (Clustering<?> clustering : clusteringColumns)
+                rowKeys.add(new RowKey(key, clustering));
+        }
+        return rowKeys;
+    }
+
+    public static class RowKey
+    {
+        public final DecoratedKey key;
+        public final Clustering<?> clustering;
+
+        public RowKey(DecoratedKey key, Clustering<?> clustering)
+        {
+            this.key = key;
+            this.clustering = clustering;
+        }
+
+        public DecoratedKey partitionKey()
+        {
+            return key;
+        }
+
+        public Clustering<?> clustering()
+        {
+            return clustering;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == this)
+                return true;
+            if (!(other instanceof RowKey))
+                return false;
+
+            RowKey that = (RowKey) other;
+            return this.partitionKey().equals(that.partitionKey()) && this.clustering().equals(that.clustering());
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return partitionKey().hashCode() * 31 + clustering().hashCode();
+        }
+    }
+
     final void addUpdates(UpdatesCollector collector,
                           List<ByteBuffer> keys,
                           ClientState state,

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -1006,14 +1006,14 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         return fragments;
     }
 
-    public List<RowKey> getRowKeys(ClientState state, QueryOptions options)
+    public List<RowKey> getRowKeys(List<TxnWrite.Fragment> writeFragments)
     {
         List<RowKey> rowKeys = new ArrayList<>();
-        List<PartitionUpdate> updates = getTxnUpdate(state, options);
-        for (PartitionUpdate update : updates)
+
+        for (TxnWrite.Fragment writeFragment : writeFragments)
         {
-            DecoratedKey key = update.partitionKey();
-            List<Clustering<?>> clusteringColumns = txnClusterings(options, state);
+            DecoratedKey key = writeFragment.key.partitionKey();
+            List<Clustering<?>> clusteringColumns = writeFragment.referenceOps.getClusterings();
             for (Clustering<?> clustering : clusteringColumns)
                 rowKeys.add(new RowKey(key, clustering));
         }

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -23,13 +23,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -1008,20 +1008,32 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         return fragments;
     }
 
-    public Set<RowKey> getRowKeys(List<TxnWrite.Fragment> writeFragments)
+    public <V> void forEachRowKey(List<TxnWrite.Fragment> writeFragments, Map<? super RowKey, V> map, V param, BiFunction<V, V, V> merge)
     {
-        Set<RowKey> rowKeys = new HashSet<>();
-
-        for (TxnWrite.Fragment writeFragment : writeFragments)
+        for (int i = 0, size = writeFragments.size() ; i < size ; i++)
         {
+            TxnWrite.Fragment writeFragment = writeFragments.get(i);
             DecoratedKey key = writeFragment.key.partitionKey();
             List<Clustering<?>> clusteringColumns = writeFragment.referenceOps.getClusterings();
             for (Clustering<?> clustering : clusteringColumns)
-                rowKeys.add(new RowKey(key, clustering));
+                map.merge(new RowKey(key, clustering), param, merge);
             for (Row row : writeFragment.baseUpdate)
-                rowKeys.add(new RowKey(key, row.clustering()));
+            {
+                RowKey rowKey = new RowKey(key, row.clustering());
+                if (!map.containsKey(rowKey))
+                    map.merge(new RowKey(key, row.clustering()), param, merge);
+            }
         }
-        return rowKeys;
+    }
+
+    public <V> void forEachPartitionKey(List<TxnWrite.Fragment> writeFragments, Map<? super DecoratedKey, V> map, V param, BiFunction<V, V, V> mergeFunction)
+    {
+        for (int i = 0, size = writeFragments.size(); i < size; i++)
+        {
+            TxnWrite.Fragment writeFragment = writeFragments.get(i);
+            DecoratedKey key = writeFragment.key.partitionKey();
+            map.merge(key, param, mergeFunction);
+        }
     }
 
     public static class RowKey

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -1014,15 +1014,8 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         {
             TxnWrite.Fragment writeFragment = writeFragments.get(i);
             DecoratedKey key = writeFragment.key.partitionKey();
-            List<Clustering<?>> clusteringColumns = writeFragment.referenceOps.getClusterings();
-            for (Clustering<?> clustering : clusteringColumns)
-                map.merge(new RowKey(key, clustering), param, merge);
             for (Row row : writeFragment.baseUpdate)
-            {
-                RowKey rowKey = new RowKey(key, row.clustering());
-                if (!map.containsKey(rowKey))
-                    map.merge(new RowKey(key, row.clustering()), param, merge);
-            }
+                map.merge(new RowKey(key, row.clustering()), param, merge);
         }
     }
 

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -1018,12 +1018,8 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
             List<Clustering<?>> clusteringColumns = writeFragment.referenceOps.getClusterings();
             for (Clustering<?> clustering : clusteringColumns)
                 rowKeys.add(new RowKey(key, clustering));
-            for (Iterator<Row> it = writeFragment.baseUpdate.iterator(); it.hasNext();)
-            {
-                Row row = it.next();
-                if (!clusteringColumns.contains(row.clustering()))
-                    rowKeys.add(new RowKey(key, row.clustering()));
-            }
+            for (Row row : writeFragment.baseUpdate)
+                rowKeys.add(new RowKey(key, row.clustering()));
         }
         return rowKeys;
     }

--- a/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/ModificationStatement.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -96,6 +97,7 @@ import org.apache.cassandra.db.partitions.Partition;
 import org.apache.cassandra.db.partitions.PartitionIterator;
 import org.apache.cassandra.db.partitions.PartitionIterators;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
+import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.RowIterator;
 import org.apache.cassandra.db.view.View;
 import org.apache.cassandra.dht.Token;
@@ -1006,9 +1008,9 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
         return fragments;
     }
 
-    public List<RowKey> getRowKeys(List<TxnWrite.Fragment> writeFragments)
+    public Set<RowKey> getRowKeys(List<TxnWrite.Fragment> writeFragments)
     {
-        List<RowKey> rowKeys = new ArrayList<>();
+        Set<RowKey> rowKeys = new HashSet<>();
 
         for (TxnWrite.Fragment writeFragment : writeFragments)
         {
@@ -1016,6 +1018,12 @@ public abstract class ModificationStatement implements CQLStatement.SingleKeyspa
             List<Clustering<?>> clusteringColumns = writeFragment.referenceOps.getClusterings();
             for (Clustering<?> clustering : clusteringColumns)
                 rowKeys.add(new RowKey(key, clustering));
+            for (Iterator<Row> it = writeFragment.baseUpdate.iterator(); it.hasNext();)
+            {
+                Row row = it.next();
+                if (!clusteringColumns.contains(row.clustering()))
+                    rowKeys.add(new RowKey(key, row.clustering()));
+            }
         }
         return rowKeys;
     }

--- a/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
@@ -62,7 +62,6 @@ import org.apache.cassandra.cql3.transactions.RowDataReference;
 import org.apache.cassandra.cql3.transactions.SelectReferenceSource;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.Columns;
-import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.SinglePartitionReadQuery;
 import org.apache.cassandra.db.filter.DataLimits;
@@ -106,7 +105,6 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
-import org.apache.cassandra.cql3.statements.ModificationStatement.RowKey;
 import static org.apache.cassandra.service.accord.txn.TxnData.TxnDataNameKind.AUTO_READ;
 import static org.apache.cassandra.service.accord.txn.TxnData.TxnDataNameKind.RETURNING;
 import static org.apache.cassandra.service.accord.txn.TxnData.TxnDataNameKind.USER;
@@ -133,7 +131,7 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
     public static final String SELECT_REFS_NEED_COLUMN_MESSAGE = "SELECT references must specify a column.";
     public static final String TRANSACTIONS_DISABLED_MESSAGE = "Accord transactions are disabled. (See accord.enabled in cassandra.yaml)";
     public static final String ILLEGAL_RANGE_QUERY_MESSAGE = "Range queries are not allowed for reads within a transaction; %s %s";
-    public static final String DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE = "Transaction contains update to the same key";
+    public static final String DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE = "Transaction contains multiple updates to the same key and fields";
     public static final String UNSUPPORTED_MIGRATION = "Transaction Statement is unsupported when migrating away from Accord or before migration to Accord is complete for a range";
     public static final String NO_PARTITION_IN_CLAUSE_WITH_LIMIT = "Partition key is present in IN clause and there is a LIMIT... this is currently not supported; %s statement %s";
     public static final String WRITE_TXN_EMPTY_WITH_IGNORED_READS = "Write txn produced no mutation, and its reads do not return to the caller; ignoring...";
@@ -362,8 +360,7 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
     List<TxnWrite.Fragment> createWriteFragments(ClientState state, QueryOptions options, Map<Integer, NamedSelect> autoReads, TableMetadatasAndKeys.KeyCollector keyCollector)
     {
         // check that within a transaction we don't have multiple updates to the same primary key, column pair
-        HashMap<RowKey, Columns> seenRegularColumns = new HashMap<>();
-        HashMap<DecoratedKey, Columns> seenStaticColumns = new HashMap<>();
+        HashMap<Object, Columns> seenColumns = new HashMap<>();
 
         List<TxnWrite.Fragment> fragments = new ArrayList<>(updates.size());
         int idx = 0;
@@ -372,7 +369,7 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
             minEpoch = Math.max(minEpoch, modification.metadata().epoch.getEpoch());
             List<TxnWrite.Fragment> writeFragments = modification.getTxnWriteFragment(idx, state, options, keyCollector);
             fragments.addAll(writeFragments);
-            validateOnlyModifyPrimaryKeyColumnPairOnce(seenRegularColumns, seenStaticColumns, modification, writeFragments);
+            validateOnlyModifyPrimaryKeyColumnPairOnce(seenColumns, modification, writeFragments);
 
             if (modification.allReferenceOperations().stream().anyMatch(ReferenceOperation::requiresRead))
             {
@@ -387,31 +384,21 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
         return fragments;
     }
 
-    private static void validateOnlyModifyPrimaryKeyColumnPairOnce(HashMap<RowKey, Columns> seenRegularColumns, HashMap<DecoratedKey, Columns> seenStaticColumns,
-                                                  ModificationStatement statement, List<TxnWrite.Fragment> writeFragments)
+    private static void validateOnlyModifyPrimaryKeyColumnPairOnce(HashMap<Object, Columns> seenColumns,
+                                                                   ModificationStatement statement, List<TxnWrite.Fragment> writeFragments)
     {
-        Set<RowKey> rowKeys = statement.getRowKeys(writeFragments);
         Columns regularColumns = statement.updatedColumns().columns(false);
+        statement.forEachRowKey(writeFragments, seenColumns, regularColumns, TransactionStatement::mergeColumnsIfNoDuplicates);
         Columns staticColumns = statement.updatedColumns().columns(true);
+        statement.forEachPartitionKey(writeFragments, seenColumns, staticColumns, TransactionStatement::mergeColumnsIfNoDuplicates);
+    }
 
-        for (RowKey rowKey : rowKeys)
-        {
-            Columns existingRegularColumns = seenRegularColumns.putIfAbsent(rowKey, regularColumns);
-            if (existingRegularColumns != null)
-            {
-                for (ColumnMetadata column : regularColumns)
-                    checkFalse(existingRegularColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
-                seenRegularColumns.put(rowKey, existingRegularColumns.mergeTo(regularColumns));
-            }
-
-            Columns existingStaticColumns = seenStaticColumns.putIfAbsent(rowKey.partitionKey(), staticColumns);
-            if (existingStaticColumns != null)
-            {
-                for (ColumnMetadata column : staticColumns)
-                    checkFalse(existingStaticColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
-                seenStaticColumns.put(rowKey.partitionKey(), existingStaticColumns.mergeTo(staticColumns));
-            }
-        }
+    private static Columns mergeColumnsIfNoDuplicates(Columns existing, Columns add)
+    {
+        Columns merged = existing.mergeTo(add);
+        if (merged.size() != existing.size() + add.size())
+            throw invalidRequest(DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
+        return merged;
     }
 
     private ConsistencyLevel consistencyLevelForAccordRead(ClusterMetadata cm, TableMetadatas.Complete tables, Keys keys, @Nullable ConsistencyLevel consistencyLevel)

--- a/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
@@ -361,12 +361,18 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
 
     List<TxnWrite.Fragment> createWriteFragments(ClientState state, QueryOptions options, Map<Integer, NamedSelect> autoReads, TableMetadatasAndKeys.KeyCollector keyCollector)
     {
+        // check that within a transaction we don't have multiple updates to the same primary key, column pair
+        HashMap<RowKey, Columns> seenRegularColumns = new HashMap<>();
+        HashMap<DecoratedKey, Columns> seenStaticColumns = new HashMap<>();
+
         List<TxnWrite.Fragment> fragments = new ArrayList<>(updates.size());
         int idx = 0;
         for (ModificationStatement modification : updates)
         {
             minEpoch = Math.max(minEpoch, modification.metadata().epoch.getEpoch());
-            fragments.addAll(modification.getTxnWriteFragment(idx, state, options, keyCollector));
+            List<TxnWrite.Fragment> writeFragments = modification.getTxnWriteFragment(idx, state, options, keyCollector);
+            fragments.addAll(writeFragments);
+            validateOnlyModifyPrimaryKeyColumnPairOnce(seenRegularColumns, seenStaticColumns, modification, writeFragments);
 
             if (modification.allReferenceOperations().stream().anyMatch(ReferenceOperation::requiresRead))
             {
@@ -379,6 +385,33 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
             idx++;
         }
         return fragments;
+    }
+
+    private static void validateOnlyModifyPrimaryKeyColumnPairOnce(HashMap<RowKey, Columns> seenRegularColumns, HashMap<DecoratedKey, Columns> seenStaticColumns,
+                                                  ModificationStatement statement, List<TxnWrite.Fragment> writeFragments)
+    {
+        List<RowKey> rowKeys = statement.getRowKeys(writeFragments);
+        Columns regularColumns = statement.updatedColumns().columns(false);
+        Columns staticColumns = statement.updatedColumns().columns(true);
+
+        for (RowKey rowKey : rowKeys)
+        {
+            Columns existingRegularColumns = seenRegularColumns.putIfAbsent(rowKey, regularColumns);
+            if (existingRegularColumns != null)
+            {
+                for (ColumnMetadata column : regularColumns)
+                    checkFalse(existingRegularColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
+                seenRegularColumns.put(rowKey, existingRegularColumns.mergeTo(regularColumns));
+            }
+
+            Columns existingStaticColumns = seenStaticColumns.putIfAbsent(rowKey.partitionKey(), staticColumns);
+            if (existingStaticColumns != null)
+            {
+                for (ColumnMetadata column : staticColumns)
+                    checkFalse(existingStaticColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
+                seenStaticColumns.put(rowKey.partitionKey(), existingStaticColumns.mergeTo(staticColumns));
+            }
+        }
     }
 
     private ConsistencyLevel consistencyLevelForAccordRead(ClusterMetadata cm, TableMetadatas.Complete tables, Keys keys, @Nullable ConsistencyLevel consistencyLevel)
@@ -558,36 +591,6 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
         if (returningSelect != null && returningSelect.select.getRestrictions().keyIsInRelation())
         {
             checkTrue(returningSelect.select.getLimit(options) == DataLimits.NO_LIMIT, NO_PARTITION_IN_CLAUSE_WITH_LIMIT, "SELECT", returningSelect.select.source);
-        }
-
-        // check that within a transaction we don't have multiple updates to the same primary key, column pair
-        HashMap<RowKey, Columns> seenRegularColumns = new HashMap<>();
-        HashMap<DecoratedKey, Columns> seenStaticColumns = new HashMap<>();
-
-        for (ModificationStatement statement : updates)
-        {
-            List<RowKey> rowKeys = statement.getRowKeys(state.getClientState(), options);
-            Columns regularColumns = statement.updatedColumns().columns(false);
-            Columns staticColumns = statement.updatedColumns().columns(true);
-
-            for (RowKey rowKey : rowKeys)
-            {
-                Columns existingRegularColumns = seenRegularColumns.putIfAbsent(rowKey, regularColumns);
-                if (existingRegularColumns != null)
-                {
-                    for (ColumnMetadata column : regularColumns)
-                        checkFalse(existingRegularColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
-                    seenRegularColumns.put(rowKey, existingRegularColumns.mergeTo(regularColumns));
-                }
-
-                Columns existingStaticColumns = seenStaticColumns.putIfAbsent(rowKey.partitionKey(), staticColumns);
-                if (existingStaticColumns != null)
-                {
-                    for (ColumnMetadata column : staticColumns)
-                        checkFalse(existingStaticColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
-                    seenStaticColumns.put(rowKey.partitionKey(), existingStaticColumns.mergeTo(staticColumns));
-                }
-            }
         }
 
         Txn txn = createTxn(state.getClientState(), options);

--- a/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
@@ -61,6 +61,8 @@ import org.apache.cassandra.cql3.transactions.ReferenceOperation;
 import org.apache.cassandra.cql3.transactions.RowDataReference;
 import org.apache.cassandra.cql3.transactions.SelectReferenceSource;
 import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.db.Columns;
+import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.SinglePartitionReadCommand;
 import org.apache.cassandra.db.SinglePartitionReadQuery;
 import org.apache.cassandra.db.filter.DataLimits;
@@ -104,6 +106,7 @@ import static org.apache.cassandra.cql3.statements.RequestValidations.checkFalse
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkNotNull;
 import static org.apache.cassandra.cql3.statements.RequestValidations.checkTrue;
 import static org.apache.cassandra.cql3.statements.RequestValidations.invalidRequest;
+import org.apache.cassandra.cql3.statements.ModificationStatement.RowKey;
 import static org.apache.cassandra.service.accord.txn.TxnData.TxnDataNameKind.AUTO_READ;
 import static org.apache.cassandra.service.accord.txn.TxnData.TxnDataNameKind.RETURNING;
 import static org.apache.cassandra.service.accord.txn.TxnData.TxnDataNameKind.USER;
@@ -130,6 +133,7 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
     public static final String SELECT_REFS_NEED_COLUMN_MESSAGE = "SELECT references must specify a column.";
     public static final String TRANSACTIONS_DISABLED_MESSAGE = "Accord transactions are disabled. (See accord.enabled in cassandra.yaml)";
     public static final String ILLEGAL_RANGE_QUERY_MESSAGE = "Range queries are not allowed for reads within a transaction; %s %s";
+    public static final String DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE = "Transaction contains update to the same key";
     public static final String UNSUPPORTED_MIGRATION = "Transaction Statement is unsupported when migrating away from Accord or before migration to Accord is complete for a range";
     public static final String NO_PARTITION_IN_CLAUSE_WITH_LIMIT = "Partition key is present in IN clause and there is a LIMIT... this is currently not supported; %s statement %s";
     public static final String WRITE_TXN_EMPTY_WITH_IGNORED_READS = "Write txn produced no mutation, and its reads do not return to the caller; ignoring...";
@@ -554,6 +558,36 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
         if (returningSelect != null && returningSelect.select.getRestrictions().keyIsInRelation())
         {
             checkTrue(returningSelect.select.getLimit(options) == DataLimits.NO_LIMIT, NO_PARTITION_IN_CLAUSE_WITH_LIMIT, "SELECT", returningSelect.select.source);
+        }
+
+        // check that within a transaction we don't have multiple updates to the same primary key, column pair
+        HashMap<RowKey, Columns> seenRegularColumns = new HashMap<>();
+        HashMap<DecoratedKey, Columns> seenStaticColumns = new HashMap<>();
+
+        for (ModificationStatement statement : updates)
+        {
+            List<RowKey> rowKeys = statement.getRowKeys(state.getClientState(), options);
+            Columns regularColumns = statement.updatedColumns().columns(false);
+            Columns staticColumns = statement.updatedColumns().columns(true);
+
+            for (RowKey rowKey : rowKeys)
+            {
+                Columns existingRegularColumns = seenRegularColumns.putIfAbsent(rowKey, regularColumns);
+                if (existingRegularColumns != null)
+                {
+                    for (ColumnMetadata column : regularColumns)
+                        checkFalse(existingRegularColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
+                    seenRegularColumns.put(rowKey, existingRegularColumns.mergeTo(regularColumns));
+                }
+
+                Columns existingStaticColumns = seenStaticColumns.putIfAbsent(rowKey.partitionKey(), staticColumns);
+                if (existingStaticColumns != null)
+                {
+                    for (ColumnMetadata column : staticColumns)
+                        checkFalse(existingStaticColumns.contains(column), DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE);
+                    seenStaticColumns.put(rowKey.partitionKey(), existingStaticColumns.mergeTo(staticColumns));
+                }
+            }
         }
 
         Txn txn = createTxn(state.getClientState(), options);

--- a/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
+++ b/src/java/org/apache/cassandra/cql3/statements/TransactionStatement.java
@@ -390,7 +390,7 @@ public class TransactionStatement implements CQLStatement.CompositeCQLStatement,
     private static void validateOnlyModifyPrimaryKeyColumnPairOnce(HashMap<RowKey, Columns> seenRegularColumns, HashMap<DecoratedKey, Columns> seenStaticColumns,
                                                   ModificationStatement statement, List<TxnWrite.Fragment> writeFragments)
     {
-        List<RowKey> rowKeys = statement.getRowKeys(writeFragments);
+        Set<RowKey> rowKeys = statement.getRowKeys(writeFragments);
         Columns regularColumns = statement.updatedColumns().columns(false);
         Columns staticColumns = statement.updatedColumns().columns(true);
 

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperations.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperations.java
@@ -63,11 +63,6 @@ public class TxnReferenceOperations
         return metadata.equals(that.metadata) && clusterings.equals(that.clusterings) && regulars.equals(that.regulars) && statics.equals(that.statics);
     }
 
-    public List<Clustering<?>> getClusterings()
-    {
-        return clusterings;
-    }
-
     @Override
     public int hashCode()
     {

--- a/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperations.java
+++ b/src/java/org/apache/cassandra/service/accord/txn/TxnReferenceOperations.java
@@ -63,6 +63,11 @@ public class TxnReferenceOperations
         return metadata.equals(that.metadata) && clusterings.equals(that.clusterings) && regulars.equals(that.regulars) && statics.equals(that.statics);
     }
 
+    public List<Clustering<?>> getClusterings()
+    {
+        return clusterings;
+    }
+
     @Override
     public int hashCode()
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -206,6 +206,81 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
+    public void testRejectTransactionWithUpdatesToSamePrimaryKeySameColumns() throws Exception
+    {
+        test(cluster -> {
+            try
+            {
+                cluster.coordinator(1).execute(wrapInTxn("INSERT INTO " + qualifiedAccordTableName + " (k, c, v) VALUES (?, ?, ?)"), ConsistencyLevel.ALL, 1, 1, 2);
+                String txn = "BEGIN TRANSACTION\n" +
+                             "  UPDATE " + qualifiedAccordTableName + " SET v = 2 WHERE k = 1 AND c = 1;\n" +
+                             "  UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1 AND c = 1;\n" +
+                             "COMMIT TRANSACTION";
+
+                cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
+                assertEquals(TransactionStatement.DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE, t.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testRejectTransactionWithUpdatesToSamePrimaryKeyWithInClause() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, r int, j int, primary key (k, c, v)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            try
+            {
+                cluster.coordinator(1).execute(wrapInTxn("INSERT INTO " + qualifiedAccordTableName + " (k, c, v, r, j) VALUES (?, ?, ?, ?, ?)"), ConsistencyLevel.ALL, 1, 1, 1, 3, 5);
+                cluster.coordinator(1).execute(wrapInTxn("INSERT INTO " + qualifiedAccordTableName + " (k, c, v, r, j) VALUES (?, ?, ?, ?, ?)"), ConsistencyLevel.ALL, 2, 2, 2, 3, 5);
+                String txn = "BEGIN TRANSACTION\n" +
+                             "  UPDATE " + qualifiedAccordTableName + " SET j = 5 WHERE k = 1 AND c = 1 AND v IN (1, 2);\n" +
+                             "  UPDATE " + qualifiedAccordTableName + " SET j = 3 WHERE k = 1 AND c = 1 AND v = 2;\n" +
+                             "COMMIT TRANSACTION";
+
+                cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+                fail("Expected exception");
+            }
+            catch (Throwable t)
+            {
+                assertEquals(InvalidRequestException.class.getName(), t.getClass().getName());
+                assertEquals(TransactionStatement.DUPLICATE_KEYS_IN_SAME_TRANSACTION_MESSAGE, t.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testAcceptTransactionWithUpdatesToSamePrimaryKeyButDifferentColumns() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, r int, primary key (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            cluster.coordinator(1).execute(wrapInTxn("INSERT INTO " + qualifiedAccordTableName + " (k, c, v, r) VALUES (?, ?, ?, ?)"), ConsistencyLevel.ALL, 1, 1, 2, 3);
+            String txn = "BEGIN TRANSACTION\n" +
+                         "  UPDATE " + qualifiedAccordTableName + " SET v = 2 WHERE k = 1 AND c = 1;\n" +
+                         "  UPDATE " + qualifiedAccordTableName + " SET r = 10 WHERE k = 1 AND c = 1;\n" +
+                         "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+        });
+    }
+
+    @Test
+    public void testAcceptTransactionWithUpdatesToSamePrimaryKeyDisjointColumns() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, v int, r int, j int, primary key (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            cluster.coordinator(1).execute(wrapInTxn("INSERT INTO " + qualifiedAccordTableName + " (k, c, v, r, j) VALUES (?, ?, ?, ?, ?)"), ConsistencyLevel.ALL, 1, 1, 2, 3, 5);
+            String txn = "BEGIN TRANSACTION\n" +
+                         "  UPDATE " + qualifiedAccordTableName + " SET r = 2, j = 5 WHERE k = 1 AND c = 1;\n" +
+                         "  UPDATE " + qualifiedAccordTableName + " SET v = 10 WHERE k = 1 AND c = 1;\n" +
+                         "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+        });
+    }
+
+    @Test
     public void testCounterCreateTableTransactionalModeFails() throws Exception
     {
         try

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordCQLTestBase.java
@@ -281,6 +281,19 @@ public abstract class AccordCQLTestBase extends AccordTestBase
     }
 
     @Test
+    public void testAcceptTransactionWithSameStaticColumnUpdatedWithInClause() throws Exception
+    {
+        test("CREATE TABLE " + qualifiedAccordTableName + " (k int, c int, j int STATIC, v int, primary key (k, c)) WITH " + transactionalMode.asCqlParam(), cluster -> {
+            cluster.coordinator(1).execute(wrapInTxn("INSERT INTO " + qualifiedAccordTableName + " (k, c, j, v) VALUES (?, ?, ?, ?)"), ConsistencyLevel.ALL, 1, 1, 2, 2);
+            String txn = "BEGIN TRANSACTION\n" +
+                         "  UPDATE " + qualifiedAccordTableName + " SET j = 2, v = 1 WHERE k = 1 AND c IN (1, 2);\n" +
+                         "COMMIT TRANSACTION";
+
+            cluster.coordinator(1).executeWithResult(txn, ConsistencyLevel.SERIAL);
+        });
+    }
+
+    @Test
     public void testCounterCreateTableTransactionalModeFails() throws Exception
     {
         try


### PR DESCRIPTION
Rejects writes that modifies the same row, col pair more than once in a transaction 

patch by Alan Wang;

reviewed by for [CASSANDRA-21136](https://issues.apache.org/jira/browse/CASSANDRA-21136)

Co-authored-by: Name1
Co-authored-by: Name2