### PR TITLE
CASSANDRA-17684 Bundle CQL.html as Python package resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ data/
 conf/hotspot_compiler
 doc/cql3/CQL.html
 doc/build/
+pylib/cqlshlib/resources/CQL.html
+pylib/cqlshlib/resources/CQL.css
 lib/
 pylib/src/
 **/cqlshlib.xml

--- a/build.xml
+++ b/build.xml
@@ -65,6 +65,7 @@
     <property name="build.classes.main" value="${build.classes}/main" />
     <property name="javadoc.dir" value="${build.dir}/javadoc"/>
     <property name="interface.dir" value="${basedir}/interface"/>
+    <property name="pylib.resources" value="${basedir}/pylib/cqlshlib/resources"/>
     <property name="test.dir" value="${basedir}/test"/>
     <property name="test.resources" value="${test.dir}/resources"/>
     <property name="test.lib" value="${build.dir}/test/lib"/>
@@ -458,6 +459,8 @@
         <delete dir="${version.properties.dir}" />
         <delete dir="${jacoco.export.dir}" />
         <delete dir="${jacoco.partials.dir}"/>
+        <delete file="${pylib.resources}/CQL.html"/>
+        <delete file="${pylib.resources}/CQL.css"/>
     </target>
     <target depends="clean" name="cleanall"/>
 
@@ -504,6 +507,16 @@
                 <include name="doc/cql3/*.textile"/>
             </fileset>
         </wikitext-to-html>
+    </target>
+
+    <target name="copy-cql-docs-to-pylib" depends="generate-cql-html"
+            description="Copy CQL documentation to pylib resources for packaging">
+        <copy todir="${pylib.resources}" failonerror="true">
+            <fileset dir="doc/cql3">
+                <include name="CQL.html"/>
+                <include name="CQL.css"/>
+            </fileset>
+        </copy>
     </target>
 
     <target name="gen-asciidoc" description="Generate dynamic asciidoc pages" depends="jar" unless="ant.gen-doc.skip">
@@ -586,7 +599,7 @@
         </javac>
     </target>
 
-    <target depends="init,gen-cql3-grammar,generate-cql-html,generate-jflex-java"
+    <target depends="init,gen-cql3-grammar,copy-cql-docs-to-pylib,generate-jflex-java"
             name="build-project">
         <echo message="${ant.project.name}: ${ant.file}"/>
         <!-- Order matters! -->

--- a/build.xml
+++ b/build.xml
@@ -511,6 +511,7 @@
 
     <target name="copy-cql-docs-to-pylib" depends="generate-cql-html"
             description="Copy CQL documentation to pylib resources for packaging">
+        <mkdir dir="${pylib.resources}"/>
         <copy todir="${pylib.resources}" failonerror="true">
             <fileset dir="doc/cql3">
                 <include name="CQL.html"/>

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -2159,20 +2159,28 @@ def _get_docs_from_package_resource():
     """
     Attempt to load CQL documentation from package resources.
     Returns a file:// URL to the resource, or None if unavailable.
+
+    Note: This only works for packages installed on the filesystem.
+    For zipped packages, returns None and the caller falls back to online docs.
     """
     try:
+        from pathlib import Path
         if sys.version_info >= (3, 9):
-            from importlib.resources import files, as_file
+            from importlib.resources import files
             resource = files('cqlshlib.resources').joinpath('CQL.html')
-            with as_file(resource) as path:
-                if path.exists():
-                    return 'file://' + str(path.resolve())
+            # Convert to path and check if it exists on the real filesystem.
+            # For zipped packages, this path won't exist, so we fall back to online docs.
+            resource_path = Path(str(resource))
+            if resource_path.is_file():
+                return 'file://' + str(resource_path.resolve())
         else:
-            # Python 3.8 compatibility
-            from importlib.resources import path as resource_path
-            with resource_path('cqlshlib.resources', 'CQL.html') as path:
-                if path.exists():
-                    return 'file://' + str(path.resolve())
+            # Python 3.8 compatibility: locate the package directory directly
+            import importlib.util
+            spec = importlib.util.find_spec('cqlshlib.resources')
+            if spec and spec.origin:
+                resource_path = Path(spec.origin).parent / 'CQL.html'
+                if resource_path.is_file():
+                    return 'file://' + str(resource_path.resolve())
     except Exception:
         pass
     return None

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -2182,6 +2182,8 @@ def _get_docs_from_package_resource():
                 if resource_path.is_file():
                     return 'file://' + str(resource_path.resolve())
     except Exception:
+        # Any error while loading the bundled CQL docs is non-fatal;
+        # pass to fall back to other locations.
         pass
     return None
 

--- a/pylib/cqlshlib/cqlshmain.py
+++ b/pylib/cqlshlib/cqlshmain.py
@@ -2125,14 +2125,57 @@ def read_options(cmdlineargs, parser, config_file, cql_dir, environment=os.envir
 
 
 def get_docspath(path):
-    cqldocs_url = Shell.DEFAULT_CQLDOCS_URL
-    if os.path.exists(path + '/doc/cql3/CQL.html'):
-        # default location of local CQL.html
-        cqldocs_url = 'file://' + path + '/doc/cql3/CQL.html'
-    elif os.path.exists('/usr/share/doc/cassandra/CQL.html'):
-        # fallback to package file
-        cqldocs_url = 'file:///usr/share/doc/cassandra/CQL.html'
-    return cqldocs_url
+    """
+    Determine the URL for CQL documentation.
+
+    Priority order:
+    1. Local development/tarball path: {path}/doc/cql3/CQL.html
+    2. Linux package path: /usr/share/doc/cassandra/CQL.html
+    3. macOS path: /usr/local/share/doc/cassandra/CQL.html
+    4. Bundled package resource (for pip installs, etc.)
+    5. Online documentation URL (fallback)
+    """
+    # Check local dev/tarball path
+    local_path = os.path.join(path, 'doc', 'cql3', 'CQL.html')
+    if os.path.exists(local_path):
+        return 'file://' + os.path.abspath(local_path)
+
+    # Check system package installation paths
+    for system_path in ['/usr/share/doc/cassandra/CQL.html',
+                        '/usr/local/share/doc/cassandra/CQL.html']:
+        if os.path.exists(system_path):
+            return 'file://' + system_path
+
+    # Try to load from package resources
+    resource_url = _get_docs_from_package_resource()
+    if resource_url:
+        return resource_url
+
+    # Fall back to online documentation
+    return Shell.DEFAULT_CQLDOCS_URL
+
+
+def _get_docs_from_package_resource():
+    """
+    Attempt to load CQL documentation from package resources.
+    Returns a file:// URL to the resource, or None if unavailable.
+    """
+    try:
+        if sys.version_info >= (3, 9):
+            from importlib.resources import files, as_file
+            resource = files('cqlshlib.resources').joinpath('CQL.html')
+            with as_file(resource) as path:
+                if path.exists():
+                    return 'file://' + str(path.resolve())
+        else:
+            # Python 3.8 compatibility
+            from importlib.resources import path as resource_path
+            with resource_path('cqlshlib.resources', 'CQL.html') as path:
+                if path.exists():
+                    return 'file://' + str(path.resolve())
+    except Exception:
+        pass
+    return None
 
 
 def insert_driver_hooks():

--- a/pylib/cqlshlib/resources/__init__.py
+++ b/pylib/cqlshlib/resources/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,25 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-from distutils.core import setup
+"""
+Bundled resources for cqlshlib.
 
-
-def get_extensions():
-    if "--no-compile" in sys.argv:
-        return []
-
-    from Cython.Build import cythonize
-    return cythonize("cqlshlib/copyutil.py")
-
-
-setup(
-    name="cassandra-pylib",
-    description="Cassandra Python Libraries",
-    packages=["cqlshlib", "cqlshlib.resources"],
-    package_data={
-        "cqlshlib.resources": ["CQL.html", "CQL.css"],
-    },
-    include_package_data=True,
-    ext_modules=get_extensions(),
-)
+This package contains static resources (like CQL documentation) that are
+bundled with cqlshlib for distribution as a Python package. These resources
+are used as fallbacks when the documentation cannot be found in the standard
+installation paths.
+"""

--- a/pylib/cqlshlib/test/test_docspath.py
+++ b/pylib/cqlshlib/test/test_docspath.py
@@ -138,3 +138,52 @@ class TestGetDocsFromPackageResource(BaseTestCase):
             with patch('importlib.resources.files', side_effect=Exception("Test error")):
                 result = _get_docs_from_package_resource()
                 self.assertIsNone(result)
+
+    def test_python38_returns_none_on_import_error(self):
+        """Should return None if importlib.resources is not available on Python 3.8."""
+        with patch.dict('sys.modules', {'importlib.resources': None}):
+            with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
+                with patch('builtins.__import__', side_effect=ImportError):
+                    result = _get_docs_from_package_resource()
+                    self.assertIsNone(result)
+
+    def test_python38_returns_none_when_resource_not_found(self):
+        """Should return None if the resource file doesn't exist on Python 3.8."""
+        from unittest.mock import MagicMock
+        from contextlib import contextmanager
+
+        @contextmanager
+        def mock_resource_path(package, resource):
+            mock_path = MagicMock()
+            mock_path.exists.return_value = False
+            yield mock_path
+
+        with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
+            with patch('importlib.resources.path', mock_resource_path):
+                result = _get_docs_from_package_resource()
+                self.assertIsNone(result)
+
+    def test_python38_exception_handling(self):
+        """Should handle exceptions gracefully and return None on Python 3.8."""
+        with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
+            with patch('importlib.resources.path', side_effect=Exception("Test error")):
+                result = _get_docs_from_package_resource()
+                self.assertIsNone(result)
+
+    def test_python38_returns_file_url_when_resource_exists(self):
+        """Should return file:// URL when resource exists on Python 3.8."""
+        from unittest.mock import MagicMock
+        from contextlib import contextmanager
+        from pathlib import Path
+
+        @contextmanager
+        def mock_resource_path(package, resource):
+            mock_path = MagicMock(spec=Path)
+            mock_path.exists.return_value = True
+            mock_path.resolve.return_value = Path('/fake/path/CQL.html')
+            yield mock_path
+
+        with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
+            with patch('importlib.resources.path', mock_resource_path):
+                result = _get_docs_from_package_resource()
+                self.assertEqual(result, 'file:///fake/path/CQL.html')

--- a/pylib/cqlshlib/test/test_docspath.py
+++ b/pylib/cqlshlib/test/test_docspath.py
@@ -115,22 +115,27 @@ class TestGetDocsFromPackageResource(BaseTestCase):
                     self.assertIsNone(result)
 
     def test_returns_none_when_resource_not_found(self):
-        """Should return None if the resource file doesn't exist."""
+        """Should return None if the resource file doesn't exist on filesystem."""
         from unittest.mock import MagicMock
-        from contextlib import contextmanager
-
-        @contextmanager
-        def mock_as_file(resource):
-            mock_path = MagicMock()
-            mock_path.exists.return_value = False
-            yield mock_path
 
         with patch('cqlshlib.cqlshmain.sys.version_info', (3, 9)):
             with patch('importlib.resources.files') as mock_files:
-                with patch('importlib.resources.as_file', mock_as_file):
-                    mock_files.return_value.joinpath.return_value = MagicMock()
+                mock_files.return_value.joinpath.return_value = '/wrong/path/CQL.html'
+                result = _get_docs_from_package_resource()
+                self.assertIsNone(result)
+
+    def test_returns_file_url_when_resource_exists(self):
+        """Should return file:// URL when resource exists on filesystem."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resource_file = os.path.join(tmpdir, 'CQL.html')
+            with open(resource_file, 'w') as f:
+                f.write('<html></html>')
+
+            with patch('cqlshlib.cqlshmain.sys.version_info', (3, 9)):
+                with patch('importlib.resources.files') as mock_files:
+                    mock_files.return_value.joinpath.return_value = resource_file
                     result = _get_docs_from_package_resource()
-                    self.assertIsNone(result)
+                    self.assertEqual(result, 'file://' + os.path.realpath(resource_file))
 
     def test_exception_handling(self):
         """Should handle exceptions gracefully and return None."""
@@ -140,50 +145,52 @@ class TestGetDocsFromPackageResource(BaseTestCase):
                 self.assertIsNone(result)
 
     def test_python38_returns_none_on_import_error(self):
-        """Should return None if importlib.resources is not available on Python 3.8."""
-        with patch.dict('sys.modules', {'importlib.resources': None}):
+        """Should return None if importlib.util is not available on Python 3.8."""
+        with patch.dict('sys.modules', {'importlib.util': None}):
             with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
                 with patch('builtins.__import__', side_effect=ImportError):
                     result = _get_docs_from_package_resource()
                     self.assertIsNone(result)
 
-    def test_python38_returns_none_when_resource_not_found(self):
-        """Should return None if the resource file doesn't exist on Python 3.8."""
-        from unittest.mock import MagicMock
-        from contextlib import contextmanager
-
-        @contextmanager
-        def mock_resource_path(package, resource):
-            mock_path = MagicMock()
-            mock_path.exists.return_value = False
-            yield mock_path
-
+    def test_python38_returns_none_when_spec_not_found(self):
+        """Should return None if package spec is not found on Python 3.8."""
         with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
-            with patch('importlib.resources.path', mock_resource_path):
+            with patch('importlib.util.find_spec', return_value=None):
                 result = _get_docs_from_package_resource()
                 self.assertIsNone(result)
 
-    def test_python38_exception_handling(self):
-        """Should handle exceptions gracefully and return None on Python 3.8."""
+    def test_python38_returns_none_when_resource_not_found(self):
+        """Should return None if the resource file doesn't exist on Python 3.8."""
+        from unittest.mock import MagicMock
+
+        mock_spec = MagicMock()
+        mock_spec.origin = '/wrong/package/__init__.py'
+
         with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
-            with patch('importlib.resources.path', side_effect=Exception("Test error")):
+            with patch('importlib.util.find_spec', return_value=mock_spec):
                 result = _get_docs_from_package_resource()
                 self.assertIsNone(result)
 
     def test_python38_returns_file_url_when_resource_exists(self):
         """Should return file:// URL when resource exists on Python 3.8."""
         from unittest.mock import MagicMock
-        from contextlib import contextmanager
-        from pathlib import Path
 
-        @contextmanager
-        def mock_resource_path(package, resource):
-            mock_path = MagicMock(spec=Path)
-            mock_path.exists.return_value = True
-            mock_path.resolve.return_value = Path('/fake/path/CQL.html')
-            yield mock_path
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resource_file = os.path.join(tmpdir, 'CQL.html')
+            with open(resource_file, 'w') as f:
+                f.write('<html></html>')
 
+            mock_spec = MagicMock()
+            mock_spec.origin = os.path.join(tmpdir, '__init__.py')
+
+            with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
+                with patch('importlib.util.find_spec', return_value=mock_spec):
+                    result = _get_docs_from_package_resource()
+                    self.assertEqual(result, 'file://' + os.path.realpath(resource_file))
+
+    def test_python38_exception_handling(self):
+        """Should handle exceptions gracefully and return None on Python 3.8."""
         with patch('cqlshlib.cqlshmain.sys.version_info', (3, 8)):
-            with patch('importlib.resources.path', mock_resource_path):
+            with patch('importlib.util.find_spec', side_effect=Exception("Test error")):
                 result = _get_docs_from_package_resource()
-                self.assertEqual(result, 'file:///fake/path/CQL.html')
+                self.assertIsNone(result)

--- a/pylib/cqlshlib/test/test_docspath.py
+++ b/pylib/cqlshlib/test/test_docspath.py
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from unittest.mock import patch
+
+from .basecase import BaseTestCase
+from cqlshlib.cqlshmain import get_docspath, _get_docs_from_package_resource, Shell
+
+
+class TestGetDocspath(BaseTestCase):
+    """
+    Tests for the get_docspath() function.
+
+    Verifies that CQL documentation paths are resolved according to the
+    function's priority logic.
+    """
+
+    def test_local_dev_path(self):
+        """Local doc/cql3/CQL.html takes precedence over all other paths."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docs_dir = os.path.join(tmpdir, 'doc', 'cql3')
+            os.makedirs(docs_dir)
+            docs_file = os.path.join(docs_dir, 'CQL.html')
+            with open(docs_file, 'w') as f:
+                f.write('<html></html>')
+
+            result = get_docspath(tmpdir)
+
+            self.assertTrue(result.startswith('file://'))
+            self.assertIn('doc/cql3/CQL.html', result)
+            self.assertEqual(result, 'file://' + os.path.abspath(docs_file))
+
+    def test_linux_package_path(self):
+        """Linux package path when local path doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('os.path.exists') as mock_exists:
+                def exists_side_effect(path):
+                    if path == os.path.join(tmpdir, 'doc', 'cql3', 'CQL.html'):
+                        return False
+                    if path == '/usr/share/doc/cassandra/CQL.html':
+                        return True
+                    return False
+
+                mock_exists.side_effect = exists_side_effect
+
+                result = get_docspath(tmpdir)
+
+                self.assertEqual(result, 'file:///usr/share/doc/cassandra/CQL.html')
+
+    def test_macos_path(self):
+        """macOS path when local and Linux paths don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('os.path.exists') as mock_exists:
+                def exists_side_effect(path):
+                    if path == os.path.join(tmpdir, 'doc', 'cql3', 'CQL.html'):
+                        return False
+                    if path == '/usr/share/doc/cassandra/CQL.html':
+                        return False
+                    if path == '/usr/local/share/doc/cassandra/CQL.html':
+                        return True
+                    return False
+
+                mock_exists.side_effect = exists_side_effect
+
+                result = get_docspath(tmpdir)
+
+                self.assertEqual(result, 'file:///usr/local/share/doc/cassandra/CQL.html')
+
+    def test_package_resource(self):
+        """Package resource when filesystem paths don't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('os.path.exists', return_value=False):
+                with patch('cqlshlib.cqlshmain._get_docs_from_package_resource') as mock_resource:
+                    mock_resource.return_value = 'file:///some/resource/path/CQL.html'
+
+                    result = get_docspath(tmpdir)
+
+                    self.assertEqual(result, 'file:///some/resource/path/CQL.html')
+                    mock_resource.assert_called_once()
+
+    def test_online_url_fallback(self):
+        """Online documentation URL when all local paths fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('os.path.exists', return_value=False):
+                with patch('cqlshlib.cqlshmain._get_docs_from_package_resource', return_value=None):
+                    result = get_docspath(tmpdir)
+
+                    self.assertEqual(result, Shell.DEFAULT_CQLDOCS_URL)
+
+
+class TestGetDocsFromPackageResource(BaseTestCase):
+    """Tests for the _get_docs_from_package_resource() function."""
+
+    def test_returns_none_on_import_error(self):
+        """Should return None if importlib.resources is not available."""
+        with patch.dict('sys.modules', {'importlib.resources': None}):
+            with patch('cqlshlib.cqlshmain.sys.version_info', (3, 9)):
+                with patch('builtins.__import__', side_effect=ImportError):
+                    result = _get_docs_from_package_resource()
+                    self.assertIsNone(result)
+
+    def test_returns_none_when_resource_not_found(self):
+        """Should return None if the resource file doesn't exist."""
+        from unittest.mock import MagicMock
+        from contextlib import contextmanager
+
+        @contextmanager
+        def mock_as_file(resource):
+            mock_path = MagicMock()
+            mock_path.exists.return_value = False
+            yield mock_path
+
+        with patch('cqlshlib.cqlshmain.sys.version_info', (3, 9)):
+            with patch('importlib.resources.files') as mock_files:
+                with patch('importlib.resources.as_file', mock_as_file):
+                    mock_files.return_value.joinpath.return_value = MagicMock()
+                    result = _get_docs_from_package_resource()
+                    self.assertIsNone(result)
+
+    def test_exception_handling(self):
+        """Should handle exceptions gracefully and return None."""
+        with patch('cqlshlib.cqlshmain.sys.version_info', (3, 9)):
+            with patch('importlib.resources.files', side_effect=Exception("Test error")):
+                result = _get_docs_from_package_resource()
+                self.assertIsNone(result)

--- a/pylib/setup.py
+++ b/pylib/setup.py
@@ -34,6 +34,5 @@ setup(
     package_data={
         "cqlshlib.resources": ["CQL.html", "CQL.css"],
     },
-    include_package_data=True,
     ext_modules=get_extensions(),
 )


### PR DESCRIPTION
Fixes macOS compatibility for `cqlsh HELP` command by bundling `CQL.html` as a Python package resource. This is meant to be a second attempt of the approach in #2592.

On macOS, `/usr/share` is not writable, and `/usr/local/share` is the preferred location instead. This PR:
- adds `/usr/local/share` path as a fallback for macOS, and
- bundles the documentation as a Python package resource, allowing it to work for any installation method

## Changes

- `pylib/cqlshlib/resources/__init__.py`: New subpackage for bundled resources
- `pylib/setup.py`: Added `package_data` to include CQL.html/CSS
- `pylib/cqlshlib/cqlshmain.py`: Updated `get_docspath()` with updated retrieval logic/priority of docs path (ordered by priority):
  - Local dev/tarball path
  - Linux package path (`/usr/share/doc/cassandra/`)
  - macOS path (`/usr/local/share/doc/cassandra/`)
  - Bundled package resource via `importlib.resources`
  - Online documentation URL (fallback) *[Note: the current default CQLDOCS URL 404s]*
- `build.xml`: Added target to copy CQL docs to pylib during build
- `.gitignore`: Ignore generated resource files
- `pylib/cqlshlib/test/test_docspath.py`: Unit tests for the new functionality

## Testing

### General
- Unit tests pass
- `ant build` creates `pylib/cqlshlib/resources/CQL.{html,css}`
- `bin/cqlsh -e "HELP select”` opens appropiate path given different install locations of `CQL.{html,css}`

### Local Dev (any OS)

`HELP SELECT` should open help docs from the `doc/cql3/CQL.html` path of your local repository. If this file is renamed/deleted, then `HELP SELECT` should open from a lower priority path (such as online docs URL, or Python package resource location if installed)

```bash
# Build Cassandra + help resources
ant jar

# Start Cassandra
bin/cassandra -f &

# Wait for startup, then run “HELP SELECT” with cqlsh
bin/cqlsh -e "HELP select"
```