### PR TITLE
CASSANDRA-21135 Fix JMXFeatureTest failure due to disabled AsyncProfiler

### DIFF
--- a/src/java/org/apache/cassandra/service/AsyncProfilerService.java
+++ b/src/java/org/apache/cassandra/service/AsyncProfilerService.java
@@ -368,6 +368,10 @@ public class AsyncProfilerService implements AsyncProfilerMBean
     @Override
     public String status()
     {
+        if (!ASYNC_PROFILER_ENABLED.getBoolean())
+        {
+             return "Async Profiler is not enabled. Enable it by setting " + ASYNC_PROFILER_ENABLED.getKey() + " property to true.";
+        }
         return run(new ThrowingFunction<>()
         {
             @Override

--- a/test/unit/org/apache/cassandra/service/AsyncProfilerServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/AsyncProfilerServiceTest.java
@@ -264,14 +264,13 @@ public class AsyncProfilerServiceTest
     }
 
     @Test
-    public void testProfilerDisabledThrowsException()
+    public void testProfilerDisabledReturnsMessage()
     {
         try (WithProperties properties = new WithProperties().set(ASYNC_PROFILER_UNSAFE_MODE, true).set(ASYNC_PROFILER_ENABLED, false))
         {
-            assertThatThrownBy(() -> {
-                AsyncProfilerService profiler = getProfiler(true);
-                profiler.status();
-            }).hasMessageContaining("Async Profiler is not enabled. Enable it by setting cassandra.async_profiler.enabled property to true.");
+            AsyncProfilerService profiler = getProfiler(true);
+            String status = profiler.status();
+            assertTrue(status.contains("Async Profiler is not enabled. Enable it by setting cassandra.async_profiler.enabled property to true."));
         }
     }
 


### PR DESCRIPTION
**Jira Link:** CASSANDRA-21135

**Description:**
This PR fixes a regression in `JMXFeatureTest` caused by the recently introduced Async Profiler (CASSANDRA-20854). 

**Root Cause:**
The `AsyncProfilerService.status()` method was throwing an `IllegalStateException` when the profiler was disabled (default state). During the `JMXFeatureTest`, the node restart process triggers JMX discovery/validation. When the test probe accessed the `AsyncProfilerMBean` status, the exception caused the test to fail.

**Fix:**
- Modified `AsyncProfilerService.status()` to return a descriptive String message ("Async Profiler is not enabled...") instead of throwing an exception when disabled.
- This adheres to better JMX practices where attribute getters should be side-effect free and not throw exceptions for valid states (like being disabled).
- Updated `AsyncProfilerServiceTest` to assert the message string instead of expecting an exception.

**Verification:**
- Verified locally that `org.apache.cassandra.distributed.test.jmx.JMXFeatureTest` passes.
- Verified that `org.apache.cassandra.service.AsyncProfilerServiceTest` passes.

patch by Arvind Kandpal; for CASSANDRA-21135