### PR TITLE
Fix path traversal risk in tarfile extractall usage

### DIFF
--- a/.build/run-ci
+++ b/.build/run-ci
@@ -649,7 +649,16 @@ def download_results_and_print_summary(k8s_client, pod_name: str, kube_ns: str, 
 
     def extract_and_rename(archive_path: str, local_results_dir: str, ci_summary_file: str, ci_details_file: str):
         with tarfile.open(archive_path, "r:gz") as tar:
-            tar.extractall(path=local_results_dir)
+            def safe_extract(tar, path):
+                """Safely extract tar file by validating member paths to prevent directory traversal."""
+                for member in tar.getmembers():
+                    # Normalize the member path and check for directory traversal
+                    if os.path.isabs(member.name) or ".." in member.name:
+                        continue  # Skip potentially dangerous paths
+                    # Extract the member
+                    tar.extract(member, path)
+            
+            safe_extract(tar, local_results_dir)
             if (local_results_dir / "archive/ci_summary.html").exists():
                 (local_results_dir / "archive/ci_summary.html").rename(ci_summary_file)
                 print(f"CI summary saved as {ci_summary_file}")


### PR DESCRIPTION
Hi Maintainers 👋,

This Pull Request addresses a Semgrep security finding related to the unsafe extraction of tar archives, which may lead to path traversal vulnerabilities if the archive source is attacker-controlled.

🔍 Issue Details

Rule ID: tarfile-extractall-traversal

Severity: Medium

Rule Message:
Possible path traversal through tarfile.open($PATH).extractall() if the source tar is controlled by an attacker.

📍 Affected Location

File Path:
/tools/scanResult/unzipped-72658404/.build/run-ci

Line: 651

✅ Fix Applied

Updated the tar extraction logic to ensure that tar members are validated before extraction, preventing files from being written outside the intended destination directory.
This avoids unsafe use of extractall() on potentially untrusted archives.

🎯 Impact

This change mitigates the risk of directory traversal attacks by ensuring only safe and expected paths are extracted from tar archives, strengthening the overall security of the extraction process.

The issue was identified and remediated using AI-Guardian, a security analysis tool developed by my company OpsMx.

Thanks for your time and review 🙏