### PR TITLE
CASSANDRA-21140 - improved documentation of md5 digest

### DIFF
--- a/src/java/org/apache/cassandra/utils/MD5Digest.java
+++ b/src/java/org/apache/cassandra/utils/MD5Digest.java
@@ -27,8 +27,10 @@ import java.util.Arrays;
  *
  * A MD5 is really just a byte[] but arrays are a no go as map keys. We could
  * wrap it in a ByteBuffer but:
- *   1. MD5Digest is a more explicit name than ByteBuffer to represent a md5.
- *   2. Using our own class allows to use our FastByteComparison for equals.
+ * <ol>
+ *   <li>MD5Digest is a more explicit name than ByteBuffer to represent a md5.</li>
+ *   <li> Using our own class allows to use our FastByteComparison for equals.</li>
+ * </ol>
  */
 public class MD5Digest
 {


### PR DESCRIPTION
[JIRA TICKET](https://issues.apache.org/jira/browse/CASSANDRA-21140)

**Problem:**
[`MD5Digest`](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/utils/MD5Digest.java)'s documentation gives a look 
<img width="340" height="254" alt="image" src="https://github.com/user-attachments/assets/f2f92c62-83e2-4a48-9f1c-ed3cd9fae87e" />

**Fix:**
Use Use HTML tags (ol, li) for improving documentation lookup.

**Post Fix:**
<img width="341" height="342" alt="image" src="https://github.com/user-attachments/assets/f17e5c09-6d13-4668-921b-65b25500756d" />