### PR TITLE
Remove potential gossip deadlock during decommission

### DIFF
--- a/src/java/org/apache/cassandra/gms/Gossiper.java
+++ b/src/java/org/apache/cassandra/gms/Gossiper.java
@@ -2178,16 +2178,6 @@ public class Gossiper implements IFailureDetectionEventListener, GossiperMBean, 
             toSend.forceNewerGenerationUnsafe();
             toSend.markDead();
             VersionedValue value = StorageService.instance.valueFactory.left(tokens, computeExpireTime());
-
-            if (left.equals(getBroadcastAddressAndPort()))
-            {
-                // Adding local state bumps the value's version. To keep this consistent across
-                // the cluster, re-fetch it before broadcasting.
-                Gossiper.instance.addLocalApplicationState(ApplicationState.STATUS_WITH_PORT, value);
-                value = Gossiper.instance.endpointStateMap.get(getBroadcastAddressAndPort())
-                                                          .getApplicationState(ApplicationState.STATUS_WITH_PORT);
-            }
-
             toSend.addApplicationState(ApplicationState.STATUS_WITH_PORT, value);
             GossipDigestAck2 payload = new GossipDigestAck2(Collections.singletonMap(left, toSend));
             logger.info("Sending app state with status {} to {}", value.value, sendTo);


### PR DESCRIPTION
Remove unnecessary updating of local app state when leaving

