### PR TITLE
CASSANDRA-21145: Fix CI regression in CompactionHistoryTest by enforcing STCS

### DIFF
--- a/test/unit/org/apache/cassandra/tools/nodetool/CompactionHistoryTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/CompactionHistoryTest.java
@@ -85,7 +85,7 @@ public class CompactionHistoryTest extends CQLTester
     @Test
     public void testCompactionProperties() throws Throwable
     {
-        createTable("CREATE TABLE %s (id text, value text, PRIMARY KEY ((id)))");
+        createTable("CREATE TABLE %s (id text, value text, PRIMARY KEY ((id))) WITH compaction = {'class': 'SizeTieredCompactionStrategy'}");
         ColumnFamilyStore cfs = Keyspace.open(keyspace()).getColumnFamilyStore(currentTable());
         cfs.disableAutoCompaction();
         // write SSTables for the specific key


### PR DESCRIPTION
This PR fixes a CI regression introduced by CASSANDRA-20081.

**Context:**
The `CompactionHistoryTest#testCompactionProperties` test asserts that the compaction strategy in the `nodetool compactionhistory` output matches `SizeTieredCompactionStrategy` (STCS).

However, in the CI environment (trunk), the default compaction strategy is often randomized or defaults to `UnifiedCompactionStrategy` (UCS). This causes an assertion failure because the test creates the table without an explicit strategy, leading to a mismatch between expected (STCS) and actual (UCS) output.

**CI Failure Example:**
https://ci-cassandra.apache.org/job/Cassandra-trunk/2387/#showFailuresLink

Expected Props: {strategy=SizeTieredCompactionStrategy, ...} 
Actual Output: {strategy=UnifiedCompactionStrategy, ...}

**The Fix:**
Explicitly enforce `SizeTieredCompactionStrategy` in the test's `CREATE TABLE` statement. This ensures deterministic output regardless of the environment's default configuration.

patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-21145