### PR TITLE
CASSANDRA-21150: Fix test failure org.apache.cassandra.io.sstable.VerifyTest.testVerifyCorruptRowCorrectDigest

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/big/BigTableVerifier.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/big/BigTableVerifier.java
@@ -134,7 +134,7 @@ public class BigTableVerifier extends SortedTableVerifier<BigTableReader> implem
 
                 long partitionBase = it.dataPosition();
                 int blockCount = rowIndexEntry.blockCount();
-                if (blockCount > 0)
+                if (options.extendedVerification && blockCount > 0)
                 {
                     long expectedNextOffset = 0;
                     RowIndexEntry.IndexInfoRetriever indexInfoRetriever = rowIndexEntry.openWithIndex(it.indexFile());
@@ -172,7 +172,8 @@ public class BigTableVerifier extends SortedTableVerifier<BigTableReader> implem
             if (!Objects.equals(key, sstable.getLast().getKey()))
                 throw new CorruptSSTableException(new IOException("Last partition does not match index"), it.toString());
         }
-        dataFile.reset();
+        if (options.extendedVerification)
+            dataFile.reset();
     }
 
     private void logDuplicates(DecoratedKey key, Row first, int duplicateRows, long minTimestamp, long maxTimestamp)


### PR DESCRIPTION
The `VerifyTest.testVerifyCorruptRowCorrectDigest` was failing in CI environments (specifically with compression enabled).

**The Issue:**
The test intentionally corrupts the data file but expects "simple verification" to pass (as simple verification should primarily check the Index file and digests, not the full Data file).
However, a recent regression in `BigTableVerifier.deserializeIndex` caused it to eagerly read from the data file even during simple verification. This triggered a `CorruptSSTableException` (wrapped as `CorruptBlockException`), causing the test to fail.

**The Fix:**
Modified `BigTableVerifier.deserializeIndex` to gate the data-file reading logic and the subsequent `dataFile.reset()` call behind `options.extendedVerification`.
This ensures that simple verification remains lightweight and does not touch the (potentially corrupt) data file unless extended verification is requested.

**Verification:**
Reproduced the failure locally using the CI script (`./.build/run-tests.sh -t VerifyTest -a test-compression`) and verified that this change resolves the issue.


patch by Arvind Kandpal; reviewed by TBD for CASSANDRA-21150