### PR TITLE
CASSANDRA-21072: Prevent TombstoneOverwhelmingException from being swallowed when tracking warnings

### DIFF
--- a/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
+++ b/src/java/org/apache/cassandra/db/ReadCommandVerbHandler.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.Token;
@@ -88,7 +89,7 @@ public class ReadCommandVerbHandler implements IVerbHandler<ReadCommand>
         }
         catch (RejectException e)
         {
-            if (!command.isTrackingWarnings())
+            if (!command.isTrackingWarnings() || e instanceof TombstoneOverwhelmingException)
                 throw e;
 
             // make sure to log as the exception is swallowed

--- a/test/unit/org/apache/cassandra/db/ReadCommandVerbHandlerTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandVerbHandlerTest.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexSliceFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.locator.InetAddressAndPort;
@@ -146,6 +147,27 @@ public class ReadCommandVerbHandlerTest
                               .build());
     }
 
+    @Test(expected = TombstoneOverwhelmingException.class)
+    public void tombstoneExceptionPropagatesWithoutWarningTracking()
+    {
+        ReadCommand command = new TombstoneThrowingReadCommand(metadata);
+        handler.doVerb(Message.builder(READ_REQ, command)
+                              .from(peer())
+                              .withId(messageId())
+                              .build());
+    }
+
+    @Test(expected = TombstoneOverwhelmingException.class)
+    public void tombstoneExceptionPropagatesWithWarningTracking()
+    {
+        ReadCommand command = new TombstoneThrowingReadCommand(metadata);
+        handler.doVerb(Message.builder(READ_REQ, command)
+                              .from(peer())
+                              .withFlag(MessageFlag.TRACK_WARNINGS)
+                              .withId(messageId())
+                              .build());
+    }
+
     private static int messageId()
     {
         return random.nextInt();
@@ -196,6 +218,34 @@ public class ReadCommandVerbHandlerTest
         public boolean isTrackingRepairedData()
         {
             return trackingRepairedData;
+        }
+    }
+
+    private static class TombstoneThrowingReadCommand extends SinglePartitionReadCommand
+    {
+        TombstoneThrowingReadCommand(TableMetadata metadata)
+        {
+            super(metadata.epoch,
+                  false,
+                  0,
+                  false,
+                  PotentialTxnConflicts.DISALLOW,
+                  metadata,
+                  FBUtilities.nowInSeconds(),
+                  ColumnFilter.all(metadata),
+                  RowFilter.none(),
+                  DataLimits.NONE,
+                  KEY,
+                  new ClusteringIndexSliceFilter(Slices.ALL, false),
+                  null,
+                  false,
+                  null);
+        }
+
+        @Override
+        public UnfilteredPartitionIterator executeLocally(ReadExecutionController executionController)
+        {
+            throw new TombstoneOverwhelmingException(1000, "test_query", metadata(), KEY, Clustering.EMPTY);
         }
     }
 

--- a/test/unit/org/apache/cassandra/db/ReadCommandVerbHandlerTest.java
+++ b/test/unit/org/apache/cassandra/db/ReadCommandVerbHandlerTest.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.db.filter.ClusteringIndexSliceFilter;
 import org.apache.cassandra.db.filter.ColumnFilter;
 import org.apache.cassandra.db.filter.DataLimits;
 import org.apache.cassandra.db.filter.RowFilter;
+import org.apache.cassandra.db.filter.LocalReadSizeTooLargeException;
 import org.apache.cassandra.db.filter.TombstoneOverwhelmingException;
 import org.apache.cassandra.db.partitions.UnfilteredPartitionIterator;
 import org.apache.cassandra.exceptions.InvalidRequestException;
@@ -168,6 +169,18 @@ public class ReadCommandVerbHandlerTest
                               .build());
     }
 
+    @Test
+    public void rejectExceptionSwallowedWithWarningTracking()
+    {
+        ReadCommand command = new RejectThrowingReadCommand(metadata);
+        handler.doVerb(Message.builder(READ_REQ, command)
+                              .from(peer())
+                              .withFlag(MessageFlag.TRACK_WARNINGS)
+                              .withId(messageId())
+                              .build());
+        // If we reach here without an exception, the RejectException was correctly swallowed
+    }
+
     private static int messageId()
     {
         return random.nextInt();
@@ -246,6 +259,34 @@ public class ReadCommandVerbHandlerTest
         public UnfilteredPartitionIterator executeLocally(ReadExecutionController executionController)
         {
             throw new TombstoneOverwhelmingException(1000, "test_query", metadata(), KEY, Clustering.EMPTY);
+        }
+    }
+
+    private static class RejectThrowingReadCommand extends SinglePartitionReadCommand
+    {
+        RejectThrowingReadCommand(TableMetadata metadata)
+        {
+            super(metadata.epoch,
+                  false,
+                  0,
+                  false,
+                  PotentialTxnConflicts.DISALLOW,
+                  metadata,
+                  FBUtilities.nowInSeconds(),
+                  ColumnFilter.all(metadata),
+                  RowFilter.none(),
+                  DataLimits.NONE,
+                  KEY,
+                  new ClusteringIndexSliceFilter(Slices.ALL, false),
+                  null,
+                  false,
+                  null);
+        }
+
+        @Override
+        public UnfilteredPartitionIterator executeLocally(ReadExecutionController executionController)
+        {
+            throw new LocalReadSizeTooLargeException("test read size too large");
         }
     }
 


### PR DESCRIPTION
 ## PR Description:
  Prevent TombstoneOverwhelmingException from being swallowed when tracking warnings

## Summary
In `ReadCommandVerbHandler.doVerb()`, when `trackWarnings=true`, all `RejectException` subclasses are caught and swallowed — an empty success response is sent with failure info in `MessageParams`. While the coordinator eventually
  recognizes the failure via the side-channel params, `TombstoneOverwhelmingException` is a hard abort that should propagate as a proper failure response, not masquerade as a success.

  The fix adds `|| e instanceof TombstoneOverwhelmingException` to the catch block so it is always re-thrown. Other `RejectException` subclasses (`LocalReadSizeTooLargeException`, `QueryReferencingTooManyIndexesException`) continue
  using the `MessageParams` path since they're designed for `WarningContext` aggregation.

Related datastax commit pr --> https://github.com/datastax/cassandra/commit/f1223ec9fd9c724f00acbe338e053f3533617c8a 

  patch by Arnav Chakraborty;  for CASSANDRA-21072

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>