### PR TITLE
CASSANDRA-21167 fix build-shaded-dtest-jar.sh

### DIFF
--- a/relocate-dependencies.pom
+++ b/relocate-dependencies.pom
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.1</version>
 
                 <configuration>
                     <createSourcesJar>false</createSourcesJar>


### PR DESCRIPTION
build-shaded-dtest-jar.sh failed with error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.4.1:shade (default) on project cassandra-dtest-shaded: Error creating shaded jar: Problem shading JAR /home/klamm/.m2/repository/org/apache/cassandra/cassandra-dtest-local/4.0.0-SNAPSHOT/cassandra-dtest-local-4.0.0-SNAPSHOT.jar entry META-INF/versions/21/ch/qos/logback/core/property/ConsoleCharsetPropertyDefiner.class: java.lang.IllegalArgumentException: Unsupported class file major version 65 -> [Help 1]
```

To fix this we need to increase `maven-shade-plugin` version to 3.5.1.

https://issues.apache.org/jira/browse/CASSANDRA-21167
patch by Valery Baranov [klammrock@gmail.com](mailto:klammrock@gmail.com)