### PR TITLE
[CASSANDRA-21172][trunk] Add test container memory events printing to check if Linux OOM killer was active, fix thread dump printing on junit test timeout

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -434,6 +434,11 @@ def test(command, cell) {
             if (!cell.step.startsWith("microbench")) {
               junit testResults: "test/**/TEST-*.xml,test/**/cqlshlib*.xml,test/**/nosetests*.xml", testDataPublishers: [[$class: 'StabilityTestDataPublisher']]
             }
+            // check if we had Linux OOM killer active within the test container which could kill forked JUnit JVM processes
+             sh """
+                echo "docker memory/oomkiller debug:"
+                cat /sys/fs/cgroup/docker/memory.events || true
+              """
             sh """
                 find test/output -type f -name "*.xml" -print0 | xargs -0 -r -n1 -P"\$(nproc)" xz -f
                 echo "test result files compressed"; find test/output -type f -name "*.xml.xz" | wc -l

--- a/test/unit/org/apache/cassandra/JStackJUnitTask.java
+++ b/test/unit/org/apache/cassandra/JStackJUnitTask.java
@@ -20,7 +20,6 @@ package org.apache.cassandra;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.reflect.Field;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.ExecuteWatchdog;
@@ -77,6 +76,7 @@ public class JStackJUnitTask extends JUnitTask
                 ProcessBuilder pb = new ProcessBuilder("jstack","-l", String.valueOf(pid));
                 try
                 {
+                    pb.redirectErrorStream(true);
                     Process p = pb.start();
                     try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream())))
                     {
@@ -100,22 +100,15 @@ public class JStackJUnitTask extends JUnitTask
 
         private long getPid(Process process)
         {
-            if (process.getClass().getName().equals("java.lang.UNIXProcess"))
+            try
             {
-                try
-                {
-                    Field f = process.getClass().getDeclaredField("pid");
-                    f.setAccessible(true);
-                    long pid = f.getLong(process);
-                    f.setAccessible(false);
-                    return pid;
-                }
-                catch (IllegalAccessException | NoSuchFieldException e)
-                {
-                    System.err.println("Could not get PID");
-                }
+                return process.pid();
             }
-            return -1;
+            catch (UnsupportedOperationException e)
+            {
+                System.err.println("Could not get PID");
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
Add test container memory events printing to check if Linux OOM killer was active, fix thread dump printing on junit test timeout

Process.pid() API is available since JDK9

patch by Dmitry Konstantinov; reviewed by TBD for CASSANDRA-21172
