### PR TITLE
Make sure system.peers and peers_v2 match cluster metadata                      

### DIFF
--- a/src/java/org/apache/cassandra/db/SystemPeersValidator.java
+++ b/src/java/org/apache/cassandra/db/SystemPeersValidator.java
@@ -19,19 +19,26 @@
 package org.apache.cassandra.db;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.virtual.PeersTable;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.Location;
+import org.apache.cassandra.tcm.membership.NodeAddresses;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.utils.FBUtilities;
 
@@ -53,101 +60,168 @@ public class SystemPeersValidator
 
     public static void validateAndRepair(ClusterMetadata metadata)
     {
-        if (metadata != null)
+        Map<InetAddressAndPort, UntypedResultSet.Row> peersV2Rows = getPeersV2Rows();
+        Map<InetAddress, UntypedResultSet.Row> legacyPeersRows = getLegacyPeersRows();
+
+        Map<InetAddressAndPort, NodeId> expectedEndpoints = new HashMap<>();
+        Map<InetAddress, NodeId> expectedAddresses = new HashMap<>();
+        for (NodeId nodeId : getExpectedPeerNodes(metadata))
         {
-            Set<NodeId> expectedNodes = getExpectedPeerNodes(metadata);
-            Set<InetAddress> legacyPeersEntries = getLegacyPeersEntries();
+            InetAddressAndPort endpoint = metadata.directory.endpoint(nodeId);
+            expectedEndpoints.put(endpoint, nodeId);
+            expectedAddresses.put(endpoint.getAddress(), nodeId);
+        }
 
-            Map<InetAddressAndPort, NodeId> expectedEndpoints = new HashMap<>();
-            Map<InetAddress, NodeId> expectedAddresses = new HashMap<>();
-            for (NodeId nodeId : expectedNodes)
+        String deleteV2Query = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                                               SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        for (InetAddressAndPort endpoint : peersV2Rows.keySet())
+        {
+            if (!expectedEndpoints.containsKey(endpoint))
             {
-                InetAddressAndPort endpoint = metadata.directory.endpoint(nodeId);
-                expectedEndpoints.put(endpoint, nodeId);
-                expectedAddresses.put(endpoint.getAddress(), nodeId);
-            }
-
-            Set<InetAddressAndPort> peersV2Entries = getPeersV2Entries();
-            for (Map.Entry<InetAddressAndPort, NodeId> entry : expectedEndpoints.entrySet())
-            {
-                InetAddressAndPort endpoint = entry.getKey();
-                NodeId nodeId = entry.getValue();
-
-                boolean inPeersV2 = peersV2Entries.contains(endpoint);
-                boolean inLegacyPeers = legacyPeersEntries.contains(endpoint.getAddress());
-
-                if (!inPeersV2 || !inLegacyPeers)
-                {
-                    logger.info("Repairing missing peer entry for {} (nodeId={}, inPeersV2={}, inLegacyPeers={})",
-                                endpoint, nodeId, inPeersV2, inLegacyPeers);
-                    PeersTable.updateLegacyPeerTable(nodeId, metadata, metadata);
-                }
-            }
-
-            String deleteV2Query = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                                                 SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-            for (InetAddressAndPort endpoint : peersV2Entries)
-            {
-                if (!expectedEndpoints.containsKey(endpoint))
-                {
-                    logger.info("Removing stale entry from {}: endpoint {} not found in ClusterMetadata",
-                                PEERS_V2, endpoint);
-                    executeInternal(deleteV2Query, endpoint.getAddress(), endpoint.getPort());
-                }
-            }
-
-            String deleteQuery = String.format("DELETE FROM %s.%s WHERE peer = ?",
-                                                 SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-            for (InetAddress address : legacyPeersEntries)
-            {
-                if (!expectedAddresses.containsKey(address))
-                {
-                    logger.info("Removing stale entry from {}: address {} not found in ClusterMetadata",
-                                LEGACY_PEERS, address);
-                    executeInternal(deleteQuery, address);
-                }
+                logger.info("Removing stale peer {} from {}", endpoint, PEERS_V2);
+                executeInternal(deleteV2Query, endpoint.getAddress(), endpoint.getPort());
             }
         }
+
+        String deleteLegacyQuery = String.format("DELETE FROM %s.%s WHERE peer = ?",
+                                                   SchemaConstants.SYSTEM_KEYSPACE_NAME,
+                                                   LEGACY_PEERS);
+        for (InetAddress address : legacyPeersRows.keySet())
+        {
+            if (!expectedAddresses.containsKey(address))
+            {
+                logger.info("Removing stale peer {} from {}", address, LEGACY_PEERS);
+                executeInternal(deleteLegacyQuery, address);
+            }
+        }
+
+        for (Map.Entry<InetAddressAndPort, NodeId> entry : expectedEndpoints.entrySet())
+        {
+            NodeId nodeId = entry.getValue();
+            InetAddressAndPort endpoint = entry.getKey();
+            UntypedResultSet.Row v2Row = peersV2Rows.get(endpoint);
+            UntypedResultSet.Row legacyRow = legacyPeersRows.get(endpoint.getAddress());
+
+            List<String> v2Discrepancies = collectV2Discrepancies(v2Row, nodeId, metadata);
+            List<String> legacyDiscrepancies = collectLegacyDiscrepancies(legacyRow, nodeId, metadata);
+
+            boolean v2NeedsRepair = logDiscrepancies(v2Row, endpoint, PEERS_V2, v2Discrepancies);
+            boolean legacyNeedsRepair = logDiscrepancies(legacyRow, endpoint, LEGACY_PEERS, legacyDiscrepancies);
+
+            if (v2NeedsRepair || legacyNeedsRepair)
+                PeersTable.updateLegacyPeerTable(nodeId, metadata, metadata);
+        }
+    }
+
+    private static boolean logDiscrepancies(UntypedResultSet.Row row,
+                                            InetAddressAndPort endpoint,
+                                            String table,
+                                            List<String> discrepancies)
+    {
+        if (row == null)
+        {
+            logger.info("Adding missing peer {} to {}", endpoint, table);
+            return true;
+        }
+        if (!discrepancies.isEmpty())
+        {
+            logger.info("Updating peer {} in {} for stale fields {}", endpoint, table, discrepancies);
+            return true;
+        }
+        return false;
+    }
+
+    private static List<String> collectV2Discrepancies(UntypedResultSet.Row row,
+                                                       NodeId nodeId,
+                                                       ClusterMetadata metadata)
+    {
+        if (row == null)
+            return Collections.emptyList();
+
+        NodeAddresses addresses = metadata.directory.getNodeAddresses(nodeId);
+        Location location = metadata.directory.location(nodeId);
+        List<String> discrepancies = new ArrayList<>();
+        collectIfStale(discrepancies, "preferred_ip", row.getInetAddress("preferred_ip"),
+                       addresses.broadcastAddress.getAddress());
+        collectIfStale(discrepancies, "preferred_port", row.getInt("preferred_port"),
+                       addresses.broadcastAddress.getPort());
+        collectIfStale(discrepancies, "native_address", row.getInetAddress("native_address"),
+                       addresses.nativeAddress.getAddress());
+        collectIfStale(discrepancies, "native_port", row.getInt("native_port"),
+                       addresses.nativeAddress.getPort());
+        collectIfStale(discrepancies, "data_center", row.getString("data_center"), location.datacenter);
+        collectIfStale(discrepancies, "rack", row.getString("rack"), location.rack);
+        collectIfStale(discrepancies, "host_id", row.getUUID("host_id"), nodeId.toUUID());
+        collectIfStale(discrepancies, "release_version", row.getString("release_version"),
+                       metadata.directory.version(nodeId).cassandraVersion.toString());
+        collectIfStale(discrepancies, "schema_version", row.getUUID("schema_version"),
+                       metadata.schema.getVersion());
+        collectIfStale(discrepancies, "tokens", row.getSet("tokens", UTF8Type.instance),
+                       SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)));
+        return discrepancies;
+    }
+
+    private static List<String> collectLegacyDiscrepancies(UntypedResultSet.Row row, NodeId nodeId,
+                                                           ClusterMetadata metadata)
+    {
+        if (row == null)
+            return Collections.emptyList();
+
+        NodeAddresses addresses = metadata.directory.getNodeAddresses(nodeId);
+        Location location = metadata.directory.location(nodeId);
+        List<String> discrepancies = new ArrayList<>();
+        collectIfStale(discrepancies, "preferred_ip", row.getInetAddress("preferred_ip"),
+                       addresses.broadcastAddress.getAddress());
+        collectIfStale(discrepancies, "rpc_address", row.getInetAddress("rpc_address"),
+                       addresses.nativeAddress.getAddress());
+        collectIfStale(discrepancies, "data_center", row.getString("data_center"), location.datacenter);
+        collectIfStale(discrepancies, "rack", row.getString("rack"), location.rack);
+        collectIfStale(discrepancies, "host_id", row.getUUID("host_id"), nodeId.toUUID());
+        collectIfStale(discrepancies, "release_version", row.getString("release_version"),
+                       metadata.directory.version(nodeId).cassandraVersion.toString());
+        collectIfStale(discrepancies, "schema_version", row.getUUID("schema_version"),
+                       metadata.schema.getVersion());
+        collectIfStale(discrepancies, "tokens", row.getSet("tokens", UTF8Type.instance),
+                       SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)));
+        return discrepancies;
+    }
+
+    private static void collectIfStale(List<String> discrepancies, String field, Object actual, Object expected)
+    {
+        if (!Objects.equals(actual, expected))
+            discrepancies.add(field);
     }
 
     private static Set<NodeId> getExpectedPeerNodes(ClusterMetadata metadata)
     {
         Set<NodeId> expectedNodes = new HashSet<>();
         InetAddressAndPort localEndpoint = FBUtilities.getBroadcastAddressAndPort();
-
         for (InetAddressAndPort endpoint : metadata.directory.allJoinedEndpoints())
         {
-            if (endpoint.equals(localEndpoint)) continue;
-            expectedNodes.add(metadata.directory.peerId(endpoint));
+            if (!endpoint.equals(localEndpoint))
+                expectedNodes.add(metadata.directory.peerId(endpoint));
         }
+
         return expectedNodes;
     }
 
-    private static Set<InetAddressAndPort> getPeersV2Entries()
+    private static Map<InetAddressAndPort, UntypedResultSet.Row> getPeersV2Rows()
     {
-        Set<InetAddressAndPort> entries = new HashSet<>();
-        String query = String.format("SELECT peer, peer_port FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-        UntypedResultSet rows = executeInternal(query);
-
-        for (UntypedResultSet.Row row : rows)
-        {
-            InetAddressAndPort endpoint = InetAddressAndPort.getByAddressOverrideDefaults(
-                row.getInetAddress("peer"),
-                row.getInt("peer_port"));
-            entries.add(endpoint);
-        }
-        return entries;
+        Map<InetAddressAndPort, UntypedResultSet.Row> rows = new HashMap<>();
+        String query = String.format("SELECT * FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        for (UntypedResultSet.Row row : executeInternal(query))
+            rows.put(InetAddressAndPort.getByAddressOverrideDefaults(row.getInetAddress("peer"),
+                                                                     row.getInt("peer_port")), row);
+        return rows;
     }
 
-    private static Set<InetAddress> getLegacyPeersEntries()
+    private static Map<InetAddress, UntypedResultSet.Row> getLegacyPeersRows()
     {
-        Set<InetAddress> entries = new HashSet<>();
-        String query = String.format("SELECT peer FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-        UntypedResultSet rows = executeInternal(query);
+        Map<InetAddress, UntypedResultSet.Row> rows = new HashMap<>();
+        String query = String.format("SELECT * FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+        for (UntypedResultSet.Row row : executeInternal(query))
+            rows.put(row.getInetAddress("peer"), row);
 
-        for (UntypedResultSet.Row row : rows)
-            entries.add(row.getInetAddress("peer"));
-
-        return entries;
+        return rows;
     }
 }

--- a/src/java/org/apache/cassandra/db/SystemPeersValidator.java
+++ b/src/java/org/apache/cassandra/db/SystemPeersValidator.java
@@ -19,11 +19,8 @@
 package org.apache.cassandra.db;
 
 import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -47,181 +44,142 @@ import static org.apache.cassandra.db.SystemKeyspace.LEGACY_PEERS;
 import static org.apache.cassandra.db.SystemKeyspace.PEERS_V2;
 
 /**
- * Validator to ensure system.peers and system.peers_v2 tables match ClusterMetadata on startup.
- * This is critical for backward compatibility as older clients and tools read from these
- * legacy tables while TCM uses ClusterMetadata as the source of truth.
+ * Validator to ensure system.peers and system.peers_v2 tables match ClusterMetadata.
+ * These tables are maintained for existing clients and tools which read from them to determine
+ * topology and schema information, while Cassandra itself uses ClusterMetadata as the source of truth.
  *
- * The validator detects inconsistencies and automatically repairs them by synchronizing
+ * This validator detects inconsistencies and automatically repairs them by synchronizing
  * the peers tables with the current ClusterMetadata.
+ *
+ * The system_views.peers virtual table provides a live view on the current ClusterMetadata
+ * and includes all members of the cluster, unlike the legacy tables which exclude the local node.
  */
-public class SystemPeersValidator
+public final class SystemPeersValidator
 {
     private static final Logger logger = LoggerFactory.getLogger(SystemPeersValidator.class);
+    private static final String SELECT_PEERS_V2_QUERY = String.format("SELECT * FROM %s.%s",
+                                                                      SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+    private static final String SELECT_PEERS_QUERY = String.format("SELECT * FROM %s.%s",
+                                                                    SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+    private static final String DELETE_PEERS_V2_QUERY = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                                                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+    private static final String DELETE_PEERS_QUERY = String.format("DELETE FROM %s.%s WHERE peer = ?",
+                                                                   SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
 
     public static void validateAndRepair(ClusterMetadata metadata)
     {
         Map<InetAddressAndPort, UntypedResultSet.Row> peersV2Rows = getPeersV2Rows();
-        Map<InetAddress, UntypedResultSet.Row> legacyPeersRows = getLegacyPeersRows();
+        Map<InetAddress, UntypedResultSet.Row> peersRows = getPeersRows();
 
-        Map<InetAddressAndPort, NodeId> expectedEndpoints = new HashMap<>();
-        Map<InetAddress, NodeId> expectedAddresses = new HashMap<>();
-        for (NodeId nodeId : getExpectedPeerNodes(metadata))
+        Map<InetAddressAndPort, NodeId> knownEndpoints = new HashMap<>();
+        Set<InetAddress> knownAddresses = new HashSet<>();
+        InetAddressAndPort localEndpoint = FBUtilities.getBroadcastAddressAndPort();
+        for (InetAddressAndPort endpoint : metadata.directory.allJoinedEndpoints())
         {
-            InetAddressAndPort endpoint = metadata.directory.endpoint(nodeId);
-            expectedEndpoints.put(endpoint, nodeId);
-            expectedAddresses.put(endpoint.getAddress(), nodeId);
+            if (endpoint.equals(localEndpoint))
+                continue;
+            knownEndpoints.put(endpoint, metadata.directory.peerId(endpoint));
+            knownAddresses.add(endpoint.getAddress());
         }
 
-        String deleteV2Query = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                                               SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
         for (InetAddressAndPort endpoint : peersV2Rows.keySet())
         {
-            if (!expectedEndpoints.containsKey(endpoint))
+            if (!knownEndpoints.containsKey(endpoint))
             {
                 logger.info("Removing stale peer {} from {}", endpoint, PEERS_V2);
-                executeInternal(deleteV2Query, endpoint.getAddress(), endpoint.getPort());
+                executeInternal(DELETE_PEERS_V2_QUERY, endpoint.getAddress(), endpoint.getPort());
             }
         }
 
-        String deleteLegacyQuery = String.format("DELETE FROM %s.%s WHERE peer = ?",
-                                                   SchemaConstants.SYSTEM_KEYSPACE_NAME,
-                                                   LEGACY_PEERS);
-        for (InetAddress address : legacyPeersRows.keySet())
+        for (InetAddress address : peersRows.keySet())
         {
-            if (!expectedAddresses.containsKey(address))
+            if (!knownAddresses.contains(address))
             {
                 logger.info("Removing stale peer {} from {}", address, LEGACY_PEERS);
-                executeInternal(deleteLegacyQuery, address);
+                executeInternal(DELETE_PEERS_QUERY, address);
             }
         }
 
-        for (Map.Entry<InetAddressAndPort, NodeId> entry : expectedEndpoints.entrySet())
+        for (Map.Entry<InetAddressAndPort, NodeId> entry : knownEndpoints.entrySet())
         {
             NodeId nodeId = entry.getValue();
             InetAddressAndPort endpoint = entry.getKey();
-            UntypedResultSet.Row v2Row = peersV2Rows.get(endpoint);
-            UntypedResultSet.Row legacyRow = legacyPeersRows.get(endpoint.getAddress());
+            UntypedResultSet.Row peersV2Row = peersV2Rows.get(endpoint);
+            UntypedResultSet.Row peersRow = peersRows.get(endpoint.getAddress());
 
-            List<String> v2Discrepancies = collectV2Discrepancies(v2Row, nodeId, metadata);
-            List<String> legacyDiscrepancies = collectLegacyDiscrepancies(legacyRow, nodeId, metadata);
+            boolean peersV2NeedsRepair = needsRepair(peersV2Row, endpoint, PEERS_V2, nodeId, metadata);
+            boolean peersNeedsRepair = needsRepair(peersRow, endpoint, LEGACY_PEERS, nodeId, metadata);
 
-            boolean v2NeedsRepair = logDiscrepancies(v2Row, endpoint, PEERS_V2, v2Discrepancies);
-            boolean legacyNeedsRepair = logDiscrepancies(legacyRow, endpoint, LEGACY_PEERS, legacyDiscrepancies);
-
-            if (v2NeedsRepair || legacyNeedsRepair)
+            if (peersV2NeedsRepair || peersNeedsRepair)
                 PeersTable.updateLegacyPeerTable(nodeId, metadata, metadata);
         }
     }
 
-    private static boolean logDiscrepancies(UntypedResultSet.Row row,
-                                            InetAddressAndPort endpoint,
-                                            String table,
-                                            List<String> discrepancies)
+    private static boolean needsRepair(UntypedResultSet.Row row, InetAddressAndPort endpoint,
+                                       String table, NodeId nodeId, ClusterMetadata metadata)
     {
         if (row == null)
         {
             logger.info("Adding missing peer {} to {}", endpoint, table);
             return true;
         }
-        if (!discrepancies.isEmpty())
+        boolean isEquivalent = PEERS_V2.equals(table)
+                               ? peersV2RowIsEquivalent(row, nodeId, metadata)
+                               : peersRowIsEquivalent(row, nodeId, metadata);
+        if (!isEquivalent)
         {
-            logger.info("Updating peer {} in {} for stale fields {}", endpoint, table, discrepancies);
+            logger.info("Repairing mismatched peer {} in {}: {}", endpoint, table, row);
             return true;
         }
         return false;
     }
 
-    private static List<String> collectV2Discrepancies(UntypedResultSet.Row row,
-                                                       NodeId nodeId,
-                                                       ClusterMetadata metadata)
+    private static boolean peersV2RowIsEquivalent(UntypedResultSet.Row row, NodeId nodeId, ClusterMetadata metadata)
     {
-        if (row == null)
-            return Collections.emptyList();
-
         NodeAddresses addresses = metadata.directory.getNodeAddresses(nodeId);
-        Location location = metadata.directory.location(nodeId);
-        List<String> discrepancies = new ArrayList<>();
-        collectIfStale(discrepancies, "preferred_ip", row.getInetAddress("preferred_ip"),
-                       addresses.broadcastAddress.getAddress());
-        collectIfStale(discrepancies, "preferred_port", row.getInt("preferred_port"),
-                       addresses.broadcastAddress.getPort());
-        collectIfStale(discrepancies, "native_address", row.getInetAddress("native_address"),
-                       addresses.nativeAddress.getAddress());
-        collectIfStale(discrepancies, "native_port", row.getInt("native_port"),
-                       addresses.nativeAddress.getPort());
-        collectIfStale(discrepancies, "data_center", row.getString("data_center"), location.datacenter);
-        collectIfStale(discrepancies, "rack", row.getString("rack"), location.rack);
-        collectIfStale(discrepancies, "host_id", row.getUUID("host_id"), nodeId.toUUID());
-        collectIfStale(discrepancies, "release_version", row.getString("release_version"),
-                       metadata.directory.version(nodeId).cassandraVersion.toString());
-        collectIfStale(discrepancies, "schema_version", row.getUUID("schema_version"),
-                       metadata.schema.getVersion());
-        collectIfStale(discrepancies, "tokens", row.getSet("tokens", UTF8Type.instance),
-                       SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)));
-        return discrepancies;
+        return commonColumnsAreEquivalent(row, nodeId, addresses, metadata)
+               && row.has("preferred_port") && row.getInt("preferred_port") == addresses.broadcastAddress.getPort()
+               && row.has("native_port") && row.getInt("native_port") == addresses.nativeAddress.getPort();
     }
 
-    private static List<String> collectLegacyDiscrepancies(UntypedResultSet.Row row, NodeId nodeId,
-                                                           ClusterMetadata metadata)
+    private static boolean peersRowIsEquivalent(UntypedResultSet.Row row, NodeId nodeId, ClusterMetadata metadata)
     {
-        if (row == null)
-            return Collections.emptyList();
-
         NodeAddresses addresses = metadata.directory.getNodeAddresses(nodeId);
+        return commonColumnsAreEquivalent(row, nodeId, addresses, metadata);
+    }
+
+    private static boolean commonColumnsAreEquivalent(UntypedResultSet.Row row, NodeId nodeId,
+                                                      NodeAddresses addresses, ClusterMetadata metadata)
+    {
         Location location = metadata.directory.location(nodeId);
-        List<String> discrepancies = new ArrayList<>();
-        collectIfStale(discrepancies, "preferred_ip", row.getInetAddress("preferred_ip"),
-                       addresses.broadcastAddress.getAddress());
-        collectIfStale(discrepancies, "rpc_address", row.getInetAddress("rpc_address"),
-                       addresses.nativeAddress.getAddress());
-        collectIfStale(discrepancies, "data_center", row.getString("data_center"), location.datacenter);
-        collectIfStale(discrepancies, "rack", row.getString("rack"), location.rack);
-        collectIfStale(discrepancies, "host_id", row.getUUID("host_id"), nodeId.toUUID());
-        collectIfStale(discrepancies, "release_version", row.getString("release_version"),
-                       metadata.directory.version(nodeId).cassandraVersion.toString());
-        collectIfStale(discrepancies, "schema_version", row.getUUID("schema_version"),
-                       metadata.schema.getVersion());
-        collectIfStale(discrepancies, "tokens", row.getSet("tokens", UTF8Type.instance),
-                       SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)));
-        return discrepancies;
-    }
+        // This column is differently named in the peers and peers_v2 tables
+        String nativeAddressColumn = row.has("native_address") ? "native_address" : "rpc_address";
 
-    private static void collectIfStale(List<String> discrepancies, String field, Object actual, Object expected)
-    {
-        if (!Objects.equals(actual, expected))
-            discrepancies.add(field);
-    }
-
-    private static Set<NodeId> getExpectedPeerNodes(ClusterMetadata metadata)
-    {
-        Set<NodeId> expectedNodes = new HashSet<>();
-        InetAddressAndPort localEndpoint = FBUtilities.getBroadcastAddressAndPort();
-        for (InetAddressAndPort endpoint : metadata.directory.allJoinedEndpoints())
-        {
-            if (!endpoint.equals(localEndpoint))
-                expectedNodes.add(metadata.directory.peerId(endpoint));
-        }
-
-        return expectedNodes;
+        // Check existence first because row.getXXX can NPE if the column is not present
+        return row.has("preferred_ip") && Objects.equals(row.getInetAddress("preferred_ip"), addresses.broadcastAddress.getAddress())
+               && row.has(nativeAddressColumn) && Objects.equals(row.getInetAddress(nativeAddressColumn), addresses.nativeAddress.getAddress())
+               && row.has("data_center") && Objects.equals(row.getString("data_center"), location.datacenter)
+               && row.has("rack") && Objects.equals(row.getString("rack"), location.rack)
+               && row.has("host_id") && Objects.equals(row.getUUID("host_id"), nodeId.toUUID())
+               && row.has("release_version") && Objects.equals(row.getString("release_version"), metadata.directory.version(nodeId).cassandraVersion.toString())
+               && row.has("schema_version") && Objects.equals(row.getUUID("schema_version"), metadata.schema.getVersion())
+               && row.has("tokens") && Objects.equals(row.getSet("tokens", UTF8Type.instance), SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)));
     }
 
     private static Map<InetAddressAndPort, UntypedResultSet.Row> getPeersV2Rows()
     {
         Map<InetAddressAndPort, UntypedResultSet.Row> rows = new HashMap<>();
-        String query = String.format("SELECT * FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-        for (UntypedResultSet.Row row : executeInternal(query))
+        for (UntypedResultSet.Row row : executeInternal(SELECT_PEERS_V2_QUERY))
             rows.put(InetAddressAndPort.getByAddressOverrideDefaults(row.getInetAddress("peer"),
                                                                      row.getInt("peer_port")), row);
         return rows;
     }
 
-    private static Map<InetAddress, UntypedResultSet.Row> getLegacyPeersRows()
+    private static Map<InetAddress, UntypedResultSet.Row> getPeersRows()
     {
         Map<InetAddress, UntypedResultSet.Row> rows = new HashMap<>();
-        String query = String.format("SELECT * FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-        for (UntypedResultSet.Row row : executeInternal(query))
+        for (UntypedResultSet.Row row : executeInternal(SELECT_PEERS_QUERY))
             rows.put(row.getInetAddress("peer"), row);
-
         return rows;
     }
 }

--- a/src/java/org/apache/cassandra/db/SystemPeersValidator.java
+++ b/src/java/org/apache/cassandra/db/SystemPeersValidator.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.virtual.PeersTable;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.NodeId;
+import org.apache.cassandra.utils.FBUtilities;
+
+import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
+import static org.apache.cassandra.db.SystemKeyspace.LEGACY_PEERS;
+import static org.apache.cassandra.db.SystemKeyspace.PEERS_V2;
+
+/**
+ * Validator to ensure system.peers and system.peers_v2 tables match ClusterMetadata on startup.
+ * This is critical for backward compatibility as older clients and tools read from these
+ * legacy tables while TCM uses ClusterMetadata as the source of truth.
+ *
+ * The validator detects inconsistencies and automatically repairs them by synchronizing
+ * the peers tables with the current ClusterMetadata.
+ */
+public class SystemPeersValidator
+{
+    private static final Logger logger = LoggerFactory.getLogger(SystemPeersValidator.class);
+
+    public static void validateAndRepair(ClusterMetadata metadata)
+    {
+        if (metadata != null)
+        {
+            Set<NodeId> expectedNodes = getExpectedPeerNodes(metadata);
+            Set<InetAddress> legacyPeersEntries = getLegacyPeersEntries();
+
+            Map<InetAddressAndPort, NodeId> expectedEndpoints = new HashMap<>();
+            Map<InetAddress, NodeId> expectedAddresses = new HashMap<>();
+            for (NodeId nodeId : expectedNodes)
+            {
+                InetAddressAndPort endpoint = metadata.directory.endpoint(nodeId);
+                expectedEndpoints.put(endpoint, nodeId);
+                expectedAddresses.put(endpoint.getAddress(), nodeId);
+            }
+
+            Set<InetAddressAndPort> peersV2Entries = getPeersV2Entries();
+            for (Map.Entry<InetAddressAndPort, NodeId> entry : expectedEndpoints.entrySet())
+            {
+                InetAddressAndPort endpoint = entry.getKey();
+                NodeId nodeId = entry.getValue();
+
+                boolean inPeersV2 = peersV2Entries.contains(endpoint);
+                boolean inLegacyPeers = legacyPeersEntries.contains(endpoint.getAddress());
+
+                if (!inPeersV2 || !inLegacyPeers)
+                {
+                    logger.info("Repairing missing peer entry for {} (nodeId={}, inPeersV2={}, inLegacyPeers={})",
+                                endpoint, nodeId, inPeersV2, inLegacyPeers);
+                    PeersTable.updateLegacyPeerTable(nodeId, metadata, metadata);
+                }
+            }
+
+            String deleteV2Query = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                                                 SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+            for (InetAddressAndPort endpoint : peersV2Entries)
+            {
+                if (!expectedEndpoints.containsKey(endpoint))
+                {
+                    logger.info("Removing stale entry from {}: endpoint {} not found in ClusterMetadata",
+                                PEERS_V2, endpoint);
+                    executeInternal(deleteV2Query, endpoint.getAddress(), endpoint.getPort());
+                }
+            }
+
+            String deleteQuery = String.format("DELETE FROM %s.%s WHERE peer = ?",
+                                                 SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+            for (InetAddress address : legacyPeersEntries)
+            {
+                if (!expectedAddresses.containsKey(address))
+                {
+                    logger.info("Removing stale entry from {}: address {} not found in ClusterMetadata",
+                                LEGACY_PEERS, address);
+                    executeInternal(deleteQuery, address);
+                }
+            }
+        }
+    }
+
+    private static Set<NodeId> getExpectedPeerNodes(ClusterMetadata metadata)
+    {
+        Set<NodeId> expectedNodes = new HashSet<>();
+        InetAddressAndPort localEndpoint = FBUtilities.getBroadcastAddressAndPort();
+
+        for (InetAddressAndPort endpoint : metadata.directory.allJoinedEndpoints())
+        {
+            if (endpoint.equals(localEndpoint)) continue;
+            expectedNodes.add(metadata.directory.peerId(endpoint));
+        }
+        return expectedNodes;
+    }
+
+    private static Set<InetAddressAndPort> getPeersV2Entries()
+    {
+        Set<InetAddressAndPort> entries = new HashSet<>();
+        String query = String.format("SELECT peer, peer_port FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        UntypedResultSet rows = executeInternal(query);
+
+        for (UntypedResultSet.Row row : rows)
+        {
+            InetAddressAndPort endpoint = InetAddressAndPort.getByAddressOverrideDefaults(
+                row.getInetAddress("peer"),
+                row.getInt("peer_port"));
+            entries.add(endpoint);
+        }
+        return entries;
+    }
+
+    private static Set<InetAddress> getLegacyPeersEntries()
+    {
+        Set<InetAddress> entries = new HashSet<>();
+        String query = String.format("SELECT peer FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+        UntypedResultSet rows = executeInternal(query);
+
+        for (UntypedResultSet.Row row : rows)
+            entries.add(row.getInetAddress("peer"));
+
+        return entries;
+    }
+}

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -102,6 +102,7 @@ import org.apache.cassandra.db.DecoratedKey;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.SizeEstimatesRecorder;
 import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.db.SystemPeersValidator;
 import org.apache.cassandra.db.commitlog.CommitLog;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.OperationType;
@@ -855,6 +856,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
         RegistrationStatus.instance.onRegistration();
         Startup.maybeExecuteStartupTransformation(self);
+
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
         try
         {
@@ -5750,6 +5753,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     public List<String> getTablesForKeyspace(String keyspace)
     {
         return Keyspace.open(keyspace).getColumnFamilyStores().stream().map(cfs -> cfs.name).collect(Collectors.toList());
+    }
+
+    @Override
+    public void validateAndRepairPeersMetadata()
+    {
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
     }
 
     @Override

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -1398,6 +1398,15 @@ public interface StorageServiceMBean extends NotificationEmitter
     /** Gets the names of all tables for the given keyspace */
     public List<String> getTablesForKeyspace(String keyspace);
 
+    /**
+     * Validates that system.peers and system.peers_v2 are consistent with ClusterMetadata,
+     * inserting missing peer entries and removing stale ones. This runs automatically on
+     * startup but can be triggered manually if a discrepancy is suspected.
+     * <p>
+     * Note: mutates data in system.peers and system.peers_v2.
+     */
+    public void validateAndRepairPeersMetadata();
+
     /** Mutates the repaired state of all SSTables for the given SSTables */
     public List<String> mutateSSTableRepairedState(boolean repaired, boolean preview, String keyspace, List<String> tables);
 }

--- a/test/unit/org/apache/cassandra/db/SystemPeersValidatorTest.java
+++ b/test/unit/org/apache/cassandra/db/SystemPeersValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.db;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashSet;
+import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
@@ -45,13 +46,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Unit tests for SystemPeersValidator to verify it correctly validates and repairs
- * inconsistencies between system.peers/peers_v2 tables and ClusterMetadata.
- */
 public class SystemPeersValidatorTest
 {
     private CMSTestBase.CMSSut sut;
+    private InetAddressAndPort peerEndpoint;
 
     @BeforeClass
     public static void beforeClass()
@@ -63,7 +61,11 @@ public class SystemPeersValidatorTest
     public void before() throws Exception
     {
         ClusterMetadataService.unsetInstance();
-        sut = new CMSTestBase.CMSSut(AtomicLongBackedProcessor::new, false, new TokenPlacementModel.SimpleReplicationFactor(3));
+        sut = new CMSTestBase.CMSSut(AtomicLongBackedProcessor::new, false,
+                                     new TokenPlacementModel.SimpleReplicationFactor(3));
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+        peerEndpoint = ClusterMetadata.current().directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
         cleanupPeersTables();
     }
 
@@ -75,171 +77,115 @@ public class SystemPeersValidatorTest
     }
 
     @Test
-    public void testValidationWithConsistentTables()
+    public void testNoRepairWhenTablesAreConsistent()
     {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-        ClusterMetadataTestHelper.register(2);
-        ClusterMetadataTestHelper.join(2, 2);
-        ClusterMetadataTestHelper.register(3);
-        ClusterMetadataTestHelper.join(3, 3);
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        ClusterMetadata metadata = ClusterMetadata.current();
-        SystemPeersValidator.validateAndRepair(metadata);
+        assertEquals("peers_v2 should have 1 peer", 1, countEntries(PEERS_V2));
+        assertEquals("legacy peers should have 1 peer", 1, countEntries(LEGACY_PEERS));
 
-        int peersV2CountBefore = countPeersV2Entries();
-        int legacyPeersCountBefore = countLegacyPeersEntries();
+        // Second call should be a no-op
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        SystemPeersValidator.validateAndRepair(metadata);
-
-        int peersV2CountAfter = countPeersV2Entries();
-        int legacyPeersCountAfter = countLegacyPeersEntries();
-
-        assertEquals("peers_v2 count should not change", peersV2CountBefore, peersV2CountAfter);
-        assertEquals("legacy peers count should not change", legacyPeersCountBefore, legacyPeersCountAfter);
+        assertEquals("peers_v2 count should not change on second call", 1, countEntries(PEERS_V2));
+        assertEquals("legacy peers count should not change on second call", 1, countEntries(LEGACY_PEERS));
     }
 
     @Test
-    public void testValidationRemovesExtraEntries() throws UnknownHostException
+    public void testStaleEntriesAreRemovedFromBothTables() throws UnknownHostException
     {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-        ClusterMetadataTestHelper.register(2);
-        ClusterMetadataTestHelper.join(2, 2);
+        InetAddressAndPort staleEndpoint = InetAddressAndPort.getByName("127.0.0.99");
+        insertStalePeerEntry(staleEndpoint, PEERS_V2);
+        insertStalePeerEntry(staleEndpoint, LEGACY_PEERS);
 
-        InetAddressAndPort staleEndpoint1 = InetAddressAndPort.getByName("127.0.0.97");
-        InetAddressAndPort staleEndpoint2 = InetAddressAndPort.getByName("127.0.0.98");
-        InetAddressAndPort staleEndpoint3 = InetAddressAndPort.getByName("127.0.0.99");
-        addStalePeerEntry(staleEndpoint1);
-        addStalePeerEntry(staleEndpoint2);
-        addStalePeerEntry(staleEndpoint3);
+        assertTrue(entryExistsInPeersV2(staleEndpoint));
+        assertTrue(entryExistsInLegacyPeers(staleEndpoint.getAddress()));
 
-        assertTrue("Stale entry 1 should exist in peers_v2", entryExistsInPeersV2(staleEndpoint1));
-        assertTrue("Stale entry 1 should exist in legacy peers", entryExistsInLegacyPeers(staleEndpoint1.getAddress()));
-        assertTrue("Stale entry 2 should exist in peers_v2", entryExistsInPeersV2(staleEndpoint2));
-        assertTrue("Stale entry 2 should exist in legacy peers", entryExistsInLegacyPeers(staleEndpoint2.getAddress()));
-        assertTrue("Stale entry 3 should exist in peers_v2", entryExistsInPeersV2(staleEndpoint3));
-        assertTrue("Stale entry 3 should exist in legacy peers", entryExistsInLegacyPeers(staleEndpoint3.getAddress()));
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        ClusterMetadata metadata = ClusterMetadata.current();
-
-        SystemPeersValidator.validateAndRepair(metadata);
-
-        assertFalse("Stale entry 1 should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint1));
-        assertFalse("Stale entry 1 should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint1.getAddress()));
-        assertFalse("Stale entry 2 should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint2));
-        assertFalse("Stale entry 2 should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint2.getAddress()));
-        assertFalse("Stale entry 3 should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint3));
-        assertFalse("Stale entry 3 should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint3.getAddress()));
+        assertFalse("Stale entry should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint));
+        assertFalse("Stale entry should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint.getAddress()));
     }
 
     @Test
-    public void testValidationAddsMissingEntries()
+    public void testStaleEntryOnlyInPeersV2IsRemoved() throws UnknownHostException
     {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-        ClusterMetadataTestHelper.register(2);
-        ClusterMetadataTestHelper.join(2, 2);
+        InetAddressAndPort staleEndpoint = InetAddressAndPort.getByName("127.0.0.99");
+        insertStalePeerEntry(staleEndpoint, PEERS_V2);
 
-        ClusterMetadata metadata = ClusterMetadata.current();
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        InetAddressAndPort peerEndpoint = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
+        assertFalse("Stale entry should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint));
+    }
+
+    @Test
+    public void testStaleEntryOnlyInLegacyPeersIsRemoved() throws UnknownHostException
+    {
+        InetAddressAndPort staleEndpoint = InetAddressAndPort.getByName("127.0.0.99");
+        insertStalePeerEntry(staleEndpoint, LEGACY_PEERS);
+
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        assertFalse("Stale entry should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint.getAddress()));
+    }
+
+    @Test
+    public void testMissingPeerIsAddedToBothTables()
+    {
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
         removePeerEntry(peerEndpoint);
 
-        assertFalse("Entry should be missing from peers_v2", entryExistsInPeersV2(peerEndpoint));
-        assertFalse("Entry should be missing from legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+        assertFalse(entryExistsInPeersV2(peerEndpoint));
+        assertFalse(entryExistsInLegacyPeers(peerEndpoint.getAddress()));
 
-        SystemPeersValidator.validateAndRepair(metadata);
-
-        assertTrue("Entry should be added back to peers_v2", entryExistsInPeersV2(peerEndpoint));
-        assertTrue("Entry should be added back to legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
-    }
-
-    @Test
-    public void testValidationRepairsMissingFromPeersV2Only()
-    {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-        ClusterMetadataTestHelper.register(2);
-        ClusterMetadataTestHelper.join(2, 2);
-
-        ClusterMetadata metadata = ClusterMetadata.current();
-
-        InetAddressAndPort peerEndpoint = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
-
-        // Populate both tables via the validator, then remove only the peers_v2 entry
-        SystemPeersValidator.validateAndRepair(metadata);
-        removePeersV2Entry(peerEndpoint);
-
-        assertTrue("Entry should still exist in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
-        assertFalse("Entry should be missing from peers_v2", entryExistsInPeersV2(peerEndpoint));
-
-        SystemPeersValidator.validateAndRepair(metadata);
-
-        assertTrue("Entry should be restored in peers_v2", entryExistsInPeersV2(peerEndpoint));
-        assertTrue("Entry should still exist in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
-    }
-
-    @Test
-    public void testValidationRepairsMissingFromLegacyPeersOnly()
-    {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-        ClusterMetadataTestHelper.register(2);
-        ClusterMetadataTestHelper.join(2, 2);
-
-        ClusterMetadata metadata = ClusterMetadata.current();
-
-        InetAddressAndPort peerEndpoint = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
-
-        // Populate both tables via the validator, then remove only the legacy peers entry
-        SystemPeersValidator.validateAndRepair(metadata);
-        removeLegacyPeersEntry(peerEndpoint);
-
-        assertTrue("Entry should still exist in peers_v2", entryExistsInPeersV2(peerEndpoint));
-        assertFalse("Entry should be missing from legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
-
-        SystemPeersValidator.validateAndRepair(metadata);
-
-        assertTrue("Entry should be restored in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
-        assertTrue("Entry should still exist in peers_v2", entryExistsInPeersV2(peerEndpoint));
-    }
-
-    @Test
-    public void testValidationWithNullMetadata()
-    {
-        SystemPeersValidator.validateAndRepair(null);
-    }
-
-    @Test
-    public void testValidationWithSingleNode()
-    {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-
-        ClusterMetadata metadata = ClusterMetadata.current();
-
-        SystemPeersValidator.validateAndRepair(metadata);
-
-        assertEquals("peers_v2 should be empty for single node", 0, countPeersV2Entries());
-        assertEquals("legacy peers should be empty for single node", 0, countLegacyPeersEntries());
-    }
-
-    @Test
-    public void testJmxEntryPoint()
-    {
-        ClusterMetadataTestHelper.register(1);
-        ClusterMetadataTestHelper.join(1, 1);
-        ClusterMetadataTestHelper.register(2);
-        ClusterMetadataTestHelper.join(2, 2);
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
-        ClusterMetadata metadata = ClusterMetadata.current();
-        InetAddressAndPort peer = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
-        removePeerEntry(peer);
+
+        assertTrue("Missing peer should be added to peers_v2", entryExistsInPeersV2(peerEndpoint));
+        assertTrue("Missing peer should be added to legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+    }
+
+    @Test
+    public void testStaleFieldInPeersV2IsRepaired()
+    {
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        executeInternal(String.format("UPDATE %s.%s SET data_center = 'stale-dc' WHERE peer = ? AND peer_port = ?",
+                                      SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2),
+                        peerEndpoint.getAddress(), peerEndpoint.getPort());
+
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        String expectedDc = ClusterMetadata.current().directory.location(ClusterMetadataTestHelper.nodeId(2)).datacenter;
+        assertEquals("data_center in peers_v2 should match ClusterMetadata",
+                     expectedDc, getDataCenter(peerEndpoint, PEERS_V2));
+    }
+
+    @Test
+    public void testStaleFieldInLegacyPeersIsRepaired()
+    {
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        executeInternal(String.format("UPDATE %s.%s SET data_center = 'stale-dc' WHERE peer = ?",
+                                      SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+                        peerEndpoint.getAddress());
+
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        String expectedDc = ClusterMetadata.current().directory.location(ClusterMetadataTestHelper.nodeId(2)).datacenter;
+        assertEquals("data_center in legacy peers should match ClusterMetadata",
+                     expectedDc, getDataCenter(peerEndpoint, LEGACY_PEERS));
+    }
+
+    @Test
+    public void testJmxEntryPointRepairsMissingPeer()
+    {
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+        removePeerEntry(peerEndpoint);
 
         StorageService.instance.validateAndRepairPeersMetadata();
 
-        assertTrue(entryExistsInPeersV2(peer));
+        assertTrue("JMX repair should restore peer in peers_v2", entryExistsInPeersV2(peerEndpoint));
+        assertTrue("JMX repair should restore peer in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
     }
 
     private void cleanupPeersTables()
@@ -248,79 +194,72 @@ public class SystemPeersValidatorTest
         executeInternal(String.format("TRUNCATE %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS));
     }
 
-    private int countPeersV2Entries()
+    private int countEntries(String table)
     {
-        String query = String.format("SELECT COUNT(*) FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-        UntypedResultSet result = executeInternal(query);
-        return (int) result.one().getLong("count");
-    }
-
-    private int countLegacyPeersEntries()
-    {
-        String query = String.format("SELECT COUNT(*) FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-        UntypedResultSet result = executeInternal(query);
+        UntypedResultSet result = executeInternal(String.format("SELECT COUNT(*) FROM %s.%s",
+                                                                SchemaConstants.SYSTEM_KEYSPACE_NAME, table));
         return (int) result.one().getLong("count");
     }
 
     private boolean entryExistsInPeersV2(InetAddressAndPort endpoint)
     {
-        String query = String.format("SELECT peer FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-        UntypedResultSet result = executeInternal(query, endpoint.getAddress(), endpoint.getPort());
+        UntypedResultSet result = executeInternal(
+            String.format("SELECT peer FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                          SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2),
+            endpoint.getAddress(), endpoint.getPort());
         return !result.isEmpty();
     }
 
     private boolean entryExistsInLegacyPeers(InetAddress address)
     {
-        String query = String.format("SELECT peer FROM %s.%s WHERE peer = ?",
-                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-        UntypedResultSet result = executeInternal(query, address);
+        UntypedResultSet result = executeInternal(
+            String.format("SELECT peer FROM %s.%s WHERE peer = ?",
+                          SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+            address);
         return !result.isEmpty();
     }
 
-    private void addStalePeerEntry(InetAddressAndPort endpoint)
+    private String getDataCenter(InetAddressAndPort endpoint, String table)
     {
-        String queryV2 = String.format("INSERT INTO %s.%s (peer, peer_port, data_center, host_id, rack, release_version, tokens) " +
-                                       "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                                       SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-        executeInternal(queryV2,
-                        endpoint.getAddress(),
-                        endpoint.getPort(),
-                        "dc1",
-                        java.util.UUID.randomUUID(),
-                        "rack1",
-                        "5.0.0",
-                        new HashSet<String>());
+        UntypedResultSet result;
+        if (table.equals(PEERS_V2))
+            result = executeInternal(
+                String.format("SELECT data_center FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
+                endpoint.getAddress(), endpoint.getPort());
+        else
+            result = executeInternal(
+                String.format("SELECT data_center FROM %s.%s WHERE peer = ?",
+                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
+                endpoint.getAddress());
+        return result.one().getString("data_center");
+    }
 
-        String queryLegacy = String.format("INSERT INTO %s.%s (peer, data_center, host_id, rack, release_version, tokens) " +
-                                           "VALUES (?, ?, ?, ?, ?, ?)",
-                                           SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-        executeInternal(queryLegacy,
-                        endpoint.getAddress(),
-                        "dc1",
-                        java.util.UUID.randomUUID(),
-                        "rack1",
-                        "5.0.0",
-                        new HashSet<String>());
+    private void insertStalePeerEntry(InetAddressAndPort endpoint, String table)
+    {
+        if (table.equals(PEERS_V2))
+            executeInternal(
+                String.format("INSERT INTO %s.%s (peer, peer_port, data_center, host_id, rack, release_version, tokens) " +
+                              "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
+                endpoint.getAddress(), endpoint.getPort(), "dc1", UUID.randomUUID(), "rack1", "5.0.0", new HashSet<String>());
+        else
+            executeInternal(
+                String.format("INSERT INTO %s.%s (peer, data_center, host_id, rack, release_version, tokens) " +
+                              "VALUES (?, ?, ?, ?, ?, ?)",
+                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
+                endpoint.getAddress(), "dc1", UUID.randomUUID(), "rack1", "5.0.0", new HashSet<String>());
     }
 
     private void removePeerEntry(InetAddressAndPort endpoint)
     {
-        removePeersV2Entry(endpoint);
-        removeLegacyPeersEntry(endpoint);
-    }
+        executeInternal(
+            String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                      SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2),
+            endpoint.getAddress(), endpoint.getPort());
 
-    private void removePeersV2Entry(InetAddressAndPort endpoint)
-    {
-        String query = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
-        executeInternal(query, endpoint.getAddress(), endpoint.getPort());
-    }
-
-    private void removeLegacyPeersEntry(InetAddressAndPort endpoint)
-    {
-        String query = String.format("DELETE FROM %s.%s WHERE peer = ?",
-                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
-        executeInternal(query, endpoint.getAddress());
+        executeInternal(
+            String.format("DELETE FROM %s.%s WHERE peer = ?",
+                      SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS), endpoint.getAddress());
     }
 }

--- a/test/unit/org/apache/cassandra/db/SystemPeersValidatorTest.java
+++ b/test/unit/org/apache/cassandra/db/SystemPeersValidatorTest.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.distributed.test.log.CMSTestBase;
+import org.apache.cassandra.distributed.test.log.ClusterMetadataTestHelper;
+import org.apache.cassandra.harry.model.TokenPlacementModel;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.tcm.AtomicLongBackedProcessor;
+import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.ClusterMetadataService;
+
+import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
+import static org.apache.cassandra.db.SystemKeyspace.LEGACY_PEERS;
+import static org.apache.cassandra.db.SystemKeyspace.PEERS_V2;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for SystemPeersValidator to verify it correctly validates and repairs
+ * inconsistencies between system.peers/peers_v2 tables and ClusterMetadata.
+ */
+public class SystemPeersValidatorTest
+{
+    private CMSTestBase.CMSSut sut;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        ServerTestUtils.prepareServerNoRegister();
+    }
+
+    @Before
+    public void before() throws Exception
+    {
+        ClusterMetadataService.unsetInstance();
+        sut = new CMSTestBase.CMSSut(AtomicLongBackedProcessor::new, false, new TokenPlacementModel.SimpleReplicationFactor(3));
+        cleanupPeersTables();
+    }
+
+    @After
+    public void after()
+    {
+        if (sut != null)
+            sut.close();
+    }
+
+    @Test
+    public void testValidationWithConsistentTables()
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+        ClusterMetadataTestHelper.register(3);
+        ClusterMetadataTestHelper.join(3, 3);
+
+        ClusterMetadata metadata = ClusterMetadata.current();
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        int peersV2CountBefore = countPeersV2Entries();
+        int legacyPeersCountBefore = countLegacyPeersEntries();
+
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        int peersV2CountAfter = countPeersV2Entries();
+        int legacyPeersCountAfter = countLegacyPeersEntries();
+
+        assertEquals("peers_v2 count should not change", peersV2CountBefore, peersV2CountAfter);
+        assertEquals("legacy peers count should not change", legacyPeersCountBefore, legacyPeersCountAfter);
+    }
+
+    @Test
+    public void testValidationRemovesExtraEntries() throws UnknownHostException
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+
+        InetAddressAndPort staleEndpoint1 = InetAddressAndPort.getByName("127.0.0.97");
+        InetAddressAndPort staleEndpoint2 = InetAddressAndPort.getByName("127.0.0.98");
+        InetAddressAndPort staleEndpoint3 = InetAddressAndPort.getByName("127.0.0.99");
+        addStalePeerEntry(staleEndpoint1);
+        addStalePeerEntry(staleEndpoint2);
+        addStalePeerEntry(staleEndpoint3);
+
+        assertTrue("Stale entry 1 should exist in peers_v2", entryExistsInPeersV2(staleEndpoint1));
+        assertTrue("Stale entry 1 should exist in legacy peers", entryExistsInLegacyPeers(staleEndpoint1.getAddress()));
+        assertTrue("Stale entry 2 should exist in peers_v2", entryExistsInPeersV2(staleEndpoint2));
+        assertTrue("Stale entry 2 should exist in legacy peers", entryExistsInLegacyPeers(staleEndpoint2.getAddress()));
+        assertTrue("Stale entry 3 should exist in peers_v2", entryExistsInPeersV2(staleEndpoint3));
+        assertTrue("Stale entry 3 should exist in legacy peers", entryExistsInLegacyPeers(staleEndpoint3.getAddress()));
+
+        ClusterMetadata metadata = ClusterMetadata.current();
+
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        assertFalse("Stale entry 1 should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint1));
+        assertFalse("Stale entry 1 should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint1.getAddress()));
+        assertFalse("Stale entry 2 should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint2));
+        assertFalse("Stale entry 2 should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint2.getAddress()));
+        assertFalse("Stale entry 3 should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint3));
+        assertFalse("Stale entry 3 should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint3.getAddress()));
+    }
+
+    @Test
+    public void testValidationAddsMissingEntries()
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+
+        ClusterMetadata metadata = ClusterMetadata.current();
+
+        InetAddressAndPort peerEndpoint = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
+        removePeerEntry(peerEndpoint);
+
+        assertFalse("Entry should be missing from peers_v2", entryExistsInPeersV2(peerEndpoint));
+        assertFalse("Entry should be missing from legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        assertTrue("Entry should be added back to peers_v2", entryExistsInPeersV2(peerEndpoint));
+        assertTrue("Entry should be added back to legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+    }
+
+    @Test
+    public void testValidationRepairsMissingFromPeersV2Only()
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+
+        ClusterMetadata metadata = ClusterMetadata.current();
+
+        InetAddressAndPort peerEndpoint = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
+
+        // Populate both tables via the validator, then remove only the peers_v2 entry
+        SystemPeersValidator.validateAndRepair(metadata);
+        removePeersV2Entry(peerEndpoint);
+
+        assertTrue("Entry should still exist in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+        assertFalse("Entry should be missing from peers_v2", entryExistsInPeersV2(peerEndpoint));
+
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        assertTrue("Entry should be restored in peers_v2", entryExistsInPeersV2(peerEndpoint));
+        assertTrue("Entry should still exist in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+    }
+
+    @Test
+    public void testValidationRepairsMissingFromLegacyPeersOnly()
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+
+        ClusterMetadata metadata = ClusterMetadata.current();
+
+        InetAddressAndPort peerEndpoint = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
+
+        // Populate both tables via the validator, then remove only the legacy peers entry
+        SystemPeersValidator.validateAndRepair(metadata);
+        removeLegacyPeersEntry(peerEndpoint);
+
+        assertTrue("Entry should still exist in peers_v2", entryExistsInPeersV2(peerEndpoint));
+        assertFalse("Entry should be missing from legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        assertTrue("Entry should be restored in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+        assertTrue("Entry should still exist in peers_v2", entryExistsInPeersV2(peerEndpoint));
+    }
+
+    @Test
+    public void testValidationWithNullMetadata()
+    {
+        SystemPeersValidator.validateAndRepair(null);
+    }
+
+    @Test
+    public void testValidationWithSingleNode()
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+
+        ClusterMetadata metadata = ClusterMetadata.current();
+
+        SystemPeersValidator.validateAndRepair(metadata);
+
+        assertEquals("peers_v2 should be empty for single node", 0, countPeersV2Entries());
+        assertEquals("legacy peers should be empty for single node", 0, countLegacyPeersEntries());
+    }
+
+    @Test
+    public void testJmxEntryPoint()
+    {
+        ClusterMetadataTestHelper.register(1);
+        ClusterMetadataTestHelper.join(1, 1);
+        ClusterMetadataTestHelper.register(2);
+        ClusterMetadataTestHelper.join(2, 2);
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+        ClusterMetadata metadata = ClusterMetadata.current();
+        InetAddressAndPort peer = metadata.directory.endpoint(ClusterMetadataTestHelper.nodeId(2));
+        removePeerEntry(peer);
+
+        StorageService.instance.validateAndRepairPeersMetadata();
+
+        assertTrue(entryExistsInPeersV2(peer));
+    }
+
+    private void cleanupPeersTables()
+    {
+        executeInternal(String.format("TRUNCATE %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2));
+        executeInternal(String.format("TRUNCATE %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS));
+    }
+
+    private int countPeersV2Entries()
+    {
+        String query = String.format("SELECT COUNT(*) FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        UntypedResultSet result = executeInternal(query);
+        return (int) result.one().getLong("count");
+    }
+
+    private int countLegacyPeersEntries()
+    {
+        String query = String.format("SELECT COUNT(*) FROM %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+        UntypedResultSet result = executeInternal(query);
+        return (int) result.one().getLong("count");
+    }
+
+    private boolean entryExistsInPeersV2(InetAddressAndPort endpoint)
+    {
+        String query = String.format("SELECT peer FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        UntypedResultSet result = executeInternal(query, endpoint.getAddress(), endpoint.getPort());
+        return !result.isEmpty();
+    }
+
+    private boolean entryExistsInLegacyPeers(InetAddress address)
+    {
+        String query = String.format("SELECT peer FROM %s.%s WHERE peer = ?",
+                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+        UntypedResultSet result = executeInternal(query, address);
+        return !result.isEmpty();
+    }
+
+    private void addStalePeerEntry(InetAddressAndPort endpoint)
+    {
+        String queryV2 = String.format("INSERT INTO %s.%s (peer, peer_port, data_center, host_id, rack, release_version, tokens) " +
+                                       "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                                       SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        executeInternal(queryV2,
+                        endpoint.getAddress(),
+                        endpoint.getPort(),
+                        "dc1",
+                        java.util.UUID.randomUUID(),
+                        "rack1",
+                        "5.0.0",
+                        new HashSet<String>());
+
+        String queryLegacy = String.format("INSERT INTO %s.%s (peer, data_center, host_id, rack, release_version, tokens) " +
+                                           "VALUES (?, ?, ?, ?, ?, ?)",
+                                           SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+        executeInternal(queryLegacy,
+                        endpoint.getAddress(),
+                        "dc1",
+                        java.util.UUID.randomUUID(),
+                        "rack1",
+                        "5.0.0",
+                        new HashSet<String>());
+    }
+
+    private void removePeerEntry(InetAddressAndPort endpoint)
+    {
+        removePeersV2Entry(endpoint);
+        removeLegacyPeersEntry(endpoint);
+    }
+
+    private void removePeersV2Entry(InetAddressAndPort endpoint)
+    {
+        String query = String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2);
+        executeInternal(query, endpoint.getAddress(), endpoint.getPort());
+    }
+
+    private void removeLegacyPeersEntry(InetAddressAndPort endpoint)
+    {
+        String query = String.format("DELETE FROM %s.%s WHERE peer = ?",
+                                     SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS);
+        executeInternal(query, endpoint.getAddress());
+    }
+}

--- a/test/unit/org/apache/cassandra/db/SystemPeersValidatorTest.java
+++ b/test/unit/org/apache/cassandra/db/SystemPeersValidatorTest.java
@@ -29,19 +29,23 @@ import org.junit.Test;
 
 import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.cql3.UntypedResultSet;
+import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.distributed.test.log.CMSTestBase;
 import org.apache.cassandra.distributed.test.log.ClusterMetadataTestHelper;
 import org.apache.cassandra.harry.model.TokenPlacementModel;
 import org.apache.cassandra.locator.InetAddressAndPort;
-import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.AtomicLongBackedProcessor;
 import org.apache.cassandra.tcm.ClusterMetadata;
 import org.apache.cassandra.tcm.ClusterMetadataService;
+import org.apache.cassandra.tcm.membership.Location;
+import org.apache.cassandra.tcm.membership.NodeAddresses;
+import org.apache.cassandra.tcm.membership.NodeId;
 
 import static org.apache.cassandra.cql3.QueryProcessor.executeInternal;
 import static org.apache.cassandra.db.SystemKeyspace.LEGACY_PEERS;
 import static org.apache.cassandra.db.SystemKeyspace.PEERS_V2;
+import static org.apache.cassandra.schema.SchemaConstants.SYSTEM_KEYSPACE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -82,29 +86,13 @@ public class SystemPeersValidatorTest
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
         assertEquals("peers_v2 should have 1 peer", 1, countEntries(PEERS_V2));
-        assertEquals("legacy peers should have 1 peer", 1, countEntries(LEGACY_PEERS));
+        assertEquals("peers should have 1 peer", 1, countEntries(LEGACY_PEERS));
 
         // Second call should be a no-op
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
         assertEquals("peers_v2 count should not change on second call", 1, countEntries(PEERS_V2));
-        assertEquals("legacy peers count should not change on second call", 1, countEntries(LEGACY_PEERS));
-    }
-
-    @Test
-    public void testStaleEntriesAreRemovedFromBothTables() throws UnknownHostException
-    {
-        InetAddressAndPort staleEndpoint = InetAddressAndPort.getByName("127.0.0.99");
-        insertStalePeerEntry(staleEndpoint, PEERS_V2);
-        insertStalePeerEntry(staleEndpoint, LEGACY_PEERS);
-
-        assertTrue(entryExistsInPeersV2(staleEndpoint));
-        assertTrue(entryExistsInLegacyPeers(staleEndpoint.getAddress()));
-
-        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
-
-        assertFalse("Stale entry should be removed from peers_v2", entryExistsInPeersV2(staleEndpoint));
-        assertFalse("Stale entry should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint.getAddress()));
+        assertEquals("peers count should not change on second call", 1, countEntries(LEGACY_PEERS));
     }
 
     @Test
@@ -119,14 +107,14 @@ public class SystemPeersValidatorTest
     }
 
     @Test
-    public void testStaleEntryOnlyInLegacyPeersIsRemoved() throws UnknownHostException
+    public void testStaleEntryOnlyInPeersIsRemoved() throws UnknownHostException
     {
         InetAddressAndPort staleEndpoint = InetAddressAndPort.getByName("127.0.0.99");
         insertStalePeerEntry(staleEndpoint, LEGACY_PEERS);
 
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        assertFalse("Stale entry should be removed from legacy peers", entryExistsInLegacyPeers(staleEndpoint.getAddress()));
+        assertFalse("Stale entry should be removed from peers", entryExistsInPeers(staleEndpoint.getAddress()));
     }
 
     @Test
@@ -136,12 +124,12 @@ public class SystemPeersValidatorTest
         removePeerEntry(peerEndpoint);
 
         assertFalse(entryExistsInPeersV2(peerEndpoint));
-        assertFalse(entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+        assertFalse(entryExistsInPeers(peerEndpoint.getAddress()));
 
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        assertTrue("Missing peer should be added to peers_v2", entryExistsInPeersV2(peerEndpoint));
-        assertTrue("Missing peer should be added to legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+        assertPeersV2RowMatchesMetadata(peerEndpoint);
+        assertPeersRowMatchesMetadata(peerEndpoint);
     }
 
     @Test
@@ -150,30 +138,68 @@ public class SystemPeersValidatorTest
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
         executeInternal(String.format("UPDATE %s.%s SET data_center = 'stale-dc' WHERE peer = ? AND peer_port = ?",
-                                      SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2),
+                                      SYSTEM_KEYSPACE_NAME, PEERS_V2),
                         peerEndpoint.getAddress(), peerEndpoint.getPort());
 
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        String expectedDc = ClusterMetadata.current().directory.location(ClusterMetadataTestHelper.nodeId(2)).datacenter;
-        assertEquals("data_center in peers_v2 should match ClusterMetadata",
-                     expectedDc, getDataCenter(peerEndpoint, PEERS_V2));
+        assertPeersV2RowMatchesMetadata(peerEndpoint);
     }
 
     @Test
-    public void testStaleFieldInLegacyPeersIsRepaired()
+    public void testStaleFieldInPeersIsRepaired()
     {
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
         executeInternal(String.format("UPDATE %s.%s SET data_center = 'stale-dc' WHERE peer = ?",
-                                      SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+                                      SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
                         peerEndpoint.getAddress());
 
         SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
 
-        String expectedDc = ClusterMetadata.current().directory.location(ClusterMetadataTestHelper.nodeId(2)).datacenter;
-        assertEquals("data_center in legacy peers should match ClusterMetadata",
-                     expectedDc, getDataCenter(peerEndpoint, LEGACY_PEERS));
+        assertPeersRowMatchesMetadata(peerEndpoint);
+    }
+
+    @Test
+    public void testNullColumnInPeersV2IsRepaired()
+    {
+        String[] columns = { "data_center", "host_id", "preferred_ip", "preferred_port",
+                             "rack", "release_version", "native_address", "native_port",
+                             "schema_version", "tokens" };
+
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        for (String column : columns)
+        {
+            executeInternal(String.format("DELETE %s FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                                          column, SYSTEM_KEYSPACE_NAME, PEERS_V2),
+                            peerEndpoint.getAddress(), peerEndpoint.getPort());
+
+            SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+            assertPeersV2RowMatchesMetadata(peerEndpoint);
+        }
+    }
+
+    @Test
+    public void testNullColumnInPeersIsRepaired()
+    {
+        String[] columns = { "data_center", "host_id", "preferred_ip",
+                             "rack", "release_version", "rpc_address",
+                             "schema_version", "tokens" };
+
+        SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+        for (String column : columns)
+        {
+            executeInternal(String.format("DELETE %s FROM %s.%s WHERE peer = ?",
+                                          column, SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+                            peerEndpoint.getAddress());
+
+            SystemPeersValidator.validateAndRepair(ClusterMetadata.current());
+
+            assertPeersRowMatchesMetadata(peerEndpoint);
+        }
     }
 
     @Test
@@ -185,19 +211,19 @@ public class SystemPeersValidatorTest
         StorageService.instance.validateAndRepairPeersMetadata();
 
         assertTrue("JMX repair should restore peer in peers_v2", entryExistsInPeersV2(peerEndpoint));
-        assertTrue("JMX repair should restore peer in legacy peers", entryExistsInLegacyPeers(peerEndpoint.getAddress()));
+        assertTrue("JMX repair should restore peer in peers", entryExistsInPeers(peerEndpoint.getAddress()));
     }
 
     private void cleanupPeersTables()
     {
-        executeInternal(String.format("TRUNCATE %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2));
-        executeInternal(String.format("TRUNCATE %s.%s", SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS));
+        executeInternal(String.format("TRUNCATE %s.%s", SYSTEM_KEYSPACE_NAME, PEERS_V2));
+        executeInternal(String.format("TRUNCATE %s.%s", SYSTEM_KEYSPACE_NAME, LEGACY_PEERS));
     }
 
     private int countEntries(String table)
     {
         UntypedResultSet result = executeInternal(String.format("SELECT COUNT(*) FROM %s.%s",
-                                                                SchemaConstants.SYSTEM_KEYSPACE_NAME, table));
+                                                                SYSTEM_KEYSPACE_NAME, table));
         return (int) result.one().getLong("count");
     }
 
@@ -205,34 +231,66 @@ public class SystemPeersValidatorTest
     {
         UntypedResultSet result = executeInternal(
             String.format("SELECT peer FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                          SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2),
+                          SYSTEM_KEYSPACE_NAME, PEERS_V2),
             endpoint.getAddress(), endpoint.getPort());
         return !result.isEmpty();
     }
 
-    private boolean entryExistsInLegacyPeers(InetAddress address)
+    private boolean entryExistsInPeers(InetAddress address)
     {
         UntypedResultSet result = executeInternal(
             String.format("SELECT peer FROM %s.%s WHERE peer = ?",
-                          SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+                          SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
             address);
         return !result.isEmpty();
     }
 
-    private String getDataCenter(InetAddressAndPort endpoint, String table)
+    private void assertPeersV2RowMatchesMetadata(InetAddressAndPort endpoint)
     {
-        UntypedResultSet result;
-        if (table.equals(PEERS_V2))
-            result = executeInternal(
-                String.format("SELECT data_center FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
-                endpoint.getAddress(), endpoint.getPort());
-        else
-            result = executeInternal(
-                String.format("SELECT data_center FROM %s.%s WHERE peer = ?",
-                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
-                endpoint.getAddress());
-        return result.one().getString("data_center");
+        ClusterMetadata metadata = ClusterMetadata.current();
+        NodeId nodeId = ClusterMetadataTestHelper.nodeId(2);
+        NodeAddresses addresses = metadata.directory.getNodeAddresses(nodeId);
+        Location location = metadata.directory.location(nodeId);
+
+        UntypedResultSet result = executeInternal(
+            String.format("SELECT * FROM %s.%s WHERE peer = ? AND peer_port = ?",
+                          SYSTEM_KEYSPACE_NAME, PEERS_V2),
+            endpoint.getAddress(), endpoint.getPort());
+        UntypedResultSet.Row row = result.one();
+
+        assertEquals(addresses.broadcastAddress.getAddress(), row.getInetAddress("preferred_ip"));
+        assertEquals(addresses.broadcastAddress.getPort(), row.getInt("preferred_port"));
+        assertEquals(addresses.nativeAddress.getAddress(), row.getInetAddress("native_address"));
+        assertEquals(addresses.nativeAddress.getPort(), row.getInt("native_port"));
+        assertEquals(location.datacenter, row.getString("data_center"));
+        assertEquals(location.rack, row.getString("rack"));
+        assertEquals(nodeId.toUUID(), row.getUUID("host_id"));
+        assertEquals(metadata.directory.version(nodeId).cassandraVersion.toString(), row.getString("release_version"));
+        assertEquals(metadata.schema.getVersion(), row.getUUID("schema_version"));
+        assertEquals(SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)), row.getSet("tokens", UTF8Type.instance));
+    }
+
+    private void assertPeersRowMatchesMetadata(InetAddressAndPort endpoint)
+    {
+        ClusterMetadata metadata = ClusterMetadata.current();
+        NodeId nodeId = ClusterMetadataTestHelper.nodeId(2);
+        NodeAddresses addresses = metadata.directory.getNodeAddresses(nodeId);
+        Location location = metadata.directory.location(nodeId);
+
+        UntypedResultSet result = executeInternal(
+            String.format("SELECT * FROM %s.%s WHERE peer = ?",
+                          SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+            endpoint.getAddress());
+        UntypedResultSet.Row row = result.one();
+
+        assertEquals(addresses.broadcastAddress.getAddress(), row.getInetAddress("preferred_ip"));
+        assertEquals(addresses.nativeAddress.getAddress(), row.getInetAddress("rpc_address"));
+        assertEquals(location.datacenter, row.getString("data_center"));
+        assertEquals(location.rack, row.getString("rack"));
+        assertEquals(nodeId.toUUID(), row.getUUID("host_id"));
+        assertEquals(metadata.directory.version(nodeId).cassandraVersion.toString(), row.getString("release_version"));
+        assertEquals(metadata.schema.getVersion(), row.getUUID("schema_version"));
+        assertEquals(SystemKeyspace.tokensAsSet(metadata.tokenMap.tokens(nodeId)), row.getSet("tokens", UTF8Type.instance));
     }
 
     private void insertStalePeerEntry(InetAddressAndPort endpoint, String table)
@@ -241,25 +299,24 @@ public class SystemPeersValidatorTest
             executeInternal(
                 String.format("INSERT INTO %s.%s (peer, peer_port, data_center, host_id, rack, release_version, tokens) " +
                               "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
+                              SYSTEM_KEYSPACE_NAME, table),
                 endpoint.getAddress(), endpoint.getPort(), "dc1", UUID.randomUUID(), "rack1", "5.0.0", new HashSet<String>());
         else
             executeInternal(
                 String.format("INSERT INTO %s.%s (peer, data_center, host_id, rack, release_version, tokens) " +
                               "VALUES (?, ?, ?, ?, ?, ?)",
-                              SchemaConstants.SYSTEM_KEYSPACE_NAME, table),
+                              SYSTEM_KEYSPACE_NAME, table),
                 endpoint.getAddress(), "dc1", UUID.randomUUID(), "rack1", "5.0.0", new HashSet<String>());
     }
 
     private void removePeerEntry(InetAddressAndPort endpoint)
     {
         executeInternal(
-            String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?",
-                      SchemaConstants.SYSTEM_KEYSPACE_NAME, PEERS_V2),
+            String.format("DELETE FROM %s.%s WHERE peer = ? AND peer_port = ?", SYSTEM_KEYSPACE_NAME, PEERS_V2),
             endpoint.getAddress(), endpoint.getPort());
 
         executeInternal(
-            String.format("DELETE FROM %s.%s WHERE peer = ?",
-                      SchemaConstants.SYSTEM_KEYSPACE_NAME, LEGACY_PEERS), endpoint.getAddress());
+            String.format("DELETE FROM %s.%s WHERE peer = ?", SYSTEM_KEYSPACE_NAME, LEGACY_PEERS),
+                endpoint.getAddress());
     }
 }


### PR DESCRIPTION
**Description:**                                                                    
`system.peers` and `system.peers_v2` can drift out of sync with `ClusterMetadata`, causing clients who use older C* version and tools that read these legacy tables to observe incorrect cluster topology.

Adds `SystemPeersValidator` which reconciles both peer tables against ClusterMetadata on startup- removing stale entries for nodes no longer in the cluster, repairing missing entries for joined nodes and updating the stale fields of nodes if present in both. Also exposes this as a JMX operation via `StorageServiceMBean` so operators can trigger it on demand without restarting.

Quick diagram of what the patch is about:
<img width="1576" height="470" alt="image" src="https://github.com/user-attachments/assets/e72271ce-6833-4fd2-945d-fadc58d9b391" />


patch by @minal-kyada; reviewed by @beobal @ifesdjeen for [CASSANDRA-21187](https://issues.apache.org/jira/browse/CASSANDRA-21187)