### PR TITLE
CASSANDRA-17693: Missing type checking on reused bind variables

### DIFF
--- a/src/java/org/apache/cassandra/cql3/VariableSpecifications.java
+++ b/src/java/org/apache/cassandra/cql3/VariableSpecifications.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
 
@@ -108,7 +109,23 @@ public class VariableSpecifications
         ColumnIdentifier bindMarkerName = variableNames.get(bindIndex);
         // Use the user name, if there is one
         if (bindMarkerName != null)
+        {
+            for (int i = 0; i < bindIndex; i++)
+            {
+                ColumnIdentifier prevName = variableNames.get(i);
+                if (prevName != null && prevName.equals(bindMarkerName))
+                {
+                    ColumnSpecification prevSpec = specs.get(i);
+                    if (prevSpec != null && !prevSpec.type.isCompatibleWith(spec.type))
+                    {
+                        throw new InvalidRequestException(
+                            String.format("Bind variable '%s' is used for columns of incompatible types: %s and %s",
+                                bindMarkerName, prevSpec.type.asCQL3Type(), spec.type.asCQL3Type()));
+                    }
+                }
+            }
             spec = new ColumnSpecification(spec.ksName, spec.cfName, bindMarkerName, spec.type);
+        }
         specs.set(bindIndex, spec);
     }
 

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/PreparedStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/PreparedStatementTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.transport.messages.ResultMessage;
@@ -81,5 +82,118 @@ public class PreparedStatementTest extends CQLTester
         // Wait for all threads to finish
         finishLatch.await();
         Assert.assertTrue(preparedStatementPresentInCache.get());
+    }
+
+    /**
+     * CASSANDRA-17693: Using the same named bind variable for columns of incompatible types
+     * should be rejected during preparation.
+     *
+     * For example: INSERT INTO t (id, col_text, col_int) VALUES (:id, :a, :a)
+     * where col_text is text and col_int is int — the :a variable cannot be both types.
+     */
+    @Test
+    public void testReusedNamedBindVariableWithIncompatibleTypes() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, col_text text, col_int int)");
+
+        String query = formatQuery("INSERT INTO %s (id, col_text, col_int) VALUES (:id, :a, :a)");
+        ClientState state = ClientState.forInternalCalls();
+
+        try
+        {
+            QueryProcessor.instance.prepare(query, state);
+            Assert.fail("Expected InvalidRequestException for bind variable :a used with incompatible types text and int");
+        }
+        catch (InvalidRequestException e)
+        {
+            Assert.assertTrue("Error should mention the conflicting bind variable",
+                              e.getMessage().contains("'a'"));
+            Assert.assertTrue("Error should mention incompatible types",
+                              e.getMessage().contains("incompatible types"));
+        }
+    }
+
+    /**
+     * CASSANDRA-17693: Reusing a named bind variable for columns of the same type should still be accepted.
+     */
+    @Test
+    public void testReusedNamedBindVariableWithCompatibleTypes() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, col_text1 text, col_text2 text)");
+
+        String query = formatQuery("INSERT INTO %s (id, col_text1, col_text2) VALUES (:id, :a, :a)");
+        ClientState state = ClientState.forInternalCalls();
+
+        // Should succeed — :a is used for two text columns, which is compatible
+        ResultMessage.Prepared prepared = QueryProcessor.instance.prepare(query, state);
+        Assert.assertNotNull(prepared);
+    }
+
+    /**
+     * CASSANDRA-17693: When a named bind variable is reused across 3+ columns and only the third
+     * conflicts, preparation should still be rejected.
+     */
+    @Test
+    public void testReusedNamedBindVariableThirdColumnConflicts() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, col_text1 text, col_text2 text, col_int int)");
+
+        String query = formatQuery("INSERT INTO %s (id, col_text1, col_text2, col_int) VALUES (:id, :a, :a, :a)");
+        ClientState state = ClientState.forInternalCalls();
+
+        try
+        {
+            QueryProcessor.instance.prepare(query, state);
+            Assert.fail("Expected InvalidRequestException for bind variable :a used with incompatible types");
+        }
+        catch (InvalidRequestException e)
+        {
+            Assert.assertTrue("Error should mention the conflicting bind variable",
+                              e.getMessage().contains("'a'"));
+            Assert.assertTrue("Error should mention incompatible types",
+                              e.getMessage().contains("incompatible types"));
+        }
+    }
+
+    /**
+     * CASSANDRA-17693: When multiple named bind variables are used and only one pair conflicts,
+     * the conflicting pair should be rejected without affecting the valid ones.
+     */
+    @Test
+    public void testMultipleBindVariablesOnlyOneConflicts() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, col_text1 text, col_text2 text, col_int int)");
+
+        // :b is used for compatible columns (text, text), but :a is used for incompatible columns (text, int)
+        String query = formatQuery("INSERT INTO %s (id, col_text1, col_int, col_text2) VALUES (:id, :a, :a, :b)");
+        ClientState state = ClientState.forInternalCalls();
+
+        try
+        {
+            QueryProcessor.instance.prepare(query, state);
+            Assert.fail("Expected InvalidRequestException for bind variable :a used with incompatible types");
+        }
+        catch (InvalidRequestException e)
+        {
+            Assert.assertTrue("Error should mention the conflicting bind variable",
+                              e.getMessage().contains("'a'"));
+        }
+    }
+
+    /**
+     * CASSANDRA-17693: Reusing a named bind variable for ascii and text columns should be accepted,
+     * since text (UTF8Type) is compatible with ascii (AsciiType).
+     */
+    @Test
+    public void testReusedNamedBindVariableWithAsciiAndText() throws Throwable
+    {
+        createTable("CREATE TABLE %s (id int PRIMARY KEY, col_ascii ascii, col_text text)");
+
+        String query = formatQuery("INSERT INTO %s (id, col_text, col_ascii) VALUES (:id, :a, :a)");
+        ClientState state = ClientState.forInternalCalls();
+
+        // Should succeed — text is compatible with ascii
+        ResultMessage.Prepared prepared = QueryProcessor.instance.prepare(query, state);
+        Assert.assertNotNull(prepared);
     }
 }


### PR DESCRIPTION
## Summary
- Detect when a named bind variable (e.g. `:a`) is reused for columns of incompatible types during prepared statement preparation, and reject with a clear `InvalidRequestException`
- The check is performed in `VariableSpecifications.add()` by comparing the type of each named bind variable against all previous occurrences with the same name using `isCompatibleWith`
- Compatible type reuse (e.g. `:a` for two `text` columns, or `ascii` and `text`) continues to work as expected

## Test plan
- [x] `testReusedNamedBindVariableWithIncompatibleTypes` — verifies rejection when `:a` is used for `text` and `int`
- [x] `testReusedNamedBindVariableWithCompatibleTypes` — verifies acceptance when `:a` is used for two `text` columns
- [x] `testReusedNamedBindVariableThirdColumnConflicts` — verifies rejection when the 3rd usage of `:a` conflicts (`text`, `text`, `int`)
- [x] `testMultipleBindVariablesOnlyOneConflicts` — verifies only the conflicting variable is rejected when multiple bind variables are used
- [x] `testReusedNamedBindVariableWithAsciiAndText` — verifies compatible-but-not-equal types (`ascii` and `text`) are accepted
- [x] All tests pass via `ant testsome -Dtest.name=org.apache.cassandra.cql3.validation.miscellaneous.PreparedStatementTest`

### Manual testing with reproducer from [CASSANDRA-17693](https://issues.apache.org/jira/browse/CASSANDRA-17693)

Tested against a local single-node cluster using the reproducer script from the Jira ticket.

**Before (trunk):** The prepared statement with mismatched types was accepted and the insert went through, but reading the value back failed with a confusing error:
```
python3 ~/bind-var-type-conflict.py 
Traceback (most recent call last):
  File "/root/bind-var-type-conflict.py", line 31, in <module>
    result = session.execute(stmt2, (2,))
  File "cassandra/cluster.py", line 2618, in cassandra.cluster.Session.execute
  File "cassandra/cluster.py", line 4877, in cassandra.cluster.ResponseFuture.result
cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="Invalid unset value for column b"
```

**After (this branch):** The prepared statement is rejected at prepare time before any data is written, with a clear error:
```
python3 ~/bind-var-type-conflict.py
Traceback (most recent call last):
  File "/root/bind-var-type-conflict.py", line 18, in <module>
    stmt1 = session.prepare('''\
  File "cassandra/cluster.py", line 3072, in cassandra.cluster.Session.prepare
  File "cassandra/cluster.py", line 3069, in cassandra.cluster.Session.prepare
  File "cassandra/cluster.py", line 4877, in cassandra.cluster.ResponseFuture.result
cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="Bind variable 'a' is used for columns of incompatible types: int and text"
```
