### PR TITLE
CASSANDRA-21194 Sampling data for dictionary training on more than Integer.MAX_VALUE bytes in pointless

### DIFF
--- a/src/java/org/apache/cassandra/db/compression/CompressionDictionaryManager.java
+++ b/src/java/org/apache/cassandra/db/compression/CompressionDictionaryManager.java
@@ -464,15 +464,7 @@ public class CompressionDictionaryManager implements CompressionDictionaryManage
             else
                 resolvedValue = userSuppliedValue;
 
-            DataStorageSpec.IntKibibytesBound bound = new DataStorageSpec.IntKibibytesBound(resolvedValue);
-
-            if (bound.toBytesInLong() == 0)
-                throw new IllegalArgumentException("can not be equal to 0 bytes.");
-
-            if (bound.toBytesInLong() > Integer.MAX_VALUE)
-                throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
-
-            return bound.toBytes();
+            return new DataStorageSpec.IntBytesBound(resolvedValue).toBytes();
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/db/compression/CompressionDictionaryManager.java
+++ b/src/java/org/apache/cassandra/db/compression/CompressionDictionaryManager.java
@@ -464,7 +464,15 @@ public class CompressionDictionaryManager implements CompressionDictionaryManage
             else
                 resolvedValue = userSuppliedValue;
 
-            return new DataStorageSpec.IntKibibytesBound(resolvedValue).toBytes();
+            DataStorageSpec.IntKibibytesBound bound = new DataStorageSpec.IntKibibytesBound(resolvedValue);
+
+            if (bound.toBytesInLong() == 0)
+                throw new IllegalArgumentException("can not be equal to 0 bytes.");
+
+            if (bound.toBytesInLong() > Integer.MAX_VALUE)
+                throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
+
+            return bound.toBytes();
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/io/compress/IDictionaryCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/IDictionaryCompressor.java
@@ -59,14 +59,7 @@ public interface IDictionaryCompressor<T extends CompressionDictionary>
     {
         try
         {
-            DataStorageSpec.IntKibibytesBound bound = new DataStorageSpec.IntKibibytesBound(resolvedValue);
-            bound.toBytes();
-
-            if (bound.toBytesInLong() == 0)
-                throw new IllegalArgumentException("can not be equal to 0 bytes.");
-
-            if (bound.toBytesInLong() > Integer.MAX_VALUE)
-                throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
+            new DataStorageSpec.IntBytesBound(resolvedValue).toBytes();
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/io/compress/IDictionaryCompressor.java
+++ b/src/java/org/apache/cassandra/io/compress/IDictionaryCompressor.java
@@ -59,7 +59,14 @@ public interface IDictionaryCompressor<T extends CompressionDictionary>
     {
         try
         {
-            new DataStorageSpec.IntKibibytesBound(resolvedValue).toBytes();
+            DataStorageSpec.IntKibibytesBound bound = new DataStorageSpec.IntKibibytesBound(resolvedValue);
+            bound.toBytes();
+
+            if (bound.toBytesInLong() == 0)
+                throw new IllegalArgumentException("can not be equal to 0 bytes.");
+
+            if (bound.toBytesInLong() > Integer.MAX_VALUE)
+                throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
         }
         catch (Throwable t)
         {

--- a/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
@@ -182,7 +182,13 @@ public class CompressionDictionaryCommandGroup
             {
                 try
                 {
-                    new DataStorageSpec.IntKibibytesBound(trainingMaxDictionarySize).toBytes();
+                    DataStorageSpec.IntKibibytesBound maxDictSizeBound = new DataStorageSpec.IntKibibytesBound(trainingMaxDictionarySize);
+
+                    if (maxDictSizeBound.toBytesInLong() == 0)
+                        throw new IllegalArgumentException("can not be equal to 0 bytes.");
+
+                    if (maxDictSizeBound.toBytesInLong() > Integer.MAX_VALUE)
+                        throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
                 }
                 catch (Throwable t)
                 {
@@ -195,7 +201,13 @@ public class CompressionDictionaryCommandGroup
             {
                 try
                 {
-                    new DataStorageSpec.IntKibibytesBound(trainingMaxTotalSampleSize).toBytes();
+                    DataStorageSpec.IntKibibytesBound maxTotalSampleSizeBound = new DataStorageSpec.IntKibibytesBound(trainingMaxTotalSampleSize);
+
+                    if (maxTotalSampleSizeBound.toBytesInLong() == 0)
+                        throw new IllegalArgumentException("can not be equal to 0 bytes.");
+
+                    if (maxTotalSampleSizeBound.toBytesInLong() > Integer.MAX_VALUE)
+                        throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
                 }
                 catch (Throwable t)
                 {

--- a/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/CompressionDictionaryCommandGroup.java
@@ -182,13 +182,7 @@ public class CompressionDictionaryCommandGroup
             {
                 try
                 {
-                    DataStorageSpec.IntKibibytesBound maxDictSizeBound = new DataStorageSpec.IntKibibytesBound(trainingMaxDictionarySize);
-
-                    if (maxDictSizeBound.toBytesInLong() == 0)
-                        throw new IllegalArgumentException("can not be equal to 0 bytes.");
-
-                    if (maxDictSizeBound.toBytesInLong() > Integer.MAX_VALUE)
-                        throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
+                    new DataStorageSpec.IntBytesBound(trainingMaxDictionarySize).toBytes();
                 }
                 catch (Throwable t)
                 {
@@ -201,13 +195,7 @@ public class CompressionDictionaryCommandGroup
             {
                 try
                 {
-                    DataStorageSpec.IntKibibytesBound maxTotalSampleSizeBound = new DataStorageSpec.IntKibibytesBound(trainingMaxTotalSampleSize);
-
-                    if (maxTotalSampleSizeBound.toBytesInLong() == 0)
-                        throw new IllegalArgumentException("can not be equal to 0 bytes.");
-
-                    if (maxTotalSampleSizeBound.toBytesInLong() > Integer.MAX_VALUE)
-                        throw new IllegalArgumentException("can not be bigger than " + Integer.MAX_VALUE + " bytes.");
+                    new DataStorageSpec.IntBytesBound(trainingMaxTotalSampleSize).toBytes();
                 }
                 catch (Throwable t)
                 {

--- a/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryIntegrationTest.java
+++ b/test/unit/org/apache/cassandra/db/compression/CompressionDictionaryIntegrationTest.java
@@ -234,6 +234,33 @@ public class CompressionDictionaryIntegrationTest extends CQLTester
         .hasMessageContaining("No SSTables available for training");
     }
 
+    @Test
+    public void testMaxBoundForTrainingParameters()
+    {
+        String table = createTable(getTableCql());
+        ColumnFamilyStore cfs = Keyspace.open(keyspace()).getColumnFamilyStore(table);
+        CompressionDictionaryManager manager = cfs.compressionDictionaryManager();
+
+        assertThatThrownBy(() -> manager.train(false, Map.of(TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME, "5GiB",
+                                                             TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME, TRAINING_MAX_TOTAL_SAMPLE_SIZE)))
+        .as("Should fail when " + TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME + " is bigger than " + Integer.MAX_VALUE)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid value for training_max_dictionary_size: 5GiB");
+
+        assertThatThrownBy(() -> manager.train(false, Map.of(TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME, TRAINING_MAX_DICTIONARY_SIZE,
+                                                             TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME, "5GiB")))
+        .as("Should fail when " + TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME + " is bigger than " + Integer.MAX_VALUE)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid value for " + TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME + ": 5GiB");
+    }
+
+    @Test
+    public void testInvalidTableCreation()
+    {
+        assertThatThrownBy(() -> createTable(getTableCqlWithInvalidTotalMaxSampleSize())).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> createTable(getTableCqlWithInvalidMaxDictionarySize())).isInstanceOf(RuntimeException.class);
+    }
+
     private String getTableCqlWithChunkLength()
     {
         return "CREATE TABLE %s (pk text PRIMARY KEY, data text) " +
@@ -251,6 +278,26 @@ public class CompressionDictionaryIntegrationTest extends CQLTester
                "WITH compression = {" +
                "'class': 'ZstdDictionaryCompressor'," +
                '\'' + TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME + "': '" + DEFAULT_TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_VALUE + "'," +
+               '\'' + TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME + "': '" + DEFAULT_TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_VALUE + '\'' +
+               '}';
+    }
+
+    private String getTableCqlWithInvalidTotalMaxSampleSize()
+    {
+        return "CREATE TABLE %s (pk text PRIMARY KEY, data text) " +
+               "WITH compression = {" +
+               "'class': 'ZstdDictionaryCompressor'," +
+               '\'' + TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME + "': '" + DEFAULT_TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_VALUE + "'," +
+               '\'' + TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME + "': '5GiB'" +
+               '}';
+    }
+
+    private String getTableCqlWithInvalidMaxDictionarySize()
+    {
+        return "CREATE TABLE %s (pk text PRIMARY KEY, data text) " +
+               "WITH compression = {" +
+               "'class': 'ZstdDictionaryCompressor'," +
+               '\'' + TRAINING_MAX_DICTIONARY_SIZE_PARAMETER_NAME + "': '5GiB'," +
                '\'' + TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_NAME + "': '" + DEFAULT_TRAINING_MAX_TOTAL_SAMPLE_SIZE_PARAMETER_VALUE + '\'' +
                '}';
     }


### PR DESCRIPTION
patch by Stefan Miklosovic; reviewed by TBD for CASSANDRA-21194

Thanks for sending a pull request! Here are some tips if you're new here:
 
 * Ensure you have added or run the [appropriate tests](https://cassandra.apache.org/_/development/testing.html) for your PR.
 * Be sure to keep the PR description updated to reflect all changes.
 * Write your PR title to summarize what this PR proposes.
 * If possible, provide a concise example to reproduce the issue for a faster review.
 * Read our [contributor guidelines](https://cassandra.apache.org/_/development/index.html)
 * If you're making a documentation change, see our [guide to documentation contribution](https://cassandra.apache.org/_/development/documentation.html)
 
Commit messages should follow the following format:

```
<One sentence description, usually Jira title or CHANGES.txt summary>

<Optional lengthier description (context on patch)>

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-#####

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/)

