### PR TITLE
CASSANDRA-20178: Make SetGetCompactionThroughputTest locale-agnostic

### DIFF
--- a/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetGetCompactionThroughputTest.java
@@ -87,9 +87,9 @@ public class SetGetCompactionThroughputTest extends CQLTester
         ToolResult tool = invokeNodetool("getcompactionthroughput");
         tool.assertOnCleanExit();
 
-        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(1 minute\\): \\d+\\.\\d+ MiB/s");
-        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(5 minute\\): \\d+\\.\\d+ MiB/s");
-        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(15 minute\\): \\d+\\.\\d+ MiB/s");
+        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(1 minute\\): \\d+[.,]\\d+ MiB/s");
+        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(5 minute\\): \\d+[.,]\\d+ MiB/s");
+        assertThat(tool.getStdout()).containsPattern("Current compaction throughput \\(15 minute\\): \\d+[.,]\\d+ MiB/s");
     }
 
     private static void assertSetGetValidThroughput(int throughput)
@@ -151,8 +151,8 @@ public class SetGetCompactionThroughputTest extends CQLTester
         tool.assertOnCleanExit();
 
         if (expected > 0)
-            assertThat(tool.getStdout()).contains("Current compaction throughput: " + expected + " MiB/s");
+            assertThat(tool.getStdout()).containsPattern("Current compaction throughput: " + expected + "[.,]0 MiB/s");
         else
-            assertThat(tool.getStdout()).contains("Current compaction throughput: 0.0 MiB/s");
+            assertThat(tool.getStdout()).containsPattern("Current compaction throughput: 0[.,]0 MiB/s");
     }
 }


### PR DESCRIPTION
The test `SetGetCompactionThroughputTest` fails on locales that use a comma (`,`) as a decimal separator (like `de_DE`). This PR makes the regex pattern locale-agnostic by using `[.,]` for decimals.

patch by Rajneesh180; reviewed by TBD for CASSANDRA-20178